### PR TITLE
AERIE-1609 Adding foo-missionmodel package to Github

### DIFF
--- a/foo-missionmodel/build.gradle
+++ b/foo-missionmodel/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'java-library'
+  id 'maven-publish'
 }
 
 java {
@@ -23,4 +24,25 @@ dependencies {
   testImplementation 'org.assertj:assertj-core:3.21.0'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+}
+
+publishing {
+  publications {
+    library(MavenPublication) {
+      from components.java
+    }
+  }
+
+  publishing {
+    repositories {
+      maven {
+        name = "GitHubPackages"
+        url = "https://maven.pkg.github.com/nasa-ammos/aerie"
+        credentials {
+          username = System.getenv("GITHUB_ACTOR")
+          password = System.getenv("GITHUB_TOKEN")
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION

* **Tickets addressed:** AERIE-1609
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Since going public, we are using Github actions to push packages to Github. We already added the banananation model to Github packages. This ticket is to include the other mission models. The only other one located in this project is foo-missionmodel

## Verification
I am unable to test this because I need this branch merged in for the Github action to be ran. This might require multiple attempts....

## Documentation
None

## Future work
Verify that the foo-missionmodel package is generated upon merge
