### PR TITLE
[AERIE-1639] Plan ID Record

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/NoSuchActivityInstanceException.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/NoSuchActivityInstanceException.java
@@ -1,13 +1,14 @@
 package gov.nasa.jpl.aerie.merlin.server.exceptions;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
 public class NoSuchActivityInstanceException extends Exception {
-  private final String planId;
+  private final PlanId planId;
   private final ActivityInstanceId activityInstanceId;
 
-  public NoSuchActivityInstanceException(final String planId, final ActivityInstanceId activityInstanceId) {
-    super("No activity exists with id `" + planId + "` in plan with id `" + planId + "`");
+  public NoSuchActivityInstanceException(final PlanId planId, final ActivityInstanceId activityInstanceId) {
+    super("No activity exists with id `" + activityInstanceId + "` in plan with id `" + planId + "`");
     this.planId = planId;
     this.activityInstanceId = activityInstanceId;
   }
@@ -16,7 +17,7 @@ public class NoSuchActivityInstanceException extends Exception {
     return this.activityInstanceId;
   }
 
-  public String getPlanId() {
+  public PlanId getPlanId() {
     return this.planId;
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/NoSuchPlanException.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/NoSuchPlanException.java
@@ -1,14 +1,16 @@
 package gov.nasa.jpl.aerie.merlin.server.exceptions;
 
-public class NoSuchPlanException extends Exception {
-  private final String id;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
-  public NoSuchPlanException(final String id) {
+public class NoSuchPlanException extends Exception {
+  private final PlanId id;
+
+  public NoSuchPlanException(final PlanId id) {
     super("No plan exists with id `" + id + "`");
     this.id = id;
   }
 
-  public String getInvalidPlanId() {
+  public PlanId getInvalidPlanId() {
     return this.id;
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
@@ -8,6 +8,7 @@ import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.server.models.HasuraAction;
 import gov.nasa.jpl.aerie.merlin.server.models.HasuraMissionModelEvent;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.services.UnexpectedSubtypeError;
 import org.apache.commons.lang3.tuple.Pair;
@@ -74,6 +75,12 @@ public abstract class MerlinParsers {
           ActivityInstanceId::new,
           ActivityInstanceId::id));
 
+  public static final JsonParser<PlanId> planIdP
+      = longP
+      . map(Iso.of(
+          PlanId::new,
+          PlanId::id));
+
   private static final JsonParser<HasuraAction.Session> hasuraActionSessionP
       = productP
       . field("x-hasura-role", stringP)
@@ -96,7 +103,7 @@ public abstract class MerlinParsers {
           $ -> tuple($.name(), $.input().missionModelId(), $.session())));
 
   public static final JsonParser<HasuraAction<HasuraAction.PlanInput>> hasuraPlanActionP
-      = hasuraActionP(productP.field("planId", stringP))
+      = hasuraActionP(productP.field("planId", planIdP))
       . map(Iso.of(
           untuple((name, planId, session) -> new HasuraAction<>(name, new HasuraAction.PlanInput(planId), session)),
           $ -> tuple($.name(), $.input().planId(), $.session())));
@@ -135,7 +142,7 @@ public abstract class MerlinParsers {
 
   public static final JsonParser<HasuraAction.UploadExternalDatasetInput> hasuraUploadExternalDatasetActionP
       = productP
-      . field("planId", stringP)
+      . field("planId", planIdP)
       . field("datasetStart", timestampP)
       . field("profileSet", profileSetP)
       . map(Iso.of(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
@@ -11,11 +11,11 @@ public record HasuraAction<I extends HasuraAction.Input>(String name, I input, S
   public interface Input { }
 
   public record MissionModelInput(String missionModelId) implements Input { }
-  public record PlanInput(String planId) implements Input { }
+  public record PlanInput(PlanId planId) implements Input { }
   public record ActivityInput(String missionModelId,
                               String activityTypeName,
                               Map<String, SerializedValue> arguments) implements Input {}
-  public record UploadExternalDatasetInput(String planId,
+  public record UploadExternalDatasetInput(PlanId planId,
                                            Timestamp datasetStart,
                                            ProfileSet profileSet) implements Input {}
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/PlanId.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/PlanId.java
@@ -1,0 +1,3 @@
+package gov.nasa.jpl.aerie.merlin.server.models;
+
+public record PlanId(long id) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.mocks.InMemoryPlanRepository;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -11,7 +12,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 public final class InMemoryResultsCellRepository implements ResultsCellRepository {
-  public record Key(String planId, long planRevision) {}
+  public record Key(PlanId planId, long planRevision) {}
 
   private final Map<InMemoryResultsCellRepository.Key, InMemoryCell> cells = new HashMap<>();
   private final PlanRepository planRepository;
@@ -21,7 +22,7 @@ public final class InMemoryResultsCellRepository implements ResultsCellRepositor
   }
 
   @Override
-  public ResultsProtocol.OwnerRole allocate(final String planId) {
+  public ResultsProtocol.OwnerRole allocate(final PlanId planId) {
     try {
       final var planRevision = planRepository.getPlanRevision(planId);
       final var cell = new InMemoryCell(planId, planRevision);
@@ -33,7 +34,7 @@ public final class InMemoryResultsCellRepository implements ResultsCellRepositor
   }
 
   @Override
-  public Optional<ResultsProtocol.ReaderRole> lookup(final String planId) {
+  public Optional<ResultsProtocol.ReaderRole> lookup(final PlanId planId) {
     try {
       final var planRevision = planRepository.getPlanRevision(planId);
       return Optional.ofNullable(this.cells.get(new InMemoryResultsCellRepository.Key(planId, planRevision)));
@@ -75,10 +76,10 @@ public final class InMemoryResultsCellRepository implements ResultsCellRepositor
   public static final class InMemoryCell implements ResultsProtocol.OwnerRole {
     private volatile boolean canceled = false;
     private volatile ResultsProtocol.State state = new ResultsProtocol.State.Incomplete();
-    public final String planId;
+    public final PlanId planId;
     public final long planRevision;
 
-    public InMemoryCell(final String planId, final long planRevision) {
+    public InMemoryCell(final PlanId planId, final long planRevision) {
       this.planId = planId;
       this.planRevision = planRevision;
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
@@ -8,6 +8,7 @@ import gov.nasa.jpl.aerie.merlin.server.models.ActivityInstance;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.NewPlan;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.services.RevisionData;
@@ -25,25 +26,25 @@ import java.util.Map;
  */
 public interface PlanRepository {
   // Queries
-  Map<String, Plan> getAllPlans();
-  Plan getPlan(String planId) throws NoSuchPlanException;
-  long getPlanRevision(String planId) throws NoSuchPlanException;
-  RevisionData getPlanRevisionData(String planId) throws NoSuchPlanException;
-  Map<ActivityInstanceId, ActivityInstance> getAllActivitiesInPlan(String planId) throws NoSuchPlanException;
+  Map<PlanId, Plan> getAllPlans();
+  Plan getPlan(PlanId planId) throws NoSuchPlanException;
+  long getPlanRevision(PlanId planId) throws NoSuchPlanException;
+  RevisionData getPlanRevisionData(PlanId planId) throws NoSuchPlanException;
+  Map<ActivityInstanceId, ActivityInstance> getAllActivitiesInPlan(PlanId planId) throws NoSuchPlanException;
 
   // Mutations
   CreatedPlan createPlan(NewPlan plan) throws MissionModelRepository.NoSuchMissionModelException;
-  PlanTransaction updatePlan(String planId) throws NoSuchPlanException;
-  void deletePlan(String planId) throws NoSuchPlanException;
+  PlanTransaction updatePlan(PlanId planId) throws NoSuchPlanException;
+  void deletePlan(PlanId planId) throws NoSuchPlanException;
 
-  ActivityInstanceId createActivity(String planId, ActivityInstance activity) throws NoSuchPlanException;
-  void deleteAllActivities(String planId) throws NoSuchPlanException;
+  ActivityInstanceId createActivity(PlanId planId, ActivityInstance activity) throws NoSuchPlanException;
+  void deleteAllActivities(PlanId planId) throws NoSuchPlanException;
 
-  Map<String, Constraint> getAllConstraintsInPlan(String planId) throws NoSuchPlanException;
+  Map<String, Constraint> getAllConstraintsInPlan(PlanId planId) throws NoSuchPlanException;
 
-  long addExternalDataset(String planId, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
+  long addExternalDataset(PlanId planId, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
 
-  record CreatedPlan(String planId, List<ActivityInstanceId> activityIds) {}
+  record CreatedPlan(PlanId planId, List<ActivityInstanceId> activityIds) {}
 
   interface PlanTransaction {
     void commit() throws NoSuchPlanException;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/ResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/ResultsCellRepository.java
@@ -1,13 +1,14 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes;
 
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
 import java.util.Optional;
 
 public interface ResultsCellRepository {
-  ResultsProtocol.OwnerRole allocate(String planId);
+  ResultsProtocol.OwnerRole allocate(PlanId planId);
 
-  Optional<ResultsProtocol.ReaderRole> lookup(String planId);
+  Optional<ResultsProtocol.ReaderRole> lookup(PlanId planId);
 
   void deallocate(ResultsProtocol.OwnerRole resultsCell);
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/AssociatePlanDatasetAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/AssociatePlanDatasetAction.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.intellij.lang.annotations.Language;
 
@@ -21,11 +22,11 @@ import java.sql.SQLException;
   }
 
   public PlanDatasetRecord apply(
-      final long planId,
+      final PlanId planId,
       final long datasetId,
       final Timestamp planStart
   ) throws SQLException {
-    this.statement.setLong(1, planId);
+    this.statement.setLong(1, planId.id());
     this.statement.setLong(2, datasetId);
 
     final var results = this.statement.executeQuery();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateActivityAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateActivityAction.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.intellij.lang.annotations.Language;
 
@@ -23,12 +24,12 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
   }
 
   public long apply(
-      final long planId,
+      final PlanId planId,
       final Timestamp planStartTime,
       final Timestamp activityStartTime,
       final String type
   ) throws SQLException, FailedInsertException {
-    this.statement.setLong(1, planId);
+    this.statement.setLong(1, planId.id());
     setTimestamp(this.statement, 2, activityStartTime);
     setTimestamp(this.statement, 3, planStartTime);
     this.statement.setString(4, type);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreatePlanAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreatePlanAction.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.remotes.MissionModelRepository;
 import org.intellij.lang.annotations.Language;
@@ -24,7 +25,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
     this.statement = connection.prepareStatement(sql);
   }
 
-  public long apply(
+  public PlanId apply(
       final String name,
       final long modelId,
       final Timestamp startTime,
@@ -39,7 +40,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
     try (final var results = this.statement.executeQuery()) {
       if (!results.next()) throw new FailedInsertException("plan");
 
-      return results.getLong(1);
+      return new PlanId(results.getLong(1));
     } catch (final SQLException ex) {
       // https://www.postgresql.org/docs/current/errcodes-appendix.html
       if (Objects.equals(ex.getSQLState(), "23503")) {  /* foreign_key_violation */

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreatePlanDatasetAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreatePlanDatasetAction.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.intellij.lang.annotations.Language;
 
@@ -24,13 +25,13 @@ import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
   }
 
   public PlanDatasetRecord apply(
-      final long planId,
+      final PlanId planId,
       final Timestamp planStart,
       final Timestamp datasetStart
   ) throws SQLException {
     final var offsetFromPlanStart = Duration.of(planStart.microsUntil(datasetStart), MICROSECONDS);
 
-    this.statement.setLong(1, planId);
+    this.statement.setLong(1, planId.id());
     PreparedStatements.setTimestamp(this.statement, 2, datasetStart);
     PreparedStatements.setTimestamp(this.statement, 3, planStart);
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateSimulationAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateSimulationAction.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
@@ -24,8 +25,8 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
     this.statement = connection.prepareStatement(sql);
   }
 
-  public SimulationRecord apply(final long planId, final Map<String, SerializedValue> arguments) throws SQLException, FailedInsertException {
-    this.statement.setLong(1, planId);
+  public SimulationRecord apply(final PlanId planId, final Map<String, SerializedValue> arguments) throws SQLException, FailedInsertException {
+    this.statement.setLong(1, planId.id());
     this.statement.setString(2, simulationArgumentsP.unparse(arguments).toString());
 
     final var results = statement.executeQuery();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivitiesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivitiesAction.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityInstance;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.intellij.lang.annotations.Language;
 
@@ -56,11 +57,11 @@ import java.util.Map;
     this.statement = connection.prepareStatement(sql);
   }
 
-  public Map<ActivityInstanceId, ActivityInstance> get(final long planId) throws SQLException, NoSuchPlanException {
-    this.statement.setLong(1, planId);
+  public Map<ActivityInstanceId, ActivityInstance> get(final PlanId planId) throws SQLException, NoSuchPlanException {
+    this.statement.setLong(1, planId.id());
 
     try (final var results = this.statement.executeQuery()) {
-      if (!results.next()) throw new NoSuchPlanException(Long.toString(planId));
+      if (!results.next()) throw new NoSuchPlanException(planId);
 
       final var startTimestamp = Timestamp.fromString(results.getString(1));
       final var activitiesJson = results.getString(2);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityAction.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchActivityInstanceException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityInstance;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.intellij.lang.annotations.Language;
 
@@ -42,16 +43,16 @@ import java.util.function.Supplier;
     this.statement = connection.prepareStatement(sql);
   }
 
-  public ActivityInstance get(final long planId, final long activityId)
+  public ActivityInstance get(final PlanId planId, final long activityId)
   throws SQLException, NoSuchPlanException, NoSuchActivityInstanceException
   {
-    this.statement.setLong(1, planId);
+    this.statement.setLong(1, planId.id());
     this.statement.setLong(2, activityId);
 
     try (final var results = this.statement.executeQuery()) {
-      if (!results.next()) throw new NoSuchPlanException(Long.toString(planId));
+      if (!results.next()) throw new NoSuchPlanException(planId);
       requireColumnNonNull(results, 1, () -> new NoSuchActivityInstanceException(
-          Long.toString(planId),
+          planId,
           new ActivityInstanceId(activityId)));
 
       final var startTimestamp = Timestamp.fromString(results.getString(2));

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetAllPlansAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetAllPlansAction.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.intellij.lang.annotations.Language;
 
@@ -52,12 +53,12 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresPlanRepo
     this.statement = connection.prepareStatement(sql);
   }
 
-  public Map<String, Plan> get() throws SQLException {
+  public Map<PlanId, Plan> get() throws SQLException {
     try (final var results = this.statement.executeQuery()) {
-      final var plans = new HashMap<String, Plan>();
+      final var plans = new HashMap<PlanId, Plan>();
 
       while (results.next()) {
-        final var id = Long.toString(results.getLong(1));
+        final var id = new PlanId(results.getLong(1));
 
         final var name = results.getString(2);
         final var missionModelId = Long.toString(results.getLong(3));

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanAction.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.intellij.lang.annotations.Language;
 
@@ -51,11 +52,11 @@ import java.util.Map;
     this.statement = connection.prepareStatement(sql);
   }
 
-  public PlanRecord get(final long planId) throws SQLException, NoSuchPlanException {
-    this.statement.setLong(1, planId);
+  public PlanRecord get(final PlanId planId) throws SQLException, NoSuchPlanException {
+    this.statement.setLong(1, planId.id());
 
     try (final var results = this.statement.executeQuery()) {
-      if (!results.next()) throw new NoSuchPlanException(Long.toString(planId));
+      if (!results.next()) throw new NoSuchPlanException(planId);
 
       final var name = results.getString(1);
       final var revision = results.getLong(2);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanConstraintsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanConstraintsAction.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
@@ -29,13 +30,13 @@ import java.util.Map;
     this.statement = connection.prepareStatement(sql);
   }
 
-  public Map<String, Constraint> get(final long planId)
+  public Map<String, Constraint> get(final PlanId planId)
   throws SQLException, NoSuchPlanException
   {
-    this.statement.setLong(1, planId);
+    this.statement.setLong(1, planId.id());
 
     try (final var results = this.statement.executeQuery()) {
-      if (!results.next()) throw new NoSuchPlanException(Long.toString(planId));
+      if (!results.next()) throw new NoSuchPlanException(planId);
 
       final var constraints = new HashMap<String, Constraint>();
       do {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanExistenceAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanExistenceAction.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
@@ -17,8 +18,8 @@ import java.sql.SQLException;
     this.statement = connection.prepareStatement(sql);
   }
 
-  public boolean get(final long planId) throws SQLException {
-    this.statement.setLong(1, planId);
+  public boolean get(final PlanId planId) throws SQLException {
+    this.statement.setLong(1, planId.id());
 
     try (final var results = this.statement.executeQuery()) {
       return results.next();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanRevisionAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanRevisionAction.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
@@ -20,11 +21,11 @@ import java.sql.SQLException;
     this.statement = connection.prepareStatement(sql);
   }
 
-  public long get(final long planId) throws SQLException, NoSuchPlanException {
-    this.statement.setLong(1, planId);
+  public long get(final PlanId planId) throws SQLException, NoSuchPlanException {
+    this.statement.setLong(1, planId.id());
 
     try (final var results = this.statement.executeQuery()) {
-      if (!results.next()) throw new NoSuchPlanException(Long.toString(planId));
+      if (!results.next()) throw new NoSuchPlanException(planId);
 
       return results.getLong(1);
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanRevisionDataAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanRevisionDataAction.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
@@ -30,8 +31,8 @@ import java.util.Optional;
     this.statement = connection.prepareStatement(sql);
   }
 
-  public Optional<PostgresPlanRevisionData> get(final long planId) throws SQLException {
-    this.statement.setLong(1, planId);
+  public Optional<PostgresPlanRevisionData> get(final PlanId planId) throws SQLException {
+    this.statement.setLong(1, planId.id());
 
     final var results = this.statement.executeQuery();
     if (!results.next()) return Optional.empty();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationAction.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import org.intellij.lang.annotations.Language;
 
 import javax.json.Json;
@@ -31,9 +32,9 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
     this.statement = connection.prepareStatement(sql);
   }
 
-  public Optional<SimulationRecord> get(final long planId)
+  public Optional<SimulationRecord> get(final PlanId planId)
   throws SQLException {
-      this.statement.setLong(1, planId);
+      this.statement.setLong(1, planId.id());
       final ResultSet results = this.statement.executeQuery();
 
       if (!results.next()) return Optional.empty();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PlanDatasetRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PlanDatasetRecord.java
@@ -1,8 +1,9 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
 public final record PlanDatasetRecord(
-    long planId,
+    PlanId planId,
     long datasetId,
     Duration offsetFromPlanStart) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PlanRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PlanRecord.java
@@ -2,12 +2,13 @@ package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityInstance;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 
 import java.util.Map;
 
 public final record PlanRecord(
-    long id,
+    PlanId id,
     long revision,
     String name,
     long missionModelId,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -11,6 +11,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol.State;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.remotes.ResultsCellRepository;
@@ -36,9 +37,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
   }
 
   @Override
-  public ResultsProtocol.OwnerRole allocate(final String planIdString) {
-    // TODO: We should really address the fact that the plan ID is a string in merlin, but stored as a long
-    final var planId = Long.parseLong(planIdString);
+  public ResultsProtocol.OwnerRole allocate(final PlanId planId) {
     try (final var connection = this.dataSource.getConnection()) {
       final var planStart = getPlan(connection, planId).startTime();
       // TODO: At the time of writing, simulation starts at the plan start every time
@@ -72,9 +71,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
   }
 
   @Override
-  public Optional<ResultsProtocol.ReaderRole> lookup(final String planIdString) {
-    // TODO: We should really address the fact that the plan ID is a string in merlin, but stored as a long
-    final var planId = Long.parseLong(planIdString);
+  public Optional<ResultsProtocol.ReaderRole> lookup(final PlanId planId) {
     try (final var connection = this.dataSource.getConnection()) {
       final var planStart = getPlan(connection, planId).startTime();
 
@@ -117,7 +114,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
   /* Database accessors */
   private static Optional<SimulationRecord> getSimulation(
       final Connection connection,
-      final long planId
+      final PlanId planId
   ) throws SQLException
   {
     try (final var getSimulationAction = new GetSimulationAction(connection)) {
@@ -149,7 +146,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
 
   private static SimulationRecord createSimulation(
       final Connection connection,
-      final long planId,
+      final PlanId planId,
       final Map<String, SerializedValue> arguments
   ) throws SQLException
   {
@@ -203,7 +200,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
   private static Optional<State> getSimulationState(
       final Connection connection,
       final long datasetId,
-      final long planId,
+      final PlanId planId,
       final Timestamp planStart
   ) throws SQLException {
     final var record$ = getSimulationDatasetRecord(
@@ -225,7 +222,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
   private static SimulationResults getSimulationResults(
       final Connection connection,
       final SimulationDatasetRecord simulationDatasetRecord,
-      final long planId
+      final PlanId planId
   ) throws SQLException {
     final var simulationWindow = getSimulationWindow(connection, simulationDatasetRecord, planId);
     final var startTimestamp = simulationWindow.start();
@@ -333,7 +330,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
   private static Window getSimulationWindow(
       final Connection connection,
       final SimulationDatasetRecord simulationDatasetRecord,
-      final long planId
+      final PlanId planId
   ) throws SQLException {
     try {
       final var plan = getPlan(connection, planId);
@@ -348,7 +345,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
 
   private static PlanRecord getPlan(
       final Connection connection,
-      final long planId
+      final PlanId planId
   ) throws SQLException, NoSuchPlanException {
     try (final var getPlanAction = new GetPlanAction(connection)) {
       return getPlanAction.get(planId);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulationRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulationRecord.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
 import java.util.Optional;
 import java.util.Map;
@@ -8,6 +9,6 @@ import java.util.Map;
 public final record SimulationRecord(
     long id,
     long revision,
-    long planId,
+    PlanId planId,
     Optional<Long> simulationTemplateId,
     Map<String, SerializedValue> arguments) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdatePlanAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdatePlanAction.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.Nullable;
@@ -21,7 +22,7 @@ import java.util.List;
   }
 
   public void apply(
-      final long planId,
+      final PlanId planId,
       final @Nullable String name,
       final @Nullable Timestamp startTime,
       final @Nullable Timestamp endTime
@@ -34,7 +35,7 @@ import java.util.List;
       }
 
       final var count = statement.executeUpdate();
-      if (count != 1) throw new NoSuchPlanException(Long.toString(planId));
+      if (count != 1) throw new NoSuchPlanException(planId);
     }
   }
 
@@ -46,7 +47,7 @@ import java.util.List;
   public record GeneratedSql(String sql, List<ArgumentSetter> argumentSetters) {}
 
   public static GeneratedSql generateSql(
-      final long planId,
+      final PlanId planId,
       final @Nullable String name,
       final @Nullable Timestamp startTime,
       final @Nullable Timestamp endTime

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.remotes.ResultsCellRepository;
 
 public record CachedSimulationService (
@@ -8,7 +9,7 @@ public record CachedSimulationService (
     SimulationAgent agent
 ) implements SimulationService {
   @Override
-  public ResultsProtocol.State getSimulationResults(final String planId, final RevisionData revisionData) {
+  public ResultsProtocol.State getSimulationResults(final PlanId planId, final RevisionData revisionData) {
     final var cell$ = this.store.lookup(planId);
     if (cell$.isPresent()) {
       return cell$.get().get();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -14,6 +14,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
 import javax.json.Json;
 import java.io.StringReader;
@@ -46,7 +47,7 @@ public final class GetSimulationResultsAction {
     this.simulationService = Objects.requireNonNull(simulationService);
   }
 
-  public Response run(final String planId) throws NoSuchPlanException {
+  public Response run(final PlanId planId) throws NoSuchPlanException {
     final var revisionData = this.planService.getPlanRevisionData(planId);
 
     final var response = this.simulationService.getSimulationResults(planId, revisionData);
@@ -65,7 +66,7 @@ public final class GetSimulationResultsAction {
     }
   }
 
-  public Map<String, List<Violation>> getViolations(final String planId, final SimulationResults results)
+  public Map<String, List<Violation>> getViolations(final PlanId planId, final SimulationResults results)
   throws NoSuchPlanException
   {
     final var plan = this.planService.getPlan(planId);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.remotes.PlanRepository;
@@ -19,24 +20,24 @@ public final class LocalPlanService implements PlanService {
   }
 
   @Override
-  public Plan getPlan(final String planId) throws NoSuchPlanException {
+  public Plan getPlan(final PlanId planId) throws NoSuchPlanException {
     return this.planRepository.getPlan(planId);
   }
 
   @Override
-  public RevisionData getPlanRevisionData(final String planId) throws NoSuchPlanException {
+  public RevisionData getPlanRevisionData(final PlanId planId) throws NoSuchPlanException {
     return this.planRepository.getPlanRevisionData(planId);
   }
 
   @Override
-  public Map<String, Constraint> getConstraintsForPlan(final String planId) throws NoSuchPlanException {
+  public Map<String, Constraint> getConstraintsForPlan(final PlanId planId) throws NoSuchPlanException {
     return this.planRepository.getAllConstraintsInPlan(planId);
   }
 
   @Override
-  public long addExternalDataset(final String id, final Timestamp datasetStart, final ProfileSet profileSet)
+  public long addExternalDataset(final PlanId planId, final Timestamp datasetStart, final ProfileSet profileSet)
   throws NoSuchPlanException
   {
-    return this.planRepository.addExternalDataset(id, datasetStart, profileSet);
+    return this.planRepository.addExternalDataset(planId, datasetStart, profileSet);
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
@@ -3,16 +3,17 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 
 import java.util.Map;
 
 public interface PlanService {
-  Plan getPlan(String planId) throws NoSuchPlanException;
-  RevisionData getPlanRevisionData(String planId) throws NoSuchPlanException;
+  Plan getPlan(PlanId planId) throws NoSuchPlanException;
+  RevisionData getPlanRevisionData(PlanId planId) throws NoSuchPlanException;
 
-  Map<String, Constraint> getConstraintsForPlan(String planId) throws NoSuchPlanException;
+  Map<String, Constraint> getConstraintsForPlan(PlanId planId) throws NoSuchPlanException;
 
-  long addExternalDataset(String id, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
+  long addExternalDataset(PlanId planId, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationAgent.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationAgent.java
@@ -1,7 +1,8 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
 public interface SimulationAgent {
-  void simulate(String planId, RevisionData revisionData, ResultsProtocol.WriterRole writer) throws InterruptedException;
+  void simulate(PlanId planId, RevisionData revisionData, ResultsProtocol.WriterRole writer) throws InterruptedException;
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
@@ -1,7 +1,8 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
 public interface SimulationService {
-  ResultsProtocol.State getSimulationResults(String planId, RevisionData revisionData);
+  ResultsProtocol.State getSimulationResults(PlanId planId, RevisionData revisionData);
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SynchronousSimulationAgent.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SynchronousSimulationAgent.java
@@ -8,6 +8,7 @@ import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelFacade;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.time.Instant;
@@ -25,7 +26,7 @@ public record SynchronousSimulationAgent (
   }
 
   @Override
-  public void simulate(final String planId, final RevisionData revisionData, final ResultsProtocol.WriterRole writer) {
+  public void simulate(final PlanId planId, final RevisionData revisionData, final ResultsProtocol.WriterRole writer) {
     final Plan plan;
     try {
       plan = this.planService.getPlan(planId);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ThreadedSimulationAgent.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ThreadedSimulationAgent.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
@@ -8,7 +9,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 public final class ThreadedSimulationAgent implements SimulationAgent {
   private /*sealed*/ interface SimulationRequest {
-    record Simulate(String planId, RevisionData revisionData, ResultsProtocol.WriterRole writer) implements SimulationRequest {}
+    record Simulate(PlanId planId, RevisionData revisionData, ResultsProtocol.WriterRole writer) implements SimulationRequest {}
 
     record Terminate() implements SimulationRequest {}
   }
@@ -31,7 +32,7 @@ public final class ThreadedSimulationAgent implements SimulationAgent {
   }
 
   @Override
-  public void simulate(final String planId, final RevisionData revisionData, final ResultsProtocol.WriterRole writer)
+  public void simulate(final PlanId planId, final RevisionData revisionData, final ResultsProtocol.WriterRole writer)
   throws InterruptedException
   {
     this.requestQueue.put(new SimulationRequest.Simulate(planId, revisionData, writer));

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/UncachedSimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/UncachedSimulationService.java
@@ -2,11 +2,12 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.mocks.InMemoryRevisionData;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.remotes.InMemoryResultsCellRepository.InMemoryCell;
 
 public record UncachedSimulationService (SimulationAgent action) implements SimulationService {
   @Override
-  public ResultsProtocol.State getSimulationResults(final String planId, final RevisionData revisionData) {
+  public ResultsProtocol.State getSimulationResults(final PlanId planId, final RevisionData revisionData) {
     if (!(revisionData instanceof InMemoryRevisionData inMemoryRevisionData)) {
       throw new Error("UncachedSimulationService only accepts InMemoryRevisionData");
     }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/Fixtures.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/Fixtures.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityInstance;
 import gov.nasa.jpl.aerie.merlin.server.models.NewPlan;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 
 import java.util.ArrayList;
@@ -13,7 +14,7 @@ public final class Fixtures {
   public final StubMissionModelService missionModelService;
 
   public final String EXISTENT_MISSION_MODEL_ID;
-  public final String EXISTENT_PLAN_ID;
+  public final PlanId EXISTENT_PLAN_ID;
   public final String EXISTENT_ACTIVITY_TYPE_ID;
   public final ActivityInstanceId EXISTENT_ACTIVITY_INSTANCE_ID;
   public final ActivityInstance EXISTENT_ACTIVITY_INSTANCE;

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
@@ -6,6 +6,7 @@ import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityInstance;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.services.PlanService;
@@ -43,7 +44,7 @@ public final class StubPlanService implements PlanService {
   }
 
 
-  public Plan getPlan(final String planId) throws NoSuchPlanException {
+  public Plan getPlan(final PlanId planId) throws NoSuchPlanException {
     if (!Objects.equals(planId, EXISTENT_PLAN_ID)) {
       throw new NoSuchPlanException(planId);
     }
@@ -52,7 +53,7 @@ public final class StubPlanService implements PlanService {
   }
 
   @Override
-  public RevisionData getPlanRevisionData(final String planId) throws NoSuchPlanException {
+  public RevisionData getPlanRevisionData(final PlanId planId) throws NoSuchPlanException {
     if (!Objects.equals(planId, EXISTENT_PLAN_ID)) {
       throw new NoSuchPlanException(planId);
     }
@@ -61,13 +62,13 @@ public final class StubPlanService implements PlanService {
   }
 
   @Override
-  public Map<String, Constraint> getConstraintsForPlan(final String planId)
+  public Map<String, Constraint> getConstraintsForPlan(final PlanId planId)
   throws NoSuchPlanException {
     return Map.of();
   }
 
   @Override
-  public long addExternalDataset(final String id, final Timestamp datasetStart, final ProfileSet profileSet)
+  public long addExternalDataset(final PlanId planId, final Timestamp datasetStart, final ProfileSet profileSet)
   throws NoSuchPlanException
   {
     return 0;

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
@@ -11,6 +11,7 @@ import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
 import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
+import static gov.nasa.jpl.aerie.merlin.server.http.MerlinParsers.planIdP;
 
 /**
  * json parsers for data objects used in the scheduler service endpoints
@@ -52,7 +53,7 @@ public class SchedulerParsers {
    * parser for a hasura action that accepts a plan id as its sole input, along with normal hasura session details
    */
   public static final JsonParser<HasuraAction<HasuraAction.PlanInput>> hasuraPlanActionP
-      = hasuraActionP(productP.field("planId", stringP))
+      = hasuraActionP(productP.field("planId", planIdP))
       .map(Iso.of(
           untuple((name, planId, session) -> new HasuraAction<>(name, new HasuraAction.PlanInput(planId), session)),
           action -> tuple(action.name(), action.input().planId(), action.session())));

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/PlanMetadata.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/PlanMetadata.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.scheduler.server.models;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.scheduler.PlanningHorizon;
 
 import java.nio.file.Path;
@@ -19,7 +20,7 @@ import java.util.Map;
  * @param modelConfiguration plan-specific arguments to tune the behavior of the mission model
  */
 public record PlanMetadata(
-    long planId,
+    PlanId planId,
     long planRev,
     PlanningHorizon horizon,
     long modelId,

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/MerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/MerlinService.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.scheduler.server.services;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.scheduler.MissionModelWrapper;
 import gov.nasa.jpl.aerie.scheduler.Plan;
 import gov.nasa.jpl.aerie.scheduler.Time;
@@ -21,7 +22,7 @@ public interface MerlinService {
    * @return the current revision number of the plan as stored in aerie
    * @throws NoSuchPlanException when the plan container does not exist in aerie
    */
-  long getPlanRevision(final String planId) throws IOException, NoSuchPlanException;
+  long getPlanRevision(final PlanId planId) throws IOException, NoSuchPlanException;
 
   /**
    * fetch current metadata of the target plan (not the activity instance content)
@@ -30,7 +31,7 @@ public interface MerlinService {
    * @return metadata about the plan that is useful to the scheduler, including current plan revision
    * @throws NoSuchPlanException when the plan container does not exist in aerie
    */
-  PlanMetadata getPlanMetadata(final String planId) throws IOException, NoSuchPlanException;
+  PlanMetadata getPlanMetadata(final PlanId planId) throws IOException, NoSuchPlanException;
 
   /**
    * create an in-memory snapshot of the target plan's activity contents from aerie
@@ -53,7 +54,7 @@ public interface MerlinService {
    * @return the database id of the newly created aerie plan container
    * @throws NoSuchPlanException when the plan container could not be found in aerie after creation
    */
-  long createNewPlanWithActivities(final PlanMetadata planMetadata, final Plan plan)
+  PlanId createNewPlanWithActivities(final PlanMetadata planMetadata, final Plan plan)
   throws IOException, NoSuchPlanException;
 
   /**
@@ -68,7 +69,7 @@ public interface MerlinService {
    * @return the database id of the newly created aerie plan container
    * @throws NoSuchPlanException when the plan container could not be found in aerie after creation
    */
-  long createEmptyPlan(final String name, final long modelId, final Time startTime, final Duration duration)
+  PlanId createEmptyPlan(final String name, final long modelId, final Time startTime, final Duration duration)
   throws IOException, NoSuchPlanException;
 
 
@@ -78,7 +79,7 @@ public interface MerlinService {
    * @param planId the database id of the aerie plan container to attach the simulation container to
    * @throws NoSuchPlanException when the plan container does not exist in aerie
    */
-  void createSimulationForPlan(final long planId) throws IOException, NoSuchPlanException;
+  void createSimulationForPlan(final PlanId planId) throws IOException, NoSuchPlanException;
 
   /**
    * synchronize the in-memory plan back over to aerie data stores via update operations
@@ -89,7 +90,7 @@ public interface MerlinService {
    * @param plan plan with all activity instances that should be stored to target merlin plan container
    * @throws NoSuchPlanException when the plan container does not exist in aerie
    */
-  void updatePlanActivities(final long planId, final Plan plan) throws IOException, NoSuchPlanException;
+  void updatePlanActivities(final PlanId planId, final Plan plan) throws IOException, NoSuchPlanException;
 
   /**
    * confirms that the specified plan exists in the aerie database, throwing exception if not
@@ -98,7 +99,7 @@ public interface MerlinService {
    * @throws NoSuchPlanException when the plan container does not exist in aerie
    */
   //TODO: (defensive) should combine such checks into the mutations they are guarding, but not possible in graphql?
-  void ensurePlanExists(final long planId) throws IOException, NoSuchPlanException;
+  void ensurePlanExists(final PlanId planId) throws IOException, NoSuchPlanException;
 
   /**
    * delete all the activity instances stored in the target plan container
@@ -108,7 +109,7 @@ public interface MerlinService {
    * @param planId the database id of the plan container to clear
    * @throws NoSuchPlanException when the plan container does not exist in aerie
    */
-  void clearPlanActivities(final long planId) throws IOException, NoSuchPlanException;
+  void clearPlanActivities(final PlanId planId) throws IOException, NoSuchPlanException;
 
   /**
    * create activity instances in the target plan container for each activity in the input plan
@@ -121,7 +122,7 @@ public interface MerlinService {
    * @param plan the plan from which to copy all activity instances into aerie
    * @throws NoSuchPlanException when the plan container does not exist in aerie
    */
-  void createAllPlanActivities(final long planId, final Plan plan) throws IOException, NoSuchPlanException;
+  void createAllPlanActivities(final PlanId planId, final Plan plan) throws IOException, NoSuchPlanException;
 
 
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleAction.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.services.UnexpectedSubtypeError;
 import gov.nasa.jpl.aerie.scheduler.server.ResultsProtocol;
 
@@ -52,7 +53,7 @@ public record ScheduleAction(MerlinService merlinService, SchedulerService sched
    * @return a response object wrapping summary results of the run (either successful or not)
    * @throws NoSuchPlanException if the target plan could not be found
    */
-  public Response run(final String planId) throws NoSuchPlanException, IOException {
+  public Response run(final PlanId planId) throws NoSuchPlanException, IOException {
     //record the plan revision as of the scheduling request time (in case work commences much later eg in worker thread)
     //TODO may also need to verify the model revision / other volatile metadata matches one from request
     final long planRev = this.merlinService.getPlanMetadata(planId).planRev();

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleRequest.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleRequest.java
@@ -1,5 +1,7 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+
 import java.util.Objects;
 
 /**
@@ -8,7 +10,7 @@ import java.util.Objects;
  * @param planId target plan to read as initial input schedule as well as target for the output schedule
  * @param planRev the revision of the plan when the schedule request was placed (to determine if stale)
  */
-public record ScheduleRequest(String planId, long planRev) {
+public record ScheduleRequest(PlanId planId, long planRev) {
   public ScheduleRequest {
     Objects.requireNonNull(planId, "planId must not be null");
     Objects.requireNonNull(planRev, "planRev must not be null");

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.scheduler.server.services;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelLoader;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.scheduler.GlobalConstraint;
 import gov.nasa.jpl.aerie.scheduler.Goal;
 import gov.nasa.jpl.aerie.scheduler.HuginnConfiguration;
@@ -94,7 +95,7 @@ public record SynchronousSchedulerAgent(
    * @return snapshot of current metadata for target plan from merlin
    * @throws ResultsProtocolFailure when the requested plan cannot be found, or aerie could not be reached
    */
-  private PlanMetadata getMerlinPlanMetadata(final String planId) {
+  private PlanMetadata getMerlinPlanMetadata(final PlanId planId) {
     try {
       return merlinService.getPlanMetadata(planId);
     } catch (NoSuchPlanException | IOException e) {
@@ -109,7 +110,7 @@ public record SynchronousSchedulerAgent(
    * @return the current revision number of the target plan according to a fresh query
    * @throws ResultsProtocolFailure when the requested plan cannot be found, or aerie could not be reached
    */
-  private long getMerlinPlanRev(final String planId) {
+  private long getMerlinPlanRev(final PlanId planId) {
     try {
       return merlinService.getPlanRevision(planId);
     } catch (NoSuchPlanException | IOException e) {


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1639
* **Review:** By file  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This branch introduces the `PlanId` record, analogous to the `ActivityInstanceId` record introduced in [the other PR (UPDATE)]. There should be no changes to the system from an external perspective, as this merely changes the mechanism by which Plan IDs are passed around inside Merlin.

## Verification
System successfully builds, and simulation of a Banananation plan with the parent activity ran successfully. Plan was then modified to ensure updates to the plan by ID were successful, and simulations re-run. Everything worked as expected. I would also like to wait for the go ahead from @camargo before merging to prevent the need for any hotfixes as was found with the `ActivityInstanceId` record PR.

## Documentation
All changes internal to the system, no documentation update required.

## Future work
Perhaps we'll do this again for mission model ID? We could also consider just doing that now and add it onto this PR.
