### PR TITLE
[AERIE-1618] Add DB testing infrastructure

### DIFF
--- a/db-tests/build.gradle
+++ b/db-tests/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+  id 'java-library'
+}
+
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(17)
+  }
+}
+
+test {
+  useJUnitPlatform()
+}
+
+dependencies {
+  testImplementation 'org.assertj:assertj-core:3.21.0'
+  testImplementation 'com.impossibl.pgjdbc-ng:pgjdbc-ng:0.8.9'
+  testImplementation 'org.postgresql:postgresql:42.2.5'
+  testImplementation 'com.zaxxer:HikariCP:5.0.0'
+  testImplementation 'junit:junit:4.13.2'
+
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+}

--- a/db-tests/src/test/java/TestTriggers.java
+++ b/db-tests/src/test/java/TestTriggers.java
@@ -1,0 +1,95 @@
+import com.impossibl.postgres.jdbc.PGDataSource;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.Assume;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DatabaseTests {
+  private static final File initSqlScriptFile = new File("../deployment/postgres-init-db/sql/merlin/init.sql");
+  private java.sql.Connection connection;
+
+  // Setup test database
+  @BeforeAll
+  void beforeAll() throws SQLException, IOException, InterruptedException {
+
+    // Create test database and grant privileges
+    {
+      final var pb = new ProcessBuilder("psql",
+                                             "postgresql://postgres:postgres@localhost:5432",
+                                             "-v", "ON_ERROR_STOP=1",
+                                             "-c", "CREATE DATABASE aerie_merlin_test;",
+                                             "-c", "GRANT ALL PRIVILEGES ON DATABASE aerie_merlin_test TO aerie;"
+      );
+
+      final var proc = pb.start();
+
+      // Handle the case where we cannot connect to postgres by skipping the tests
+      final var errors = new String(proc.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+      Assume.assumeFalse(errors.contains("could not connect to server: Connection refused"));
+      proc.waitFor();
+      proc.destroy();
+    }
+
+    // Grant table privileges to aerie user for the tests
+    // Apparently, the previous privileges are insufficient on their own
+    {
+      final var pb = new ProcessBuilder("psql",
+                              "postgresql://postgres:postgres@localhost:5432/aerie_merlin_test",
+                              "-v", "ON_ERROR_STOP=1",
+                              "-c", "ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO aerie;",
+                              "-c", "\\ir %s".formatted(initSqlScriptFile.getAbsolutePath())
+      );
+
+      pb.redirectError(ProcessBuilder.Redirect.INHERIT);
+      final var proc = pb.start();
+      proc.waitFor();
+      proc.destroy();
+    }
+
+    final var pgDataSource = new PGDataSource();
+
+    pgDataSource.setServerName("localhost");
+    pgDataSource.setPortNumber(5432);
+    pgDataSource.setDatabaseName("aerie_merlin_test");
+    pgDataSource.setApplicationName("Merlin Database Tests");
+
+    final var hikariConfig = new HikariConfig();
+    hikariConfig.setUsername("aerie");
+    hikariConfig.setPassword("aerie");
+    hikariConfig.setDataSource(pgDataSource);
+
+    final var hikariDataSource = new HikariDataSource(hikariConfig);
+
+    connection = hikariDataSource.getConnection();
+  }
+
+  // Teardown test database
+  @AfterAll
+  void afterall() throws SQLException, IOException, InterruptedException {
+    Assume.assumeNotNull(connection);
+    connection.close();
+
+    // Clear out all data from the database on test conclusion
+    // This is done WITH (FORCE) so there aren't issues with trying
+    // to drop a database while there are connected sessions from
+    // dev tools
+    final var pb = new ProcessBuilder("psql",
+                            "postgresql://postgres:postgres@localhost:5432",
+                            "-v", "ON_ERROR_STOP=1",
+                            "-c", "DROP DATABASE IF EXISTS aerie_merlin_test WITH (FORCE);"
+    );
+
+    pb.redirectError(ProcessBuilder.Redirect.INHERIT);
+    final var proc = pb.start();
+    proc.waitFor();
+    proc.destroy();
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,3 +22,6 @@ include 'scheduler-server'
 // Command-line interface direct to services
 include 'constraints'
 include 'scheduler'
+
+// DB tests
+include 'db-tests'


### PR DESCRIPTION
Add a test file into the deployment project that has the setup and
teardown for database tests. This creates and initializes a test
database (aerie_merlin_test) using the merlin init script to
mirror the production database. The teardown drops the test database
WITH (FORCE).

* **Tickets addressed:** AERIE-1618
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
I looked into a variety of solutions for database testing infrastructure and eventually landed on just using JUnit for a number of reasons.

Alternatives considered: [PGTap](https://pgtap.org/), [PGUnit](https://github.com/adrianandrei-ca/pgunit)

Both of the alternatives attempt to implement testing directly in SQL - which sounds great, but does not have the flexibility that a general purpose language does. For example, if a trigger under test is on data in a table with a non nullable foreign key, then additional data needs to be added for that foreign table. Ideally, when doing this, you would use the primary key to manage the items to ensure that you have solid cleanup and association within the tests, but neither of the SQL embedded solutions allowed for general variable usages, so we'd have to create some sort of temporary table to do this. In the end, it just seemed to be not worth the effort when our developers are primarily skilled in GP languages.

Initialization and cleanup are an important part of DB testing, so we needed a way to isolate everything. The simplest and most surefire way was to create a new test database and initialize it the same way we do our production database and then drop the database on test conclusion. The other option would have been rolled back transactions on the production database, but I didn't want to risk messing that up and so went this direction.

Another consideration was in the dependence on a postgres DB to be up in order to run the tests. The solution at this point in time was to ignore the tests if the database could not be reached, though I think there may be benefit in adjusting where we are doing these test (more as integration style tests) in the future.

## Documentation
No documentation updates that I am aware of are necessary.

## Future work
Implementation of the actual tests for triggers will follow this PR.
