### PR TITLE
[AERIE-1629] Computed Attributes in Simulation Results

### DIFF
--- a/deployment/postgres-init-db/sql/merlin/tables/activity_type.sql
+++ b/deployment/postgres-init-db/sql/merlin/tables/activity_type.sql
@@ -3,6 +3,7 @@ create table activity_type (
   name text not null,
   parameters merlin_parameter_set not null,
   required_parameters merlin_required_parameter_set not null,
+  computed_attributes_value_schema jsonb,
 
   constraint activity_type_natural_key
     primary key (model_id, name),
@@ -21,3 +22,7 @@ comment on column activity_type.model_id is e''
   'The model defining this activity type.';
 comment on column activity_type.parameters is e''
   'The set of parameters accepted by this activity type.';
+comment on column activity_type.required_parameters is e''
+  'A description of which parameters are required to be provided to instantiate this activity type';
+comment on column activity_type.computed_attributes_value_schema is e''
+  'The type of value returned by the effect model of this activity type';

--- a/deployment/postgres-init-db/sql/merlin/tables/span.sql
+++ b/deployment/postgres-init-db/sql/merlin/tables/span.sql
@@ -7,8 +7,7 @@ create table span (
   start_offset interval not null,
   duration interval null,
   type text not null,
-  attributes merlin_argument_set not null,
-  -- TODO: add time-ordered logs (events)
+  attributes jsonb not null,
 
   constraint span_synthetic_key
     primary key (dataset_id, id),

--- a/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/SimulatedActivityTest.java
+++ b/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/SimulatedActivityTest.java
@@ -26,8 +26,8 @@ public final class SimulatedActivityTest {
 
     assertEquals(1, simulationResults.simulatedActivities.size());
     simulationResults.simulatedActivities.forEach( (id, act) -> {
-        assertEquals(1, act.parameters.size());
-        assertTrue(act.parameters.containsKey("peelDirection"));
+        assertEquals(1, act.arguments.size());
+        assertTrue(act.arguments.containsKey("peelDirection"));
     });
   }
 }

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
@@ -69,7 +69,7 @@ public final class MissionModel<Model> {
       @Override
       public TaskStatus step(final Scheduler scheduler) {
         MissionModel.this.daemons.forEach(daemon -> scheduler.spawn(daemon.create()));
-        return TaskStatus.completed();
+        return TaskStatus.completed(Unit.UNIT);
       }
 
       @Override

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
@@ -3,7 +3,6 @@ package gov.nasa.jpl.aerie.merlin.driver;
 import gov.nasa.jpl.aerie.merlin.driver.engine.Directive;
 import gov.nasa.jpl.aerie.merlin.driver.timeline.LiveCells;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer;
-import gov.nasa.jpl.aerie.merlin.protocol.driver.Query;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.ConfigurationType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Resource;
@@ -12,8 +11,6 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.lang3.tuple.Triple;
 
 import java.util.Collections;
 import java.util.List;
@@ -64,7 +61,7 @@ public final class MissionModel<Model> {
   public Directive<Model, ?> instantiateDirective(final SerializedActivity specification)
   throws TaskSpecType.UnconstructableTaskSpecException
   {
-    return Directive.instantiate(this.taskSpecTypes.get(specification.getTypeName()), specification.getParameters());
+    return Directive.instantiate(this.taskSpecTypes.get(specification.getTypeName()), specification.getArguments());
   }
 
   public Task getDaemon() {

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
@@ -24,18 +24,18 @@ public final class MissionModel<Model> {
   private final LiveCells initialCells;
   private final Map<String, Resource<?>> resources;
   private final List<SerializableTopic<?>> topics;
-  private final Map<String, TaskSpecType<Model, ?>> taskSpecTypes;
+  private final Map<String, TaskSpecType<Model, ?, ?>> taskSpecTypes;
   private final Optional<ConfigurationType<?>> configurationType;
-  private final List<Initializer.TaskFactory> daemons;
+  private final List<Initializer.TaskFactory<?>> daemons;
 
   public MissionModel(
       final Model model,
       final LiveCells initialCells,
       final Map<String, Resource<?>> resources,
       final List<SerializableTopic<?>> topics,
-      final List<Initializer.TaskFactory> daemons,
+      final List<Initializer.TaskFactory<?>> daemons,
       final Optional<ConfigurationType<?>> configurationType,
-      final Map<String, TaskSpecType<Model, ?>> taskSpecTypes)
+      final Map<String, TaskSpecType<Model, ?, ?>> taskSpecTypes)
   {
     this.model = Objects.requireNonNull(model);
     this.initialCells = Objects.requireNonNull(initialCells);
@@ -54,20 +54,20 @@ public final class MissionModel<Model> {
     return this.configurationType;
   }
 
-  public Map<String, TaskSpecType<Model, ?>> getTaskSpecificationTypes() {
+  public Map<String, TaskSpecType<Model, ?, ?>> getTaskSpecificationTypes() {
     return this.taskSpecTypes;
   }
 
-  public Directive<Model, ?> instantiateDirective(final SerializedActivity specification)
+  public Directive<Model, ?, ?> instantiateDirective(final SerializedActivity specification)
   throws TaskSpecType.UnconstructableTaskSpecException
   {
     return Directive.instantiate(this.taskSpecTypes.get(specification.getTypeName()), specification.getArguments());
   }
 
-  public Task getDaemon() {
-    return new Task() {
+  public Task<Unit> getDaemon() {
+    return new Task<>() {
       @Override
-      public TaskStatus step(final Scheduler scheduler) {
+      public TaskStatus<Unit> step(final Scheduler scheduler) {
         MissionModel.this.daemons.forEach(daemon -> scheduler.spawn(daemon.create()));
         return TaskStatus.completed(Unit.UNIT);
       }

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelBuilder.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelBuilder.java
@@ -63,7 +63,7 @@ public final class MissionModelBuilder implements Initializer {
   }
 
   @Override
-  public String daemon(final TaskFactory task) {
+  public <Return> String daemon(final TaskFactory<Return> task) {
     return this.state.daemon(task);
   }
 
@@ -73,7 +73,7 @@ public final class MissionModelBuilder implements Initializer {
   }
 
   public <Model>
-  MissionModel<Model> build(final Model model, final Map<String, TaskSpecType<Model, ?>> taskSpecTypes) {
+  MissionModel<Model> build(final Model model, final Map<String, TaskSpecType<Model, ?, ?>> taskSpecTypes) {
     return this.state.build(model, taskSpecTypes);
   }
 
@@ -81,14 +81,14 @@ public final class MissionModelBuilder implements Initializer {
     MissionModelBuilderState withConfigurationType(ConfigurationType<?> configurationType);
 
     <Model>
-    MissionModel<Model> build(Model model, Map<String, TaskSpecType<Model, ?>> taskSpecTypes);
+    MissionModel<Model> build(Model model, Map<String, TaskSpecType<Model, ?, ?>> taskSpecTypes);
   }
 
   private final class UnbuiltState implements MissionModelBuilderState {
     private final LiveCells initialCells = new LiveCells(new CausalEventSource());
 
     private final Map<String, Resource<?>> resources = new HashMap<>();
-    private final List<TaskFactory> daemons = new ArrayList<>();
+    private final List<TaskFactory<?>> daemons = new ArrayList<>();
     private final List<MissionModel.SerializableTopic<?>> topics = new ArrayList<>();
 
     private ConfigurationType<?> configurationType;
@@ -144,7 +144,7 @@ public final class MissionModelBuilder implements Initializer {
     }
 
     @Override
-    public String daemon(final TaskFactory task) {
+    public <Return> String daemon(final TaskFactory<Return> task) {
       this.daemons.add(task);
       return null;  // TODO: get some way to refer to the daemon task
     }
@@ -157,7 +157,7 @@ public final class MissionModelBuilder implements Initializer {
 
     @Override
     public <Model>
-    MissionModel<Model> build(final Model model, final Map<String, TaskSpecType<Model, ?>> taskSpecTypes) {
+    MissionModel<Model> build(final Model model, final Map<String, TaskSpecType<Model, ?, ?>> taskSpecTypes) {
       final var missionModel = new MissionModel<>(
           model,
           this.initialCells,
@@ -208,7 +208,7 @@ public final class MissionModelBuilder implements Initializer {
     }
 
     @Override
-    public String daemon(final TaskFactory task) {
+    public <Return> String daemon(final TaskFactory<Return> task) {
       throw new IllegalStateException("Daemons cannot be added after the schema is built");
     }
 
@@ -219,7 +219,7 @@ public final class MissionModelBuilder implements Initializer {
 
     @Override
     public <Model>
-    MissionModel<Model> build(final Model model, final Map<String, TaskSpecType<Model, ?>> taskSpecTypes) {
+    MissionModel<Model> build(final Model model, final Map<String, TaskSpecType<Model, ?, ?>> taskSpecTypes) {
       throw new IllegalStateException("Cannot build a builder multiple times");
     }
   }

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SerializedActivity.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SerializedActivity.java
@@ -24,11 +24,11 @@ import static java.util.Collections.unmodifiableMap;
  */
 public final class SerializedActivity {
   private final String typeName;
-  private final Map<String, SerializedValue> parameters;
+  private final Map<String, SerializedValue> arguments;
 
-  public SerializedActivity(final String typeName, final Map<String, SerializedValue> parameters) {
+  public SerializedActivity(final String typeName, final Map<String, SerializedValue> arguments) {
     this.typeName = Objects.requireNonNull(typeName);
-    this.parameters = Objects.requireNonNull(parameters);
+    this.arguments = Objects.requireNonNull(arguments);
   }
 
   /**
@@ -45,8 +45,8 @@ public final class SerializedActivity {
    *
    * @return A map of serialized parameters keyed by parameter name.
    */
-  public Map<String, SerializedValue> getParameters() {
-    return unmodifiableMap(this.parameters);
+  public Map<String, SerializedValue> getArguments() {
+    return unmodifiableMap(this.arguments);
   }
 
   // SAFETY: If equals is overridden, then hashCode must also be overridden.
@@ -57,17 +57,17 @@ public final class SerializedActivity {
     final SerializedActivity other = (SerializedActivity)o;
     return
         (  Objects.equals(this.typeName, other.typeName)
-        && Objects.equals(this.parameters, other.parameters)
+        && Objects.equals(this.arguments, other.arguments)
         );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.typeName, this.parameters);
+    return Objects.hash(this.typeName, this.arguments);
   }
 
   @Override
   public String toString() {
-    return "SerializedActivity { typeName = " + this.typeName + ", parameters = " + this.parameters.toString() + " }";
+    return "SerializedActivity { typeName = " + this.typeName + ", arguments = " + this.arguments.toString() + " }";
   }
 }

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulatedActivity.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulatedActivity.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public final class SimulatedActivity {
   public final String type;
-  public final Map<String, SerializedValue> parameters;
+  public final Map<String, SerializedValue> arguments;
   public final Instant start;
   public final Duration duration;
   public final ActivityInstanceId parentId;
@@ -19,7 +19,7 @@ public final class SimulatedActivity {
 
   public SimulatedActivity(
       final String type,
-      final Map<String, SerializedValue> parameters,
+      final Map<String, SerializedValue> arguments,
       final Instant start,
       final Duration duration,
       final ActivityInstanceId parentId,
@@ -27,7 +27,7 @@ public final class SimulatedActivity {
       final Optional<ActivityInstanceId> directiveId
   ) {
     this.type = type;
-    this.parameters = parameters;
+    this.arguments = arguments;
     this.start = start;
     this.duration = duration;
     this.parentId = parentId;
@@ -40,7 +40,7 @@ public final class SimulatedActivity {
     return
         "SimulatedActivity "
         + "{ type=" + this.type
-        + ", parameters=" + this.parameters
+        + ", arguments=" + this.arguments
         + ", start=" + this.start
         + ", duration=" + this.duration
         + ", parentId=" + this.parentId

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulatedActivity.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulatedActivity.java
@@ -16,6 +16,7 @@ public final class SimulatedActivity {
   public final ActivityInstanceId parentId;
   public final List<ActivityInstanceId> childIds;
   public final Optional<ActivityInstanceId> directiveId;
+  public final SerializedValue computedAttributes;
 
   public SimulatedActivity(
       final String type,
@@ -24,7 +25,8 @@ public final class SimulatedActivity {
       final Duration duration,
       final ActivityInstanceId parentId,
       final List<ActivityInstanceId> childIds,
-      final Optional<ActivityInstanceId> directiveId
+      final Optional<ActivityInstanceId> directiveId,
+      final SerializedValue computedAttributes
   ) {
     this.type = type;
     this.arguments = arguments;
@@ -33,6 +35,7 @@ public final class SimulatedActivity {
     this.parentId = parentId;
     this.childIds = childIds;
     this.directiveId = directiveId;
+    this.computedAttributes = computedAttributes;
   }
 
   @Override

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
@@ -81,8 +81,8 @@ public final class SimulationDriver {
     }
   }
 
-  public static <Model>
-  void simulateTask(final MissionModel<Model> missionModel, final Task task) {
+  public static <Model, Return>
+  void simulateTask(final MissionModel<Model> missionModel, final Task<Return> task) {
     try (final var engine = new SimulationEngine()) {
       /* The top-level simulation timeline. */
       var timeline = new TemporalEventSource();
@@ -128,7 +128,7 @@ public final class SimulationDriver {
     }
   }
 
-  private static final class ControlTask implements Task {
+  private static final class ControlTask implements Task<Unit> {
     private final Map<ActivityInstanceId, Pair<Duration, SerializedActivity>> schedule;
 
     /* The directive that caused a task (if any). */
@@ -152,7 +152,7 @@ public final class SimulationDriver {
     }
 
     @Override
-    public TaskStatus step(final Scheduler scheduler) {
+    public TaskStatus<Unit> step(final Scheduler scheduler) {
       while (true) {
         var nextTask = this.scheduledTasks.peek();
         if (nextTask == null) break;

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
@@ -169,7 +169,7 @@ public final class SimulationDriver {
         final var directiveId = nextTask.getMiddle();
         final var specification = nextTask.getRight();
 
-        final var id = scheduler.spawn(specification.getTypeName(), specification.getParameters());
+        final var id = scheduler.spawn(specification.getTypeName(), specification.getArguments());
         this.taskToPlannedDirective.put(id, directiveId);
       }
 

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
@@ -173,7 +173,7 @@ public final class SimulationDriver {
         this.taskToPlannedDirective.put(id, directiveId);
       }
 
-      return TaskStatus.completed();
+      return TaskStatus.completed(Unit.UNIT);
     }
 
     @Override

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/Unit.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/Unit.java
@@ -1,0 +1,9 @@
+package gov.nasa.jpl.aerie.merlin.driver;
+
+/**
+ * Represents the return value for a task that returns no data.
+ */
+public enum Unit {
+  UNIT
+}
+

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/Directive.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/Directive.java
@@ -8,12 +8,12 @@ import java.util.Map;
 
 /** A directive to a specific mission model. */
 // TODO: Move this into the framework basement layer.
-public final record Directive<Model, DirectiveType> (
-    TaskSpecType<Model, DirectiveType> directiveType,
+public final record Directive<Model, DirectiveType, Return> (
+    TaskSpecType<Model, DirectiveType, Return> directiveType,
     DirectiveType directive
 ) {
-  public static <Model, DirectiveType> Directive<Model, DirectiveType>
-  instantiate(final @Nullable TaskSpecType<Model, DirectiveType> directiveType, final Map<String, SerializedValue> arguments)
+  public static <Model, DirectiveType, Return> Directive<Model, DirectiveType, Return>
+  instantiate(final @Nullable TaskSpecType<Model, DirectiveType, Return> directiveType, final Map<String, SerializedValue> arguments)
   throws TaskSpecType.UnconstructableTaskSpecException
   {
     if (directiveType == null) throw new TaskSpecType.UnconstructableTaskSpecException();
@@ -28,7 +28,7 @@ public final record Directive<Model, DirectiveType> (
     return this.directiveType.getArguments(this.directive);
   }
 
-  public Task createTask(final Model model) {
+  public Task<Return> createTask(final Model model) {
     return this.directiveType.createTask(model, this.directive);
   }
 

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -472,7 +472,8 @@ public final class SimulationEngine implements AutoCloseable {
             e.joinOffset().minus(e.startOffset()),
             activityParents.get(activityId),
             activityChildren.getOrDefault(activityId, Collections.emptyList()),
-            (activityParents.containsKey(activityId)) ? Optional.empty() : Optional.of(activityId)
+            (activityParents.containsKey(activityId)) ? Optional.empty() : Optional.of(activityId),
+            serializeReturnValue(directive, e.returnValue())
         ));
       } else {
         unsimulatedActivities.put(activityId, new SerializedActivity(
@@ -522,6 +523,16 @@ public final class SimulationEngine implements AutoCloseable {
                                  topics,
                                  serializedTimeline);
   }
+
+  @SuppressWarnings("unchecked")
+  private static <DirectiveReturn, TaskReturn> SerializedValue serializeReturnValue(
+      final Directive<?, ?, DirectiveReturn> directive,
+      final TaskReturn taskReturnValue
+  ) {
+    // SAFETY: Tasks always return the same type as the TaskSpecType that declares them
+    return directive.directiveType().serializeReturnValue((DirectiveReturn) taskReturnValue);
+  }
+
 
   private <EventType> Optional<SerializedValue> trySerializeEvent(Event event, MissionModel.SerializableTopic<EventType> serializableTopic) {
     return event.extract(topicOfSerializableTopic(serializableTopic), serializableTopic.serializer());

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/TaskSource.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/TaskSource.java
@@ -3,6 +3,6 @@ package gov.nasa.jpl.aerie.merlin.driver.engine;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
 
 /** The source of the definition of a task's behavior. */
-public interface TaskSource {
-  Task createTask();
+public interface TaskSource<Return> {
+  Task<Return> createTask();
 }

--- a/merlin-framework-junit/src/main/java/gov/nasa/jpl/aerie/merlin/framework/junit/MerlinTestContext.java
+++ b/merlin-framework-junit/src/main/java/gov/nasa/jpl/aerie/merlin/framework/junit/MerlinTestContext.java
@@ -9,13 +9,13 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 public final class MerlinTestContext<Model> {
   private final Registrar registrar;
   private Model model;
-  private Map<String, TaskSpecType<RootModel<Model>, ?>> activityTypes = Map.of();
+  private Map<String, TaskSpecType<RootModel<Model>, ?, ?>> activityTypes = Map.of();
 
   public MerlinTestContext(final Registrar registrar) {
     this.registrar = registrar;
   }
 
-  public void use(final Model model, final Map<String, TaskSpecType<RootModel<Model>, ?>> activityTypes) {
+  public void use(final Model model, final Map<String, TaskSpecType<RootModel<Model>, ?, ?>> activityTypes) {
     this.model = model;
     this.activityTypes = activityTypes;
   }
@@ -28,7 +28,7 @@ public final class MerlinTestContext<Model> {
     return model;
   }
 
-  public Map<String, TaskSpecType<RootModel<Model>, ?>> activityTypes() {
+  public Map<String, TaskSpecType<RootModel<Model>, ?, ?>> activityTypes() {
     return activityTypes;
   }
 }

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
@@ -10,6 +10,7 @@ import gov.nasa.jpl.aerie.merlin.processor.metamodel.ConfigurationTypeRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ParameterRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityTypeRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ParameterValidationRecord;
+import gov.nasa.jpl.aerie.merlin.processor.metamodel.EffectModelRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.MissionModelRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.TypeRule;
 
@@ -341,7 +342,7 @@ import java.util.function.Predicate;
         .toList();
   }
 
-  private Optional<Pair<String, ActivityType.Executor>> getActivityEffectModel(final TypeElement activityTypeElement)
+  private Optional<EffectModelRecord> getActivityEffectModel(final TypeElement activityTypeElement)
   {
     for (final var element : activityTypeElement.getEnclosedElements()) {
       if (element.getKind() != ElementKind.METHOD) continue;
@@ -349,7 +350,7 @@ import java.util.function.Predicate;
       final var executorAnnotation = element.getAnnotation(ActivityType.EffectModel.class);
       if (executorAnnotation == null) continue;
 
-      return Optional.of(Pair.of(element.getSimpleName().toString(), executorAnnotation.value()));
+      return Optional.of(new EffectModelRecord(element.getSimpleName().toString(), executorAnnotation.value()));
     }
 
     return Optional.empty();

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
@@ -25,6 +25,8 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import java.lang.annotation.Annotation;
@@ -350,7 +352,14 @@ import java.util.function.Predicate;
       final var executorAnnotation = element.getAnnotation(ActivityType.EffectModel.class);
       if (executorAnnotation == null) continue;
 
-      return Optional.of(new EffectModelRecord(element.getSimpleName().toString(), executorAnnotation.value()));
+      if (!(element instanceof ExecutableElement executableElement)) continue;
+
+      final var returnType = executableElement.getReturnType();
+      final var nonVoidReturnType = returnType.getKind() == TypeKind.VOID
+          ? Optional.<TypeMirror>empty()
+          : Optional.of(returnType);
+
+      return Optional.of(new EffectModelRecord(element.getSimpleName().toString(), executorAnnotation.value(), nonVoidReturnType));
     }
 
     return Optional.empty();

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -530,14 +530,14 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                     Modifier.FINAL)
                 .addCode(
                     activityType.effectModel()
-                        .map(effectModel -> switch (effectModel.getRight()) {
+                        .map(effectModel -> switch (effectModel.executor()) {
                           case Threaded -> CodeBlock
                               .builder()
                               .addStatement(
                                   "return $T.threaded(() -> $L.$L($L.model())).create($L.executor())",
                                   gov.nasa.jpl.aerie.merlin.framework.ModelActions.class,
                                   "activity",
-                                  effectModel.getLeft(),
+                                  effectModel.methodName(),
                                   "model",
                                   "model")
                               .build();
@@ -548,7 +548,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                   "return $T.replaying(() -> $L.$L($L.model())).create($L.executor())",
                                   gov.nasa.jpl.aerie.merlin.framework.ModelActions.class,
                                   "activity",
-                                  effectModel.getLeft(),
+                                  effectModel.methodName(),
                                   "model",
                                   "model")
                               .build();

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -12,10 +12,13 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.WildcardTypeName;
 import gov.nasa.jpl.aerie.merlin.framework.VoidEnum;
+import gov.nasa.jpl.aerie.contrib.serialization.mappers.EnumValueMapper;
+import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
 import gov.nasa.jpl.aerie.merlin.processor.MissionModelProcessor;
 import gov.nasa.jpl.aerie.merlin.processor.Resolver;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityTypeRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ConfigurationTypeRecord;
+import gov.nasa.jpl.aerie.merlin.processor.metamodel.EffectModelRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.MissionModelRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ExportTypeRecord;
 import gov.nasa.jpl.aerie.merlin.protocol.model.ConfigurationType;
@@ -36,6 +39,8 @@ import javax.tools.Diagnostic;
 
 /** Auto-generates Java source files from mission model metamodels. */
 public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Messager messager) {
+
+  private static final String COMPUTED_ATTRIBUTES_VALUE_MAPPER_FIELD_NAME = "computedAttributesValueMapper";
 
   /** Generate `GeneratedMerlinPlugin` class. */
   public JavaFile generateMerlinPlugin(final MissionModelRecord missionModel) {
@@ -423,6 +428,8 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
         .build();
   }
 
+  private record ComputedAttributesCodeBlocks(TypeName typeName, FieldSpec fieldDef, CodeBlock fieldInit) {}
+
   /** Generate common `${activity_name}Mapper` methods. */
   public Optional<TypeSpec> generateCommonMapperMethods(final MissionModelRecord missionModel, final ExportTypeRecord exportType) {
     final var maybeMapperBlocks = generateParameterMapperBlocks(missionModel, exportType);
@@ -434,15 +441,23 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
     // TODO currently only 2 permitted classes (activity and config. type records),
     //  this should be changed to a switch expression once sealed class pattern-matching switch expressions exist
     final TypeName superInterface;
-    if (exportType instanceof ActivityTypeRecord) {
+    final Optional<ComputedAttributesCodeBlocks> computedAttributesCodeBlocks;
+    if (exportType instanceof ActivityTypeRecord activityType) {
+      computedAttributesCodeBlocks = this.getComputedAttributesCodeBlocks(
+          missionModel,
+          activityType);
+      if (computedAttributesCodeBlocks.isEmpty()) {
+        return Optional.empty();
+      }
       superInterface = ParameterizedTypeName.get(
           ClassName.get(gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType.class),
           ParameterizedTypeName.get(
               ClassName.get(gov.nasa.jpl.aerie.merlin.framework.RootModel.class),
               ClassName.get(missionModel.topLevelModel)),
           ClassName.get(exportType.declaration()),
-          ClassName.get(VoidEnum.class));
+          computedAttributesCodeBlocks.get().typeName().box());
     } else { // is instanceof ConfigurationTypeRecord
+      computedAttributesCodeBlocks = Optional.empty();
       superInterface = ParameterizedTypeName.get(
           ClassName.get(gov.nasa.jpl.aerie.merlin.protocol.model.ConfigurationType.class),
           ClassName.get(exportType.declaration()));
@@ -474,6 +489,11 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                     .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
                     .build())
                 .collect(Collectors.toList()))
+        .addFields(
+            computedAttributesCodeBlocks
+                .stream()
+                .map(codeBlocks -> codeBlocks.fieldDef())
+                .collect(Collectors.toList()))
         .addMethod(
             MethodSpec
                 .constructorBuilder()
@@ -497,6 +517,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                 mapperBlocks.get(parameter.name)))
                         .reduce(CodeBlock.builder(), (x, y) -> x.add(y.build()))
                         .build())
+                .addCode(computedAttributesCodeBlocks.map(ComputedAttributesCodeBlocks::fieldInit).orElse(CodeBlock.of("")))
                 .build())
         .addMethod(
             MethodSpec
@@ -514,6 +535,50 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
         .build());
   }
 
+  private Optional<ComputedAttributesCodeBlocks> getComputedAttributesCodeBlocks(
+      final MissionModelRecord missionModel,
+      final ActivityTypeRecord activityType)
+  {
+    final Optional<CodeBlock> effectModelReturnMapperBlock;
+    final TypeName computedAttributesTypeName;
+    final Optional<EffectModelRecord> effectModel;
+    effectModel = activityType.effectModel();
+    final var typeMirror = effectModel.flatMap(EffectModelRecord::returnType);
+    if (typeMirror.isPresent()) {
+      effectModelReturnMapperBlock = new Resolver(this.typeUtils, this.elementUtils, missionModel.typeRules)
+                  .instantiateNullableMapperFor(typeMirror.get());
+      if (effectModelReturnMapperBlock.isEmpty()) {
+        this.messager.printMessage(
+            Diagnostic.Kind.ERROR,
+            "Failed to generate value mapper for effect model return type "
+            + typeMirror.get()
+            + " of activity "
+            + activityType.name());
+        return Optional.empty();
+      }
+      computedAttributesTypeName = TypeName.get(typeMirror.get());
+    } else {
+      effectModelReturnMapperBlock = Optional.of(CodeBlock.of("new $T(VoidEnum.class)", EnumValueMapper.class));
+      computedAttributesTypeName = TypeName.get(VoidEnum.class);
+    }
+    return Optional.of(new ComputedAttributesCodeBlocks(
+        computedAttributesTypeName,
+        FieldSpec
+            .builder(
+                ParameterizedTypeName.get(
+                    ClassName.get(ValueMapper.class),
+                    computedAttributesTypeName.box()),
+                COMPUTED_ATTRIBUTES_VALUE_MAPPER_FIELD_NAME)
+            .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+            .build(),
+        CodeBlock
+            .builder()
+            .addStatement(
+                "this.$L =\n$L",
+                COMPUTED_ATTRIBUTES_VALUE_MAPPER_FIELD_NAME,
+                effectModelReturnMapperBlock.get()).build()));
+  }
+
   /** Generate `${activity_name}Mapper` class. */
   public Optional<JavaFile> generateActivityMapper(final MissionModelRecord missionModel, final ActivityTypeRecord activityType) {
     return generateCommonMapperMethods(missionModel, activityType).map(typeSpec -> typeSpec.toBuilder()
@@ -524,7 +589,11 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                 .addAnnotation(Override.class)
                 .returns(ParameterizedTypeName.get(
                     ClassName.get(gov.nasa.jpl.aerie.merlin.protocol.model.Task.class),
-                    ClassName.get(VoidEnum.class)))
+                    activityType
+                        .effectModel()
+                        .flatMap(EffectModelRecord::returnType)
+                        .map(returnType -> TypeName.get(returnType).box())
+                        .orElse(TypeName.get(VoidEnum.class))))
                 .addParameter(
                     ParameterizedTypeName.get(
                         ClassName.get(gov.nasa.jpl.aerie.merlin.framework.RootModel.class),

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -530,29 +530,20 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                     Modifier.FINAL)
                 .addCode(
                     activityType.effectModel()
-                        .map(effectModel -> switch (effectModel.executor()) {
-                          case Threaded -> CodeBlock
+                        .map(effectModel -> CodeBlock
                               .builder()
                               .addStatement(
-                                  "return $T.threaded(() -> $L.$L($L.model())).create($L.executor())",
+                                  "return $T.$L(() -> $L.$L($L.model())).create($L.executor())",
                                   gov.nasa.jpl.aerie.merlin.framework.ModelActions.class,
+                                  switch (effectModel.executor()) {
+                                    case Threaded -> "threaded";
+                                    case Replaying -> "replaying";
+                                  },
                                   "activity",
                                   effectModel.methodName(),
                                   "model",
                                   "model")
-                              .build();
-
-                          case Replaying -> CodeBlock
-                              .builder()
-                              .addStatement(
-                                  "return $T.replaying(() -> $L.$L($L.model())).create($L.executor())",
-                                  gov.nasa.jpl.aerie.merlin.framework.ModelActions.class,
-                                  "activity",
-                                  effectModel.methodName(),
-                                  "model",
-                                  "model")
-                              .build();
-                        })
+                              .build())
                         .orElseGet(() -> CodeBlock
                             .builder()
                             .addStatement(

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -11,6 +11,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.WildcardTypeName;
+import gov.nasa.jpl.aerie.merlin.framework.VoidEnum;
 import gov.nasa.jpl.aerie.merlin.processor.MissionModelProcessor;
 import gov.nasa.jpl.aerie.merlin.processor.Resolver;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityTypeRecord;
@@ -131,6 +132,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                             ParameterizedTypeName.get(
                                 ClassName.get(gov.nasa.jpl.aerie.merlin.framework.RootModel.class),
                                 ClassName.get(missionModel.topLevelModel)),
+                            WildcardTypeName.subtypeOf(Object.class),
                             WildcardTypeName.subtypeOf(Object.class))))
                     .addStatement("return $T.activityTypes", missionModel.getTypesName())
                     .build())
@@ -379,6 +381,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                 ParameterizedTypeName.get(
                                     ClassName.get(gov.nasa.jpl.aerie.merlin.framework.RootModel.class),
                                     ClassName.get(missionModel.topLevelModel)),
+                                WildcardTypeName.subtypeOf(Object.class),
                                 WildcardTypeName.subtypeOf(Object.class))),
                         "activityTypeList",
                         Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
@@ -403,6 +406,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                 ParameterizedTypeName.get(
                                     ClassName.get(gov.nasa.jpl.aerie.merlin.framework.RootModel.class),
                                     ClassName.get(missionModel.topLevelModel)),
+                                WildcardTypeName.subtypeOf(Object.class),
                                 WildcardTypeName.subtypeOf(Object.class))),
                         "activityTypes",
                         Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
@@ -436,7 +440,8 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
           ParameterizedTypeName.get(
               ClassName.get(gov.nasa.jpl.aerie.merlin.framework.RootModel.class),
               ClassName.get(missionModel.topLevelModel)),
-          ClassName.get(exportType.declaration()));
+          ClassName.get(exportType.declaration()),
+          ClassName.get(VoidEnum.class));
     } else { // is instanceof ConfigurationTypeRecord
       superInterface = ParameterizedTypeName.get(
           ClassName.get(gov.nasa.jpl.aerie.merlin.protocol.model.ConfigurationType.class),
@@ -517,7 +522,9 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                 .methodBuilder("createTask")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(Override.class)
-                .returns(ClassName.get(gov.nasa.jpl.aerie.merlin.protocol.model.Task.class))
+                .returns(ParameterizedTypeName.get(
+                    ClassName.get(gov.nasa.jpl.aerie.merlin.protocol.model.Task.class),
+                    ClassName.get(VoidEnum.class)))
                 .addParameter(
                     ParameterizedTypeName.get(
                         ClassName.get(gov.nasa.jpl.aerie.merlin.framework.RootModel.class),

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -25,6 +25,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.ConfigurationType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.MerlinPlugin;
 import gov.nasa.jpl.aerie.merlin.protocol.model.MissionModelFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
 import java.util.HashMap;
 import java.util.List;
@@ -582,6 +583,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
   /** Generate `${activity_name}Mapper` class. */
   public Optional<JavaFile> generateActivityMapper(final MissionModelRecord missionModel, final ActivityTypeRecord activityType) {
     return generateCommonMapperMethods(missionModel, activityType).map(typeSpec -> typeSpec.toBuilder()
+        .addMethod(makeGetReturnValueSchemaMethod())
         .addMethod(
             MethodSpec
                 .methodBuilder("createTask")
@@ -632,6 +634,15 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
             .builder(activityType.mapper().name.packageName(), typeSpec)
             .skipJavaLangImports(true)
             .build());
+  }
+
+  private static MethodSpec makeGetReturnValueSchemaMethod() {
+    return MethodSpec.methodBuilder("getReturnValueSchema")
+                     .addModifiers(Modifier.PUBLIC)
+                     .addAnnotation(Override.class)
+                     .returns(ValueSchema.class)
+                     .addStatement("return this." + COMPUTED_ATTRIBUTES_VALUE_MAPPER_FIELD_NAME + ".getValueSchema()")
+                     .build();
   }
 
   private Optional<Map<String, CodeBlock>> generateParameterMapperBlocks(final MissionModelRecord missionModel, final ExportTypeRecord exportType)

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ActivityTypeRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ActivityTypeRecord.java
@@ -1,7 +1,5 @@
 package gov.nasa.jpl.aerie.merlin.processor.metamodel;
 
-import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
-import org.apache.commons.lang3.tuple.Pair;
 
 import javax.lang.model.element.TypeElement;
 import java.util.List;
@@ -14,5 +12,5 @@ public record ActivityTypeRecord(
     List<ParameterValidationRecord> validations,
     MapperRecord mapper,
     ExportDefaultsStyle defaultsStyle,
-    Optional<Pair<String, ActivityType.Executor>> effectModel
+    Optional<EffectModelRecord> effectModel
   ) implements ExportTypeRecord { }

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
@@ -1,0 +1,6 @@
+package gov.nasa.jpl.aerie.merlin.processor.metamodel;
+
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+
+public record EffectModelRecord(String methodName, ActivityType.Executor executor) {
+}

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
@@ -2,5 +2,8 @@ package gov.nasa.jpl.aerie.merlin.processor.metamodel;
 
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 
-public record EffectModelRecord(String methodName, ActivityType.Executor executor) {
+import javax.lang.model.type.TypeMirror;
+import java.util.Optional;
+
+public record EffectModelRecord(String methodName, ActivityType.Executor executor, Optional<TypeMirror> returnType) {
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
@@ -32,9 +32,9 @@ public interface Context {
   // Usable during simulation
   <Event> void emit(Event event, Query<Event, ?> query);
 
-  interface TaskFactory { Task create(ExecutorService executor); }
+  interface TaskFactory<Return> { Task<Return> create(ExecutorService executor); }
 
-  String spawn(TaskFactory task);
+  <Return> String spawn(TaskFactory<Return> task);
   String spawn(String type, Map<String, SerializedValue> arguments);
 
   void delay(Duration duration);

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
@@ -56,7 +56,7 @@ public final class InitializationContext implements Context {
   }
 
   @Override
-  public String spawn(final TaskFactory task) {
+  public <Return> String spawn(final TaskFactory<Return> task) {
     return this.builder.daemon(() -> task.create(InitializationContext.this.executor));
   }
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
@@ -13,22 +13,22 @@ public /*non-final*/ class ModelActions {
   static final Scoped<Context> context = Scoped.create();
 
 
-  public static <T> Context.TaskFactory threaded(final Supplier<T> task) {
+  public static <T> Context.TaskFactory<T> threaded(final Supplier<T> task) {
     return executor -> new ThreadedTask<>(executor, ModelActions.context, task);
   }
 
-  public static Context.TaskFactory threaded(final Runnable task) {
+  public static Context.TaskFactory<VoidEnum> threaded(final Runnable task) {
     return threaded(() -> {
       task.run();
       return VoidEnum.VOID;
     });
   }
 
-  public static <T> Context.TaskFactory replaying(final Supplier<T> task) {
+  public static <T> Context.TaskFactory<T> replaying(final Supplier<T> task) {
     return executor -> new ReplayingTask<>(executor, ModelActions.context, task);
   }
 
-  public static Context.TaskFactory replaying(final Runnable task) {
+  public static Context.TaskFactory<VoidEnum> replaying(final Runnable task) {
     return replaying(() -> {
       task.run();
       return VoidEnum.VOID;
@@ -47,7 +47,7 @@ public /*non-final*/ class ModelActions {
     });
   }
 
-  public static String spawn(final Context.TaskFactory task) {
+  public static <T> String spawn(final Context.TaskFactory<T> task) {
     return context.get().spawn(task);
   }
 
@@ -63,7 +63,7 @@ public /*non-final*/ class ModelActions {
     call(threaded(task));
   }
 
-  public static void call(final Context.TaskFactory task) {
+  public static <T> void call(final Context.TaskFactory<T> task) {
     waitFor(spawn(task));
   }
 
@@ -75,7 +75,7 @@ public /*non-final*/ class ModelActions {
     return spawn(replaying(() -> { delay(duration); spawn(task); }));
   }
 
-  public static String defer(final Duration duration, final Context.TaskFactory task) {
+  public static String defer(final Duration duration, final Context.TaskFactory<?> task) {
     return spawn(replaying(() -> { delay(duration); spawn(task); }));
   }
 
@@ -87,7 +87,7 @@ public /*non-final*/ class ModelActions {
     return spawn(replaying(() -> { delay(quantity, unit); spawn(task); }));
   }
 
-  public static String defer(final long quantity, final Duration unit, final Context.TaskFactory task) {
+  public static String defer(final long quantity, final Duration unit, final Context.TaskFactory<?> task) {
     return spawn(replaying(() -> { delay(quantity, unit); spawn(task); }));
   }
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/OneShotTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/OneShotTask.java
@@ -7,7 +7,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 import java.util.Objects;
 import java.util.function.Consumer;
 
-public final class OneShotTask implements Task {
+public final class OneShotTask implements Task<VoidEnum> {
   private final Consumer<Scheduler> task;
   private boolean isTerminated = false;
 
@@ -16,7 +16,7 @@ public final class OneShotTask implements Task {
   }
 
   @Override
-  public TaskStatus step(final Scheduler scheduler) {
+  public TaskStatus<VoidEnum> step(final Scheduler scheduler) {
     if (this.isTerminated) throw new IllegalStateException("step() called on a terminated task");
 
     this.task.accept(scheduler);

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/OneShotTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/OneShotTask.java
@@ -22,7 +22,7 @@ public final class OneShotTask implements Task {
     this.task.accept(scheduler);
 
     this.isTerminated = true;
-    return TaskStatus.completed();
+    return TaskStatus.completed(VoidEnum.VOID);
   }
 
   @Override

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
@@ -17,10 +17,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /* package-local */
-final class ReplayingReactionContext implements Context {
+final class ReplayingReactionContext<Return> implements Context {
   private final ExecutorService executor;
   private final Scoped<Context> rootContext;
-  private final TaskHandle handle;
+  private final TaskHandle<Return> handle;
   private Scheduler scheduler;
 
   private final MemoryCursor memory;
@@ -30,7 +30,7 @@ final class ReplayingReactionContext implements Context {
       final Scoped<Context> rootContext,
       final Memory memory,
       final Scheduler scheduler,
-      final TaskHandle handle)
+      final TaskHandle<Return> handle)
   {
     this.executor = Objects.requireNonNull(executor);
     this.rootContext = Objects.requireNonNull(rootContext);
@@ -69,7 +69,7 @@ final class ReplayingReactionContext implements Context {
   }
 
   @Override
-  public String spawn(final TaskFactory task) {
+  public <T> String spawn(final TaskFactory<T> task) {
     return this.memory.doOnce(() -> {
       return this.scheduler.spawn(task.create(this.executor));
     });

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingTask.java
@@ -10,23 +10,23 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.concurrent.ExecutorService;
 
-public final class ReplayingTask<ReturnType> implements Task {
+public final class ReplayingTask<Return> implements Task<Return> {
   private final ExecutorService executor;
   private final Scoped<Context> rootContext;
-  private final Supplier<ReturnType> task;
+  private final Supplier<Return> task;
 
   private final ReplayingReactionContext.Memory memory = new ReplayingReactionContext.Memory(new ArrayList<>(), new MutableInt(0));
 
-  public ReplayingTask(final ExecutorService executor, final Scoped<Context> rootContext, final Supplier<ReturnType> task) {
+  public ReplayingTask(final ExecutorService executor, final Scoped<Context> rootContext, final Supplier<Return> task) {
     this.executor = Objects.requireNonNull(executor);
     this.rootContext = Objects.requireNonNull(rootContext);
     this.task = Objects.requireNonNull(task);
   }
 
   @Override
-  public TaskStatus step(final Scheduler scheduler) {
-    final var handle = new ReplayingTaskHandle();
-    final var context = new ReplayingReactionContext(this.executor, this.rootContext, this.memory, scheduler, handle);
+  public TaskStatus<Return> step(final Scheduler scheduler) {
+    final var handle = new ReplayingTaskHandle<Return>();
+    final var context = new ReplayingReactionContext<>(this.executor, this.rootContext, this.memory, scheduler, handle);
 
     try (final var restore = this.rootContext.set(context)){
       final var returnValue = this.task.get();
@@ -44,11 +44,11 @@ public final class ReplayingTask<ReturnType> implements Task {
     this.memory.clear();
   }
 
-  private static final class ReplayingTaskHandle implements TaskHandle {
-    public TaskStatus status = TaskStatus.completed(VoidEnum.VOID);
+  private static final class ReplayingTaskHandle<Return> implements TaskHandle<Return> {
+    public TaskStatus<Return> status = TaskStatus.completed(null);
 
     @Override
-    public Scheduler yield(final TaskStatus status) {
+    public Scheduler yield(final TaskStatus<Return> status) {
       this.status = status;
       throw Yield;
     }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/TaskHandle.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/TaskHandle.java
@@ -3,6 +3,6 @@ package gov.nasa.jpl.aerie.merlin.framework;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 
-public interface TaskHandle {
-  Scheduler yield(TaskStatus status);
+public interface TaskHandle<Return> {
+  Scheduler yield(TaskStatus<Return> status);
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
@@ -14,17 +14,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
 /* package-local */
-final class ThreadedReactionContext implements Context {
+final class ThreadedReactionContext<Return> implements Context {
   private final ExecutorService executor;
   private final Scoped<Context> rootContext;
-  private final TaskHandle handle;
+  private final TaskHandle<Return> handle;
   private Scheduler scheduler;
 
   public ThreadedReactionContext(
       final ExecutorService executor,
       final Scoped<Context> rootContext,
       final Scheduler scheduler,
-      final TaskHandle handle)
+      final TaskHandle<Return> handle)
   {
     this.executor = Objects.requireNonNull(executor);
     this.rootContext = Objects.requireNonNull(rootContext);
@@ -58,7 +58,7 @@ final class ThreadedReactionContext implements Context {
   }
 
   @Override
-  public String spawn(final TaskFactory task) {
+  public <T> String spawn(final TaskFactory<T> task) {
     return this.scheduler.spawn(task.create(this.executor));
   }
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/VoidEnum.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/VoidEnum.java
@@ -1,0 +1,12 @@
+package gov.nasa.jpl.aerie.merlin.framework;
+
+/**
+ * The VoidEnum represents a "Unit" type, which is a type that allows only one value (and thus can hold no information)
+ * It is useful as a return type for void functions. It is in some cases preferable to Java's
+ * Void type (capital V) because its single value is not null, but rather VoidEnum.VOID.
+ *
+ * https://en.wikipedia.org/wiki/Unit_type
+ */
+public enum VoidEnum {
+  VOID
+}

--- a/merlin-framework/src/test/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTaskTest.java
+++ b/merlin-framework/src/test/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTaskTest.java
@@ -43,7 +43,7 @@ public final class ThreadedTaskTest {
     try {
       class TestException extends RuntimeException {}
 
-      final var task = new ThreadedTask(
+      final var task = new ThreadedTask<>(
         pool,
         Scoped.create(),
         () -> { throw new TestException(); });

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Initializer.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Initializer.java
@@ -19,13 +19,13 @@ public interface Initializer {
       EffectTrait<Effect> trait,
       Function<Event, Effect> projection);
 
-  String daemon(TaskFactory factory);
+  <Return> String daemon(TaskFactory<Return> factory);
 
   void resource(String name, Resource<?> resource);
 
   <Event> void topic(String name, Query<Event, ?> query, ValueSchema schema, Function<Event, SerializedValue> serializer);
 
-  interface TaskFactory {
-    Task create();
+  interface TaskFactory<Return> {
+    Task<Return> create();
   }
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Scheduler.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Scheduler.java
@@ -10,6 +10,6 @@ public interface Scheduler {
 
   <Event> void emit(Event event, Query<? super Event, ?> query);
 
-  String spawn(Task task);
+  <Return> String spawn(Task<Return> task);
   String spawn(String type, Map<String, SerializedValue> arguments);
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/MissionModelFactory.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/MissionModelFactory.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public interface MissionModelFactory<Model> {
   Optional<ConfigurationType<?>> getConfigurationType();
-  Map<String, TaskSpecType<Model, ?>> getTaskSpecTypes();
+  Map<String, TaskSpecType<Model, ?, ?>> getTaskSpecTypes();
   List<Parameter> getParameters();
   Model instantiate(SerializedValue configuration, Initializer builder) throws MissionModelInstantiationException;
 

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/Task.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/Task.java
@@ -3,14 +3,14 @@ package gov.nasa.jpl.aerie.merlin.protocol.model;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 
-public interface Task extends AutoCloseable {
+public interface Task<Return> extends AutoCloseable {
   /**
    * Perform one step of the task, returning the conditions under which to progress to the next step.
    *
    * If this method returns {@link TaskStatus.Completed}, then any system resources held must be released.
    * See {@link #reset()} for more details on resource management.
    */
-  TaskStatus step(Scheduler scheduler);
+  TaskStatus<Return> step(Scheduler scheduler);
 
   /**
    * Reset this task to its state before {@link #step(Scheduler)} was ever called.

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
@@ -6,7 +6,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import java.util.List;
 import java.util.Map;
 
-public interface TaskSpecType<Model, Specification> {
+public interface TaskSpecType<Model, Specification, Return> {
   String getName();
   List<Parameter> getParameters();
   List<String> getRequiredParameters();
@@ -17,7 +17,7 @@ public interface TaskSpecType<Model, Specification> {
   Map<String, SerializedValue> getArguments(Specification taskSpec);
   List<String> getValidationFailures(Specification taskSpec);
 
-  Task createTask(Model model, Specification taskSpec);
+  Task<Return> createTask(Model model, Specification taskSpec);
 
   class UnconstructableTaskSpecException extends Exception {}
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
@@ -20,6 +20,7 @@ public interface TaskSpecType<Model, Specification, Return> {
 
   Task<Return> createTask(Model model, Specification taskSpec);
   ValueSchema getReturnValueSchema();
+  SerializedValue serializeReturnValue(Return returnValue);
 
   class UnconstructableTaskSpecException extends Exception {}
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.protocol.model;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
 import java.util.List;
 import java.util.Map;
@@ -18,6 +19,7 @@ public interface TaskSpecType<Model, Specification, Return> {
   List<String> getValidationFailures(Specification taskSpec);
 
   Task<Return> createTask(Model model, Specification taskSpec);
+  ValueSchema getReturnValueSchema();
 
   class UnconstructableTaskSpecException extends Exception {}
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskStatus.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskStatus.java
@@ -3,7 +3,7 @@ package gov.nasa.jpl.aerie.merlin.protocol.types;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Condition;
 
 public sealed interface TaskStatus {
-  record Completed() implements TaskStatus {}
+  record Completed<Return>(Return returnValue) implements TaskStatus {}
 
   record Delayed(Duration delay) implements TaskStatus {}
 
@@ -12,8 +12,8 @@ public sealed interface TaskStatus {
   record AwaitingCondition(Condition condition) implements TaskStatus {}
 
 
-  static Completed completed() {
-    return new Completed();
+  static <Return> Completed<Return> completed(final Return returnValue) {
+    return new Completed<>(returnValue);
   }
 
   static Delayed delayed(final Duration delay) {

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskStatus.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskStatus.java
@@ -2,29 +2,29 @@ package gov.nasa.jpl.aerie.merlin.protocol.types;
 
 import gov.nasa.jpl.aerie.merlin.protocol.model.Condition;
 
-public sealed interface TaskStatus {
-  record Completed<Return>(Return returnValue) implements TaskStatus {}
+public sealed interface TaskStatus<Return> {
+  record Completed<Return>(Return returnValue) implements TaskStatus<Return> {}
 
-  record Delayed(Duration delay) implements TaskStatus {}
+  record Delayed<Return>(Duration delay) implements TaskStatus<Return> {}
 
-  record AwaitingTask(String target) implements TaskStatus {}
+  record AwaitingTask<Return>(String target) implements TaskStatus<Return> {}
 
-  record AwaitingCondition(Condition condition) implements TaskStatus {}
+  record AwaitingCondition<Return>(Condition condition) implements TaskStatus<Return> {}
 
 
   static <Return> Completed<Return> completed(final Return returnValue) {
     return new Completed<>(returnValue);
   }
 
-  static Delayed delayed(final Duration delay) {
-    return new Delayed(delay);
+  static <Return> Delayed<Return> delayed(final Duration delay) {
+    return new Delayed<>(delay);
   }
 
-  static AwaitingTask awaiting(final String id) {
-    return new AwaitingTask(id);
+  static <Return> AwaitingTask<Return> awaiting(final String id) {
+    return new AwaitingTask<>(id);
   }
 
-  static AwaitingCondition awaiting(final Condition condition) {
-    return new AwaitingCondition(condition);
+  static <Return> AwaitingCondition<Return> awaiting(final Condition condition) {
+    return new AwaitingCondition<>(condition);
   }
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/ValueSchema.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/ValueSchema.java
@@ -516,15 +516,9 @@ public abstract class ValueSchema {
     });
   }
 
-  public static final class Variant {
-    /** The unique internal name of this variant. */
-    public final String key;
-    /** The user-facing presentation of this variant. */
-    public final String label;
-
-    public Variant(final String key, final String label) {
-      this.key = Objects.requireNonNull(key);
-      this.label = Objects.requireNonNull(label);
-    }
-  }
+  /**
+   * @param key The unique internal name of this variant
+   * @param label The user-facing presentation of this variant
+   */
+  public record Variant(String key, String label) {}
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -163,7 +163,7 @@ public final class MerlinBindings implements Plugin {
 
       final var serializedActivity = new SerializedActivity(activityTypeName, activityArguments);
 
-      final var failures = this.missionModelService.validateActivityParameters(missionModelId, serializedActivity);
+      final var failures = this.missionModelService.validateActivityArguments(missionModelId, serializedActivity);
 
       ctx.result(ResponseSerializers.serializeFailures(failures).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -157,6 +157,7 @@ public final class ResponseSerializers {
         .add("duration", serializeDuration(simulatedActivity.duration))
         .add("parent", serializeNullable(id -> Json.createValue(id.id()), simulatedActivity.parentId))
         .add("children", serializeIterable((id -> Json.createValue(id.id())), simulatedActivity.childIds))
+        .add("computedAttributes", serializeArgument(simulatedActivity.computedAttributes))
         .build();
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -152,7 +152,7 @@ public final class ResponseSerializers {
     return Json
         .createObjectBuilder()
         .add("type", simulatedActivity.type)
-        .add("parameters", serializeArgumentMap(simulatedActivity.arguments))
+        .add("arguments", serializeArgumentMap(simulatedActivity.arguments))
         .add("startTimestamp", serializeTimestamp(simulatedActivity.start))
         .add("duration", serializeDuration(simulatedActivity.duration))
         .add("parent", serializeNullable(id -> Json.createValue(id.id()), simulatedActivity.parentId))

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -152,7 +152,7 @@ public final class ResponseSerializers {
     return Json
         .createObjectBuilder()
         .add("type", simulatedActivity.type)
-        .add("parameters", serializeArgumentMap(simulatedActivity.parameters))
+        .add("parameters", serializeArgumentMap(simulatedActivity.arguments))
         .add("startTimestamp", serializeTimestamp(simulatedActivity.start))
         .add("duration", serializeDuration(simulatedActivity.duration))
         .add("parent", serializeNullable(id -> Json.createValue(id.id()), simulatedActivity.parentId))

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -429,8 +429,8 @@ public final class ResponseSerializers {
           .add("variants", serializeIterable(
               v -> Json
                   .createObjectBuilder()
-                  .add("key", v.key)
-                  .add("label", v.label)
+                  .add("key", v.key())
+                  .add("label", v.label())
                   .build(),
               variants))
           .build();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
@@ -247,7 +247,7 @@ public final class InMemoryPlanRepository implements PlanRepository {
 
       this.type.ifPresent(type -> activity.type = type);
       this.startTimestamp.ifPresent(startTimestamp -> activity.startTimestamp = startTimestamp);
-      this.parameters.ifPresent(parameters -> activity.parameters = parameters);
+      this.parameters.ifPresent(arguments -> activity.arguments = arguments);
 
       InMemoryPlanRepository.this.plans.put(this.planId, Pair.of(revision, plan));
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityInstance.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityInstance.java
@@ -9,20 +9,20 @@ import java.util.Objects;
 public final class ActivityInstance {
   public String type;
   public Timestamp startTimestamp;
-  public Map<String, SerializedValue> parameters;
+  public Map<String, SerializedValue> arguments;
 
   public ActivityInstance() {}
 
   public ActivityInstance(final ActivityInstance other) {
     this.type = other.type;
     this.startTimestamp = other.startTimestamp;
-    this.parameters = (other.parameters == null) ? null : new HashMap<>(other.parameters);
+    this.arguments = (other.arguments == null) ? null : new HashMap<>(other.arguments);
   }
 
-  public ActivityInstance(final String type, final Timestamp startTimestamp, final Map<String, SerializedValue> parameters) {
+  public ActivityInstance(final String type, final Timestamp startTimestamp, final Map<String, SerializedValue> arguments) {
     this.type = type;
     this.startTimestamp = startTimestamp;
-    this.parameters = (parameters != null) ? Map.copyOf(parameters) : null;
+    this.arguments = (arguments != null) ? Map.copyOf(arguments) : null;
   }
 
   @Override
@@ -35,7 +35,7 @@ public final class ActivityInstance {
     return
         (  Objects.equals(this.type, other.type)
         && Objects.equals(this.startTimestamp, other.startTimestamp)
-        && Objects.equals(this.parameters, other.parameters)
+        && Objects.equals(this.arguments, other.arguments)
         );
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityType.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityType.java
@@ -1,6 +1,13 @@
 package gov.nasa.jpl.aerie.merlin.server.models;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+
 import java.util.List;
 
-public final record ActivityType(String name, List<Parameter> parameters, List<String> requiredParameters) { }
+public final record ActivityType(
+    String name,
+    List<Parameter> parameters,
+    List<String> requiredParameters,
+    ValueSchema computedAttributesValueSchema
+) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
@@ -135,7 +135,7 @@ public final class MissionModelFacade {
     {
       final var activityTypes = new HashMap<String, ActivityType>();
       factory.getTaskSpecTypes().forEach((name, specType) -> {
-        activityTypes.put(name, new ActivityType(name, specType.getParameters(), specType.getRequiredParameters()));
+        activityTypes.put(name, new ActivityType(name, specType.getParameters(), specType.getRequiredParameters(), specType.getReturnValueSchema()));
       });
       return activityTypes;
     }
@@ -147,7 +147,7 @@ public final class MissionModelFacade {
           .ofNullable(factory.getTaskSpecTypes().get(typeName))
           .orElseThrow(MissionModelFacade.NoSuchActivityTypeException::new);
 
-      return new ActivityType(typeName, specType.getParameters(), specType.getRequiredParameters());
+      return new ActivityType(typeName, specType.getParameters(), specType.getRequiredParameters(), specType.getReturnValueSchema());
     }
 
     public List<Parameter> getParameters() {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
@@ -58,8 +58,8 @@ public final class MissionModelFacade {
     return getValidationFailures(specType, arguments);
   }
 
-  private <Specification> List<String> getValidationFailures(
-      final TaskSpecType<?, Specification> specType,
+  private <Specification, Return> List<String> getValidationFailures(
+      final TaskSpecType<?, Specification, Return> specType,
       final Map<String, SerializedValue> arguments)
   throws UnconstructableActivityInstanceException
   {
@@ -84,8 +84,8 @@ public final class MissionModelFacade {
     return getActivityEffectiveArguments(specType, arguments);
   }
 
-  private static <Specification> Map<String, SerializedValue> getActivityEffectiveArguments(
-      final TaskSpecType<?, Specification> specType,
+  private static <Specification, Return> Map<String, SerializedValue> getActivityEffectiveArguments(
+      final TaskSpecType<?, Specification, Return> specType,
       final Map<String, SerializedValue> arguments)
   throws UnconstructableActivityInstanceException, MissingArgumentException
   {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ActivityAttributesRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ActivityAttributesRecord.java
@@ -1,0 +1,12 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+
+import java.util.Map;
+import java.util.Optional;
+
+public record ActivityAttributesRecord(
+    Optional<ActivityInstanceId> directiveId,
+    Map<String, SerializedValue> arguments
+) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ActivityAttributesRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ActivityAttributesRecord.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 
 public record ActivityAttributesRecord(
     Optional<ActivityInstanceId> directiveId,
-    Map<String, SerializedValue> arguments
+    Map<String, SerializedValue> arguments,
+    SerializedValue computedAttributes
 ) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateActivityTypeAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateActivityTypeAction.java
@@ -1,18 +1,25 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
+
+import static gov.nasa.jpl.aerie.merlin.server.http.ValueSchemaJsonParser.valueSchemaP;
 
 /*package-local*/ final class CreateActivityTypeAction implements AutoCloseable {
   private static final @Language("SQL") String sql = """
-    insert into activity_type (model_id, name, parameters, required_parameters)
-    values (?, ?, ?::json, ?::json)
-    on conflict (model_id, name) do update set parameters = ?::json, required_parameters = ?::json
+    insert into activity_type (model_id, name, parameters, required_parameters, computed_attributes_value_schema)
+    values (?, ?, ?::json, ?::json, ?::json)
+    on conflict (model_id, name) do update
+      set parameters = ?::json,
+      required_parameters = ?::json,
+      computed_attributes_value_schema = ?::json
     returning model_id
     """;
 
@@ -22,15 +29,24 @@ import java.util.List;
     this.statement = connection.prepareStatement(sql);
   }
 
-  public long apply(final long modelId, final String name, final List<Parameter> parameters, final List<String> requiredParameters)
+  public long apply(
+      final long modelId,
+      final String name,
+      final List<Parameter> parameters,
+      final List<String> requiredParameters,
+      final ValueSchema computedAttributesValueSchema)
   throws SQLException, FailedInsertException
   {
+    final var valueSchemaString = valueSchemaP.unparse(computedAttributesValueSchema).toString();
+
     this.statement.setLong(1, modelId);
     this.statement.setString(2, name);
     PreparedStatements.setParameters(this.statement, 3, parameters);
     PreparedStatements.setRequiredParameters(this.statement, 4, requiredParameters);
-    PreparedStatements.setParameters(this.statement, 5, parameters);
-    PreparedStatements.setRequiredParameters(this.statement, 6, requiredParameters);
+    this.statement.setString(5, valueSchemaString);
+    PreparedStatements.setParameters(this.statement, 6, parameters);
+    PreparedStatements.setRequiredParameters(this.statement, 7, requiredParameters);
+    this.statement.setString(8, valueSchemaString);
 
     try (final var results = statement.executeQuery()) {
       if (!results.next()) throw new FailedInsertException("activity_type");

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulatedActivitiesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulatedActivitiesAction.java
@@ -1,9 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
-import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
-import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
-import org.apache.commons.lang3.tuple.Pair;
 import org.intellij.lang.annotations.Language;
 
 import javax.json.Json;
@@ -65,7 +62,8 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
           duration,
           parentId,
           initialChildIds,
-          attributes.directiveId()
+          attributes.directiveId(),
+          attributes.computedAttributes()
       ));
     }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulatedActivitiesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulatedActivitiesAction.java
@@ -55,18 +55,18 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
       final var start = simulationStart.toInstant().plus(startOffset.in(MICROSECONDS), ChronoUnit.MICROS);
       final var duration = parseOffset(resultSet, 5, start);
       final var attributes = parseActivityAttributes(resultSet.getCharacterStream(6));
-      final var directiveId = attributes.getLeft();
-      final var arguments = attributes.getRight();
+
       final var initialChildIds = new ArrayList<Long>();
 
       activities.put(id, new SimulatedActivityRecord(
           type,
-          arguments,
+          attributes.arguments(),
           start,
           duration,
           parentId,
           initialChildIds,
-          directiveId));
+          attributes.directiveId()
+      ));
     }
 
     // Since child IDs are not stored, we assign them by examining the parent ID of each activity
@@ -84,7 +84,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
     return Optional.of(value);
   }
 
-  private Pair<Optional<ActivityInstanceId>, Map<String, SerializedValue>> parseActivityAttributes(final Reader jsonStream) {
+  private ActivityAttributesRecord parseActivityAttributes(final Reader jsonStream) {
     final var json = Json.createReader(jsonStream).readValue();
     return activityAttributesP
         .parse(json)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSimulatedActivitiesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSimulatedActivitiesAction.java
@@ -68,7 +68,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
   }
 
   private String buildAttributes(final Optional<ActivityInstanceId> directiveId, final Map<String, SerializedValue> arguments) {
-    return activityAttributesP.unparse(Pair.of(directiveId, arguments)).toString();
+    return activityAttributesP.unparse(new ActivityAttributesRecord(directiveId, arguments)).toString();
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSimulatedActivitiesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSimulatedActivitiesAction.java
@@ -5,7 +5,6 @@ import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
-import org.apache.commons.lang3.tuple.Pair;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
@@ -50,7 +49,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
       setTimestamp(statement, 4, endTimestamp);
       setTimestamp(statement, 5, startTimestamp);
       statement.setString(6, act.type);
-      statement.setString(7, buildAttributes(act.directiveId, act.arguments));
+      statement.setString(7, buildAttributes(act.directiveId, act.arguments, act.computedAttributes));
 
       statement.addBatch();
     }
@@ -67,8 +66,8 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
     return simIdToPostgresId;
   }
 
-  private String buildAttributes(final Optional<ActivityInstanceId> directiveId, final Map<String, SerializedValue> arguments) {
-    return activityAttributesP.unparse(new ActivityAttributesRecord(directiveId, arguments)).toString();
+  private String buildAttributes(final Optional<ActivityInstanceId> directiveId, final Map<String, SerializedValue> arguments, final SerializedValue returnValue) {
+    return activityAttributesP.unparse(new ActivityAttributesRecord(directiveId, arguments, returnValue)).toString();
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSimulatedActivitiesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSimulatedActivitiesAction.java
@@ -50,7 +50,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
       setTimestamp(statement, 4, endTimestamp);
       setTimestamp(statement, 5, startTimestamp);
       statement.setString(6, act.type);
-      statement.setString(7, buildAttributes(act.directiveId, act.parameters));
+      statement.setString(7, buildAttributes(act.directiveId, act.arguments));
 
       statement.addBatch();
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresMissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresMissionModelRepository.java
@@ -135,7 +135,12 @@ public final class PostgresMissionModelRepository implements MissionModelReposit
       try (final var createActivityTypeAction = new CreateActivityTypeAction(connection)) {
         final var id = toMissionModelId(missionModelId);
         for (final var activityType : activityTypes.values()) {
-          createActivityTypeAction.apply(id, activityType.name(), activityType.parameters(), activityType.requiredParameters());
+          createActivityTypeAction.apply(
+              id,
+              activityType.name(),
+              activityType.parameters(),
+              activityType.requiredParameters(),
+              activityType.computedAttributesValueSchema());
         }
       }
     } catch (final SQLException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
@@ -61,11 +61,11 @@ public final class PostgresParsers {
   public static final JsonParser<Map<String, SerializedValue>> activityArgumentsP = mapP(serializedValueP);
   public static final JsonParser<Map<String, SerializedValue>> simulationArgumentsP = mapP(serializedValueP);
 
-  public static final JsonParser<Pair<Optional<ActivityInstanceId>, Map<String, SerializedValue>>> activityAttributesP = productP
+  public static final JsonParser<ActivityAttributesRecord> activityAttributesP = productP
       .optionalField("directiveId", activityInstanceIdP)
       .field("arguments", activityArgumentsP)
         .map(Iso.of(
-            untuple((directiveId, arguments) -> Pair.of(directiveId, arguments)),
-            $ -> tuple($.getLeft(), $.getRight())
+            untuple(ActivityAttributesRecord::new),
+            $ -> tuple($.directiveId(), $.arguments())
         ));
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
@@ -4,7 +4,6 @@ import com.impossibl.postgres.api.data.Interval;
 import gov.nasa.jpl.aerie.json.Iso;
 import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.json.Unit;
-import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
@@ -15,7 +14,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Optional;
 
 import static gov.nasa.jpl.aerie.json.BasicParsers.chooseP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.literalP;
@@ -64,8 +62,9 @@ public final class PostgresParsers {
   public static final JsonParser<ActivityAttributesRecord> activityAttributesP = productP
       .optionalField("directiveId", activityInstanceIdP)
       .field("arguments", activityArgumentsP)
+      .field("computedAttributes", serializedValueP)
         .map(Iso.of(
             untuple(ActivityAttributesRecord::new),
-            $ -> tuple($.directiveId(), $.arguments())
+            $ -> tuple($.directiveId(), $.arguments(), $.computedAttributes())
         ));
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -164,7 +164,7 @@ public final class PostgresPlanRepository implements PlanRepository {
                 activity.startTimestamp,
                 activity.type);
 
-            for (final var argument : activity.parameters.entrySet()) {
+            for (final var argument : activity.arguments.entrySet()) {
               // Add this argument to the staged batch of arguments.
               setActivityArgumentsAction.add(activityId, argument.getKey(), argument.getValue());
             }
@@ -312,7 +312,7 @@ public final class PostgresPlanRepository implements PlanRepository {
                                                        planStartTime.plusMicros(startOffsetInMicros),
                                                        arguments))),
                   untuple((ActivityInstanceId actId, ActivityInstance $) ->
-                              tuple(actId, planStartTime.microsUntil($.startTimestamp), $.type, $.parameters))));
+                              tuple(actId, planStartTime.microsUntil($.startTimestamp), $.type, $.arguments))));
 
       final var activities = new HashMap<ActivityInstanceId, ActivityInstance>();
       for (final var entry : parseJson(json, listP(activityRowP))) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -285,7 +285,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
 
         simulatedActivities.put(pgIdToSimId.get(pgId), new SimulatedActivity(
             record.type(),
-            record.parameters(),
+            record.arguments(),
             record.start(),
             record.duration(),
             record.parentId().map(pgIdToSimId::get).orElse(null),

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -290,7 +290,8 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
             record.duration(),
             record.parentId().map(pgIdToSimId::get).orElse(null),
             record.childIds().stream().map(pgIdToSimId::get).collect(Collectors.toList()),
-            record.directiveId()
+            record.directiveId(),
+            SerializedValue.of("VOID") // TODO retrieve return value from database
         ));
       }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -291,7 +291,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
             record.parentId().map(pgIdToSimId::get).orElse(null),
             record.childIds().stream().map(pgIdToSimId::get).collect(Collectors.toList()),
             record.directiveId(),
-            SerializedValue.of("VOID") // TODO retrieve return value from database
+            record.computedAttributes()
         ));
       }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulatedActivityRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulatedActivityRecord.java
@@ -16,5 +16,6 @@ import java.util.Optional;
     Duration duration,
     Optional<Long> parentId,
     List<Long> childIds,
-    Optional<ActivityInstanceId> directiveId
+    Optional<ActivityInstanceId> directiveId,
+    SerializedValue computedAttributes
 ) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulatedActivityRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulatedActivityRecord.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 /*package-local*/ record SimulatedActivityRecord(
     String type,
-    Map<String, SerializedValue> parameters,
+    Map<String, SerializedValue> arguments,
     Instant start,
     Duration duration,
     Optional<Long> parentId,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -97,7 +97,7 @@ public final class GetSimulationResultsAction {
       activities.add(new ActivityInstance(
           id.id(),
           activity.type,
-          activity.parameters,
+          activity.arguments,
           Window.between(activityOffset, activityOffset.plus(activity.duration))));
     }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -92,7 +92,7 @@ public final class LocalMissionModelService implements MissionModelService {
    * Validate that a set of activity parameters conforms to the expectations of a named mission model.
    *
    * @param missionModelId The ID of the mission model to load.
-   * @param activityParameters The serialized activity to validate against the named mission model.
+   * @param activity The serialized activity to validate against the named mission model.
    * @return A list of validation errors that is empty if validation succeeds.
    * @throws NoSuchMissionModelException If no mission model is known by the given ID.
    * @throws MissionModelFacade.MissionModelContractException If the named mission model does not abide by the expected contract.
@@ -100,13 +100,13 @@ public final class LocalMissionModelService implements MissionModelService {
    * it contains may not abide by the expected contract at load time.
    */
   @Override
-  public List<String> validateActivityParameters(final String missionModelId, final SerializedActivity activityParameters)
+  public List<String> validateActivityArguments(final String missionModelId, final SerializedActivity activity)
   throws NoSuchMissionModelException, MissionModelFacade.MissionModelContractException, MissionModelLoadException
   {
     try {
       // TODO: [AERIE-1516] Teardown the missionModel after use to release any system resources (e.g. threads).
       return this.loadConfiguredMissionModel(missionModelId)
-                 .validateActivity(activityParameters.getTypeName(), activityParameters.getParameters());
+                 .validateActivity(activity.getTypeName(), activity.getArguments());
     } catch (final MissionModelFacade.NoSuchActivityTypeException ex) {
       return List.of("unknown activity type");
     } catch (final MissionModelFacade.UnconstructableActivityInstanceException ex) {
@@ -124,7 +124,7 @@ public final class LocalMissionModelService implements MissionModelService {
   {
     try {
       return this.loadConfiguredMissionModel(missionModelId)
-                 .getActivityEffectiveArguments(activity.getTypeName(), activity.getParameters());
+                 .getActivityEffectiveArguments(activity.getTypeName(), activity.getArguments());
     } catch (final MissionModelFacade.NoSuchActivityTypeException ex) {
       throw new NoSuchActivityTypeException(activity.getTypeName(), ex);
     } catch (final MissionModelFacade.UnconstructableActivityInstanceException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -29,7 +29,7 @@ public interface MissionModelService {
   Map<String, ActivityType> getActivityTypes(String missionModelId)
   throws NoSuchMissionModelException;
   // TODO: Provide a finer-scoped validation return type. Mere strings make all validations equally severe.
-  List<String> validateActivityParameters(String missionModelId, SerializedActivity activityParameters)
+  List<String> validateActivityArguments(String missionModelId, SerializedActivity activity)
   throws NoSuchMissionModelException;
 
   Map<String, SerializedValue> getActivityEffectiveArguments(String missionModelId, SerializedActivity activity)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SynchronousSimulationAgent.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SynchronousSimulationAgent.java
@@ -79,7 +79,7 @@ public record SynchronousSimulationAgent (
 
       scheduledActivities.put(id, Pair.of(
           Duration.of(startTime.until(activity.startTimestamp.toInstant(), ChronoUnit.MICROS), Duration.MICROSECONDS),
-          new SerializedActivity(activity.type, activity.parameters)));
+          new SerializedActivity(activity.type, activity.arguments)));
     }
 
     return scheduledActivities;

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/Fixtures.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/Fixtures.java
@@ -69,7 +69,7 @@ public final class Fixtures {
 
     activityInstance.type = this.EXISTENT_ACTIVITY_TYPE_ID;
     activityInstance.startTimestamp = Timestamp.fromString("0000-111T22:33:44");
-    activityInstance.parameters = StubMissionModelService.VALID_ACTIVITY_INSTANCE.getParameters();
+    activityInstance.arguments = StubMissionModelService.VALID_ACTIVITY_INSTANCE.getArguments();
 
     return activityInstance;
   }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -1,7 +1,9 @@
 package gov.nasa.jpl.aerie.merlin.server.mocks;
 
+import gov.nasa.jpl.aerie.contrib.serialization.mappers.EnumValueMapper;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
+import gov.nasa.jpl.aerie.merlin.framework.VoidEnum;
 import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
@@ -30,7 +32,9 @@ public final class StubMissionModelService implements MissionModelService {
   public static final String NONEXISTENT_ACTIVITY_TYPE = "no-activity";
   public static final ActivityType EXISTENT_ACTIVITY = new ActivityType(
       EXISTENT_ACTIVITY_TYPE,
-      List.of(new Parameter("Param", ValueSchema.STRING)), List.of());
+      List.of(new Parameter("Param", ValueSchema.STRING)),
+      List.of(),
+      new EnumValueMapper<>(VoidEnum.class).getValueSchema());
 
   public static final SerializedActivity VALID_ACTIVITY_INSTANCE = new SerializedActivity(
       EXISTENT_ACTIVITY_TYPE,

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -106,18 +106,18 @@ public final class StubMissionModelService implements MissionModelService {
   }
 
   @Override
-  public List<String> validateActivityParameters(final String missionModelId, final SerializedActivity activityParameters)
+  public List<String> validateActivityArguments(final String missionModelId, final SerializedActivity activity)
   throws NoSuchMissionModelException
   {
     if (!Objects.equals(missionModelId, EXISTENT_MISSION_MODEL_ID)) {
       throw new NoSuchMissionModelException(missionModelId);
     }
 
-    if (Objects.equals(activityParameters.getTypeName(), NONEXISTENT_ACTIVITY_INSTANCE.getTypeName())) {
+    if (Objects.equals(activity.getTypeName(), NONEXISTENT_ACTIVITY_INSTANCE.getTypeName())) {
       return NO_SUCH_ACTIVITY_TYPE_FAILURES;
-    } else if (Objects.equals(activityParameters, UNCONSTRUCTABLE_ACTIVITY_INSTANCE)) {
+    } else if (Objects.equals(activity, UNCONSTRUCTABLE_ACTIVITY_INSTANCE)) {
       return UNCONSTRUCTABLE_ACTIVITY_INSTANCE_FAILURES;
-    } else if (Objects.equals(activityParameters, INVALID_ACTIVITY_INSTANCE)) {
+    } else if (Objects.equals(activity, INVALID_ACTIVITY_INSTANCE)) {
       return INVALID_ACTIVITY_INSTANCE_FAILURES;
     } else {
       return Collections.emptyList();

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
@@ -34,7 +34,7 @@ public final class StubPlanService implements PlanService {
     EXISTENT_ACTIVITY = new ActivityInstance();
     EXISTENT_ACTIVITY.type = "existent activity";
     EXISTENT_ACTIVITY.startTimestamp = Timestamp.fromString("2016-123T14:25:36");
-    EXISTENT_ACTIVITY.parameters = Map.of(
+    EXISTENT_ACTIVITY.arguments = Map.of(
         "abc", SerializedValue.of("test-param")
     );
 

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
@@ -47,7 +47,7 @@ public final class MissionModelTest {
     @Test
     public void shouldGetActivityTypeList() throws MissionModelFacade.MissionModelContractException {
         // GIVEN
-        final Map<String, ActivityType> expectedTypes = Map.of(
+      final Map<String, ActivityType> expectedTypes = Map.of(
             "foo", new ActivityType(
                 "foo",
                 List.of(
@@ -68,7 +68,7 @@ public final class MissionModelTest {
     @Test
     public void shouldGetActivityType() throws MissionModelFacade.NoSuchActivityTypeException, MissionModelFacade.MissionModelContractException {
         // GIVEN
-        final ActivityType expectedType = new ActivityType(
+      final ActivityType expectedType = new ActivityType(
             "foo",
             List.of(
                 new Parameter("x", ValueSchema.INT),

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
@@ -1,10 +1,11 @@
 package gov.nasa.jpl.aerie.merlin.server.models;
 
+import gov.nasa.jpl.aerie.contrib.serialization.mappers.EnumValueMapper;
 import gov.nasa.jpl.aerie.foomissionmodel.Configuration;
 import gov.nasa.jpl.aerie.foomissionmodel.generated.ConfigurationMapper;
 import gov.nasa.jpl.aerie.foomissionmodel.generated.GeneratedMissionModelFactory;
-import gov.nasa.jpl.aerie.foomissionmodel.mappers.FooValueMappers;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
+import gov.nasa.jpl.aerie.merlin.framework.VoidEnum;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
@@ -52,7 +53,10 @@ public final class MissionModelTest {
                 List.of(
                     new Parameter("x", ValueSchema.INT),
                     new Parameter("y", ValueSchema.STRING),
-                    new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))), List.of()));
+                    new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))),
+                List.of(),
+                new EnumValueMapper<>(VoidEnum.class).getValueSchema()
+            ));
 
         // WHEN
         final Map<String, ActivityType> typeList = unconfiguredMissionModel.getActivityTypes();
@@ -69,7 +73,10 @@ public final class MissionModelTest {
             List.of(
                 new Parameter("x", ValueSchema.INT),
                 new Parameter("y", ValueSchema.STRING),
-                new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))), List.of());
+                new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))),
+            List.of(),
+            new EnumValueMapper<>(VoidEnum.class).getValueSchema()
+        );
 
         // WHEN
         final ActivityType type = unconfiguredMissionModel.getActivityType(expectedType.name());

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepositoryContractTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepositoryContractTest.java
@@ -66,7 +66,7 @@ public abstract class PlanRepositoryContractTest {
     // WHEN
     final ActivityInstance activity = new ActivityInstance();
     activity.type = "abc";
-    activity.parameters = Map.of("abc", SerializedValue.of(1));
+    activity.arguments = Map.of("abc", SerializedValue.of(1));
 
     final NewPlan newPlan = new NewPlan();
     newPlan.name = "new-plan";

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/SimulationFacade.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/SimulationFacade.java
@@ -414,7 +414,7 @@ public class SimulationFacade {
     final var startT = Duration.of(planStartT.until(driverActivity.start, ChronoUnit.MICROS), MICROSECONDS);
     final var endT = startT.plus(driverActivity.duration);
     return new gov.nasa.jpl.aerie.constraints.model.ActivityInstance(
-        id, driverActivity.type, driverActivity.parameters,
+        id, driverActivity.type, driverActivity.arguments,
         Window.betweenClosedOpen(startT, endT));
   }
 


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1629
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
I've taken #17 and split it into three branches. I'll PR them sequentially, so we can focus on one at a time.

EDIT: If it would help declutter, I can make a separate PR for the refactoring commits. Let me know if anyone would prefer that.

The focus of this PR is reporting a value as part of simulation results upon completion of an activity instance.

The commits in this PR fall into one of the following phases
1. Preliminary refactoring (first 5 commits)
1. Use Supplier instead of Runnable to represent an effect model
1. Generate mapper and supplier for EffectModels with non-void return types
1. Reporting:
    - Include ValueSchema in ActivityType
    - Include return value in SimulatedActivity
    - Persist all of that in postgres

We continue to support `void` return types as before. These activities will have a `SerializedValue.UNIT` return value.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I've done some simple manual testing by giving BiteBanana a non-void return type and viewing it via hasura. Some more thorough verification is needed prior to merging.

- [ ] more thorough testing. (unit test?)

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
This work is part of the Activity Computed Attributes working group: https://wiki.jpl.nasa.gov/display/MPSA/Working+Group%3A+Activity+Computed+Attributes

- [ ] We should update some user-facing documentation to explain how to use this feature.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Step 2: (AERIE-1630) Make this value available to the caller
Step 3. (AERIE-1631) Tag events with activity ids