### PR TITLE
Allow test reporter to write to `checks`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
+      checks: write
       contents: read
       packages: write
     steps:


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1636
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

Fixes permission error with writing test report results to "checks".
Issue description: https://github.com/dorny/test-reporter/issues/149

Big thanks to @camargo for help on this.
