### PR TITLE
[HOTFIX] Fix Broken Activity IDs

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/NoSuchActivityInstanceException.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/NoSuchActivityInstanceException.java
@@ -1,16 +1,18 @@
 package gov.nasa.jpl.aerie.merlin.server.exceptions;
 
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
+
 public class NoSuchActivityInstanceException extends Exception {
   private final String planId;
-  private final String activityInstanceId;
+  private final ActivityInstanceId activityInstanceId;
 
-  public NoSuchActivityInstanceException(final String planId, final String activityInstanceId) {
+  public NoSuchActivityInstanceException(final String planId, final ActivityInstanceId activityInstanceId) {
     super("No activity exists with id `" + planId + "` in plan with id `" + planId + "`");
     this.planId = planId;
     this.activityInstanceId = activityInstanceId;
   }
 
-  public String getInvalidActivityId() {
+  public ActivityInstanceId getInvalidActivityId() {
     return this.activityInstanceId;
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
@@ -220,13 +220,13 @@ public final class InMemoryPlanRepository implements PlanRepository {
 
   private class MockActivityTransaction implements ActivityTransaction {
     private final String planId;
-    private final String activityId;
+    private final ActivityInstanceId activityId;
 
     private Optional<String> type = Optional.empty();
     private Optional<Timestamp> startTimestamp = Optional.empty();
     private Optional<Map<String, SerializedValue>> parameters = Optional.empty();
 
-    public MockActivityTransaction(final String planId, final String activityId) {
+    public MockActivityTransaction(final String planId, final ActivityInstanceId activityId) {
       this.planId = planId;
       this.activityId = activityId;
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateActivityAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateActivityAction.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.intellij.lang.annotations.Language;
 
@@ -22,7 +23,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
     this.statement = connection.prepareStatement(sql);
   }
 
-  public long apply(
+  public ActivityInstanceId apply(
       final long planId,
       final Timestamp planStartTime,
       final Timestamp activityStartTime,
@@ -36,7 +37,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
     try (final var results = this.statement.executeQuery()) {
       if (!results.next()) throw new FailedInsertException("activity");
 
-      return results.getLong(1);
+      return new ActivityInstanceId(results.getLong(1));
     }
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateActivityArgumentsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateActivityArgumentsAction.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.intellij.lang.annotations.Language;
 
@@ -23,11 +24,11 @@ import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.se
   }
 
   public void add(
-      final long activityId,
+      final ActivityInstanceId activityId,
       final String name,
       final SerializedValue value
   ) throws SQLException {
-    this.statement.setLong(1, activityId);
+    this.statement.setLong(1, activityId.id());
     this.statement.setString(2, name);
     this.statement.setString(3, serializedValueP.unparse(value).toString());
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityAction.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchActivityInstanceException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityInstance;
@@ -41,17 +42,17 @@ import java.util.function.Supplier;
     this.statement = connection.prepareStatement(sql);
   }
 
-  public ActivityInstance get(final long planId, final long activityId)
+  public ActivityInstance get(final long planId, final ActivityInstanceId activityId)
   throws SQLException, NoSuchPlanException, NoSuchActivityInstanceException
   {
     this.statement.setLong(1, planId);
-    this.statement.setLong(2, activityId);
+    this.statement.setLong(2, activityId.id());
 
     try (final var results = this.statement.executeQuery()) {
       if (!results.next()) throw new NoSuchPlanException(Long.toString(planId));
       requireColumnNonNull(results, 1, () -> new NoSuchActivityInstanceException(
           Long.toString(planId),
-          Long.toString(activityId)));
+          activityId));
 
       final var startTimestamp = Timestamp.fromString(results.getString(2));
       final var type = results.getString(3);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulatedActivitiesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulatedActivitiesAction.java
@@ -41,22 +41,22 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
     this.statement = connection.prepareStatement(sql);
   }
 
-  public Map<Long, SimulatedActivityRecord> get(final long datasetId, final Timestamp simulationStart) throws SQLException {
-    final var activities = new HashMap<Long, SimulatedActivityRecord>();
+  public Map<ActivityInstanceId, SimulatedActivityRecord> get(final long datasetId, final Timestamp simulationStart) throws SQLException {
+    final var activities = new HashMap<ActivityInstanceId, SimulatedActivityRecord>();
 
     this.statement.setLong(1, datasetId);
     final var resultSet = statement.executeQuery();
     while (resultSet.next()) {
-      final var id = resultSet.getLong(1);
+      final var id = new ActivityInstanceId(resultSet.getLong(1));
       final var type = resultSet.getString(2);
-      final var parentId = resultSet.getLong(3);
+      final var parentId = new ActivityInstanceId(resultSet.getLong(3));
       final var startOffset = parseOffset(resultSet, 4, simulationStart);
       final var start = simulationStart.toInstant().plus(startOffset.in(MICROSECONDS), ChronoUnit.MICROS);
       final var duration = parseOffset(resultSet, 5, start);
       final var attributes = parseActivityAttributes(resultSet.getCharacterStream(6));
       final var directiveId = attributes.getLeft();
       final var arguments = attributes.getRight();
-      final var initialChildIds = new ArrayList<Long>();
+      final var initialChildIds = new ArrayList<ActivityInstanceId>();
 
       activities.put(id, new SimulatedActivityRecord(
           type,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -170,7 +170,7 @@ public final class PostgresPlanRepository implements PlanRepository {
               setActivityArgumentsAction.add(activityId, argument.getKey(), argument.getValue());
             }
 
-            activityIds.add(new ActivityInstanceId(activityId));
+            activityIds.add(activityId);
           }
 
           // Insert all the accumulated arguments for all activities at once.
@@ -271,14 +271,6 @@ public final class PostgresPlanRepository implements PlanRepository {
       return Long.parseLong(id, 10);
     } catch (final NumberFormatException ex) {
       throw new NoSuchPlanException(id);
-    }
-  }
-
-  private static long toActivityId(final String planId, final String id) throws NoSuchActivityInstanceException {
-    try {
-      return Long.parseLong(id, 10);
-    } catch (final NumberFormatException ex) {
-      throw new NoSuchActivityInstanceException(planId, id);
     }
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -301,9 +301,9 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
     }
   }
 
-  private static HashMap<Long, ActivityInstanceId> liftDirectiveIds(final Map<Long, SimulatedActivityRecord> activityRecords) {
-    final var pgIdToSimId = new HashMap<Long, ActivityInstanceId>(activityRecords.size());
-    final var simIds = new HashSet<Long>(activityRecords.size());
+  private static HashMap<ActivityInstanceId, ActivityInstanceId> liftDirectiveIds(final Map<ActivityInstanceId, SimulatedActivityRecord> activityRecords) {
+    final var pgIdToSimId = new HashMap<ActivityInstanceId, ActivityInstanceId>(activityRecords.size());
+    final var simIds = new HashSet<ActivityInstanceId>(activityRecords.size());
 
     for (final var id : activityRecords.keySet()) {
       final var record = activityRecords.get(id);
@@ -311,7 +311,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
 
       final var directiveId = record.directiveId().get();
       pgIdToSimId.put(id, directiveId);
-      simIds.add(directiveId.id());
+      simIds.add(directiveId);
     }
 
     var counter = 1L;
@@ -319,12 +319,12 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
       final var record = activityRecords.get(id);
       if (record.directiveId().isPresent()) continue;
 
-      long newId;
+      ActivityInstanceId newId;
       do {
-        newId = counter++;
+        newId = new ActivityInstanceId(counter++);
       } while (simIds.contains(newId));
 
-      pgIdToSimId.put(id, new ActivityInstanceId(newId));
+      pgIdToSimId.put(id, newId);
       simIds.add(newId);
     }
     return pgIdToSimId;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulatedActivityRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulatedActivityRecord.java
@@ -14,7 +14,7 @@ import java.util.Optional;
     Map<String, SerializedValue> parameters,
     Instant start,
     Duration duration,
-    Long parentId,
-    List<Long> childIds,
+    ActivityInstanceId parentId,
+    List<ActivityInstanceId> childIds,
     Optional<ActivityInstanceId> directiveId
 ) {}


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Fix some broken activity instance IDs which were left as `long` instead of being converted to `ActivityInstanceId`.

## Verification
Tested locally, requesting test from UI developer who found the issue as well.

## Documentation
None.

## Future work
Hopefully none.
