### PR TITLE
[GITHUB] Use gradle build action for quicker builds

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,7 @@ jobs:
           distribution: "temurin"
           java-version: "17"
       - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/gradle-build-action@v2
       - name: Build Classes
         run: ./gradlew classes
       - name: Test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
           distribution: "temurin"
           java-version: "17"
       - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/gradle-build-action@v2
       - name: Build Classes
         run: ./gradlew classes
       - name: Test


### PR DESCRIPTION
See: https://github.com/marketplace/actions/gradle-build-action#use-the-action-to-setup-gradle

* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Uses [gradle build action](https://github.com/marketplace/actions/gradle-build-action) for quicker build setup times. With our current setup build times are delayed by downloading a Gradle wrapper.

See: https://github.com/marketplace/actions/gradle-build-action#use-the-action-to-setup-gradle

## Verification
Somewhat difficult to test and verify that this change helps with our automated PR Gradle builds. As a rough benchmark I've recorded the build times for all PRs currently open:
```
31
pr      pass    2m30s   https://github.com/NASA-AMMOS/aerie/runs/4899947038?check_suite_focus=true
30
pr      pass    2m30s   https://github.com/NASA-AMMOS/aerie/runs/4887333239?check_suite_focus=true
28
pr      pass    2m29s   https://github.com/NASA-AMMOS/aerie/runs/4910258945?check_suite_focus=true
27
pr      pass    2m24s   https://github.com/NASA-AMMOS/aerie/runs/4795926358?check_suite_focus=true
26
pr      pass    3m25s   https://github.com/NASA-AMMOS/aerie/runs/4885646522?check_suite_focus=true
25
pr      pass    2m29s   https://github.com/NASA-AMMOS/aerie/runs/4924172982?check_suite_focus=true
23
pr      pass    2m4s    https://github.com/NASA-AMMOS/aerie/runs/4874694252?check_suite_focus=true
```
After this PR is merged I plan to periodically record the same data to see if any noticeable improvement has been made.

Script:
```sh
gh pr list --json number --jq '.[] | .number' | xargs -L 1 -I {} sh -c "echo {}; gh pr checks {}"
```

**Update**

```
31
pr      pass    2m48s   https://github.com/NASA-AMMOS/aerie/runs/4928799653?check_suite_focus=true
30
pr      pass    2m2s    https://github.com/NASA-AMMOS/aerie/runs/4928801192?check_suite_focus=true
28
pr      pass    2m34s   https://github.com/NASA-AMMOS/aerie/runs/4928799159?check_suite_focus=true
27
pr      pass    2m21s   https://github.com/NASA-AMMOS/aerie/runs/4928806361?check_suite_focus=true
26
pr      pass    2m17s   https://github.com/NASA-AMMOS/aerie/runs/4928806664?check_suite_focus=true
25
pr      pass    2m48s   https://github.com/NASA-AMMOS/aerie/runs/4928798507?check_suite_focus=true
23
pr      pass    2m6s    https://github.com/NASA-AMMOS/aerie/runs/4928801716?check_suite_focus=true
```

Overall we appear to now have slightly faster builds and tests.

## Documentation
None.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
AERIE-1636.