### PR TITLE
[AERIE-1638] Mission model configuration validation

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -41,6 +41,13 @@ type Query {
   ): ValidationResponse
 }
 
+type Query {
+  validateModelArguments(
+    missionModelId: ID!
+    modelArguments: ModelArguments!
+  ): ValidationResponse
+}
+
 enum MerlinSimulationStatus {
   complete
   failed

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -23,6 +23,10 @@ actions:
   definition:
     kind: ""
     handler: http://aerie_merlin:27183/validateActivityArguments
+- name: validateModelArguments
+  definition:
+    kind: ""
+    handler: http://aerie_merlin:27183/validateModelArguments
 custom_types:
   enums:
   - name: MerlinSimulationStatus

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/Configuration.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/Configuration.java
@@ -4,11 +4,23 @@ import java.nio.file.Path;
 
 import static gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Template;
 
+import gov.nasa.jpl.aerie.merlin.framework.annotations.Export;
+
 public record Configuration(int initialPlantCount, String initialProducer, Path initialDataPath) {
 
   public static final int DEFAULT_PLANT_COUNT = 200;
   public static final String DEFAULT_PRODUCER = "Chiquita";
   public static final Path DEFAULT_DATA_PATH = Path.of("/etc/os-release");
+
+  @Export.Validation("plant count must be positive")
+  public boolean validateInitialPlantCount() {
+    return this.initialPlantCount > 0;
+  }
+
+  @Export.Validation("data path must exist")
+  public boolean validateInitialDataPath() {
+    return initialDataPath.toFile().exists();
+  }
 
   public static @Template Configuration defaultConfiguration() {
     return new Configuration(DEFAULT_PLANT_COUNT, DEFAULT_PRODUCER, DEFAULT_DATA_PATH);

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
@@ -112,10 +112,10 @@ import java.util.function.Predicate;
     final var declaration = (TypeElement) ((DeclaredType) attribute.getValue()).asElement();
     final var name = declaration.getSimpleName().toString();
     final var parameters = getExportParameters(declaration);
-    final List<ParameterValidationRecord> validations = List.of(); // TODO validation list is empty, not parsing those yet
+    final var validations = this.getExportValidations(declaration);
     final var mapper = getExportMapper(missionModelElement, declaration);
     final var defaultsStyle = getExportDefaultsStyle(declaration);
-    return Optional.of(new ConfigurationTypeRecord(name, declaration, parameters, List.of(), mapper, defaultsStyle));
+    return Optional.of(new ConfigurationTypeRecord(name, declaration, parameters, validations, mapper, defaultsStyle));
   }
 
   private List<TypeElement> getMissionModelMapperClasses(final PackageElement missionModelElement)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
@@ -99,6 +99,29 @@ public final class MissionModelFacade {
     }
   }
 
+  public List<String> validateConfiguration(final Map<String, SerializedValue> arguments)
+  throws UnconfigurableMissionModelException, UnconstructableMissionModelConfigurationException
+  {
+    final var configType = this.missionModel.getConfigurationType()
+        .orElseThrow(UnconfigurableMissionModelException::new);
+
+    return getValidationFailures(configType, arguments);
+  }
+
+  private <Config> List<String> getValidationFailures(
+      final ConfigurationType<Config> configurationType,
+      final Map<String, SerializedValue> arguments)
+  throws UnconstructableMissionModelConfigurationException
+  {
+    try {
+      return configurationType.getValidationFailures(configurationType.instantiate(arguments));
+    } catch (final ConfigurationType.UnconstructableConfigurationException e) {
+      throw new UnconstructableMissionModelConfigurationException(
+          "Unknown failure when deserializing configuration -- do the parameters match the schema?",
+          e);
+    }
+  }
+
   /** Get mission model configuration effective arguments. */
   public Map<String, SerializedValue> getEffectiveArguments(final Map<String, SerializedValue> arguments)
   throws UnconfigurableMissionModelException, MissingArgumentException, UnconstructableMissionModelConfigurationException

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -133,6 +133,23 @@ public final class LocalMissionModelService implements MissionModelService {
   }
 
   @Override
+  public List<String> validateModelArguments(final String missionModelId, final Map<String, SerializedValue> arguments)
+  throws NoSuchMissionModelException,
+         MissionModelLoadException,
+         UnconstructableMissionModelConfigurationException,
+         UnconfigurableMissionModelException
+  {
+    try {
+      return this.loadConfiguredMissionModel(missionModelId)
+                 .validateConfiguration(arguments);
+    } catch (final MissionModelFacade.UnconfigurableMissionModelException ex) {
+      throw new UnconfigurableMissionModelException(ex);
+    } catch (final MissionModelFacade.UnconstructableMissionModelConfigurationException ex) {
+      throw new UnconstructableMissionModelConfigurationException(ex);
+    }
+  }
+
+  @Override
   public List<Parameter> getModelParameters(final String missionModelId)
   throws NoSuchMissionModelException, MissionModelLoadException
   {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -38,6 +38,12 @@ public interface MissionModelService {
     UnconstructableActivityInstanceException,
     MissingArgumentException;
 
+  List<String> validateModelArguments(String missionModelId, Map<String, SerializedValue> arguments)
+  throws NoSuchMissionModelException,
+    LocalMissionModelService.MissionModelLoadException,
+    UnconstructableMissionModelConfigurationException,
+    UnconfigurableMissionModelException;
+
   List<Parameter> getModelParameters(String missionModelId)
   throws NoSuchMissionModelException, MissionModelLoader.MissionModelLoadException;
 

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -137,6 +137,13 @@ public final class StubMissionModelService implements MissionModelService {
   }
 
   @Override
+  public List<String> validateModelArguments(final String missionModelId, final Map<String, SerializedValue> arguments)
+  throws LocalMissionModelService.MissionModelLoadException
+  {
+    return List.of();
+  }
+
+  @Override
   public List<Parameter> getModelParameters(final String missionModelId) {
     return List.of();
   }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1638
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Expands on changes made in #20. #20 and related refactoring basically implemented all of the annotation processing needed for this change, so the bulk of this PR is just routing validation failures up to the HTTP service.

### Changes
- Allows `@Validation` annotations to be used within mission model configurations.
- Exposes validation failures through `validateModelArguments` Hasura action.

## Verification

### Return Failure
```gql
query TestValidateModelArguments {
  validateModelArguments(missionModelId: 1, modelArguments: {initialDataPath: "/this/path/does/not/exist"}) {
    success
    errors
  }
}
```
Returns:
```json
{
  "data": {
    "validateModelArguments": {
      "success": false,
      "errors": [
        "data path must exist"
      ]
    }
  }
}
```

### Return Success

```gql
query TestValidateModelArguments {
  validateModelArguments(missionModelId: 1, modelArguments: {initialDataPath: "/etc/os-release"}) {
    success
    errors
  }
}
```
Returns:
```json
{
  "data": {
    "validateModelArguments": {
      "success": true
    }
  }
}
```

## Documentation
See https://github.com/NASA-AMMOS/aerie/wiki/Declaring-Parameters#validation.

## Future work
None that I am aware of.