### PR TITLE
[AERIE-1628] Incremental simulation driver for scheduling

### DIFF
--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/activities/BasicActivity.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/activities/BasicActivity.java
@@ -1,0 +1,16 @@
+package gov.nasa.jpl.aerie.foomissionmodel.activities;
+
+import gov.nasa.jpl.aerie.foomissionmodel.Mission;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
+
+@ActivityType("BasicActivity")
+public final class BasicActivity {
+  @EffectModel
+  public void run(final Mission mission) {
+    delay(Duration.of(1, Duration.SECONDS));
+  }
+}

--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/package-info.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/package-info.java
@@ -5,6 +5,7 @@
 @WithMappers(BasicValueMappers.class)
 @WithMappers(FooValueMappers.class)
 
+@WithActivityType(BasicActivity.class)
 @WithActivityType(FooActivity.class)
 @WithActivityType(BarActivity.class)
 @WithActivityType(DecompositionTestActivities.ParentActivity.class)
@@ -14,6 +15,7 @@ package gov.nasa.jpl.aerie.foomissionmodel;
 
 import gov.nasa.jpl.aerie.contrib.serialization.rulesets.BasicValueMappers;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.BarActivity;
+import gov.nasa.jpl.aerie.foomissionmodel.activities.BasicActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.DecompositionTestActivities;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.FooActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.mappers.FooValueMappers;

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
@@ -128,6 +128,10 @@ public final class SimulationDriver {
     }
   }
 
+  public static ControlTask buildPlanTask(Map<ActivityInstanceId, Pair<Duration, SerializedActivity>> schedule){
+    return new ControlTask(schedule);
+  }
+
   private static final class ControlTask implements Task<Unit> {
     private final Map<ActivityInstanceId, Pair<Duration, SerializedActivity>> schedule;
 

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -524,6 +524,14 @@ public final class SimulationEngine implements AutoCloseable {
                                  serializedTimeline);
   }
 
