### PR TITLE
[AERIE-1582] Fix concurrent composition of register effects

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/cells/register/RegisterEffect.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/cells/register/RegisterEffect.java
@@ -54,7 +54,7 @@ public final class RegisterEffect<T> {
         // The suffix is a pure conflict, and the prefix performed a valid write.
         return new RegisterEffect<>(prefix.newValue, suffix.conflicted);
       } else {
-        // Both suffix and prefix are pure conflicts, so the suffix dominates the prefix.
+        // The suffix is a pure conflict, and the prefix performs no write, so the suffix dominates the prefix.
         return suffix;
       }
     }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1582
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The previous logic would produce an incorrect result for the expression `(set(1) | set(2)) | set(3)`, namely `set(3)`. The expected result is a pure conflict. As a result, @Twisol produced this fix int he logic and added a truth table of sorts to document explicitly the behavior of the RegisterEffect. 

## Verification
Unit test to come

## Documentation
I have created a documentation ticket AERIE-1681 for explaining the various cell types in the Merlin's contrib package.

## Future work
Possible formal tests.
