### PR TITLE
[DRAFT] Activity computed attributes

### DIFF
--- a/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BananaPhotographer.java
+++ b/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BananaPhotographer.java
@@ -1,0 +1,57 @@
+package gov.nasa.jpl.aerie.banananation.activities;
+
+import gov.nasa.jpl.aerie.banananation.Mission;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.Parameter;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.util.UUID;
+
+import static gov.nasa.jpl.aerie.banananation.generated.ActivityActions.call;
+import static gov.nasa.jpl.aerie.banananation.generated.ActivityActions.spawn;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
+
+@ActivityType("BananaPhotographer")
+public class BananaPhotographer {
+
+  @EffectModel
+  public void run(Mission mission) {
+    final var filename = call(new TakePicture());
+    delay(Duration.of(2, Duration.HOURS));
+    spawn(new MakeGif()
+              .withFilename(filename));
+  }
+
+
+  @ActivityType("TakePicture")
+  public static class TakePicture {
+
+    @EffectModel
+    public String run(Mission mission) {
+      return UUID.randomUUID() + ".jpg";
+    }
+  }
+
+  @ActivityType("MakeGif")
+  public static class MakeGif {
+
+    @Parameter
+    public String filename = "";
+
+    public MakeGif() {
+    }
+
+    MakeGif withFilename(String filename) {
+      this.filename = filename;
+      return this;
+    }
+
+    @EffectModel
+    public boolean run(Mission mission) {
+      // closefile;
+      boolean success = true;
+      return success;
+    }
+  }
+}

--- a/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
+++ b/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
@@ -17,10 +17,14 @@
 @WithActivityType(DecomposingActivity.ChildActivity.class)
 @WithActivityType(DecomposingActivity.GrandchildActivity.class)
 @WithActivityType(BakeBananaBreadActivity.class)
+@WithActivityType(BananaPhotographer.class)
+@WithActivityType(BananaPhotographer.TakePicture.class)
+@WithActivityType(BananaPhotographer.MakeGif.class)
 
 package gov.nasa.jpl.aerie.banananation;
 
 import gov.nasa.jpl.aerie.banananation.activities.BakeBananaBreadActivity;
+import gov.nasa.jpl.aerie.banananation.activities.BananaPhotographer;
 import gov.nasa.jpl.aerie.banananation.activities.BiteBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.GrowBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DecomposingActivity;

--- a/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/SimulatedActivityTest.java
+++ b/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/SimulatedActivityTest.java
@@ -26,8 +26,8 @@ public final class SimulatedActivityTest {
 
     assertEquals(1, simulationResults.simulatedActivities.size());
     simulationResults.simulatedActivities.forEach( (id, act) -> {
-        assertEquals(1, act.parameters.size());
-        assertTrue(act.parameters.containsKey("peelDirection"));
+        assertEquals(1, act.arguments.size());
+        assertTrue(act.arguments.containsKey("peelDirection"));
     });
   }
 }

