### PR TITLE
Implement defer() in terms of other primitives

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -650,31 +650,6 @@ public final class SimulationEngine implements AutoCloseable {
 
       return task.id();
     }
-
-    @Override
-    public String defer(final Duration delay, final Task state) {
-      if (delay.isNegative()) throw new IllegalArgumentException("Cannot schedule a task in the past");
-
-      final var task = TaskId.generate();
-      SimulationEngine.this.tasks.put(task, new ExecutionState.InProgress(this.currentTime, state));
-      SimulationEngine.this.taskParent.put(task, this.activeTask);
-      SimulationEngine.this.taskChildren.computeIfAbsent(this.activeTask, $ -> new HashSet<>()).add(task);
-      SimulationEngine.this.scheduledJobs.schedule(JobId.forTask(task), SubInstant.Tasks.at(this.currentTime.plus(delay)));
-
-      return task.id();
-    }
-
-    @Override
-    public String defer(final Duration delay, final String type, final Map<String, SerializedValue> arguments) {
-      if (delay.isNegative()) throw new IllegalArgumentException("Cannot schedule a task in the past");
-
-      final var task = initiateTaskFromInput(this.model, new SerializedActivity(type, arguments));
-      SimulationEngine.this.taskParent.put(task, this.activeTask);
-      SimulationEngine.this.taskChildren.computeIfAbsent(this.activeTask, $ -> new HashSet<>()).add(task);
-      SimulationEngine.this.scheduledJobs.schedule(JobId.forTask(task), SubInstant.Tasks.at(this.currentTime.plus(delay)));
-
-      return task.id();
-    }
   }
 
   /** A representation of a job processable by the {@link SimulationEngine}. */

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
@@ -37,9 +37,6 @@ public interface Context {
   String spawn(TaskFactory task);
   String spawn(String type, Map<String, SerializedValue> arguments);
 
-  String defer(Duration duration, TaskFactory task);
-  String defer(Duration duration, String type, Map<String, SerializedValue> arguments);
-
   void delay(Duration duration);
   void waitFor(String id);
   void waitUntil(Condition condition);

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
@@ -66,16 +66,6 @@ public final class InitializationContext implements Context {
   }
 
   @Override
-  public String defer(final Duration duration, final TaskFactory task) {
-    throw new IllegalStateException("Cannot schedule tasks during initialization");
-  }
-
-  @Override
-  public String defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
-    throw new IllegalStateException("Cannot schedule activities during initialization");
-  }
-
-  @Override
   public void delay(final Duration duration) {
     throw new IllegalStateException("Cannot yield during initialization");
   }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
@@ -45,27 +45,27 @@ public /*non-final*/ class ModelActions {
   }
 
   public static String defer(final Duration duration, final Runnable task) {
-    return defer(duration, threaded(task));
+    return spawn(replaying(() -> { delay(duration); spawn(task); }));
   }
 
   public static String defer(final Duration duration, final Context.TaskFactory task) {
-    return context.get().defer(duration, task);
+    return spawn(replaying(() -> { delay(duration); spawn(task); }));
   }
 
   public static String defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
-    return context.get().defer(duration, type, arguments);
+    return spawn(replaying(() -> { delay(duration); spawn(type, arguments); }));
   }
 
   public static String defer(final long quantity, final Duration unit, final Runnable task) {
-    return defer(unit.times(quantity), threaded(task));
-  }
-
-  public static String defer(final long quantity, final Duration unit, final String type, final Map<String, SerializedValue> arguments) {
-    return defer(unit.times(quantity), type, arguments);
+    return spawn(replaying(() -> { delay(quantity, unit); spawn(task); }));
   }
 
   public static String defer(final long quantity, final Duration unit, final Context.TaskFactory task) {
-    return context.get().defer(unit.times(quantity), task);
+    return spawn(replaying(() -> { delay(quantity, unit); spawn(task); }));
+  }
+
+  public static String defer(final long quantity, final Duration unit, final String type, final Map<String, SerializedValue> arguments) {
+    return spawn(replaying(() -> { delay(quantity, unit); spawn(type, arguments); }));
   }
 
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/QueryContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/QueryContext.java
@@ -53,16 +53,6 @@ public final class QueryContext implements Context {
   }
 
   @Override
-  public String defer(final Duration duration, final TaskFactory task) {
-    throw new IllegalStateException("Cannot schedule tasks in a query-only context");
-  }
-
-  @Override
-  public String defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
-    throw new IllegalStateException("Cannot schedule activities in a query-only context");
-  }
-
-  @Override
   public void delay(final Duration duration) {
     throw new IllegalStateException("Cannot yield in a query-only context");
   }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
