### PR TITLE
[HOTFIX] Optional Parent Activity IDs

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/NoSuchActivityInstanceException.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/NoSuchActivityInstanceException.java
@@ -1,16 +1,18 @@
 package gov.nasa.jpl.aerie.merlin.server.exceptions;
 
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
+
 public class NoSuchActivityInstanceException extends Exception {
   private final String planId;
-  private final String activityInstanceId;
+  private final ActivityInstanceId activityInstanceId;
 
-  public NoSuchActivityInstanceException(final String planId, final String activityInstanceId) {
+  public NoSuchActivityInstanceException(final String planId, final ActivityInstanceId activityInstanceId) {
     super("No activity exists with id `" + planId + "` in plan with id `" + planId + "`");
     this.planId = planId;
     this.activityInstanceId = activityInstanceId;
   }
 
-  public String getInvalidActivityId() {
+  public ActivityInstanceId getInvalidActivityId() {
     return this.activityInstanceId;
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -155,7 +155,7 @@ public final class ResponseSerializers {
         .add("parameters", serializeArgumentMap(simulatedActivity.parameters))
         .add("startTimestamp", serializeTimestamp(simulatedActivity.start))
         .add("duration", serializeDuration(simulatedActivity.duration))
-        .add("parent", serializeNullable(Json::createValue, simulatedActivity.parentId.id()))
+        .add("parent", serializeNullable(id -> Json.createValue(id.id()), simulatedActivity.parentId))
         .add("children", serializeIterable((id -> Json.createValue(id.id())), simulatedActivity.childIds))
         .build();
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
@@ -220,13 +220,13 @@ public final class InMemoryPlanRepository implements PlanRepository {
 
   private class MockActivityTransaction implements ActivityTransaction {
     private final String planId;
-    private final String activityId;
+    private final ActivityInstanceId activityId;
 
     private Optional<String> type = Optional.empty();
     private Optional<Timestamp> startTimestamp = Optional.empty();
     private Optional<Map<String, SerializedValue>> parameters = Optional.empty();
 
-    public MockActivityTransaction(final String planId, final String activityId) {
+    public MockActivityTransaction(final String planId, final ActivityInstanceId activityId) {
       this.planId = planId;
       this.activityId = activityId;
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityAction.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchActivityInstanceException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityInstance;
@@ -51,7 +52,7 @@ import java.util.function.Supplier;
       if (!results.next()) throw new NoSuchPlanException(Long.toString(planId));
       requireColumnNonNull(results, 1, () -> new NoSuchActivityInstanceException(
           Long.toString(planId),
-          Long.toString(activityId)));
+          new ActivityInstanceId(activityId)));
 
       final var startTimestamp = Timestamp.fromString(results.getString(2));
       final var type = results.getString(3);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -4,7 +4,6 @@ import gov.nasa.jpl.aerie.json.Iso;
 import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
-import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchActivityInstanceException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.http.InvalidEntityException;
 import gov.nasa.jpl.aerie.merlin.server.http.InvalidJsonException;
@@ -271,14 +270,6 @@ public final class PostgresPlanRepository implements PlanRepository {
       return Long.parseLong(id, 10);
     } catch (final NumberFormatException ex) {
       throw new NoSuchPlanException(id);
-    }
-  }
-
-  private static long toActivityId(final String planId, final String id) throws NoSuchActivityInstanceException {
-    try {
-      return Long.parseLong(id, 10);
-    } catch (final NumberFormatException ex) {
-      throw new NoSuchActivityInstanceException(planId, id);
     }
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -291,7 +291,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
             record.parameters(),
             record.start(),
             record.duration(),
-            pgIdToSimId.get(record.parentId()),
+            record.parentId().map(pgIdToSimId::get).orElse(null),
             record.childIds().stream().map(pgIdToSimId::get).collect(Collectors.toList()),
             record.directiveId()
         ));

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulatedActivityRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulatedActivityRecord.java
@@ -14,7 +14,7 @@ import java.util.Optional;
     Map<String, SerializedValue> parameters,
     Instant start,
     Duration duration,
-    Long parentId,
+    Optional<Long> parentId,
     List<Long> childIds,
     Optional<ActivityInstanceId> directiveId
 ) {}


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This branch fixes a bug @camargo found while running with our latest changes. When reading activity instances from Postgres, parent IDs that were null were being read in as 0, causing issues. This branch makes the parent ID field optional, and properly reads null values into empty optionals.

## Verification
I tested locally, and will not merge until @camargo gives the green light on the bug disappearing on his end as well.

## Documentation
None.

## Future work
Let's hope none.
