### PR TITLE
[AERIE-1679] SQL tables to postgres for Command Expansions

### DIFF
--- a/deployment/postgres-init-db/init-aerie.sh
+++ b/deployment/postgres-init-db/init-aerie.sh
@@ -26,6 +26,7 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
   CREATE DATABASE aerie_ui;
   GRANT ALL PRIVILEGES ON DATABASE aerie_ui TO aerie;
   \echo 'Done!'
+
 EOSQL
 
 export PGPASSWORD=aerie

--- a/deployment/postgres-init-db/sql/expansion/init.sql
+++ b/deployment/postgres-init-db/sql/expansion/init.sql
@@ -1,0 +1,13 @@
+-- The order of inclusion is important! Tables referenced by foreign keys must be loaded before their dependants.
+
+begin;
+
+  -- Command Expansion Tables.
+  \ir tables/command_dictionary.sql
+  \ir tables/expansion_set.sql
+  \ir tables/expansion_rules.sql
+  \ir tables/expansion_set_to_rule.sql
+  \ir tables/expansion_run.sql
+  \ir tables/activity_instance_commands.sql
+
+end;

--- a/deployment/postgres-init-db/sql/expansion/tables/activity_instance_commands.sql
+++ b/deployment/postgres-init-db/sql/expansion/tables/activity_instance_commands.sql
@@ -1,0 +1,20 @@
+create table activity_instance_commands (
+  activity_instance_id integer not null,
+  commands jsonb not null,
+  expansion_run_id integer not null,
+
+  constraint activity_instance_primary_key
+    primary key (activity_instance_id),
+
+  foreign key (expansion_run_id)
+  references expansion_run (id)
+);
+
+comment on table activity_instance_commands is e''
+  'The commands generated from activities instances in the plan.';
+comment on column activity_instance_commands.activity_instance_id is e''
+  'The activity_instance in the plan.';
+comment on column activity_instance_commands.commands is e''
+  'Commands generated for the activity_instance.';
+comment on column activity_instance_commands.expansion_run_id is e''
+  'The configuration used during command generation';

--- a/deployment/postgres-init-db/sql/expansion/tables/command_dictionary.sql
+++ b/deployment/postgres-init-db/sql/expansion/tables/command_dictionary.sql
@@ -1,0 +1,21 @@
+create table command_dictionary (
+  id integer generated always as identity,
+
+  command_types text not null,
+  mission text not null,
+  version text not null,
+
+  constraint command_dictionary_primary_key
+      primary key (id)
+);
+
+comment on table command_dictionary is e''
+  'A Command Dictionary for a mission.';
+comment on column command_dictionary.id is e''
+  'The synthetic identifier for this command dictionary.';
+comment on column command_dictionary.command_types is e''
+  'The location of command dictionary types (.ts) on the filesystem';
+comment on column command_dictionary.mission is e''
+  'A human-meaningful identifier for the mission described by the command dictionary';
+comment on column command_dictionary.version is e''
+  'A human-meaningful version qualifier.';

--- a/deployment/postgres-init-db/sql/expansion/tables/expansion_rules.sql
+++ b/deployment/postgres-init-db/sql/expansion/tables/expansion_rules.sql
@@ -1,0 +1,17 @@
+create table expansion_rules (
+  id integer generated always as identity,
+
+  activity_type text not null,
+  expansion_logic text not null,
+
+  constraint expansion_rules_primary_key
+  primary key (id)
+);
+comment on table expansion_rules is e''
+  'The user defined logic to expand an activity type.';
+comment on column expansion_rules.id is e''
+  'The synthetic identifier for this expansion rule.';
+comment on column expansion_rules.activity_type is e''
+  'The user selected activity type.';
+comment on column expansion_rules.expansion_logic is e''
+  'The expansion logic used to generate commands.';

--- a/deployment/postgres-init-db/sql/expansion/tables/expansion_run.sql
+++ b/deployment/postgres-init-db/sql/expansion/tables/expansion_run.sql
@@ -1,0 +1,20 @@
+create table expansion_run (
+  id integer generated always as identity,
+
+  simulation_id integer not null,
+  expansion_set_id integer not null,
+
+  constraint expansion_run_primary_key
+    primary key (id),
+
+  foreign key (expansion_set_id)
+  references expansion_set (id)
+);
+comment on table expansion_run is e''
+  'The configuration for an expansion run for a plan.';
+comment on column expansion_run.id is e''
+  'The synthetic identifier for this expansion run.';
+comment on column expansion_run.simulation_id is e''
+  'The simulation results for the plan.';
+comment on column expansion_run.expansion_set_id is e''
+  'The command dictionary and mission model set';

--- a/deployment/postgres-init-db/sql/expansion/tables/expansion_set.sql
+++ b/deployment/postgres-init-db/sql/expansion/tables/expansion_set.sql
@@ -1,0 +1,21 @@
+create table expansion_set (
+  id integer generated always as identity,
+
+  command_dict_id integer not null,
+  mission_model_id integer not null,
+
+  constraint expansion_set_primary_key
+    primary key (id),
+
+  foreign key (command_dict_id)
+  references command_dictionary (id)
+);
+
+comment on table expansion_set is e''
+  'A binding of a command dictionary to a mission model.';
+comment on column expansion_set.id is e''
+  'The synthetic identifier for the set.';
+comment on column expansion_set.command_dict_id is e''
+  'The ID of a command dictionary.';
+comment on column expansion_set.mission_model_id is e''
+  'The ID of a mission model.';

--- a/deployment/postgres-init-db/sql/expansion/tables/expansion_set_to_rule.sql
+++ b/deployment/postgres-init-db/sql/expansion/tables/expansion_set_to_rule.sql
@@ -1,0 +1,19 @@
+create table expansion_set_to_rule (
+  set_id integer not null,
+  rule_id integer not null,
+
+  constraint expansion_set_to_rule_primary_key
+  primary key (set_id,rule_id),
+
+  foreign key (set_id)
+  references expansion_set (id),
+
+  foreign key (rule_id)
+  references expansion_rules (id)
+);
+comment on table expansion_set_to_rule is e''
+  'The join table between expansion_set and expansion_rules';
+comment on column expansion_set_to_rule.set_id is e''
+  'The id for an expansion_set.';
+comment on column expansion_set_to_rule.rule_id is e''
+  'the id for an expansion_rule.';


### PR DESCRIPTION
[AERIE-1679]

* **Tickets addressed:** AERIE-1679
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
During the 'Command Dictionary WG' the team has come up with a data flow diagram for command expansions. The data models are defined in the document below and I converted the mock tables into SQL tables for Postgres. 

**Command Expansion Data Flow Diagram**
https://docs.google.com/drawings/d/1ZShnHzeWt7UVPVpVWSSYNPij7TWdtM33oMIxWMV7nbA/edit?usp=sharing


## Verification
~~I nuked everything in docker to verify that the tables were created in postgres.~~

~~- `docker system prune --all --volumes  `~~
~~- `./gradlew build; docker compose -f docker-compose.yml build; docker compose -f docker-compose.yml up`~~
~~- Verify you see 'aerie-expansion` table in postgres and the tables defined in the SQL schema ( I used pgAdmin 4)~~

No verification as there is no service using this schema at the moment. I tested locally just to make sure the table were going to be created correctly in Postgres

## Documentation
Data flow diagram

## Future work
Work out the command expansion services. 