+  public Duration getTaskDuration(TaskId taskId){
+    final var state = tasks.get(taskId);
+    if (state instanceof ExecutionState.Terminated e) {
+      return e.joinOffset().minus(e.startOffset());
+    }
+    throw new IllegalStateException("Asking for the duration of unfinished task");
+  }
+
   @SuppressWarnings("unchecked")
   private static <DirectiveReturn, TaskReturn> SerializedValue serializeReturnValue(
       final Directive<?, ?, DirectiveReturn> directive,

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/TaskId.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/TaskId.java
@@ -3,7 +3,7 @@ package gov.nasa.jpl.aerie.merlin.driver.engine;
 import java.util.UUID;
 
 /** A typed wrapper for task IDs. */
-/*package-local*/ record TaskId(String id) {
+public record TaskId(String id) {
   public static TaskId generate() {
     return new TaskId(UUID.randomUUID().toString());
   }

--- a/scheduler/build.gradle
+++ b/scheduler/build.gradle
@@ -52,7 +52,6 @@ dependencies {
   compileOnly project(':merlin-driver')
   compileOnly project(':constraints')
   compileOnly project(':contrib')
-  compileOnly project(':examples:banananation')
 
   implementation 'com.google.guava:guava:31.0.1-jre'
   implementation 'org.json:json:20211205'
@@ -68,6 +67,7 @@ dependencies {
   testImplementation project(':constraints')
   testImplementation project(':contrib')
   testImplementation project(':examples:banananation')
+  testImplementation project(':examples:foo-missionmodel')
   testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
   testImplementation 'com.google.guava:guava-testlib:31.0.1-jre'
   testImplementation 'com.google.truth.extensions:truth-java8-extension:1.1.3'

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationDriver.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationDriver.java
@@ -1,0 +1,178 @@
+package gov.nasa.jpl.aerie.scheduler;
+
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
+import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
+import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
+import gov.nasa.jpl.aerie.merlin.driver.engine.SimulationEngine;
+import gov.nasa.jpl.aerie.merlin.driver.engine.TaskId;
+import gov.nasa.jpl.aerie.merlin.driver.timeline.LiveCells;
+import gov.nasa.jpl.aerie.merlin.driver.timeline.TemporalEventSource;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class IncrementalSimulationDriver {
+
+  private Duration curTime = Duration.ZERO;
+  private SimulationEngine engine = new SimulationEngine();
+  private LiveCells cells;
+  private TemporalEventSource timeline = new TemporalEventSource();
+  private final MissionModel<?> missionModel;
+
+  //mapping each activity name to its task id (in String form) in the simulation engine
+  private final Map<ActivityInstanceId, TaskId> plannedDirectiveToTask;
+  //and the opposite
+  private final Map<TaskId, ActivityInstanceId> taskToPlannedDirective;
+
+  //simulation results so far
+  private SimulationResults lastSimResults;
+  //cached simulation results cover the period [Duration.ZERO, lastSimResultsEnd]
+  private Duration lastSimResultsEnd = Duration.ZERO;
+
+  //List of activities simulated since the last reset
+  private final List<SimulatedActivity> activitiesInserted = new ArrayList<>();
+
+  record SimulatedActivity(Duration start, SerializedActivity activity, ActivityInstanceId id) {}
+
+  public IncrementalSimulationDriver(MissionModel<?> missionModel){
+    this.missionModel = missionModel;
+    plannedDirectiveToTask = new HashMap<>();
+    taskToPlannedDirective = new HashMap<>();
+    initSimulation();
+  }
+
+  private void initSimulation(){
+    plannedDirectiveToTask.clear();
+    taskToPlannedDirective.clear();
+    lastSimResults = null;
+    lastSimResultsEnd = Duration.ZERO;
+    this.engine = new SimulationEngine();
+    activitiesInserted.clear();
+
+    /* The top-level simulation timeline. */
+    this.timeline = new TemporalEventSource();
+    this.cells = new LiveCells(timeline, missionModel.getInitialCells());
+    /* The current real time. */
+    curTime = Duration.ZERO;
+
+    // Begin tracking all resources.
+    for (final var entry : missionModel.getResources().entrySet()) {
+      final var name = entry.getKey();
+      final var resource = entry.getValue();
+      engine.trackResource(name, resource, curTime);
+    }
+
+    // Start daemon task(s) immediately, before anything else happens.
+    {
+      final var daemon = engine.initiateTaskFromSource(missionModel::getDaemon);
+      final var commit = engine.performJobs(Set.of(SimulationEngine.JobId.forTask(daemon)),
+                                            cells, curTime, Duration.MAX_VALUE, missionModel);
+      timeline.add(commit);
+    }
+  }
+
+  public void simulateActivity(SerializedActivity activity, Duration startTime, ActivityInstanceId activityId){
+    final var activityToSimulate = new SimulatedActivity(startTime, activity, activityId);
+    if(startTime.noLongerThan(curTime)){
+      final var toBeInserted = new ArrayList<>(activitiesInserted);
+      toBeInserted.add(activityToSimulate);
+      initSimulation();
+      final var schedule = toBeInserted
+          .stream()
+          .collect(Collectors.toMap( e -> e.id, e->Pair.of(e.start, e.activity)));
+      simulateSchedule(schedule);
+      activitiesInserted.addAll(toBeInserted);
+    } else {
+      final var schedule = Map.of(activityToSimulate.id,
+                                  Pair.of(activityToSimulate.start, activityToSimulate.activity));
+      simulateSchedule(schedule);
+      activitiesInserted.add(activityToSimulate);
+    }
+  }
+
+
+  /**
+   * Get the simulation results from the Duration.ZERO to the current simulation time point
+   * @return the simulation results
+   */
+  public SimulationResults getSimulationResults(){
+    return getSimulationResultsUntil(curTime);
+  }
+
+  /**
+   * Get the simulation results from the Duration.ZERO to a specified end time point.
+   * The provided simulation results might cover more than the required time period.
+   * @return the simulation results
+   */
+  public SimulationResults getSimulationResultsUntil(Duration endTime){
+    //if previous results cover a bigger period, we return do not regenerate
+    if(lastSimResults == null || endTime.longerThan(lastSimResultsEnd)) {
+      final Map<String, ActivityInstanceId> convertedTaskToPlannedDir = new HashMap<>();
+      taskToPlannedDirective.forEach((taskId, plannedDirective)->
+                                         convertedTaskToPlannedDir.put(taskId.id(), plannedDirective));
+      lastSimResults = engine.computeResults(
+          engine,
+          Instant.now(),
+          endTime,
+          convertedTaskToPlannedDir,
+          timeline,
+          missionModel);
+      lastSimResultsEnd = endTime;
+      //while sim results may not be up to date with curTime, a regeneration has taken place after the last insertion
+    }
+    return lastSimResults;
+  }
+
+  private void simulateSchedule(Map<ActivityInstanceId, Pair<Duration, SerializedActivity>> schedule){
+
+    for (final var entry : schedule.entrySet()) {
+      final var directiveId = entry.getKey();
+      final var startOffset = entry.getValue().getLeft();
+      final var directive = entry.getValue().getRight();
+
+      final var taskId = engine.initiateTaskFromInput(missionModel, directive);
+      engine.scheduleTask(taskId, startOffset);
+      plannedDirectiveToTask.put(directiveId,taskId);
+      taskToPlannedDirective.put(taskId, directiveId);
+    }
+
+    while (true) {
+      final var batch = engine.extractNextJobs(Duration.MAX_VALUE);
+      // Increment real time, if necessary.
+      final var delta = batch.offsetFromStart().minus(curTime);
+      curTime = batch.offsetFromStart();
+      timeline.add(delta);
+      // TODO: Advance a dense time counter so that future tasks are strictly ordered relative to these,
+      //   even if they occur at the same real time.
+
+      // Run the jobs in this batch.
+      final var commit = engine.performJobs(batch.jobs(), cells, curTime, Duration.MAX_VALUE, missionModel);
+      timeline.add(commit);
+
+      // Exit IFF all tasks are complete
+      if (taskToPlannedDirective.keySet().stream().allMatch(taskId -> engine.isTaskComplete(taskId))) {
+        break;
+      }
+
+    }
+    lastSimResults = null;
+  }
+
+  /**
+   * Returns the duration of a terminated simulated activity
+   * @param activityInstanceId the activity id
+   * @return its duration if the activity has been simulated and has finished simulating, an IllegalArgumentException otherwise
+   */
+  public Duration getActivityDuration(ActivityInstanceId activityInstanceId){
+    return engine.getTaskDuration(plannedDirectiveToTask.get(activityInstanceId));
+  }
+
+}

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/SimulationDriverFacade.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/SimulationDriverFacade.java
@@ -1,0 +1,42 @@
+package gov.nasa.jpl.aerie.scheduler;
+
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
+import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SimulationDriverFacade {
+
+  private final IncrementalSimulationDriver driver;
+
+  private final Map<String, ActivityInstanceId> activityNameToActivityId = new HashMap<>();
+
+  private static long count = 0;
+
+  public SimulationDriverFacade(IncrementalSimulationDriver driver){
+    this.driver = driver;
+  }
+
+  public void simulateActivity(SerializedActivity activity, String nameAct, Duration startTime){
+    final var activityId = new ActivityInstanceId(count++);
+    activityNameToActivityId.put(nameAct, activityId);
+    driver.simulateActivity(activity,startTime, activityId);
+  }
+
+  public Duration getActivityDuration(String activityName){
+    var activityId = activityNameToActivityId.get(activityName);
+    return driver.getActivityDuration(activityId);
+  }
+
+  public SimulationResults getSimulationResults(){
+    return driver.getSimulationResults();
+  }
+
+  public SimulationResults getSimulationResultsUntil(Duration endTime){
+    return driver.getSimulationResultsUntil(endTime);
+  }
+
+}

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationBenchmark.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationBenchmark.java
@@ -1,0 +1,83 @@
+package gov.nasa.jpl.aerie.scheduler;
+
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
+import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationDriver;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECOND;
+
+public class IncrementalSimulationBenchmark {
+
+  /**
+   * This benchmark builds incrementally longer plans of sequential non-overlapping activities and simulates them with
+   * incremental and non-incremental simulation drivers. Each printed timing _left _right shows the time _right it took
+   * to simulate a plan with a number of _left activities. Note that this is an ideal case for the incremental driver as
+   * it never has to reset.
+   */
+  public static void main(String[] args){
+    System.out.println("Incremental");
+    benchmarkIncrementalSimulationDriver();
+    System.out.println("Non-incremental");
+    benchMarkSimulationDriver();
+  }
+
+  private static ArrayList<IncrementalSimulationTest.TestSimulatedActivity> getActivities(){
+    final int nbActs = 5000;
+    final var step = Duration.of(3,SECOND);
+    final var durSim = step.times(nbActs);
+    final var acts = new ArrayList<IncrementalSimulationTest.TestSimulatedActivity>();
+    for(var cur = Duration.ZERO; cur.shorterThan(durSim); cur = cur.plus(step) ){
+      var act = new IncrementalSimulationTest.TestSimulatedActivity(
+          cur,
+          new SerializedActivity("BasicActivity", Map.of()),
+          String.valueOf(cur.in(MICROSECONDS)));
+      acts.add(act);
+    }
+    return acts;
+  }
+
+
+  private static void benchMarkSimulationDriver(){
+    final var acts = getActivities();
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    int i = 0;
+    var sum = 0.;
+    final var alreadyIn = new HashMap<ActivityInstanceId, Pair<Duration, SerializedActivity>>();
+    //builds incrementally long plans and simulates them
+    for(var act:acts){
+      alreadyIn.put(new ActivityInstanceId(Long.parseLong(act.name())), Pair.of(act.start(), act.activity()));
+      final var task = SimulationDriver.buildPlanTask(alreadyIn);
+      final var start = System.nanoTime();
+      SimulationDriver.simulateTask(fooMissionModel, task);
+      final var dur = System.nanoTime() - start;
+      sum += dur;
+      final var curMean = sum / (++i);
+      System.out.println(i + " " + curMean);
+    }
+  }
+
+  private static void benchmarkIncrementalSimulationDriver(){
+    final var acts = getActivities();
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    final SimulationDriverFacade incrementalSimulationDriver = new SimulationDriverFacade(new IncrementalSimulationDriver(fooMissionModel));
+    int i = 0;
+    var sum = 0.;
+    for(var act : acts) {
+      final var start = System.nanoTime();
+      incrementalSimulationDriver.simulateActivity(act.activity(), act.name(), act.start());
+      final var dur = System.nanoTime() - start;
+      sum += dur;
+      final var curMean = sum / (++i);
+      System.out.println(i + " " + curMean);
+    }
+  }
+
+
+}

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationTest.java
@@ -1,0 +1,70 @@
+package gov.nasa.jpl.aerie.scheduler;
+
+import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
+
+public class IncrementalSimulationTest {
+
+  SimulationDriverFacade incrementalSimulationDriver;
+  Duration endOfLastAct;
+
+  @BeforeEach
+  public void init() {
+    final var acts = getActivities();
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    incrementalSimulationDriver =
+        new SimulationDriverFacade(new IncrementalSimulationDriver(fooMissionModel));
+    for (var act : acts) {
+      final var start = System.nanoTime();
+      incrementalSimulationDriver.simulateActivity(act.activity, act.name, act.start);
+    }
+  }
+  @Test
+  public void simulationResultsTest(){
+    //ensures that simulation results are generated until the end of the last act;
+    var simResults = incrementalSimulationDriver.getSimulationResults();
+    assert(simResults.realProfiles.get("/utcClock").get(0).getLeft().isEqualTo(endOfLastAct));
+    /*ensures that when current simulation results cover more than the asked period and that nothing has happened
+    between two requests, the same results are returned*/
+    var simResults2 = incrementalSimulationDriver.getSimulationResultsUntil(Duration.of(7,SECONDS));
+    assert(Objects.equals(simResults, simResults2));
+  }
+
+  @Test
+  public void durationTest(){
+    var act1Dur = incrementalSimulationDriver.getActivityDuration("first");
+    var act2Dur = incrementalSimulationDriver.getActivityDuration("second");
+    assert(act1Dur.isEqualTo(Duration.of(1, SECONDS)));
+    assert(act2Dur.isEqualTo(Duration.of(1, SECONDS)));
+  }
+
+  private ArrayList<TestSimulatedActivity> getActivities(){
+    final var acts = new ArrayList<TestSimulatedActivity>();
+    var act1 = new TestSimulatedActivity(
+        Duration.of(0, SECONDS),
+        new SerializedActivity("BasicActivity", Map.of()),
+        "first");
+    acts.add(act1);
+    var act2 = new TestSimulatedActivity(
+        Duration.of(14, SECONDS),
+        new SerializedActivity("BasicActivity", Map.of()),
+        "second");
+    acts.add(act2);
+
+    endOfLastAct = Duration.of(15,SECONDS);
+    return acts;
+  }
+
+
+  record TestSimulatedActivity(Duration start, SerializedActivity activity, String name){}
+
+
+}

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
@@ -60,7 +60,7 @@ public class SimulationFacadeTest {
 
   @BeforeEach
   public void setUp() {
-    missionModel = SimulationUtility.getMissionModel();
+    missionModel = SimulationUtility.getBananaMissionModel();
     wrappedMissionModel = new MissionModelWrapper(missionModel, horizon);
     facade = new SimulationFacade(horizon, missionModel);
   }

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationUtility.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationUtility.java
@@ -2,7 +2,6 @@ package gov.nasa.jpl.aerie.scheduler;
 
 import gov.nasa.jpl.aerie.banananation.Configuration;
 import gov.nasa.jpl.aerie.banananation.generated.ConfigurationMapper;
-import gov.nasa.jpl.aerie.banananation.generated.GeneratedMissionModelFactory;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
@@ -12,13 +11,23 @@ import java.nio.file.Path;
 public final class SimulationUtility {
 
   private static MissionModel<?> makeMissionModel(final MissionModelBuilder builder, final SerializedValue config) {
-    final var factory = new GeneratedMissionModelFactory();
+    final var factory = new gov.nasa.jpl.aerie.banananation.generated.GeneratedMissionModelFactory();
     final var model = factory.instantiate(config, builder);
     return builder.build(model, factory.getTaskSpecTypes());
   }
 
+  public static MissionModel<?>
+  getFooMissionModel() {
+    final var conf = new gov.nasa.jpl.aerie.foomissionmodel.Configuration();
+    final var serializedConfig = SerializedValue.of(new gov.nasa.jpl.aerie.foomissionmodel.generated.ConfigurationMapper().getArguments(conf));
+    final var factory = new gov.nasa.jpl.aerie.foomissionmodel.generated.GeneratedMissionModelFactory();
+    final var builder = new MissionModelBuilder();
+    final var model = factory.instantiate(serializedConfig, builder);
+    return builder.build(model, factory.getTaskSpecTypes());
+  }
 
-  public static MissionModel<?> getMissionModel(){
+
+  public static MissionModel<?> getBananaMissionModel(){
     final var config = new Configuration(Configuration.DEFAULT_PLANT_COUNT, Configuration.DEFAULT_PRODUCER, Path.of("/etc/hosts"));
     final var serializedConfig = SerializedValue.of(new ConfigurationMapper().getArguments(config));
     return makeMissionModel(new MissionModelBuilder(), serializedConfig);


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1628
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The goal of this work is to build an incremental simulation driver for the scheduler. The approach is basic : the state of simulation, as well as the current time, are kept and reused when a new activity starting in the future (with regard to the current time) has to be simulated. If the new activity starts in the past: 
(1) the simulation is reset, (2) all previously inserted activities as well as the new activity are simulated 

The user can then query the duration of an activity that has been simulated. 
Simulation results can be queried and are computed only when needed. In other words, several activity simulations can happen between two computations of simulation results.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
There is a performance benchmark in `IncrementalSimulationBenchmark` comparing insertion times between the `IncrementalSimulationDriver` and the `SimulationDriver`. A large number of activities are generated. They are sequential non-overlapping 1-second activities. 

The two tests "builds" larger and larger plans and each time simulates the last activity inserted. 

A vast difference in computing time can be seen between the two cases in favor of the incremental version. Note that this is an ideal case for the incremental case as it never has to reset (new activities are always in the "future").  

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No doc yet, this is a draft.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Use in the scheduler
- Instead of resetting completely when an activity starts in the past, reset to the state the simulator was in at the start of the activity? I do not think this simulation state exists.  
