### PR TITLE
[AERIE-1636] Add JUnit test reporter action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,13 @@ jobs:
         run: ./gradlew classes
       - name: Test
         run: ./gradlew test
+      - name: Publish Test Report
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: JUnit Test Report
+          path: '**/build/test-results/test/TEST-*.xml'
+          reporter: java-junit
       - name: Assemble
         run: ./gradlew assemble
       - name: Login to the Container Registry


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1636
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds JUnit test report publishing to our `publish` action. This will effectively serve the same purpose as our old TestRails workflow.

## Verification
Ran as part of the `pr` workflow: https://github.com/NASA-AMMOS/aerie/runs/5043474122#r43
After this PR is merged I will verify that the `publish` action correctly generates the JUnit test report.

## Documentation
None.

## Future work
None.