@@ -83,20 +83,6 @@ final class ReplayingReactionContext implements Context {
   }
 
   @Override
-  public String defer(final Duration duration, final TaskFactory task) {
-    return this.memory.doOnce(() -> {
-      return this.scheduler.defer(duration, task.create(this.executor));
-    });
-  }
-
-  @Override
-  public String defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
-    return this.memory.doOnce(() -> {
-      return this.scheduler.defer(duration, type, arguments);
-    });
-  }
-
-  @Override
   public void delay(final Duration duration) {
     this.memory.doOnce(() -> {
       this.scheduler = null;  // Relinquish the current scheduler before yielding, in case an exception is thrown.

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
@@ -68,16 +68,6 @@ final class ThreadedReactionContext implements Context {
   }
 
   @Override
-  public String defer(final Duration duration, final TaskFactory task) {
-    return this.scheduler.defer(duration, task.create(this.executor));
-  }
-
-  @Override
-  public String defer(final Duration duration, final String type, final Map<String, SerializedValue> arguments) {
-    return this.scheduler.defer(duration, type, arguments);
-  }
-
-  @Override
   public void delay(final Duration duration) {
     this.scheduler = null;  // Relinquish the current scheduler before yielding, in case an exception is thrown.
     this.scheduler = this.handle.yield(TaskStatus.delayed(duration));

--- a/merlin-framework/src/test/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTaskTest.java
+++ b/merlin-framework/src/test/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTaskTest.java
@@ -3,7 +3,6 @@ package gov.nasa.jpl.aerie.merlin.framework;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Query;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,16 +35,6 @@ public final class ThreadedTaskTest {
 
       @Override
       public String spawn(final String type, final Map<String, SerializedValue> arguments) {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public String defer(final Duration delay, final Task task) {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public String defer(final Duration delay, final String type, final Map<String, SerializedValue> arguments) {
         throw new UnsupportedOperationException();
       }
     };

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Scheduler.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Scheduler.java
@@ -1,7 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.protocol.driver;
 
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.util.Map;
@@ -13,7 +12,4 @@ public interface Scheduler {
 
   String spawn(Task task);
   String spawn(String type, Map<String, SerializedValue> arguments);
-
-  String defer(Duration delay, Task task);
-  String defer(Duration delay, String type, Map<String, SerializedValue> arguments);
 }


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Back when `defer()` was introduced (which was very early, IIRC!), we didn't have the ability to spawn lambdas. Now we do, so `defer(t, a)` can simply be implemented as `spawn(() -> { delay(t); spawn(a); })`. This simplifies the model-engine interface, which needed to duplicate the `spawn` variants just for the extra `Duration` argument.

This technically costs an extra `Task` per `defer()` (since it's implemented with two `spawn`s). This cost is reduced on the model side by explicitly using a `ReplayingTask` for the delaying lambda. On the engine side, the extra task does have to be tracked, but ideally this overhead should be minimal. If we remove `waitFor` as well (see Future Work), we should be able to proactively prune completed task subtrees, and the number of tasks that need to be searched when propagating completion up the tree will also be reduced, so we should eventually see more wins than losses overall.

## Verification
I don't actually have access to any models that use `defer`; I'd like to request that somebody with access to the InSight model check that things come out the same. (Especially if there's any obvious change to performance.)

That said, semantically we've always intended that `defer` behave like a delay prefixing the spawned activity, so if this change breaks anything, there are deeper issues to be addressed.

## Documentation
This change does not impact any user-facing APIs or contracts.

## Future work
* I'd like to get rid of the `type, arguments` variant of `spawn` as well, since that incurs an extra serialization+deserialization that shouldn't *really* be necessary. That's not going to be quite as straightforward as removing `defer`, but at least this PR reduces the amount of spawn-related surface to cover in the first place.
* I'd also like to get rid of `waitFor`. I've discussed the rationale with @mattdailis and @patkenneally before, but the long-and-short is that `waitFor` interacts poorly with some desirable semantics around activity return values, specifically that we'd like `call(act)` to return the child activity's return value to its parent, or rethrow any uncaught exceptions the child activity threw. But, as noted above, since removing `waitFor` means that no model code can explicitly depend on the existence of a task, we can also eagerly prune completed tasks whose IDs have not been otherwise exposed from the engine. Since results computation still occurs at the end of simulation, we can't take full advantage of this yet -- we need to hold on to all tasks until results can be computed -- but when streaming results is implemented, we won't need to keep around any information not relevant to the ongoing simulation.