### PR TITLE
[REFACTOR] Simplify activity & configuration mapper generation

### DIFF
--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllDefinedMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllDefinedMethodMaker.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+/** Method maker for defaults style where all default arguments are provided within @Parameter annotations. */
 /*package-private*/ final class AllDefinedMethodMaker extends MapperMethodMaker {
 
   public AllDefinedMethodMaker(final ExportTypeRecord exportType) {

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllDefinedMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllDefinedMethodMaker.java
@@ -17,18 +17,20 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-public class AllDefinedMethodMaker implements MapperMethodMaker {
+/*package-private*/ final class AllDefinedMethodMaker extends MapperMethodMaker {
+
+  public AllDefinedMethodMaker(final ExportTypeRecord exportType) {
+    super(exportType);
+  }
 
   @Override
-  public MethodSpec makeInstantiateMethod(final ExportTypeRecord exportType) {
-    final var exceptionClass = MapperMethodMaker.getInstantiateException(exportType);
-
+  public MethodSpec makeInstantiateMethod() {
     // Create instantiate Method header
     var methodBuilder = MethodSpec.methodBuilder("instantiate")
         .addModifiers(Modifier.PUBLIC)
         .addAnnotation(Override.class)
         .returns(TypeName.get(exportType.declaration().asType()))
-        .addException(exceptionClass)
+        .addException(instantiationExceptionClass)
         .addParameter(
             ParameterizedTypeName.get(
                 java.util.Map.class,
@@ -73,7 +75,7 @@ public class AllDefinedMethodMaker implements MapperMethodMaker {
                         parameter.name,
                         parameter.name,
                         "entry",
-                        exceptionClass)
+                        instantiationExceptionClass)
                     .addStatement("break")
                     .unindent())
                 .reduce(CodeBlock.builder(), (x, y) -> x.add(y.build()))
@@ -85,21 +87,19 @@ public class AllDefinedMethodMaker implements MapperMethodMaker {
                 .indent()
                 .addStatement(
                     "throw new $T()",
-                    exceptionClass)
+                    instantiationExceptionClass)
                 .unindent()
                 .build())
         .endControlFlow()
         .endControlFlow().addCode("\n");
 
-    methodBuilder = MapperMethodMaker
-        .makeArgumentPresentCheck(methodBuilder, exportType).addCode("\n").addStatement("return template");
+    methodBuilder = makeArgumentPresentCheck(methodBuilder).addCode("\n").addStatement("return template");
 
     return methodBuilder.build();
   }
 
   @Override
-  public MethodSpec makeGetArgumentsMethod(final ExportTypeRecord exportType) {
-    final var metaName = MapperMethodMaker.getMetaName(exportType);
+  public MethodSpec makeGetArgumentsMethod() {
     return MethodSpec
         .methodBuilder("getArguments")
         .addModifiers(Modifier.PUBLIC)

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllDefinedMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllDefinedMethodMaker.java
@@ -139,17 +139,4 @@ public class AllDefinedMethodMaker implements MapperMethodMaker {
             "arguments")
         .build();
   }
-
-  @Override
-  public List<ParameterRecord> getParameters(final TypeElement activityTypeElement) {
-    final var parameters = new ArrayList<ParameterRecord>();
-    for (final var element : activityTypeElement.getEnclosedElements()) {
-      if (element.getKind() != ElementKind.FIELD) continue;
-      if (element.getAnnotation(Export.Parameter.class) == null) continue;
-      final var name = element.getSimpleName().toString();
-      final var type = element.asType();
-      parameters.add(new ParameterRecord(name, type, element));
-    }
-    return parameters;
-  }
 }

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllStaticallyDefinedMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllStaticallyDefinedMethodMaker.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+/** Method maker for defaults style where all default arguments are provided within a @Template static method. */
 /*package-private*/ final class AllStaticallyDefinedMethodMaker extends MapperMethodMaker {
 
   public AllStaticallyDefinedMethodMaker(final ExportTypeRecord exportType) {

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MapperMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MapperMethodMaker.java
@@ -15,6 +15,10 @@ import javax.lang.model.element.Modifier;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Mapper method generator for all export types (activities and configurations).
+ * Generates common methods betweeen all export types.
+ */
 public abstract sealed class MapperMethodMaker permits
     AllDefinedMethodMaker,
     AllStaticallyDefinedMethodMaker,

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MapperMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MapperMethodMaker.java
@@ -156,19 +156,6 @@ public interface MapperMethodMaker {
         .build();
   }
 
-  default List<ParameterRecord> getParameters(final TypeElement activityTypeElement)
-  {
-    final var parameters = new ArrayList<ParameterRecord>();
-    for (final var element : activityTypeElement.getEnclosedElements()) {
-      if (element.getKind() != ElementKind.FIELD) continue;
-      if (element.getModifiers().contains(Modifier.STATIC)) continue;
-      final var name = element.getSimpleName().toString();
-      final var type = element.asType();
-      parameters.add(new ParameterRecord(name, type, element));
-    }
-    return parameters;
-  }
-
   static MethodSpec.Builder makeArgumentPresentCheck(final MethodSpec.Builder methodBuilder, final ExportTypeRecord exportType) {
     // Ensure all parameters are non-null
     return methodBuilder.addCode(

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/NoneDefinedMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/NoneDefinedMethodMaker.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+/** Method maker for defaults style where no default arguments are provided (for example, a record class). */
 /*package-private*/ final class NoneDefinedMethodMaker extends MapperMethodMaker {
 
   public NoneDefinedMethodMaker(final ExportTypeRecord exportType) {

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/SomeStaticallyDefinedMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/SomeStaticallyDefinedMethodMaker.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+/** Method maker for defaults style where some arguments are provided within an @WithDefaults static class. */
 /*package-private*/ final class SomeStaticallyDefinedMethodMaker extends MapperMethodMaker {
 
   public SomeStaticallyDefinedMethodMaker(final ExportTypeRecord exportType) {

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/SomeStaticallyDefinedMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/SomeStaticallyDefinedMethodMaker.java
@@ -17,18 +17,21 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public class SomeStaticallyDefinedMethodMaker implements MapperMethodMaker {
+/*package-private*/ final class SomeStaticallyDefinedMethodMaker extends MapperMethodMaker {
+
+  public SomeStaticallyDefinedMethodMaker(final ExportTypeRecord exportType) {
+    super(exportType);
+  }
 
   @Override
-  public MethodSpec makeInstantiateMethod(final ExportTypeRecord exportType) {
-    final var exceptionClass = MapperMethodMaker.getInstantiateException(exportType);
+  public MethodSpec makeInstantiateMethod() {
     var activityTypeName = exportType.declaration().getSimpleName().toString();
 
     var methodBuilder = MethodSpec.methodBuilder("instantiate")
         .addModifiers(Modifier.PUBLIC)
         .addAnnotation(Override.class)
         .returns(TypeName.get(exportType.declaration().asType()))
-        .addException(exceptionClass)
+        .addException(instantiationExceptionClass)
         .addParameter(
             ParameterizedTypeName.get(
                 java.util.Map.class,
@@ -63,7 +66,7 @@ public class SomeStaticallyDefinedMethodMaker implements MapperMethodMaker {
               .reduce(CodeBlock.builder(), (x, y) -> x.add(y.build()))
               .build()).addCode("\n");
 
-      methodBuilder = produceParametersFromDefaultsClass(exportType, methodBuilder);
+      methodBuilder = produceParametersFromDefaultsClass(methodBuilder);
 
       methodBuilder = methodBuilder.beginControlFlow("for (final var $L : $L.entrySet())", "entry", "arguments")
         .beginControlFlow("switch ($L.getKey())", "entry")
@@ -79,7 +82,7 @@ public class SomeStaticallyDefinedMethodMaker implements MapperMethodMaker {
                         parameter.name,
                         parameter.name,
                         "entry",
-                        exceptionClass)
+                        instantiationExceptionClass)
                     .addStatement("break")
                     .unindent())
                 .reduce(CodeBlock.builder(), (x, y) -> x.add(y.build()))
@@ -91,15 +94,14 @@ public class SomeStaticallyDefinedMethodMaker implements MapperMethodMaker {
                 .indent()
                 .addStatement(
                     "throw new $T()",
-                    exceptionClass)
+                    instantiationExceptionClass)
                 .unindent()
                 .build())
         .endControlFlow()
         .endControlFlow().addCode("\n");
     }
 
-    methodBuilder = MapperMethodMaker
-        .makeArgumentPresentCheck(methodBuilder, exportType).addCode("\n");
+    methodBuilder = makeArgumentPresentCheck(methodBuilder).addCode("\n");
 
     // Add return statement with instantiation of class with parameters
     methodBuilder = methodBuilder.addStatement(
@@ -111,7 +113,7 @@ public class SomeStaticallyDefinedMethodMaker implements MapperMethodMaker {
   }
 
   @Override
-  public List<String> getParametersWithDefaults(final ExportTypeRecord exportType) {
+  public List<String> getParametersWithDefaults() {
     Optional<Element> defaultsClass = Optional.empty();
     for (final var element : exportType.declaration().getEnclosedElements()) {
       if (element.getAnnotation(Export.WithDefaults.class) == null) continue;
@@ -129,9 +131,9 @@ public class SomeStaticallyDefinedMethodMaker implements MapperMethodMaker {
     return fieldNameList;
   }
 
-  private MethodSpec.Builder produceParametersFromDefaultsClass(final ExportTypeRecord exportType, MethodSpec.Builder methodBuilder)
+  private MethodSpec.Builder produceParametersFromDefaultsClass(final MethodSpec.Builder methodBuilder)
   {
-    return methodBuilder.addCode(getParametersWithDefaults(exportType).stream()
+    return methodBuilder.addCode(getParametersWithDefaults().stream()
         .map(fieldName -> CodeBlock
             .builder()
             .addStatement(


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
- Uses fully qualified configuration mapper class in generated code to avoid any possible name collisions.
- Simplifies `MapperMethodMaker`, removes parsing logic from this class (for example, `getParameters()`).

## Verification

These changes did not result in unwanted changes to generated code. To demonstrate:

- Run `gradle clean classes` on `develop` and this branch, saving `examples/banananation/build/generated` with `cp -r <some_dir>`.
- Run `diff -qr banana_gen refactor_gen` (the saved directories from above)
    ```
    Files .../GeneratedMissionModelFactory.java and .../GeneratedMissionModelFactory.java differ
    ```
- Run `diff .../GeneratedMissionModelFactory.java .../GeneratedMissionModelFactory.java` (with full paths substituted):
    ```diff
    @@ -19,7 +19,7 @@
     public final class GeneratedMissionModelFactory implements MissionModelFactory<RootModel<Mission>> {
       @Override
       public Optional<ConfigurationType<?>> getConfigurationType() {
    -    return Optional.of(new ConfigurationMapper());
    +    return Optional.of(new gov.nasa.jpl.aerie.banananation.generated.ConfigurationMapper());
       }
    
       @Override
    @@ -35,7 +35,7 @@
    
         try {
           final var serializedArguments = configuration.asMap().orElseThrow(() -> new     ConfigurationType.UnconstructableConfigurationException());
    -      final var deserializedConfig = new ConfigurationMapper().instantiate(serializedArguments);
    +      final var deserializedConfig = new gov.nasa.jpl.aerie.banananation.generated.ConfigurationMapper().instantiate(serializedArguments);
           final var model = InitializationContext.initializing(executor, builder, () -> new Mission(registrar, deserializedConfig));
           return new RootModel<Mission>(model, executor);
         } catch (final ConfigurationType.UnconstructableConfigurationException ex) {
    ```
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

## Documentation
Updated javadocs.

## Future work
None.