--- a/deployment/postgres-init-db/sql/merlin/tables/activity_type.sql
+++ b/deployment/postgres-init-db/sql/merlin/tables/activity_type.sql
@@ -3,6 +3,7 @@ create table activity_type (
   name text not null,
   parameters merlin_parameter_set not null,
   required_parameters merlin_required_parameter_set not null,
+  return_value_schema jsonb,
 
   constraint activity_type_natural_key
     primary key (model_id, name),
@@ -21,3 +22,7 @@ comment on column activity_type.model_id is e''
   'The model defining this activity type.';
 comment on column activity_type.parameters is e''
   'The set of parameters accepted by this activity type.';
+comment on column activity_type.required_parameters is e''
+  'A description of which parameters are required to be provided to instantiate this activity type';
+comment on column activity_type.return_value_schema is e''
+  'The type of value returned by the effect model of this activity type';

--- a/deployment/postgres-init-db/sql/merlin/tables/event.sql
+++ b/deployment/postgres-init-db/sql/merlin/tables/event.sql
@@ -7,6 +7,7 @@ create table event
 
   value jsonb,
   topic_index integer not null,
+  task_id text not null,
 
   constraint event_natural_key
     primary key (dataset_id, real_time, causal_time),

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
@@ -3,7 +3,6 @@ package gov.nasa.jpl.aerie.merlin.driver;
 import gov.nasa.jpl.aerie.merlin.driver.engine.Directive;
 import gov.nasa.jpl.aerie.merlin.driver.timeline.LiveCells;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer;
-import gov.nasa.jpl.aerie.merlin.protocol.driver.Query;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Resource;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
@@ -11,8 +10,6 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.lang3.tuple.Triple;
 
 import java.util.Collections;
 import java.util.List;
@@ -55,7 +52,7 @@ public final class MissionModel<Model> {
   public Directive<Model, ?> instantiateDirective(final SerializedActivity specification)
   throws TaskSpecType.UnconstructableTaskSpecException
   {
-    return Directive.instantiate(this.taskSpecTypes.get(specification.getTypeName()), specification.getParameters());
+    return Directive.instantiate(this.taskSpecTypes.get(specification.getTypeName()), specification.getArguments());
   }
 
   public Task getDaemon() {

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelBuilder.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelBuilder.java
@@ -9,14 +9,13 @@ import gov.nasa.jpl.aerie.merlin.driver.timeline.RecursiveEventGraphEvaluator;
 import gov.nasa.jpl.aerie.merlin.driver.timeline.Selector;
 import gov.nasa.jpl.aerie.merlin.driver.timeline.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer;
+import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Applicator;
 import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Resource;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.lang3.tuple.Triple;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,7 +60,7 @@ public final class MissionModelBuilder implements Initializer {
   }
 
   @Override
-  public String daemon(final TaskFactory task) {
+  public Scheduler.TaskIdentifier daemon(final TaskFactory task) {
     return this.state.daemon(task);
   }
 
@@ -133,7 +132,7 @@ public final class MissionModelBuilder implements Initializer {
     }
 
     @Override
-    public String daemon(final TaskFactory task) {
+    public Scheduler.TaskIdentifier daemon(final TaskFactory task) {
       this.daemons.add(task);
       return null;  // TODO: get some way to refer to the daemon task
     }
@@ -190,7 +189,7 @@ public final class MissionModelBuilder implements Initializer {
     }
 
     @Override
-    public String daemon(final TaskFactory task) {
+    public Scheduler.TaskIdentifier daemon(final TaskFactory task) {
       throw new IllegalStateException("Daemons cannot be added after the schema is built");
     }
 

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SerializedActivity.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SerializedActivity.java
@@ -24,11 +24,11 @@ import static java.util.Collections.unmodifiableMap;
  */
 public final class SerializedActivity {
   private final String typeName;
-  private final Map<String, SerializedValue> parameters;
+  private final Map<String, SerializedValue> arguments;
 
-  public SerializedActivity(final String typeName, final Map<String, SerializedValue> parameters) {
+  public SerializedActivity(final String typeName, final Map<String, SerializedValue> arguments) {
     this.typeName = Objects.requireNonNull(typeName);
-    this.parameters = Objects.requireNonNull(parameters);
+    this.arguments = Objects.requireNonNull(arguments);
   }
 
   /**
@@ -45,8 +45,8 @@ public final class SerializedActivity {
    *
    * @return A map of serialized parameters keyed by parameter name.
    */
-  public Map<String, SerializedValue> getParameters() {
-    return unmodifiableMap(this.parameters);
+  public Map<String, SerializedValue> getArguments() {
+    return unmodifiableMap(this.arguments);
   }
 
   // SAFETY: If equals is overridden, then hashCode must also be overridden.
@@ -57,17 +57,17 @@ public final class SerializedActivity {
     final SerializedActivity other = (SerializedActivity)o;
     return
         (  Objects.equals(this.typeName, other.typeName)
-        && Objects.equals(this.parameters, other.parameters)
+        && Objects.equals(this.arguments, other.arguments)
         );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.typeName, this.parameters);
+    return Objects.hash(this.typeName, this.arguments);
   }
 
   @Override
   public String toString() {
-    return "SerializedActivity { typeName = " + this.typeName + ", parameters = " + this.parameters.toString() + " }";
+    return "SerializedActivity { typeName = " + this.typeName + ", arguments = " + this.arguments.toString() + " }";
   }
 }

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulatedActivity.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulatedActivity.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public final class SimulatedActivity {
   public final String type;
-  public final Map<String, SerializedValue> parameters;
+  public final Map<String, SerializedValue> arguments;
   public final Instant start;
   public final Duration duration;
   public final String parentId;
@@ -19,7 +19,7 @@ public final class SimulatedActivity {
 
   public SimulatedActivity(
       final String type,
-      final Map<String, SerializedValue> parameters,
+      final Map<String, SerializedValue> arguments,
       final Instant start,
       final Duration duration,
       final String parentId,
@@ -27,7 +27,7 @@ public final class SimulatedActivity {
       final Optional<String> directiveId
   ) {
     this.type = type;
-    this.parameters = parameters;
+    this.arguments = arguments;
     this.start = start;
     this.duration = duration;
     this.parentId = parentId;
@@ -40,7 +40,7 @@ public final class SimulatedActivity {
     return
         "SimulatedActivity "
         + "{ type=" + this.type
-        + ", parameters=" + this.parameters
+        + ", arguments=" + this.arguments
         + ", start=" + this.start
         + ", duration=" + this.duration
         + ", parentId=" + this.parentId

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulatedActivity.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulatedActivity.java
@@ -2,8 +2,6 @@ package gov.nasa.jpl.aerie.merlin.driver;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
-import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.time.Instant;
 import java.util.List;

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulatedActivity.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulatedActivity.java
@@ -2,6 +2,8 @@ package gov.nasa.jpl.aerie.merlin.driver;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.time.Instant;
 import java.util.List;
@@ -16,6 +18,7 @@ public final class SimulatedActivity {
   public final String parentId;
   public final List<String> childIds;
   public final Optional<String> directiveId;
+  public final SerializedValue returnValue;
 
   public SimulatedActivity(
       final String type,
@@ -24,8 +27,9 @@ public final class SimulatedActivity {
       final Duration duration,
       final String parentId,
       final List<String> childIds,
-      final Optional<String> directiveId
-  ) {
+      final Optional<String> directiveId,
+      final SerializedValue returnValue
+      ) {
     this.type = type;
     this.arguments = arguments;
     this.start = start;
@@ -33,6 +37,7 @@ public final class SimulatedActivity {
     this.parentId = parentId;
     this.childIds = childIds;
     this.directiveId = directiveId;
+    this.returnValue = returnValue;
   }
 
   @Override

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.driver;
 
 import gov.nasa.jpl.aerie.merlin.driver.engine.SimulationEngine;
 import gov.nasa.jpl.aerie.merlin.driver.engine.SimulationEngine.JobId;
+import gov.nasa.jpl.aerie.merlin.driver.engine.TaskId;
 import gov.nasa.jpl.aerie.merlin.driver.timeline.LiveCells;
 import gov.nasa.jpl.aerie.merlin.driver.timeline.TemporalEventSource;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
@@ -169,7 +170,7 @@ public final class SimulationDriver {
         final var directiveId = nextTask.getMiddle();
         final var specification = nextTask.getRight();
 
-        final var id = scheduler.spawn(specification.getTypeName(), specification.getArguments());
+        final var id = ((TaskId) scheduler.spawn(specification.getTypeName(), specification.getArguments())).id();
         this.taskToPlannedDirective.put(id, directiveId);
       }
 

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
@@ -169,7 +169,7 @@ public final class SimulationDriver {
         final var directiveId = nextTask.getMiddle();
         final var specification = nextTask.getRight();
 
-        final var id = scheduler.spawn(specification.getTypeName(), specification.getParameters());
+        final var id = scheduler.spawn(specification.getTypeName(), specification.getArguments());
         this.taskToPlannedDirective.put(id, directiveId);
       }
 

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationResults.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationResults.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.TreeMap;
 
 public final class SimulationResults {
   public final Instant startTime;
@@ -23,7 +24,7 @@ public final class SimulationResults {
   public final Map<String, SimulatedActivity> simulatedActivities;
   public final Map<String, SerializedActivity> unfinishedActivities;
   public final List<Triple<Integer, String, ValueSchema>> topics;
-  public final Map<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>> events;
+  public final SortedMap<Duration, List<EventGraph<Triple<Integer, SerializedValue, String>>>> events;
 
     public SimulationResults(
         final Map<String, List<Pair<Duration, RealDynamics>>> realProfiles,
@@ -32,7 +33,7 @@ public final class SimulationResults {
         final Map<String, SerializedActivity> unfinishedActivities,
         final Instant startTime,
         final List<Triple<Integer, String, ValueSchema>> topics,
-        final SortedMap<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>> events)
+        final SortedMap<Duration, List<EventGraph<Triple<Integer, SerializedValue, String>>>> events)
   {
     this.startTime = startTime;
     this.realProfiles = realProfiles;

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -444,6 +444,7 @@ public final class SimulationEngine implements AutoCloseable {
       final var activityId = taskToPlannedDirective.get(task.id());
 
       if (state instanceof ExecutionState.Terminated e) {
+        final var taskReturnValue = taskReturns.get(task);
         simulatedActivities.put(activityId, new SimulatedActivity(
             directive.getType(),
             directive.getArguments(),
@@ -451,7 +452,8 @@ public final class SimulationEngine implements AutoCloseable {
             e.joinOffset().minus(e.startOffset()),
             activityParents.get(activityId),
             activityChildren.getOrDefault(activityId, Collections.emptyList()),
-            (activityParents.containsKey(activityId)) ? Optional.empty() : Optional.of(activityId)
+            (activityParents.containsKey(activityId)) ? Optional.empty() : Optional.of(activityId),
+            directive.directiveType().serializeReturnValue(taskReturnValue.returnValue())
         ));
       } else {
         unsimulatedActivities.put(activityId, new SerializedActivity(

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -676,6 +676,13 @@ public final class SimulationEngine implements AutoCloseable {
 
       return task;
     }
+
+    @Override
+    public Object getTaskReturnValue(final TaskIdentifier taskId) {
+      final var taskReturnValue = SimulationEngine.this.taskReturns.get(((TaskId) taskId));
+      if (taskReturnValue == null) return null;
+      return taskReturnValue.returnValue();
+    }
   }
 
   /** A representation of a job processable by the {@link SimulationEngine}. */

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/TaskId.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/TaskId.java
@@ -1,9 +1,11 @@
 package gov.nasa.jpl.aerie.merlin.driver.engine;
 
+import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
+
 import java.util.UUID;
 
 /** A typed wrapper for task IDs. */
-/*package-local*/ record TaskId(String id) {
+public record TaskId(String id) implements Scheduler.TaskIdentifier {
   public static TaskId generate() {
     return new TaskId(UUID.randomUUID().toString());
   }

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/timeline/Event.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/timeline/Event.java
@@ -1,5 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.driver.timeline;
 
+import gov.nasa.jpl.aerie.merlin.driver.engine.TaskId;
+
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -12,8 +14,11 @@ public final class Event {
     this.inner = inner;
   }
 
-  public static <EventType> Event create(final Topic<EventType> topic, final EventType event) {
-    return new Event(new Event.GenericEvent<>(topic, event));
+  public static <EventType> Event create(
+      final Topic<EventType> topic,
+      final EventType event,
+      final TaskId activeTask) {
+    return new Event(new Event.GenericEvent<>(topic, event, activeTask));
   }
 
   public <EventType, Target>
@@ -30,12 +35,16 @@ public final class Event {
     return this.inner.topic();
   }
 
+  public TaskId activeTask() {
+    return this.inner.activeTask();
+  }
+
   @Override
   public String toString() {
     return "<@%s, %s>".formatted(System.identityHashCode(this.inner.topic), this.inner.event);
   }
 
-  private record GenericEvent<EventType>(Topic<EventType> topic, EventType event) {
+  private record GenericEvent<EventType>(Topic<EventType> topic, EventType event, TaskId activeTask) {
     private GenericEvent {
       Objects.requireNonNull(topic);
       Objects.requireNonNull(event);

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
@@ -665,6 +665,7 @@ public final class MissionModelProcessor implements Processor {
             .addMethod(getMapperInstantiator(activityType.activityDefaultsStyle).makeGetRequiredParametersMethod(activityType))
             .addMethod(getMapperInstantiator(activityType.activityDefaultsStyle).makeGetParametersMethod(activityType))
             .addMethod(getMapperInstantiator(activityType.activityDefaultsStyle).makeGetReturnValueSchemaMethod(activityType))
+            .addMethod(getMapperInstantiator(activityType.activityDefaultsStyle).makeSerializeReturnValueMethod(activityType))
             .addMethod(getMapperInstantiator(activityType.activityDefaultsStyle).makeGetArgumentsMethod(activityType))
             .addMethod(getMapperInstantiator(activityType.activityDefaultsStyle).makeInstantiateMethod(activityType))
             .addMethod(

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
@@ -671,29 +671,20 @@ public final class MissionModelProcessor implements Processor {
                         Modifier.FINAL)
                     .addCode(
                         activityType.effectModel
-                            .map(effectModel -> switch (effectModel.executor()) {
-                              case Threaded -> CodeBlock
+                            .map(effectModel -> CodeBlock
                                   .builder()
                                   .addStatement(
-                                      "return $T.threaded(() -> $L.$L($L.model())).create($L.executor())",
+                                      "return $T.$L(() -> $L.$L($L.model())).create($L.executor())",
                                       gov.nasa.jpl.aerie.merlin.framework.ModelActions.class,
+                                      switch (effectModel.executor()) {
+                                        case Threaded -> "threaded";
+                                        case Replaying -> "replaying";
+                                      },
                                       "activity",
                                       effectModel.methodName(),
                                       "model",
                                       "model")
-                                  .build();
-
-                              case Replaying -> CodeBlock
-                                  .builder()
-                                  .addStatement(
-                                      "return $T.replaying(() -> $L.$L($L.model())).create($L.executor())",
-                                      gov.nasa.jpl.aerie.merlin.framework.ModelActions.class,
-                                      "activity",
-                                      effectModel.methodName(),
-                                      "model",
-                                      "model")
-                                  .build();
-                            })
+                                  .build())
                             .orElseGet(() -> CodeBlock
                                 .builder()
                                 .addStatement(

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
@@ -664,6 +664,7 @@ public final class MissionModelProcessor implements Processor {
                     .build())
             .addMethod(getMapperInstantiator(activityType.activityDefaultsStyle).makeGetRequiredParametersMethod(activityType))
             .addMethod(getMapperInstantiator(activityType.activityDefaultsStyle).makeGetParametersMethod(activityType))
+            .addMethod(getMapperInstantiator(activityType.activityDefaultsStyle).makeGetReturnValueSchemaMethod(activityType))
             .addMethod(getMapperInstantiator(activityType.activityDefaultsStyle).makeGetArgumentsMethod(activityType))
             .addMethod(getMapperInstantiator(activityType.activityDefaultsStyle).makeInstantiateMethod(activityType))
             .addMethod(

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
@@ -25,6 +25,7 @@ import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityValidationRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.EffectModelRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.MissionModelRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.TypeRule;
+import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.MerlinPlugin;
 import gov.nasa.jpl.aerie.merlin.protocol.model.MissionModelFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
@@ -725,7 +726,7 @@ public final class MissionModelProcessor implements Processor {
                             MethodSpec
                                 .methodBuilder("spawn")
                                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                                .returns(String.class)
+                                .returns(Scheduler.TaskIdentifier.class)
                                 .addParameter(
                                     ClassName.get(entry.declaration),
                                     "activity",
@@ -744,7 +745,7 @@ public final class MissionModelProcessor implements Processor {
                             MethodSpec
                                 .methodBuilder("defer")
                                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                                .returns(String.class)
+                                .returns(Scheduler.TaskIdentifier.class)
                                 .addParameter(
                                     ParameterSpec
                                         .builder(
@@ -771,7 +772,7 @@ public final class MissionModelProcessor implements Processor {
                             MethodSpec
                                 .methodBuilder("defer")
                                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                                .returns(String.class)
+                                .returns(Scheduler.TaskIdentifier.class)
                                 .addParameter(
                                     ParameterSpec
                                         .builder(

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
@@ -10,7 +10,6 @@ import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
-import com.squareup.javapoet.TypeVariableName;
 import com.squareup.javapoet.WildcardTypeName;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.MissionModel;
@@ -23,13 +22,12 @@ import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityMapperRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityParameterRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityTypeRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityValidationRecord;
+import gov.nasa.jpl.aerie.merlin.processor.metamodel.EffectModelRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.MissionModelRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.TypeRule;
 import gov.nasa.jpl.aerie.merlin.protocol.model.MerlinPlugin;
 import gov.nasa.jpl.aerie.merlin.protocol.model.MissionModelFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
-
-import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.processing.Completion;
 import javax.annotation.processing.Filer;
@@ -385,7 +383,7 @@ public final class MissionModelProcessor implements Processor {
         .getActivityParameters(activityTypeElement);
   }
 
-  private Optional<Pair<String, ActivityType.Executor>>
+  private Optional<EffectModelRecord>
   getActivityEffectModel(final TypeElement activityTypeElement)
   {
     for (final var element : activityTypeElement.getEnclosedElements()) {
@@ -394,7 +392,7 @@ public final class MissionModelProcessor implements Processor {
       final var executorAnnotation = element.getAnnotation(ActivityType.EffectModel.class);
       if (executorAnnotation == null) continue;
 
-      return Optional.of(Pair.of(element.getSimpleName().toString(), executorAnnotation.value()));
+      return Optional.of(new EffectModelRecord(element.getSimpleName().toString(), executorAnnotation.value()));
     }
 
     return Optional.empty();
@@ -673,14 +671,14 @@ public final class MissionModelProcessor implements Processor {
                         Modifier.FINAL)
                     .addCode(
                         activityType.effectModel
-                            .map(effectModel -> switch (effectModel.getRight()) {
+                            .map(effectModel -> switch (effectModel.executor()) {
                               case Threaded -> CodeBlock
                                   .builder()
                                   .addStatement(
                                       "return $T.threaded(() -> $L.$L($L.model())).create($L.executor())",
                                       gov.nasa.jpl.aerie.merlin.framework.ModelActions.class,
                                       "activity",
-                                      effectModel.getLeft(),
+                                      effectModel.methodName(),
                                       "model",
                                       "model")
                                   .build();
@@ -691,7 +689,7 @@ public final class MissionModelProcessor implements Processor {
                                       "return $T.replaying(() -> $L.$L($L.model())).create($L.executor())",
                                       gov.nasa.jpl.aerie.merlin.framework.ModelActions.class,
                                       "activity",
-                                      effectModel.getLeft(),
+                                      effectModel.methodName(),
                                       "model",
                                       "model")
                                   .build();

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
@@ -46,6 +46,8 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
@@ -393,7 +395,14 @@ public final class MissionModelProcessor implements Processor {
       final var executorAnnotation = element.getAnnotation(ActivityType.EffectModel.class);
       if (executorAnnotation == null) continue;
 
-      return Optional.of(new EffectModelRecord(element.getSimpleName().toString(), executorAnnotation.value()));
+      if (!(element instanceof ExecutableElement executableElement)) continue;
+
+      final var returnType = executableElement.getReturnType();
+      final Optional<TypeMirror> nonVoidReturnType = returnType.getKind() == TypeKind.VOID
+          ? Optional.empty()
+          : Optional.of(returnType);
+
+      return Optional.of(new EffectModelRecord(element.getSimpleName().toString(), executorAnnotation.value(), nonVoidReturnType));
     }
 
     return Optional.empty();
@@ -549,6 +558,20 @@ public final class MissionModelProcessor implements Processor {
   {
     final var maybeMapperBlocks = buildParameterMapperBlocks(missionModel, activityType);
     if (maybeMapperBlocks.isEmpty()) return Optional.empty();
+    final var effectModelReturnType = activityType.effectModel.flatMap(EffectModelRecord::returnType);
+    final Optional<CodeBlock> effectModelReturnMapperBlock =
+        effectModelReturnType
+            .flatMap(returnType ->  new Resolver(this.typeUtils, this.elementUtils, missionModel.typeRules)
+                  .instantiateNullableMapperFor(returnType));
+    if (effectModelReturnType.isPresent() && effectModelReturnMapperBlock.isEmpty()) {
+      messager.printMessage(
+          Diagnostic.Kind.ERROR,
+          "Failed to generate value mapper for effect model return type "
+          + effectModelReturnType.get()
+          + " of activity "
+          + activityType.name);
+      return Optional.empty();
+    }
     final var mapperBlocks = maybeMapperBlocks.get();
 
     final var typeSpec =
@@ -584,6 +607,18 @@ public final class MissionModelProcessor implements Processor {
                         .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
                         .build())
                     .collect(Collectors.toList()))
+            .addFields(
+                effectModelReturnType
+                    .stream()
+                    .map(returnType -> FieldSpec
+                        .builder(
+                            ParameterizedTypeName.get(
+                                ClassName.get(gov.nasa.jpl.aerie.merlin.framework.ValueMapper.class),
+                                TypeName.get(returnType).box()),
+                            "effectModelReturnTypeMapper")
+                        .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                        .build())
+                    .collect(Collectors.toList()))
             .addMethod(
                 MethodSpec
                     .constructorBuilder()
@@ -605,6 +640,17 @@ public final class MissionModelProcessor implements Processor {
                                     "this.mapper_$L =\n$L",
                                     parameter.name,
                                     mapperBlocks.get(parameter.name)))
+                            .reduce(CodeBlock.builder(), (x, y) -> x.add(y.build()))
+                            .build())
+                    .addCode(
+                        effectModelReturnMapperBlock
+                            .stream()
+                            .map(mapperBlock -> CodeBlock
+                                .builder()
+                                .addStatement(
+                                    "this.effectModelReturnTypeMapper =\n$L",
+                                    mapperBlock
+                                ))
                             .reduce(CodeBlock.builder(), (x, y) -> x.add(y.build()))
                             .build())
                     .build())

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
@@ -848,13 +848,19 @@ public final class MissionModelProcessor implements Processor {
                             MethodSpec
                                 .methodBuilder("call")
                                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                                .returns(TypeName.VOID)
+                                .returns(entry.effectModel.flatMap(EffectModelRecord::returnType)
+                                                          .map(TypeName::get)
+                                                          .orElse(TypeName.VOID))
                                 .addParameter(
                                     ClassName.get(entry.declaration),
                                     "activity",
                                     Modifier.FINAL)
                                 .addStatement(
-                                    "$T.waitFor(spawn($L))",
+                                    "$L$T.waitFor(spawn($L))",
+                                    entry.effectModel.flatMap(EffectModelRecord::returnType)
+                                                     .map(TypeName::get)
+                                                     .map(returnType -> "return (" + returnType + ") ")
+                                                     .orElse(""),
                                     gov.nasa.jpl.aerie.merlin.framework.ModelActions.class,
                                     "activity")
                                 .build())

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/instantiators/ActivityMapperInstantiator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/instantiators/ActivityMapperInstantiator.java
@@ -4,16 +4,19 @@ import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
+import gov.nasa.jpl.aerie.merlin.processor.metamodel.EffectModelRecord;
 import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentException;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityParameterRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityTypeRecord;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public interface ActivityMapperInstantiator {
@@ -71,6 +74,19 @@ public interface ActivityMapperInstantiator {
             "return $L",
             "parameters")
         .build();
+  }
+
+  default MethodSpec makeGetReturnValueSchemaMethod(final ActivityTypeRecord activityType) {
+    return MethodSpec.methodBuilder("getReturnValueSchema")
+                     .addModifiers(Modifier.PUBLIC)
+                     .addAnnotation(Override.class)
+                     .returns(ValueSchema.class)
+                     .addStatement(
+                         activityType.effectModel
+                             .flatMap(EffectModelRecord::returnType)
+                             .map(x -> "return this.effectModelReturnTypeMapper.getValueSchema()")
+                             .orElse("return ValueSchema.UNIT"))
+                     .build();
   }
 
   default MethodSpec makeGetArgumentsMethod(final ActivityTypeRecord activityType) {

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ActivityTypeRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ActivityTypeRecord.java
@@ -15,7 +15,7 @@ public final class ActivityTypeRecord {
   public final ActivityMapperRecord mapper;
   public final List<ActivityValidationRecord> validations;
   public final List<ActivityParameterRecord> parameters;
-  public final Optional<Pair<String, ActivityType.Executor>> effectModel;
+  public final Optional<EffectModelRecord> effectModel;
   public final ActivityDefaultsStyle activityDefaultsStyle;
 
   public ActivityTypeRecord(
@@ -24,7 +24,7 @@ public final class ActivityTypeRecord {
       final ActivityMapperRecord mapper,
       final List<ActivityValidationRecord> validations,
       final List<ActivityParameterRecord> parameters,
-      final Optional<Pair<String, ActivityType.Executor>> effectModel,
+      final Optional<EffectModelRecord> effectModel,
       final ActivityDefaultsStyle activityDefaultsStyle)
   {
     this.declaration = Objects.requireNonNull(declaration);

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
@@ -1,0 +1,6 @@
+package gov.nasa.jpl.aerie.merlin.processor.metamodel;
+
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+
+public record EffectModelRecord(String methodName, ActivityType.Executor executor) {
+}

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
@@ -2,5 +2,8 @@ package gov.nasa.jpl.aerie.merlin.processor.metamodel;
 
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 
-public record EffectModelRecord(String methodName, ActivityType.Executor executor) {
+import javax.lang.model.type.TypeMirror;
+import java.util.Optional;
+
+public record EffectModelRecord(String methodName, ActivityType.Executor executor, Optional<TypeMirror> returnType) {
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.framework;
 
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Query;
+import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Applicator;
 import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
@@ -34,13 +35,13 @@ public interface Context {
 
   interface TaskFactory { Task create(ExecutorService executor); }
 
-  String spawn(TaskFactory task);
-  String spawn(String type, Map<String, SerializedValue> arguments);
+  Scheduler.TaskIdentifier spawn(TaskFactory task);
+  Scheduler.TaskIdentifier spawn(String type, Map<String, SerializedValue> arguments);
 
-  String defer(Duration duration, TaskFactory task);
-  String defer(Duration duration, String type, Map<String, SerializedValue> arguments);
+  Scheduler.TaskIdentifier defer(Duration duration, TaskFactory task);
+  Scheduler.TaskIdentifier defer(Duration duration, String type, Map<String, SerializedValue> arguments);
 
   void delay(Duration duration);
-  void waitFor(String id);
+  void waitFor(Scheduler.TaskIdentifier id);
   void waitUntil(Condition condition);
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
@@ -42,6 +42,6 @@ public interface Context {
   Scheduler.TaskIdentifier defer(Duration duration, String type, Map<String, SerializedValue> arguments);
 
   void delay(Duration duration);
-  void waitFor(Scheduler.TaskIdentifier id);
+  Object waitFor(Scheduler.TaskIdentifier id);
   void waitUntil(Condition condition);
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
@@ -82,7 +82,7 @@ public final class InitializationContext implements Context {
   }
 
   @Override
-  public void waitFor(final Scheduler.TaskIdentifier id) {
+  public Object waitFor(final Scheduler.TaskIdentifier id) {
     throw new IllegalStateException("Cannot yield during initialization");
   }
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.framework;
 
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Query;
+import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Applicator;
 import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -56,22 +57,22 @@ public final class InitializationContext implements Context {
   }
 
   @Override
-  public String spawn(final TaskFactory task) {
+  public Scheduler.TaskIdentifier spawn(final TaskFactory task) {
     return this.builder.daemon(() -> task.create(InitializationContext.this.executor));
   }
 
   @Override
-  public String spawn(final String type, final Map<String, SerializedValue> arguments) {
+  public Scheduler.TaskIdentifier spawn(final String type, final Map<String, SerializedValue> arguments) {
     throw new IllegalStateException("Cannot schedule activities during initialization");
   }
 
   @Override
-  public String defer(final Duration duration, final TaskFactory task) {
+  public Scheduler.TaskIdentifier defer(final Duration duration, final TaskFactory task) {
     throw new IllegalStateException("Cannot schedule tasks during initialization");
   }
 
   @Override
-  public String defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
+  public Scheduler.TaskIdentifier defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
     throw new IllegalStateException("Cannot schedule activities during initialization");
   }
 
@@ -81,7 +82,7 @@ public final class InitializationContext implements Context {
   }
 
   @Override
-  public void waitFor(final String id) {
+  public void waitFor(final Scheduler.TaskIdentifier id) {
     throw new IllegalStateException("Cannot yield during initialization");
   }
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.framework;
 
+import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
@@ -20,15 +21,15 @@ public /*non-final*/ class ModelActions {
   }
 
 
-  public static String spawn(final Runnable task) {
+  public static Scheduler.TaskIdentifier spawn(final Runnable task) {
     return spawn(threaded(task));
   }
 
-  public static String spawn(final Context.TaskFactory task) {
+  public static Scheduler.TaskIdentifier spawn(final Context.TaskFactory task) {
     return context.get().spawn(task);
   }
 
-  public static String spawn(final String type, final Map<String, SerializedValue> arguments) {
+  public static Scheduler.TaskIdentifier spawn(final String type, final Map<String, SerializedValue> arguments) {
     return context.get().spawn(type, arguments);
   }
 
@@ -44,27 +45,27 @@ public /*non-final*/ class ModelActions {
     waitFor(spawn(type, arguments));
   }
 
-  public static String defer(final Duration duration, final Runnable task) {
+  public static Scheduler.TaskIdentifier defer(final Duration duration, final Runnable task) {
     return defer(duration, threaded(task));
   }
 
-  public static String defer(final Duration duration, final Context.TaskFactory task) {
+  public static Scheduler.TaskIdentifier defer(final Duration duration, final Context.TaskFactory task) {
     return context.get().defer(duration, task);
   }
 
-  public static String defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
+  public static Scheduler.TaskIdentifier defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
     return context.get().defer(duration, type, arguments);
   }
 
-  public static String defer(final long quantity, final Duration unit, final Runnable task) {
+  public static Scheduler.TaskIdentifier defer(final long quantity, final Duration unit, final Runnable task) {
     return defer(unit.times(quantity), threaded(task));
   }
 
-  public static String defer(final long quantity, final Duration unit, final String type, final Map<String, SerializedValue> arguments) {
+  public static Scheduler.TaskIdentifier defer(final long quantity, final Duration unit, final String type, final Map<String, SerializedValue> arguments) {
     return defer(unit.times(quantity), type, arguments);
   }
 
-  public static String defer(final long quantity, final Duration unit, final Context.TaskFactory task) {
+  public static Scheduler.TaskIdentifier defer(final long quantity, final Duration unit, final Context.TaskFactory task) {
     return context.get().defer(unit.times(quantity), task);
   }
 
@@ -77,7 +78,7 @@ public /*non-final*/ class ModelActions {
     delay(unit.times(quantity));
   }
 
-  public static void waitFor(final String id) {
+  public static void waitFor(final Scheduler.TaskIdentifier id) {
     context.get().waitFor(id);
   }
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
@@ -58,12 +58,13 @@ public /*non-final*/ class ModelActions {
     call(threaded(task));
   }
 
-  public static <T> void call(final Supplier<T> task) {
-    call(threaded(task));
+  @SuppressWarnings("unchecked")
+  public static <T> T call(final Supplier<T> task) {
+    return (T) call(threaded(task));
   }
 
-  public static void call(final Context.TaskFactory task) {
-    waitFor(spawn(task));
+  public static Object call(final Context.TaskFactory task) {
+    return waitFor(spawn(task));
   }
 
   public static void call(final String type, final Map<String, SerializedValue> arguments) {
@@ -103,8 +104,8 @@ public /*non-final*/ class ModelActions {
     delay(unit.times(quantity));
   }
 
-  public static void waitFor(final Scheduler.TaskIdentifier id) {
-    context.get().waitFor(id);
+  public static Object waitFor(final Scheduler.TaskIdentifier id) {
+    return context.get().waitFor(id);
   }
 
   public static void waitUntil(final Condition condition) {

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/QueryContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/QueryContext.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.framework;
 
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Querier;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Query;
+import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Applicator;
 import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -43,22 +44,22 @@ public final class QueryContext implements Context {
   }
 
   @Override
-  public String spawn(final TaskFactory task) {
+  public Scheduler.TaskIdentifier spawn(final TaskFactory task) {
     throw new IllegalStateException("Cannot schedule tasks in a query-only context");
   }
 
   @Override
-  public String spawn(final String type, final Map<String, SerializedValue> arguments) {
+  public Scheduler.TaskIdentifier spawn(final String type, final Map<String, SerializedValue> arguments) {
     throw new IllegalStateException("Cannot schedule activities in a query-only context");
   }
 
   @Override
-  public String defer(final Duration duration, final TaskFactory task) {
+  public Scheduler.TaskIdentifier defer(final Duration duration, final TaskFactory task) {
     throw new IllegalStateException("Cannot schedule tasks in a query-only context");
   }
 
   @Override
-  public String defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
+  public Scheduler.TaskIdentifier defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
     throw new IllegalStateException("Cannot schedule activities in a query-only context");
   }
 
@@ -68,7 +69,7 @@ public final class QueryContext implements Context {
   }
 
   @Override
-  public void waitFor(final String id) {
+  public void waitFor(final Scheduler.TaskIdentifier id) {
     throw new IllegalStateException("Cannot yield in a query-only context");
   }
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/QueryContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/QueryContext.java
@@ -69,7 +69,7 @@ public final class QueryContext implements Context {
   }
 
   @Override
-  public void waitFor(final Scheduler.TaskIdentifier id) {
+  public Object waitFor(final Scheduler.TaskIdentifier id) {
     throw new IllegalStateException("Cannot yield in a query-only context");
   }
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
@@ -105,10 +105,13 @@ final class ReplayingReactionContext implements Context {
   }
 
   @Override
-  public void waitFor(final Scheduler.TaskIdentifier id) {
+  public Object waitFor(final Scheduler.TaskIdentifier id) {
     this.memory.doOnce(() -> {
       this.scheduler = null;  // Relinquish the current scheduler before yielding, in case an exception is thrown.
       this.scheduler = this.handle.yield(TaskStatus.awaiting(id));
+    });
+    return this.memory.doOnce(() -> {
+      return this.scheduler.getTaskReturnValue(id);
     });
   }
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
@@ -69,28 +69,28 @@ final class ReplayingReactionContext implements Context {
   }
 
   @Override
-  public String spawn(final TaskFactory task) {
+  public Scheduler.TaskIdentifier spawn(final TaskFactory task) {
     return this.memory.doOnce(() -> {
       return this.scheduler.spawn(task.create(this.executor));
     });
   }
 
   @Override
-  public String spawn(final String type, final Map<String, SerializedValue> arguments) {
+  public Scheduler.TaskIdentifier spawn(final String type, final Map<String, SerializedValue> arguments) {
     return this.memory.doOnce(() -> {
       return this.scheduler.spawn(type, arguments);
     });
   }
 
   @Override
-  public String defer(final Duration duration, final TaskFactory task) {
+  public Scheduler.TaskIdentifier defer(final Duration duration, final TaskFactory task) {
     return this.memory.doOnce(() -> {
       return this.scheduler.defer(duration, task.create(this.executor));
     });
   }
 
   @Override
-  public String defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
+  public Scheduler.TaskIdentifier defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
     return this.memory.doOnce(() -> {
       return this.scheduler.defer(duration, type, arguments);
     });
@@ -105,7 +105,7 @@ final class ReplayingReactionContext implements Context {
   }
 
   @Override
-  public void waitFor(final String id) {
+  public void waitFor(final Scheduler.TaskIdentifier id) {
     this.memory.doOnce(() -> {
       this.scheduler = null;  // Relinquish the current scheduler before yielding, in case an exception is thrown.
       this.scheduler = this.handle.yield(TaskStatus.awaiting(id));

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingTask.java
@@ -7,16 +7,17 @@ import org.apache.commons.lang3.mutable.MutableInt;
 
 import java.util.ArrayList;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.concurrent.ExecutorService;
 
-public final class ReplayingTask implements Task {
+public final class ReplayingTask<ReturnType> implements Task {
   private final ExecutorService executor;
   private final Scoped<Context> rootContext;
-  private final Runnable task;
+  private final Supplier<ReturnType> task;
 
   private final ReplayingReactionContext.Memory memory = new ReplayingReactionContext.Memory(new ArrayList<>(), new MutableInt(0));
 
-  public ReplayingTask(final ExecutorService executor, final Scoped<Context> rootContext, final Runnable task) {
+  public ReplayingTask(final ExecutorService executor, final Scoped<Context> rootContext, final Supplier<ReturnType> task) {
     this.executor = Objects.requireNonNull(executor);
     this.rootContext = Objects.requireNonNull(rootContext);
     this.task = Objects.requireNonNull(task);
@@ -28,10 +29,10 @@ public final class ReplayingTask implements Task {
     final var context = new ReplayingReactionContext(this.executor, this.rootContext, this.memory, scheduler, handle);
 
     try (final var restore = this.rootContext.set(context)){
-      this.task.run();
+      final var returnValue = this.task.get();
 
       // If we get here, the activity has completed normally.
-      return TaskStatus.completed();
+      return TaskStatus.completed(returnValue);
     } catch (final Yield ignored) {
       // If we get here, the activity has suspended.
       return handle.status;

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
@@ -58,22 +58,22 @@ final class ThreadedReactionContext implements Context {
   }
 
   @Override
-  public String spawn(final TaskFactory task) {
+  public Scheduler.TaskIdentifier spawn(final TaskFactory task) {
     return this.scheduler.spawn(task.create(this.executor));
   }
 
   @Override
-  public String spawn(final String type, final Map<String, SerializedValue> arguments) {
+  public Scheduler.TaskIdentifier spawn(final String type, final Map<String, SerializedValue> arguments) {
     return this.scheduler.spawn(type, arguments);
   }
 
   @Override
-  public String defer(final Duration duration, final TaskFactory task) {
+  public Scheduler.TaskIdentifier defer(final Duration duration, final TaskFactory task) {
     return this.scheduler.defer(duration, task.create(this.executor));
   }
 
   @Override
-  public String defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
+  public Scheduler.TaskIdentifier defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
     return this.scheduler.defer(duration, type, arguments);
   }
 
@@ -84,7 +84,7 @@ final class ThreadedReactionContext implements Context {
   }
 
   @Override
-  public void waitFor(final String id) {
+  public void waitFor(final Scheduler.TaskIdentifier id) {
     this.scheduler = null;  // Relinquish the current scheduler before yielding, in case an exception is thrown.
     this.scheduler = this.handle.yield(TaskStatus.awaiting(id));
   }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
@@ -84,9 +84,10 @@ final class ThreadedReactionContext implements Context {
   }
 
   @Override
-  public void waitFor(final Scheduler.TaskIdentifier id) {
+  public Object waitFor(final Scheduler.TaskIdentifier id) {
     this.scheduler = null;  // Relinquish the current scheduler before yielding, in case an exception is thrown.
     this.scheduler = this.handle.yield(TaskStatus.awaiting(id));
+    return this.scheduler.getTaskReturnValue(id);
   }
 
   @Override

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTask.java
@@ -6,29 +6,32 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 
 import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.function.Supplier;
 import java.util.concurrent.ExecutorService;
 
-public final class ThreadedTask implements Task {
+public final class ThreadedTask<ReturnType> implements Task {
   private final Scoped<Context> rootContext;
-  private final Runnable task;
+  private final Supplier<ReturnType> task;
   private final ExecutorService executor;
 
   private final ArrayBlockingQueue<TaskRequest> hostToTask = new ArrayBlockingQueue<>(1);
   private final ArrayBlockingQueue<TaskResponse> taskToHost = new ArrayBlockingQueue<>(1);
 
   private Lifecycle lifecycle = Lifecycle.Inactive;
+  private ReturnType returnValue;
 
-  public ThreadedTask(final ExecutorService executor, final Scoped<Context> rootContext, final Runnable task) {
+  public ThreadedTask(final ExecutorService executor, final Scoped<Context> rootContext, final Supplier<ReturnType> task) {
     this.rootContext = Objects.requireNonNull(rootContext);
     this.task = Objects.requireNonNull(task);
     this.executor = Objects.requireNonNull(executor);
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public TaskStatus step(final Scheduler scheduler) {
     try {
       if (this.lifecycle == Lifecycle.Terminated) {
-        return TaskStatus.completed();
+        return TaskStatus.completed(this.returnValue);
       } else if (this.lifecycle == Lifecycle.Inactive) {
         this.lifecycle = Lifecycle.Running;
         beginAsync();
@@ -46,8 +49,10 @@ public final class ThreadedTask implements Task {
       if (response instanceof TaskResponse.Success successResponse) {
         final var status = successResponse.status;
 
-        if (status instanceof TaskStatus.Completed) {
+        if (status instanceof TaskStatus.Completed completed) {
           this.lifecycle = Lifecycle.Terminated;
+          // SAFETY: This TaskStatus is constructed by this class, using the same ReturnType.
+          this.returnValue = (ReturnType) completed.returnValue();
         }
 
         return status;
@@ -137,8 +142,8 @@ public final class ThreadedTask implements Task {
             this);
 
         try (final var restore = ThreadedTask.this.rootContext.set(context)) {
-          ThreadedTask.this.task.run();
-          return new TaskResponse.Success(TaskStatus.completed());
+          ThreadedTask.this.returnValue = ThreadedTask.this.task.get();
+          return new TaskResponse.Success(TaskStatus.completed(ThreadedTask.this.returnValue));
         } catch (final TaskAbort ex) {
           return new TaskResponse.Success(TaskStatus.completed());
         } catch (final Throwable ex) {

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTask.java
@@ -43,28 +43,28 @@ public final class ThreadedTask implements Task {
       this.hostToTask.put(new TaskRequest.Resume(scheduler));
       final var response = this.taskToHost.take();
 
-      if (response instanceof TaskResponse.Success) {
-        final var status = ((TaskResponse.Success) response).status;
+      if (response instanceof TaskResponse.Success successResponse) {
+        final var status = successResponse.status;
 
         if (status instanceof TaskStatus.Completed) {
           this.lifecycle = Lifecycle.Terminated;
         }
 
         return status;
-      } else if (response instanceof TaskResponse.Failure) {
+      } else if (response instanceof TaskResponse.Failure failureResponse) {
         this.lifecycle = Lifecycle.Terminated;
 
         // We re-throw the received exception to avoid interfering with `catch` blocks
         //   that might be looking for this specific exception, but we add a new exception
         //   to its suppression list to provide a stack trace in this thread, too.
-        final var ex = ((TaskResponse.Failure) response).failure;
+        final var ex = failureResponse.failure;
         ex.addSuppressed(new TaskFailureException());
 
         // This exception shouldn't be a checked exception, but we have to prove it to Java.
-        if (ex instanceof RuntimeException) {
-          throw (RuntimeException) ex;
-        } else if (ex instanceof Error) {
-          throw (Error) ex;
+        if (ex instanceof RuntimeException runtimeException) {
+          throw runtimeException;
+        } else if (ex instanceof Error error) {
+          throw error;
         } else {
           throw new RuntimeException("Unexpected checked exception escaped from task thread", ex);
         }
@@ -127,8 +127,8 @@ public final class ThreadedTask implements Task {
     private boolean isAborting = false;
 
     public TaskResponse run(final TaskRequest request) {
-      if (request instanceof TaskRequest.Resume) {
-        final var scheduler = ((TaskRequest.Resume) request).scheduler;
+      if (request instanceof TaskRequest.Resume resume) {
+        final var scheduler = resume.scheduler;
 
         final var context = new ThreadedReactionContext(
             ThreadedTask.this.executor,
@@ -168,9 +168,9 @@ public final class ThreadedTask implements Task {
         throw new Error("Merlin task unexpectedly interrupted", ex);
       }
 
-      if (request instanceof TaskRequest.Resume) {
+      if (request instanceof TaskRequest.Resume resumeRequest) {
         // We've been told to continue executing.
-        return ((TaskRequest.Resume) request).scheduler;
+        return resumeRequest.scheduler;
       } else if (request instanceof TaskRequest.Abort) {
         // We've been told to bail out and release this thread ASAP.
         //

--- a/merlin-framework/src/test/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTaskTest.java
+++ b/merlin-framework/src/test/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTaskTest.java
@@ -48,6 +48,11 @@ public final class ThreadedTaskTest {
       public TaskIdentifier defer(final Duration delay, final String type, final Map<String, SerializedValue> arguments) {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public Object getTaskReturnValue(final TaskIdentifier taskId) {
+        throw new UnsupportedOperationException();
+      }
     };
 
     final var pool = Executors.newCachedThreadPool();

--- a/merlin-framework/src/test/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTaskTest.java
+++ b/merlin-framework/src/test/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTaskTest.java
@@ -30,22 +30,22 @@ public final class ThreadedTaskTest {
       }
 
       @Override
-      public String spawn(final Task task) {
+      public TaskIdentifier spawn(final Task task) {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public String spawn(final String type, final Map<String, SerializedValue> arguments) {
+      public TaskIdentifier spawn(final String type, final Map<String, SerializedValue> arguments) {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public String defer(final Duration delay, final Task task) {
+      public TaskIdentifier defer(final Duration delay, final Task task) {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public String defer(final Duration delay, final String type, final Map<String, SerializedValue> arguments) {
+      public TaskIdentifier defer(final Duration delay, final String type, final Map<String, SerializedValue> arguments) {
         throw new UnsupportedOperationException();
       }
     };

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Initializer.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Initializer.java
@@ -19,7 +19,7 @@ public interface Initializer {
       EffectTrait<Effect> trait,
       Function<Event, Effect> projection);
 
-  String daemon(TaskFactory factory);
+  Scheduler.TaskIdentifier daemon(TaskFactory factory);
 
   void resource(String name, Resource<?> resource);
 

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Scheduler.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Scheduler.java
@@ -11,9 +11,11 @@ public interface Scheduler {
 
   <Event> void emit(Event event, Query<? super Event, ?> query);
 
-  String spawn(Task task);
-  String spawn(String type, Map<String, SerializedValue> arguments);
+  TaskIdentifier spawn(Task task);
+  TaskIdentifier spawn(String type, Map<String, SerializedValue> arguments);
 
-  String defer(Duration delay, Task task);
-  String defer(Duration delay, String type, Map<String, SerializedValue> arguments);
+  TaskIdentifier defer(Duration delay, Task task);
+  TaskIdentifier defer(Duration delay, String type, Map<String, SerializedValue> arguments);
+
+  interface TaskIdentifier {}
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Scheduler.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Scheduler.java
@@ -18,4 +18,5 @@ public interface Scheduler {
   TaskIdentifier defer(Duration delay, String type, Map<String, SerializedValue> arguments);
 
   interface TaskIdentifier {}
+  Object getTaskReturnValue(TaskIdentifier taskId);
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
@@ -21,6 +21,7 @@ public interface TaskSpecType<Model, Specification> {
 
   Task createTask(Model model, Specification taskSpec);
   ValueSchema getReturnValueSchema();
+  SerializedValue serializeReturnValue(Object returnValue);
 
   class UnconstructableTaskSpecException extends Exception {}
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
@@ -2,9 +2,11 @@ package gov.nasa.jpl.aerie.merlin.protocol.model;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface TaskSpecType<Model, Specification> {
   String getName();
@@ -18,6 +20,7 @@ public interface TaskSpecType<Model, Specification> {
   List<String> getValidationFailures(Specification taskSpec);
 
   Task createTask(Model model, Specification taskSpec);
+  ValueSchema getReturnValueSchema();
 
   class UnconstructableTaskSpecException extends Exception {}
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/SerializedValue.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/SerializedValue.java
@@ -25,7 +25,8 @@ import java.util.Optional;
  * pattern on a class closed to extension allows us to guarantee that no ambiguity occurs.
  */
 public abstract class SerializedValue {
-  static public SerializedValue NULL = SerializedValue.ofNull();
+  public static final SerializedValue NULL = SerializedValue.ofNull();
+  public static final SerializedValue UNIT = SerializedValue.ofUnit();
 
 
   // Closed type family -- the only legal subclasses are those defined within the body of
@@ -75,6 +76,20 @@ public abstract class SerializedValue {
       @Override
       public <T> T match(final Visitor<T> visitor) {
         return visitor.onNull();
+      }
+    };
+  }
+
+  /**
+   * Creates a {@link SerializedValue} containing the UNIT value.
+   *
+   * @return A new {@link SerializedValue} containing the UNIT value.
+   */
+  private static SerializedValue ofUnit() {
+    return new SerializedValue() {
+      @Override
+      public <T> T match(final Visitor<T> visitor) {
+        return visitor.onString("UNIT");
       }
     };
   }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskReturnValue.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskReturnValue.java
@@ -1,0 +1,3 @@
+package gov.nasa.jpl.aerie.merlin.protocol.types;
+
+public record TaskReturnValue<T>(T returnValue) {}

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskStatus.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskStatus.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.protocol.types;
 
+import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Condition;
 
 public sealed interface TaskStatus {
@@ -7,7 +8,7 @@ public sealed interface TaskStatus {
 
   record Delayed(Duration delay) implements TaskStatus {}
 
-  record AwaitingTask(String target) implements TaskStatus {}
+  record AwaitingTask(Scheduler.TaskIdentifier target) implements TaskStatus {}
 
   record AwaitingCondition(Condition condition) implements TaskStatus {}
 
@@ -20,7 +21,7 @@ public sealed interface TaskStatus {
     return new Delayed(delay);
   }
 
-  static AwaitingTask awaiting(final String id) {
+  static AwaitingTask awaiting(final Scheduler.TaskIdentifier id) {
     return new AwaitingTask(id);
   }
 

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskStatus.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskStatus.java
@@ -3,8 +3,10 @@ package gov.nasa.jpl.aerie.merlin.protocol.types;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Condition;
 
+import java.util.Optional;
+
 public sealed interface TaskStatus {
-  record Completed() implements TaskStatus {}
+  record Completed<ReturnType>(Optional<TaskReturnValue<ReturnType>> returnValue) implements TaskStatus {}
 
   record Delayed(Duration delay) implements TaskStatus {}
 
@@ -13,8 +15,12 @@ public sealed interface TaskStatus {
   record AwaitingCondition(Condition condition) implements TaskStatus {}
 
 
-  static Completed completed() {
-    return new Completed();
+  static <ReturnType> Completed<ReturnType> completed(final ReturnType returnValue) {
+    return new Completed<>(Optional.of(new TaskReturnValue<>(returnValue)));
+  }
+
+  static Completed<Void> completed() {
+    return new Completed<>(Optional.empty());
   }
 
   static Delayed delayed(final Duration delay) {

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/ValueSchema.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/ValueSchema.java
@@ -195,6 +195,19 @@ public abstract class ValueSchema {
     };
   }
 
+  /**
+   * Creates a {@link ValueSchema} representing the Unit type.
+   *
+   * @return A new {@link ValueSchema} representing the Unit type.
+   */
+  public static ValueSchema ofUnit() {
+    return new ValueSchema() {
+      public <T> T match(final Visitor<T> visitor) {
+        return visitor.onVariant(List.of(new Variant("Unit", "UNIT")));
+      }
+    };
+  }
+
   public static final ValueSchema REAL = ofReal();
   public static final ValueSchema INT = ofInt();
   public static final ValueSchema BOOLEAN = ofBoolean();

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/ValueSchema.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/ValueSchema.java
@@ -214,6 +214,7 @@ public abstract class ValueSchema {
   public static final ValueSchema STRING = ofString();
   public static final ValueSchema DURATION = ofDuration();
   public static final ValueSchema PATH = ofPath();
+  public static final ValueSchema UNIT = ofUnit();
 
   /**
    * Provides a default case on top of the base Visitor.

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
@@ -84,7 +84,7 @@ public abstract class MerlinParsers {
       . map(Iso.of(
           untuple((type, startTimestamp, parameters) ->
               new ActivityInstance(type, startTimestamp, parameters)),
-          activity -> tuple(activity.type, activity.startTimestamp, activity.parameters)));
+          activity -> tuple(activity.type, activity.startTimestamp, activity.arguments)));
 
   public static final JsonParser<ActivityInstance> activityInstancePatchP
       = productP
@@ -94,7 +94,7 @@ public abstract class MerlinParsers {
       . map(Iso.of(
           untuple((type, startTimestamp, parameters) ->
               new ActivityInstance(type.orElse(null), startTimestamp.orElse(null), parameters.orElse(null))),
-          $ -> tuple(Optional.ofNullable($.type), Optional.ofNullable($.startTimestamp), Optional.ofNullable($.parameters))));
+          $ -> tuple(Optional.ofNullable($.type), Optional.ofNullable($.startTimestamp), Optional.ofNullable($.arguments))));
 
   public static final JsonParser<NewPlan> newPlanP
       = productP
@@ -142,7 +142,7 @@ public abstract class MerlinParsers {
       . map(Iso.of(
           untuple((defer, type, parameters) ->
               Pair.of(defer, new SerializedActivity(type, parameters.orElse(Collections.emptyMap())))),
-          $ -> tuple($.getLeft(), $.getRight().getTypeName(), Optional.of($.getRight().getParameters()))));
+          $ -> tuple($.getLeft(), $.getRight().getTypeName(), Optional.of($.getRight().getArguments()))));
 
   public static final JsonParser<CreateSimulationMessage> createSimulationMessageP
       = productP

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -151,7 +151,7 @@ public final class ResponseSerializers {
     return Json
         .createObjectBuilder()
         .add("type", simulatedActivity.type)
-        .add("parameters", serializeArgumentMap(simulatedActivity.parameters))
+        .add("parameters", serializeArgumentMap(simulatedActivity.arguments))
         .add("startTimestamp", serializeTimestamp(simulatedActivity.start))
         .add("duration", serializeDuration(simulatedActivity.duration))
         .add("parent", serializeNullable(Json::createValue, simulatedActivity.parentId))

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -156,6 +156,7 @@ public final class ResponseSerializers {
         .add("duration", serializeDuration(simulatedActivity.duration))
         .add("parent", serializeNullable(Json::createValue, simulatedActivity.parentId))
         .add("children", serializeIterable(Json::createValue, simulatedActivity.childIds))
+        .add("returnValue", serializeArgument(simulatedActivity.returnValue))
         .build();
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -30,6 +30,7 @@ import java.time.temporal.TemporalAccessor;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -182,7 +183,7 @@ public final class ResponseSerializers {
   }
 
   private static JsonValue serializeSimulationEvents(
-      Map<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>> events,
+      SortedMap<Duration, List<EventGraph<Triple<Integer, SerializedValue, String>>>> events,
       final Map<Integer, Pair<String, ValueSchema>> topics,
       final Instant startTime) {
     var arrayBuilder = Json.createArrayBuilder();
@@ -199,22 +200,23 @@ public final class ResponseSerializers {
   }
 
   private static JsonValue serializeEventGraph(
-      EventGraph<Pair<Integer, SerializedValue>> eventGraph,
+      EventGraph<Triple<Integer, SerializedValue, String>> eventGraph,
       final Map<Integer, Pair<String, ValueSchema>> topics) {
     var objectBuilder = Json.createObjectBuilder();
-    if (eventGraph instanceof EventGraph.Atom<Pair<Integer, SerializedValue>> atom) {
+    if (eventGraph instanceof EventGraph.Atom<Triple<Integer, SerializedValue, String>> atom) {
       final var event = atom.atom();
       objectBuilder = objectBuilder
           .add("type", "atom")
-          .add("value", serializedValueP.unparse(event.getRight()))
+          .add("value", serializedValueP.unparse(event.getMiddle()))
           .add("schema", valueSchemaP.unparse(topics.get(event.getLeft()).getRight()))
-          .add("topic", stringP.unparse(topics.get(event.getLeft()).getLeft()));
-    } else if (eventGraph instanceof EventGraph.Sequentially<Pair<Integer, SerializedValue>> sequentially) {
+          .add("topic", stringP.unparse(topics.get(event.getLeft()).getLeft()))
+          .add("task_id", stringP.unparse(event.getRight()));
+    } else if (eventGraph instanceof EventGraph.Sequentially<Triple<Integer, SerializedValue, String>> sequentially) {
       objectBuilder = objectBuilder
           .add("type", "sequentially")
           .add("prefix", serializeEventGraph(sequentially.prefix(), topics))
           .add("suffix", serializeEventGraph(sequentially.suffix(), topics));
-    } else if (eventGraph instanceof EventGraph.Concurrently<Pair<Integer, SerializedValue>> concurrently) {
+    } else if (eventGraph instanceof EventGraph.Concurrently<Triple<Integer, SerializedValue, String>> concurrently) {
       objectBuilder = objectBuilder
           .add("type", "concurrently")
           .add("left", serializeEventGraph(concurrently.left(), topics))

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
@@ -246,7 +246,7 @@ public final class InMemoryPlanRepository implements PlanRepository {
 
       this.type.ifPresent(type -> activity.type = type);
       this.startTimestamp.ifPresent(startTimestamp -> activity.startTimestamp = startTimestamp);
-      this.parameters.ifPresent(parameters -> activity.parameters = parameters);
+      this.parameters.ifPresent(arguments -> activity.arguments = arguments);
 
       InMemoryPlanRepository.this.plans.put(this.planId, Pair.of(revision, plan));
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityInstance.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityInstance.java
@@ -9,20 +9,20 @@ import java.util.Objects;
 public final class ActivityInstance {
   public String type;
   public Timestamp startTimestamp;
-  public Map<String, SerializedValue> parameters;
+  public Map<String, SerializedValue> arguments;
 
   public ActivityInstance() {}
 
   public ActivityInstance(final ActivityInstance other) {
     this.type = other.type;
     this.startTimestamp = other.startTimestamp;
-    this.parameters = (other.parameters == null) ? null : new HashMap<>(other.parameters);
+    this.arguments = (other.arguments == null) ? null : new HashMap<>(other.arguments);
   }
 
-  public ActivityInstance(final String type, final Timestamp startTimestamp, final Map<String, SerializedValue> parameters) {
+  public ActivityInstance(final String type, final Timestamp startTimestamp, final Map<String, SerializedValue> arguments) {
     this.type = type;
     this.startTimestamp = startTimestamp;
-    this.parameters = (parameters != null) ? Map.copyOf(parameters) : null;
+    this.arguments = (arguments != null) ? Map.copyOf(arguments) : null;
   }
 
   @Override
@@ -35,7 +35,7 @@ public final class ActivityInstance {
     return
         (  Objects.equals(this.type, other.type)
         && Objects.equals(this.startTimestamp, other.startTimestamp)
-        && Objects.equals(this.parameters, other.parameters)
+        && Objects.equals(this.arguments, other.arguments)
         );
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityType.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityType.java
@@ -1,6 +1,14 @@
 package gov.nasa.jpl.aerie.merlin.server.models;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
-import java.util.List;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
-public final record ActivityType(String name, List<Parameter> parameters, List<String> requiredParameters) { }
+import java.util.List;
+import java.util.Optional;
+
+public final record ActivityType(
+    String name,
+    List<Parameter> parameters,
+    List<String> requiredParameters,
+    ValueSchema returnTypeValueSchema
+) { }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
@@ -109,7 +109,7 @@ public final class MissionModelFacade {
     {
       final var activityTypes = new HashMap<String, ActivityType>();
       factory.getTaskSpecTypes().forEach((name, specType) -> {
-        activityTypes.put(name, new ActivityType(name, specType.getParameters(), specType.getRequiredParameters()));
+        activityTypes.put(name, new ActivityType(name, specType.getParameters(), specType.getRequiredParameters(), specType.getReturnValueSchema()));
       });
       return activityTypes;
     }
@@ -121,7 +121,7 @@ public final class MissionModelFacade {
           .ofNullable(factory.getTaskSpecTypes().get(typeName))
           .orElseThrow(MissionModelFacade.NoSuchActivityTypeException::new);
 
-      return new ActivityType(typeName, specType.getParameters(), specType.getRequiredParameters());
+      return new ActivityType(typeName, specType.getParameters(), specType.getRequiredParameters(), specType.getReturnValueSchema());
     }
 
     public List<Parameter> getParameters() {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ActivityAttributesRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ActivityAttributesRecord.java
@@ -1,0 +1,12 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+
+import java.util.Map;
+import java.util.Optional;
+
+public record ActivityAttributesRecord(
+    Optional<String> directiveId,
+    Map<String, SerializedValue> arguments,
+    SerializedValue returnValue
+) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulatedActivitiesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulatedActivitiesAction.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.driver.SimulatedActivity;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;
 import org.intellij.lang.annotations.Language;
@@ -65,7 +66,8 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
           duration,
           parentId,
           initialChildIds,
-          directiveId));
+          directiveId,
+          SerializedValue.UNIT)); // TODO: retrieve returnValue from database
     }
 
     // Since child IDs are not stored, we assign them by examining the parent ID of each activity

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/InsertSimulationEventsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/InsertSimulationEventsAction.java
@@ -5,6 +5,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
@@ -19,8 +20,8 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
 
 /*package-local*/ final class InsertSimulationEventsAction implements AutoCloseable {
   @Language("SQL") private static final String sql = """
-      insert into event (dataset_id, real_time, transaction_index, causal_time, topic_index, value)
-      values (?, ?::timestamptz - ?::timestamptz, ?, ?, ?, ?)
+      insert into event (dataset_id, real_time, transaction_index, causal_time, topic_index, task_id, value)
+      values (?, ?::timestamptz - ?::timestamptz, ?, ?, ?, ?, ?)
     """;
 
   private final PreparedStatement statement;
@@ -31,7 +32,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
 
   public void apply(
       final long datasetId,
-      final Map<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>> eventPoints,
+      final Map<Duration, List<EventGraph<Triple<Integer, SerializedValue, String>>>> eventPoints,
       final Timestamp simulationStart
   ) throws SQLException {
     for (final var eventPoint : eventPoints.entrySet()) {
@@ -51,12 +52,12 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
       final Duration duration,
       final int transactionIndex,
       final Timestamp simulationStart,
-      final List<Pair<String, Pair<Integer, SerializedValue>>> flattenedEventGraph,
+      final List<Pair<String, Triple<Integer, SerializedValue, String>>> flattenedEventGraph,
       final PreparedStatement statement
   ) throws SQLException {
-    for (final Pair<String, Pair<Integer, SerializedValue>> entry : flattenedEventGraph) {
+    for (final Pair<String, Triple<Integer, SerializedValue, String>> entry : flattenedEventGraph) {
       final var causalTime = entry.getLeft();
-      final Pair<Integer, SerializedValue> event = entry.getRight();
+      final Triple<Integer, SerializedValue, String> event = entry.getRight();
 
       statement.setLong(1, datasetId);
       setTimestamp(statement, 2, simulationStart.plusMicros(duration.in(MICROSECONDS)));
@@ -64,7 +65,8 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
       statement.setInt(4, transactionIndex);
       statement.setString(5, causalTime);
       statement.setInt(6, event.getLeft());
-      statement.setString(7, serializedValueP.unparse(event.getRight()).toString());
+      statement.setString(7, event.getRight());
+      statement.setString(8, serializedValueP.unparse(event.getMiddle()).toString());
 
       statement.addBatch();
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSimulatedActivitiesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSimulatedActivitiesAction.java
@@ -49,7 +49,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
       setTimestamp(statement, 4, endTimestamp);
       setTimestamp(statement, 5, startTimestamp);
       statement.setString(6, act.type);
-      statement.setString(7, buildAttributes(act.directiveId, act.parameters));
+      statement.setString(7, buildAttributes(act.directiveId, act.arguments));
 
       statement.addBatch();
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSimulatedActivitiesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSimulatedActivitiesAction.java
@@ -4,7 +4,6 @@ import gov.nasa.jpl.aerie.merlin.driver.SimulatedActivity;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
-import org.apache.commons.lang3.tuple.Pair;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
@@ -49,7 +48,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
       setTimestamp(statement, 4, endTimestamp);
       setTimestamp(statement, 5, startTimestamp);
       statement.setString(6, act.type);
-      statement.setString(7, buildAttributes(act.directiveId, act.arguments));
+      statement.setString(7, buildAttributes(act.directiveId, act.arguments, act.returnValue));
 
       statement.addBatch();
     }
@@ -66,8 +65,12 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
     return simIdToPostgresId;
   }
 
-  private String buildAttributes(final Optional<String> directiveId, final Map<String, SerializedValue> arguments) {
-    return activityAttributesP.unparse(Pair.of(directiveId, arguments)).toString();
+  private String buildAttributes(
+      final Optional<String> directiveId,
+      final Map<String, SerializedValue> arguments,
+      final SerializedValue returnValue
+  ) {
+    return activityAttributesP.unparse(new ActivityAttributesRecord(directiveId, arguments, returnValue)).toString();
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresMissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresMissionModelRepository.java
@@ -135,7 +135,12 @@ public final class PostgresMissionModelRepository implements MissionModelReposit
       try (final var createActivityTypeAction = new CreateActivityTypeAction(connection)) {
         final var id = toMissionModelId(missionModelId);
         for (final var activityType : activityTypes.values()) {
-          createActivityTypeAction.apply(id, activityType.name(), activityType.parameters(), activityType.requiredParameters());
+          createActivityTypeAction.apply(
+              id,
+              activityType.name(),
+              activityType.parameters(),
+              activityType.requiredParameters(),
+              activityType.returnTypeValueSchema());
         }
       }
     } catch (final SQLException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
@@ -14,7 +14,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Optional;
 
 import static gov.nasa.jpl.aerie.json.BasicParsers.chooseP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.literalP;
@@ -60,11 +59,12 @@ public final class PostgresParsers {
   public static final JsonParser<Map<String, SerializedValue>> activityArgumentsP = mapP(serializedValueP);
   public static final JsonParser<Map<String, SerializedValue>> simulationArgumentsP = mapP(serializedValueP);
 
-  public static final JsonParser<Pair<Optional<String>, Map<String, SerializedValue>>> activityAttributesP = productP
+  public static final JsonParser<ActivityAttributesRecord> activityAttributesP = productP
       .optionalField("directiveId", stringP)
       .field("arguments", activityArgumentsP)
+      .field("return_value", serializedValueP)
         .map(Iso.of(
-            untuple((directiveId, arguments) -> Pair.of(directiveId, arguments)),
-            $ -> tuple($.getLeft(), $.getRight())
+            untuple(ActivityAttributesRecord::new),
+            $ -> tuple($.directiveId(), $.arguments(), $.returnValue())
         ));
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -163,7 +163,7 @@ public final class PostgresPlanRepository implements PlanRepository {
                 activity.startTimestamp,
                 activity.type);
 
-            for (final var argument : activity.parameters.entrySet()) {
+            for (final var argument : activity.arguments.entrySet()) {
               // Add this argument to the staged batch of arguments.
               setActivityArgumentsAction.add(activityId, argument.getKey(), argument.getValue());
             }
@@ -328,7 +328,7 @@ public final class PostgresPlanRepository implements PlanRepository {
                                                        planStartTime.plusMicros(startOffsetInMicros),
                                                        arguments))),
                   untuple((String actId, ActivityInstance $) ->
-                              tuple(actId, planStartTime.microsUntil($.startTimestamp), $.type, $.parameters))));
+                              tuple(actId, planStartTime.microsUntil($.startTimestamp), $.type, $.arguments))));
 
       final var activities = new HashMap<String, ActivityInstance>();
       for (final var entry : parseJson(json, listP(activityRowP))) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -292,7 +292,8 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
             activity.duration,
             pgIdToSimId.get(activity.parentId),
             activity.childIds.stream().map(pgIdToSimId::get).collect(Collectors.toList()),
-            activity.directiveId
+            activity.directiveId,
+            activity.returnValue
         ));
       }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -13,7 +13,6 @@ import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.remotes.ResultsCellRepository;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 
 import javax.sql.DataSource;
@@ -258,7 +257,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
     }
   }
 
-  private static SortedMap<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>>
+  private static SortedMap<Duration, List<EventGraph<Triple<Integer, SerializedValue, String>>>>
   getSimulationEvents(
       final Connection connection,
       final long datasetId,
@@ -388,7 +387,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
   private static void insertSimulationEvents(
       Connection connection,
       long datasetId,
-      Map<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>> events,
+      Map<Duration, List<EventGraph<Triple<Integer, SerializedValue, String>>>> events,
       Timestamp simulationStart) throws SQLException
   {
     try (

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -287,7 +287,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
 
         processedActivities.put(pgIdToSimId.get(id), new SimulatedActivity(
             activity.type,
-            activity.parameters,
+            activity.arguments,
             activity.start,
             activity.duration,
             pgIdToSimId.get(activity.parentId),

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -96,7 +96,7 @@ public final class GetSimulationResultsAction {
       activities.add(new ActivityInstance(
           id,
           activity.type,
-          activity.parameters,
+          activity.arguments,
           Window.between(activityOffset, activityOffset.plus(activity.duration))));
     }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -106,7 +106,7 @@ public final class LocalMissionModelService implements MissionModelService {
     try {
       // TODO: [AERIE-1516] Teardown the missionModel after use to release any system resources (e.g. threads).
       return this.loadConfiguredMissionModel(missionModelId)
-                 .validateActivity(activityParameters.getTypeName(), activityParameters.getParameters());
+                 .validateActivity(activityParameters.getTypeName(), activityParameters.getArguments());
     } catch (final MissionModelFacade.NoSuchActivityTypeException ex) {
       return List.of("unknown activity type");
     } catch (final MissionModelFacade.UnconstructableActivityInstanceException ex) {
@@ -124,7 +124,7 @@ public final class LocalMissionModelService implements MissionModelService {
   {
     try {
       return this.loadConfiguredMissionModel(missionModelId)
-                 .getActivityEffectiveArguments(activity.getTypeName(), activity.getParameters());
+                 .getActivityEffectiveArguments(activity.getTypeName(), activity.getArguments());
     } catch (final MissionModelFacade.NoSuchActivityTypeException ex) {
       throw new NoSuchActivityTypeException(activity.getTypeName(), ex);
     } catch (final MissionModelFacade.UnconstructableActivityInstanceException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanValidator.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanValidator.java
@@ -32,7 +32,7 @@ public final class PlanValidator {
     try {
       validationFailures = this.missionModelService.validateActivityParameters(
           missionModelId,
-          new SerializedActivity(activityInstance.type, activityInstance.parameters));
+          new SerializedActivity(activityInstance.type, activityInstance.arguments));
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       throw new Error("Unexpectedly nonexistent mission model, when this should have been validated earlier.", ex);
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SynchronousSimulationAgent.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SynchronousSimulationAgent.java
@@ -77,7 +77,7 @@ public record SynchronousSimulationAgent (
 
       scheduledActivities.put(id, Pair.of(
           Duration.of(startTime.until(activity.startTimestamp.toInstant(), ChronoUnit.MICROS), Duration.MICROSECONDS),
-          new SerializedActivity(activity.type, activity.parameters)));
+          new SerializedActivity(activity.type, activity.arguments)));
     }
 
     return scheduledActivities;

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/Fixtures.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/Fixtures.java
@@ -67,7 +67,7 @@ public final class Fixtures {
 
     activityInstance.type = this.EXISTENT_ACTIVITY_TYPE_ID;
     activityInstance.startTimestamp = Timestamp.fromString("0000-111T22:33:44");
-    activityInstance.parameters = StubMissionModelService.VALID_ACTIVITY_INSTANCE.getParameters();
+    activityInstance.arguments = StubMissionModelService.VALID_ACTIVITY_INSTANCE.getArguments();
 
     return activityInstance;
   }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.TreeMap;
 
 public final class StubMissionModelService implements MissionModelService {
@@ -28,7 +29,9 @@ public final class StubMissionModelService implements MissionModelService {
   public static final String NONEXISTENT_ACTIVITY_TYPE = "no-activity";
   public static final ActivityType EXISTENT_ACTIVITY = new ActivityType(
       EXISTENT_ACTIVITY_TYPE,
-      List.of(new Parameter("Param", ValueSchema.STRING)), List.of());
+      List.of(new Parameter("Param", ValueSchema.STRING)),
+      List.of(),
+      Optional.empty());
 
   public static final SerializedActivity VALID_ACTIVITY_INSTANCE = new SerializedActivity(
       EXISTENT_ACTIVITY_TYPE,

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.TreeMap;
 
 public final class StubMissionModelService implements MissionModelService {
@@ -31,7 +30,7 @@ public final class StubMissionModelService implements MissionModelService {
       EXISTENT_ACTIVITY_TYPE,
       List.of(new Parameter("Param", ValueSchema.STRING)),
       List.of(),
-      Optional.empty());
+      ValueSchema.UNIT);
 
   public static final SerializedActivity VALID_ACTIVITY_INSTANCE = new SerializedActivity(
       EXISTENT_ACTIVITY_TYPE,

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
@@ -33,7 +33,7 @@ public final class StubPlanService implements PlanService {
     EXISTENT_ACTIVITY = new ActivityInstance();
     EXISTENT_ACTIVITY.type = "existent activity";
     EXISTENT_ACTIVITY.startTimestamp = Timestamp.fromString("2016-123T14:25:36");
-    EXISTENT_ACTIVITY.parameters = Map.of(
+    EXISTENT_ACTIVITY.arguments = Map.of(
         "abc", SerializedValue.of("test-param")
     );
 

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -51,7 +52,10 @@ public final class MissionModelTest {
                 List.of(
                     new Parameter("x", ValueSchema.INT),
                     new Parameter("y", ValueSchema.STRING),
-                    new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))), List.of()));
+                    new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))),
+                List.of(),
+                Optional.empty()
+            ));
 
         // WHEN
         final Map<String, ActivityType> typeList = unconfiguredMissionModel.getActivityTypes();
@@ -68,7 +72,10 @@ public final class MissionModelTest {
             List.of(
                 new Parameter("x", ValueSchema.INT),
                 new Parameter("y", ValueSchema.STRING),
-                new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))), List.of());
+                new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))),
+            List.of(),
+            Optional.empty()
+        );
 
         // WHEN
         final ActivityType type = unconfiguredMissionModel.getActivityType(expectedType.name());

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -46,7 +45,7 @@ public final class MissionModelTest {
     @Test
     public void shouldGetActivityTypeList() throws MissionModelFacade.MissionModelContractException {
         // GIVEN
-        final Map<String, ActivityType> expectedTypes = Map.of(
+      final Map<String, ActivityType> expectedTypes = Map.of(
             "foo", new ActivityType(
                 "foo",
                 List.of(
@@ -54,7 +53,7 @@ public final class MissionModelTest {
                     new Parameter("y", ValueSchema.STRING),
                     new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))),
                 List.of(),
-                Optional.empty()
+                ValueSchema.UNIT
             ));
 
         // WHEN
@@ -67,14 +66,14 @@ public final class MissionModelTest {
     @Test
     public void shouldGetActivityType() throws MissionModelFacade.NoSuchActivityTypeException, MissionModelFacade.MissionModelContractException {
         // GIVEN
-        final ActivityType expectedType = new ActivityType(
+      final ActivityType expectedType = new ActivityType(
             "foo",
             List.of(
                 new Parameter("x", ValueSchema.INT),
                 new Parameter("y", ValueSchema.STRING),
                 new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))),
             List.of(),
-            Optional.empty()
+            ValueSchema.UNIT
         );
 
         // WHEN

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepositoryContractTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepositoryContractTest.java
@@ -66,7 +66,7 @@ public abstract class PlanRepositoryContractTest {
     // WHEN
     final ActivityInstance activity = new ActivityInstance();
     activity.type = "abc";
-    activity.parameters = Map.of("abc", SerializedValue.of(1));
+    activity.arguments = Map.of("abc", SerializedValue.of(1));
 
     final NewPlan newPlan = new NewPlan();
     newPlan.name = "new-plan";

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/SimulationFacade.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/SimulationFacade.java
@@ -408,7 +408,7 @@ public class SimulationFacade {
     final var startT = Duration.of(planStartT.until(driverActivity.start, ChronoUnit.MICROS), MICROSECONDS);
     final var endT = startT.plus(driverActivity.duration);
     return new gov.nasa.jpl.aerie.constraints.model.ActivityInstance(
-        id, driverActivity.type, driverActivity.parameters,
+        id, driverActivity.type, driverActivity.arguments,
         Window.betweenClosedOpen(startT, endT));
   }
 


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1629
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This draft PR includes all the pieces I think are necessary to allow activity instances to have return values. "Having return values" involves two things:
1. Reporting a value as part of simulation results upon completion of an activity instance
2. Make this value available to the caller

The commits in this PR fall into one of the following phases
1. Preliminary refactoring
1. Use Supplier instead of Runnable to represent an effect model
1. Generate mapper and supplier for EffectModels with non-void return types
1. Reporting: Include return ValueSchema in ActivityType, and return value in SimulatedActivity, persist in postgres
1. Tag events with activity ids
1. Make return values available to caller
1. Add example activities to show usage (TODO)

Some open questions remain:
- [x] 1. How do we represent void return values? We could use a custom NoReturnValue, Optional.empty, or null.
>  DECISION: There's no need for `NoReturnValue`, since the `TaskSpecType::serializeReturnValue` method returns an `Optional`.
- [ ] 2. Is Scheduler an appropriate place for the `getTaskReturnValue` method?
- [ ] 3. Do these changes maintain our bounded context boundaries appropriately?
- [x] 4. Activities can be called in a Serialized way, such that it is impossible to statically determine what its return type will be. Should we have those return void? Or Object, and let the mission model cast it? Or SerializedValue and let them deserialize?
>  DECISION: Let's not worry about calling activities in a serialized way, and focus on supporting the case where we do know the type of the child activity.
- [ ] 5. Should we serialize and deserialize return value before providing it? That's what we do with parameters, but I think it's strange.
- [ ] 6. Should it be possible to raise an exception in a child activity and catch it in the parent? Related to this: should we get rid of waitFor and defer in favor of call?
- [ ] 7. What does OneShotTask do? Should it have a return value?

Unrelated to this, but an additional question I have:
- [ ] 8. Can we rename parameters to arguments in the `getSimulationResults` api response?

I've also added a commit tagging events with activity ids, but that'll need some more scrutiny as well (especially with decomposing activities... I'm not sure if child activities have "directives").

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I've done some simple manual testing by giving BiteBanana a non-void return type and viewing it via hasura.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
This work is part of the Activity Computed Attributes working group: https://wiki.jpl.nasa.gov/display/MPSA/Working+Group%3A+Activity+Computed+Attributes

## Future work
<!-- What next steps can we anticipate from here, if any? -->
