### PR TITLE
[AERIE-1651] Integrate `aerie_scheduler` database with scheduler

### DIFF
--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -18,7 +18,7 @@ This document provides detailed information about environment variables for each
 | `GQL_API_URL`              | URL of GraphQL API for the GraphQL Playground.                         | `string` | http://localhost:8080/v1/graphql               |
 | `PORT`                     | Port the Gateway server listens on.                                    | `number` | 9000                                           |
 | `POSTGRES_AERIE_MERLIN_DB` | Name of Merlin Postgres database.                                      | `string` | aerie_merlin                                   |
-| `POSTGRES_AERIE_SCHED_DB`  | Name of scheduler Postgres database.                                   | `string` | aerie_sched                                    |
+| `POSTGRES_AERIE_SCHED_DB`  | Name of scheduler Postgres database.                                   | `string` | aerie_scheduler                                |
 | `POSTGRES_AERIE_UI_DB`     | Name of UI Postgres database.                                          | `string` | aerie_ui                                       |
 | `POSTGRES_HOST`            | Hostname of Postgres instance.                                         | `string` | localhost                                      |
 | `POSTGRES_PASSWORD`        | Password of Postgres instance.                                         | `string` | aerie                                          |
@@ -39,11 +39,11 @@ This document provides detailed information about environment variables for each
 
 ## Hasura
 
-| Name                        | Description                             | Type     | Default                                           |
-| --------------------------- | --------------------------------------- | -------- | ------------------------------------------------- |
-| `AERIE_MERLIN_DATABASE_URL` | Url of the Merlin Postgres database.    | `string` | postgres://aerie:aerie@postgres:5432/aerie_merlin |
-| `AERIE_SCHED_DATABASE_URL`  | Url of the scheduler Postgres database. | `string` | postgres://aerie:aerie@postgres:5432/aerie_sched  |
-| `AERIE_UI_DATABASE_URL`     | Url of the UI Postgres database         | `string` | postgres://aerie:aerie@postgres:5432/aerie_ui     |
+| Name                        | Description                             | Type     | Default                                              |
+| --------------------------- | --------------------------------------- | -------- | ---------------------------------------------------- |
+| `AERIE_MERLIN_DATABASE_URL` | Url of the Merlin Postgres database.    | `string` | postgres://aerie:aerie@postgres:5432/aerie_merlin    |
+| `AERIE_SCHED_DATABASE_URL`  | Url of the scheduler Postgres database. | `string` | postgres://aerie:aerie@postgres:5432/aerie_scheduler |
+| `AERIE_UI_DATABASE_URL`     | Url of the UI Postgres database         | `string` | postgres://aerie:aerie@postgres:5432/aerie_ui        |
 
 Additionally, Hasura provides documentation on it's own environment variables you can use to fine-tune your deployment:
 
@@ -73,7 +73,7 @@ The default Aerie deployment uses the default Postgres environment. See the [Doc
 | -------------------- | --------------------------------------------------------------------- | -------- | ---------------------------------------------- |
 | `MERLIN_GRAPHQL_URL` | URI of the Merlin graphql interface to call                           | `string` | http://hasura:8080/v1/graphql                  |
 | `MERLIN_LOCAL_STORE` | Local storage for Merlin in the container (for backdoor jar access)   | `string` | /usr/src/app/merlin_file_store                 |
-| `SCHED_DB`           | The DB for scheduler                                                  | `string` | aerie_sched                                    |
+| `SCHED_DB`           | The DB for scheduler                                                  | `string` | aerie_scheduler                                |
 | `SCHED_DB_PASSWORD`  | Password of the DB instance                                           | `string` | aerie                                          |
 | `SCHED_DB_PORT`      | The DB instance port number that scheduler will connect with          | `number` | 5432                                           |
 | `SCHED_DB_SERVER`    | The DB instance that scheduler will connect with                      | `string` | postgres                                       |

--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -11,19 +11,19 @@ This document provides detailed information about environment variables for each
 
 ## Aerie Gateway
 
-| Name                       | Description                                                            | Type     | Default                                        |
-| -------------------------- | ---------------------------------------------------------------------- | -------- | ---------------------------------------------- |
-| `AUTH_TYPE`                | Mode of authentication. Set to `none` to fully disable authentication. | `string` | cam                                            |
-| `AUTH_URL`                 | URL of authentication API for the given `AUTH_TYPE`.                   | `string` | https://atb-ocio-12b.jpl.nasa.gov:8443/cam-api |
-| `GQL_API_URL`              | URL of GraphQL API for the GraphQL Playground.                         | `string` | http://localhost:8080/v1/graphql               |
-| `PORT`                     | Port the Gateway server listens on.                                    | `number` | 9000                                           |
-| `POSTGRES_AERIE_MERLIN_DB` | Name of Merlin Postgres database.                                      | `string` | aerie_merlin                                   |
-| `POSTGRES_AERIE_SCHED_DB`  | Name of scheduler Postgres database.                                   | `string` | aerie_scheduler                                |
-| `POSTGRES_AERIE_UI_DB`     | Name of UI Postgres database.                                          | `string` | aerie_ui                                       |
-| `POSTGRES_HOST`            | Hostname of Postgres instance.                                         | `string` | localhost                                      |
-| `POSTGRES_PASSWORD`        | Password of Postgres instance.                                         | `string` | aerie                                          |
-| `POSTGRES_PORT`            | Port of Postgres instance.                                             | `number` | 5432                                           |
-| `POSTGRES_USER`            | User of Postgres instance.                                             | `string` | aerie                                          |
+| Name                          | Description                                                            | Type     | Default                                        |
+| ----------------------------- | ---------------------------------------------------------------------- | -------- | ---------------------------------------------- |
+| `AUTH_TYPE`                   | Mode of authentication. Set to `none` to fully disable authentication. | `string` | cam                                            |
+| `AUTH_URL`                    | URL of authentication API for the given `AUTH_TYPE`.                   | `string` | https://atb-ocio-12b.jpl.nasa.gov:8443/cam-api |
+| `GQL_API_URL`                 | URL of GraphQL API for the GraphQL Playground.                         | `string` | http://localhost:8080/v1/graphql               |
+| `PORT`                        | Port the Gateway server listens on.                                    | `number` | 9000                                           |
+| `POSTGRES_AERIE_MERLIN_DB`    | Name of Merlin Postgres database.                                      | `string` | aerie_merlin                                   |
+| `POSTGRES_AERIE_SCHEDULER_DB` | Name of scheduler Postgres database.                                   | `string` | aerie_scheduler                                |
+| `POSTGRES_AERIE_UI_DB`        | Name of UI Postgres database.                                          | `string` | aerie_ui                                       |
+| `POSTGRES_HOST`               | Hostname of Postgres instance.                                         | `string` | localhost                                      |
+| `POSTGRES_PASSWORD`           | Password of Postgres instance.                                         | `string` | aerie                                          |
+| `POSTGRES_PORT`               | Port of Postgres instance.                                             | `number` | 5432                                           |
+| `POSTGRES_USER`               | User of Postgres instance.                                             | `string` | aerie                                          |
 
 ## Aerie UI
 
@@ -39,11 +39,11 @@ This document provides detailed information about environment variables for each
 
 ## Hasura
 
-| Name                        | Description                             | Type     | Default                                              |
-| --------------------------- | --------------------------------------- | -------- | ---------------------------------------------------- |
-| `AERIE_MERLIN_DATABASE_URL` | Url of the Merlin Postgres database.    | `string` | postgres://aerie:aerie@postgres:5432/aerie_merlin    |
-| `AERIE_SCHED_DATABASE_URL`  | Url of the scheduler Postgres database. | `string` | postgres://aerie:aerie@postgres:5432/aerie_scheduler |
-| `AERIE_UI_DATABASE_URL`     | Url of the UI Postgres database         | `string` | postgres://aerie:aerie@postgres:5432/aerie_ui        |
+| Name                           | Description                             | Type     | Default                                              |
+| ------------------------------ | --------------------------------------- | -------- | ---------------------------------------------------- |
+| `AERIE_MERLIN_DATABASE_URL`    | Url of the Merlin Postgres database.    | `string` | postgres://aerie:aerie@postgres:5432/aerie_merlin    |
+| `AERIE_SCHEDULER_DATABASE_URL` | Url of the scheduler Postgres database. | `string` | postgres://aerie:aerie@postgres:5432/aerie_scheduler |
+| `AERIE_UI_DATABASE_URL`        | Url of the UI Postgres database         | `string` | postgres://aerie:aerie@postgres:5432/aerie_ui        |
 
 Additionally, Hasura provides documentation on it's own environment variables you can use to fine-tune your deployment:
 
@@ -69,17 +69,17 @@ The default Aerie deployment uses the default Postgres environment. See the [Doc
 
 ## Scheduler
 
-| Name                 | Description                                                           | Type     | Default                                        |
-| -------------------- | --------------------------------------------------------------------- | -------- | ---------------------------------------------- |
-| `MERLIN_GRAPHQL_URL` | URI of the Merlin graphql interface to call                           | `string` | http://hasura:8080/v1/graphql                  |
-| `MERLIN_LOCAL_STORE` | Local storage for Merlin in the container (for backdoor jar access)   | `string` | /usr/src/app/merlin_file_store                 |
-| `SCHED_DB`           | The DB for scheduler                                                  | `string` | aerie_scheduler                                |
-| `SCHED_DB_PASSWORD`  | Password of the DB instance                                           | `string` | aerie                                          |
-| `SCHED_DB_PORT`      | The DB instance port number that scheduler will connect with          | `number` | 5432                                           |
-| `SCHED_DB_SERVER`    | The DB instance that scheduler will connect with                      | `string` | postgres                                       |
-| `SCHED_DB_USER`      | Username of the DB instance                                           | `string` | aerie                                          |
-| `SCHED_LOCAL_STORE`  | Local storage for scheduler in the container                          | `string` | /usr/src/app/sched_file_store                  |
-| `SCHED_LOGGING`      | Whether or not you want Javalin to log server information             | `string` | true                                           |
-| `SCHED_OUTPUT_MODE`  | how scheduler output is sent back to aerie                            | `string` | UpdateInputPlanWithNewActivities               |
-| `SCHED_PORT`         | Port number for the scheduler server                                  | `number` | 27193                                          |
-| `SCHED_RULES_JAR`    | Jar file to load scheduling rules from (until user input to database) | `string` | /usr/src/app/merlin_file_store/sched_rules.jar |
+| Name                     | Description                                                           | Type     | Default                                           |
+| --------------------     | --------------------------------------------------------------------- | -------- | ------------------------------------------------- |
+| `MERLIN_GRAPHQL_URL`     | URI of the Merlin graphql interface to call                           | `string` | http://hasura:8080/v1/graphql                     |
+| `MERLIN_LOCAL_STORE`     | Local storage for Merlin in the container (for backdoor jar access)   | `string` | /usr/src/app/merlin_file_store                    |
+| `SCHEDULER_DB`           | The DB for scheduler                                                  | `string` | aerie_scheduler                                   |
+| `SCHEDULER_DB_PASSWORD`  | Password of the DB instance                                           | `string` | aerie                                             |
+| `SCHEDULER_DB_PORT`      | The DB instance port number that scheduler will connect with          | `number` | 5432                                              |
+| `SCHEDULER_DB_SERVER`    | The DB instance that scheduler will connect with                      | `string` | postgres                                          |
+| `SCHEDULER_DB_USER`      | Username of the DB instance                                           | `string` | aerie                                             |
+| `SCHEDULER_LOCAL_STORE`  | Local storage for scheduler in the container                          | `string` | /usr/src/app/scheduler_file_store                 |
+| `SCHEDULER_LOGGING`      | Whether or not you want Javalin to log server information             | `string` | true                                              |
+| `SCHEDULER_OUTPUT_MODE`  | how scheduler output is sent back to aerie                            | `string` | UpdateInputPlanWithNewActivities                  |
+| `SCHEDULER_PORT`         | Port number for the scheduler server                                  | `number` | 27193                                             |
+| `SCHEDULER_RULES_JAR`    | Jar file to load scheduling rules from (until user input to database) | `string` | /usr/src/app/merlin_file_store/scheduler_rules.jar |

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       GQL_API_URL: http://localhost:8080/v1/graphql
       PORT: 9000
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin
-      POSTGRES_AERIE_SCHED_DB: aerie_sched
+      POSTGRES_AERIE_SCHED_DB: aerie_scheduler
       POSTGRES_AERIE_UI_DB: aerie_ui
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: aerie
@@ -43,7 +43,7 @@ services:
     environment:
       MERLIN_GRAPHQL_URL: http://hasura:8080/v1/graphql
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
-      SCHED_DB: "aerie_sched"
+      SCHED_DB: "aerie_scheduler"
       SCHED_DB_PASSWORD: "aerie"
       SCHED_DB_PORT: 5432
       SCHED_DB_SERVER: "postgres"
@@ -77,7 +77,7 @@ services:
     depends_on: ["postgres"]
     environment:
       AERIE_MERLIN_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_merlin
-      AERIE_SCHED_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_sched
+      AERIE_SCHED_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_scheduler
       AERIE_UI_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_ui
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       GQL_API_URL: http://localhost:8080/v1/graphql
       PORT: 9000
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin
+      POSTGRES_AERIE_SCHED_DB: aerie_sched
       POSTGRES_AERIE_UI_DB: aerie_ui
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: aerie
@@ -76,13 +77,14 @@ services:
     depends_on: ["postgres"]
     environment:
       AERIE_MERLIN_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_merlin
+      AERIE_SCHED_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_sched
       AERIE_UI_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_ui
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
       HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_hasura
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: "hasura/graphql-engine:v2.0.10.cli-migrations-v3"
+    image: "hasura/graphql-engine:v2.2.0.cli-migrations-v3"
     ports: ["8080:8080"]
     restart: always
     volumes:

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       GQL_API_URL: http://localhost:8080/v1/graphql
       PORT: 9000
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin
-      POSTGRES_AERIE_SCHED_DB: aerie_scheduler
+      POSTGRES_AERIE_SCHEDULER_DB: aerie_scheduler
       POSTGRES_AERIE_UI_DB: aerie_ui
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: aerie
@@ -43,16 +43,16 @@ services:
     environment:
       MERLIN_GRAPHQL_URL: http://hasura:8080/v1/graphql
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
-      SCHED_DB: "aerie_scheduler"
-      SCHED_DB_PASSWORD: "aerie"
-      SCHED_DB_PORT: 5432
-      SCHED_DB_SERVER: "postgres"
-      SCHED_DB_USER: "aerie"
-      SCHED_LOCAL_STORE: /usr/src/app/sched_file_store
-      SCHED_LOGGING: "true"
-      SCHED_OUTPUT_MODE: UpdateInputPlanWithNewActivities
-      SCHED_PORT: 27193
-      SCHED_RULES_JAR: /usr/src/app/merlin_file_store/sched_rules.jar
+      SCHEDULER_DB: "aerie_scheduler"
+      SCHEDULER_DB_PASSWORD: "aerie"
+      SCHEDULER_DB_PORT: 5432
+      SCHEDULER_DB_SERVER: "postgres"
+      SCHEDULER_DB_USER: "aerie"
+      SCHEDULER_LOCAL_STORE: /usr/src/app/scheduler_file_store
+      SCHEDULER_LOGGING: "true"
+      SCHEDULER_OUTPUT_MODE: UpdateInputPlanWithNewActivities
+      SCHEDULER_PORT: 27193
+      SCHEDULER_RULES_JAR: /usr/src/app/merlin_file_store/scheduler_rules.jar
     image: "ghcr.io/nasa-ammos/aerie-scheduler:latest"
     ports: ["27193:27193"]
     restart: always
@@ -77,7 +77,7 @@ services:
     depends_on: ["postgres"]
     environment:
       AERIE_MERLIN_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_merlin
-      AERIE_SCHED_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_scheduler
+      AERIE_SCHEDULER_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_scheduler
       AERIE_UI_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_ui
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_rule.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_rule.yaml
@@ -1,0 +1,3 @@
+table:
+  name: scheduling_rule
+  schema: public

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/tables.yaml
@@ -1,0 +1,1 @@
+- "!include public_scheduling_rule.yaml"

--- a/deployment/hasura/metadata/databases/databases.yaml
+++ b/deployment/hasura/metadata/databases/databases.yaml
@@ -12,7 +12,7 @@
   configuration:
     connection_info:
       database_url:
-        from_env: AERIE_SCHED_DATABASE_URL
+        from_env: AERIE_SCHEDULER_DATABASE_URL
       isolation_level: read-committed
       use_prepared_statements: false
   tables: "!include AerieScheduler/tables/tables.yaml"

--- a/deployment/hasura/metadata/databases/databases.yaml
+++ b/deployment/hasura/metadata/databases/databases.yaml
@@ -7,3 +7,12 @@
       isolation_level: read-committed
       use_prepared_statements: false
   tables: "!include AerieMerlin/tables/tables.yaml"
+- name: AerieScheduler
+  kind: postgres
+  configuration:
+    connection_info:
+      database_url:
+        from_env: AERIE_SCHED_DATABASE_URL
+      isolation_level: read-committed
+      use_prepared_statements: false
+  tables: "!include AerieScheduler/tables/tables.yaml"

--- a/deployment/postgres-init-db/init-aerie.sh
+++ b/deployment/postgres-init-db/init-aerie.sh
@@ -17,9 +17,9 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
   GRANT ALL PRIVILEGES ON DATABASE aerie_merlin TO aerie;
   \echo 'Done!'
 
-  \echo 'Initializing aerie_sched database...'
-  CREATE DATABASE aerie_sched;
-  GRANT ALL PRIVILEGES ON DATABASE aerie_sched TO aerie;
+  \echo 'Initializing aerie_scheduler database...'
+  CREATE DATABASE aerie_scheduler;
+  GRANT ALL PRIVILEGES ON DATABASE aerie_scheduler TO aerie;
   \echo 'Done!'
 
   \echo 'Initializing aerie_ui database...'
@@ -36,8 +36,8 @@ psql -v ON_ERROR_STOP=1 --username "aerie" --dbname "aerie_merlin" <<-EOSQL
   \echo 'Done!'
 EOSQL
 
-psql -v ON_ERROR_STOP=1 --username "aerie" --dbname "aerie_sched" <<-EOSQL
-  \echo 'Initializing aerie_sched database objects...'
+psql -v ON_ERROR_STOP=1 --username "aerie" --dbname "aerie_scheduler" <<-EOSQL
+  \echo 'Initializing aerie_scheduler database objects...'
   \ir /docker-entrypoint-initdb.d/sql/scheduler/init.sql
   \echo 'Done!'
 EOSQL

--- a/deployment/postgres-init-db/init-aerie.sh
+++ b/deployment/postgres-init-db/init-aerie.sh
@@ -17,6 +17,11 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
   GRANT ALL PRIVILEGES ON DATABASE aerie_merlin TO aerie;
   \echo 'Done!'
 
+  \echo 'Initializing aerie_sched database...'
+  CREATE DATABASE aerie_sched;
+  GRANT ALL PRIVILEGES ON DATABASE aerie_sched TO aerie;
+  \echo 'Done!'
+
   \echo 'Initializing aerie_ui database...'
   CREATE DATABASE aerie_ui;
   GRANT ALL PRIVILEGES ON DATABASE aerie_ui TO aerie;
@@ -28,6 +33,12 @@ export PGPASSWORD=aerie
 psql -v ON_ERROR_STOP=1 --username "aerie" --dbname "aerie_merlin" <<-EOSQL
   \echo 'Initializing aerie_merlin database objects...'
   \ir /docker-entrypoint-initdb.d/sql/merlin/init.sql
+  \echo 'Done!'
+EOSQL
+
+psql -v ON_ERROR_STOP=1 --username "aerie" --dbname "aerie_sched" <<-EOSQL
+  \echo 'Initializing aerie_sched database objects...'
+  \ir /docker-entrypoint-initdb.d/sql/scheduler/init.sql
   \echo 'Done!'
 EOSQL
 

--- a/deployment/postgres-init-db/sql/scheduler/init.sql
+++ b/deployment/postgres-init-db/sql/scheduler/init.sql
@@ -1,0 +1,6 @@
+-- The order of inclusion is important! Tables referenced by foreign keys must be loaded before their dependants.
+
+begin;
+  -- Scheduling intents.
+  \ir tables/scheduling_rule.sql
+end;

--- a/deployment/postgres-init-db/sql/scheduler/tables/scheduling_rule.sql
+++ b/deployment/postgres-init-db/sql/scheduler/tables/scheduling_rule.sql
@@ -1,0 +1,51 @@
+create table scheduling_rule (
+  id integer generated always as identity,
+  revision integer not null default 0,
+  definition jsonb not null,
+
+  model_id integer not null,
+  description text null,
+  author text null,
+  last_modified_by text null,
+  created_date timestamptz not null default now(),
+  modified_date timestamptz not null default now(),
+
+  constraint scheduling_rule_synthetic_key
+    primary key (id)
+);
+
+comment on table scheduling_rule is e''
+  'A rule or rule for scheduling of a plan.';
+comment on column scheduling_rule.id is e''
+  'The synthetic identifier for this scheduling rule.';
+comment on column scheduling_rule.revision is e''
+  'A monotonic clock that ticks for every change to this scheduling rule.';
+comment on column scheduling_rule.definition is e''
+  'A JSON representation of this rule''s structure';
+comment on column scheduling_rule.model_id is e''
+  'The mission model used to which this scheduling rule is associated.';
+comment on column scheduling_rule.description is e''
+  'A text description of this scheduling rule.';
+comment on column scheduling_rule.author is e''
+  'The original user who authored this scheduling rule.';
+comment on column scheduling_rule.last_modified_by is e''
+  'The last user who modified this scheduling rule.';
+comment on column scheduling_rule.created_date is e''
+  'The date this scheduling rule was created.';
+comment on column scheduling_rule.modified_date is e''
+  'The date this scheduling rule was last modified.';
+
+create function update_logging_on_update_scheduling_rule()
+  returns trigger
+  security definer
+language plpgsql as $$begin
+  new.revision = old.revision + 1;
+  new.modified_date = now();
+return new;
+end$$;
+
+create trigger update_logging_on_update_scheduling_rule_trigger
+  before update on scheduling_rule
+  for each row
+  when (pg_trigger_depth() < 1)
+  execute function update_logging_on_update_scheduling_rule();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
       HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_hasura
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: "hasura/graphql-engine:v2.0.10.cli-migrations-v3"
+    image: "hasura/graphql-engine:v2.2.0.cli-migrations-v3"
     ports: ["8080:8080"]
     restart: always
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       GQL_API_URL: http://localhost:8080/v1/graphql
       PORT: 9000
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin
-      POSTGRES_AERIE_SCHED_DB: aerie_scheduler
+      POSTGRES_AERIE_SCHEDULER_DB: aerie_scheduler
       POSTGRES_AERIE_UI_DB: aerie_ui
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: aerie
@@ -49,16 +49,16 @@ services:
     environment:
       MERLIN_GRAPHQL_URL: http://hasura:8080/v1/graphql
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
-      SCHED_DB: "aerie_scheduler"
-      SCHED_DB_PASSWORD: "aerie"
-      SCHED_DB_PORT: 5432
-      SCHED_DB_SERVER: "postgres"
-      SCHED_DB_USER: "aerie"
-      SCHED_LOCAL_STORE: /usr/src/app/sched_file_store
-      SCHED_LOGGING: "true"
-      SCHED_OUTPUT_MODE: UpdateInputPlanWithNewActivities
-      SCHED_PORT: 27193
-      SCHED_RULES_JAR: /usr/src/app/merlin_file_store/sched_rules.jar
+      SCHEDULER_DB: "aerie_scheduler"
+      SCHEDULER_DB_PASSWORD: "aerie"
+      SCHEDULER_DB_PORT: 5432
+      SCHEDULER_DB_SERVER: "postgres"
+      SCHEDULER_DB_USER: "aerie"
+      SCHEDULER_LOCAL_STORE: /usr/src/app/scheduler_file_store
+      SCHEDULER_LOGGING: "true"
+      SCHEDULER_OUTPUT_MODE: UpdateInputPlanWithNewActivities
+      SCHEDULER_PORT: 27193
+      SCHEDULER_RULES_JAR: /usr/src/app/merlin_file_store/scheduler_rules.jar
     image: aerie_scheduler
     ports: ["27193:27193"]
     restart: always
@@ -83,7 +83,7 @@ services:
     depends_on: ["postgres"]
     environment:
       AERIE_MERLIN_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_merlin
-      AERIE_SCHED_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_scheduler
+      AERIE_SCHEDULER_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_scheduler
       AERIE_UI_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_ui
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       GQL_API_URL: http://localhost:8080/v1/graphql
       PORT: 9000
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin
-      POSTGRES_AERIE_SCHED_DB: aerie_sched
+      POSTGRES_AERIE_SCHED_DB: aerie_scheduler
       POSTGRES_AERIE_UI_DB: aerie_ui
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: aerie
@@ -49,7 +49,7 @@ services:
     environment:
       MERLIN_GRAPHQL_URL: http://hasura:8080/v1/graphql
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
-      SCHED_DB: "aerie_sched"
+      SCHED_DB: "aerie_scheduler"
       SCHED_DB_PASSWORD: "aerie"
       SCHED_DB_PORT: 5432
       SCHED_DB_SERVER: "postgres"
@@ -83,7 +83,7 @@ services:
     depends_on: ["postgres"]
     environment:
       AERIE_MERLIN_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_merlin
-      AERIE_SCHED_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_sched
+      AERIE_SCHED_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_scheduler
       AERIE_UI_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_ui
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
@@ -128,18 +128,18 @@ public final class SchedulerAppDriver {
    */
   private static AppConfiguration loadConfiguration() {
     return new AppConfiguration(
-        Integer.parseInt(getEnv("SCHED_PORT", "27193")),
-        Boolean.parseBoolean(getEnv("SCHED_LOGGING", "true")) ? JavalinLoggingState.Enabled : JavalinLoggingState.Disabled,
-        Path.of(getEnv("SCHED_LOCAL_STORE", "/usr/src/app/sched_file_store")),
-        new PostgresStore(getEnv("SCHED_DB_TYPE", "postgres"),
-                          getEnv("SCHED_DB_USER", "aerie"),
-                          Integer.parseInt(getEnv("SCHED_DB_PORT", "5432")),
-                          getEnv("SCHED_DB_PASSWORD", "aerie"),
-                          getEnv("SCHED_DB", "aerie_scheduler")),
+        Integer.parseInt(getEnv("SCHEDULER_PORT", "27193")),
+        Boolean.parseBoolean(getEnv("SCHEDULER_LOGGING", "true")) ? JavalinLoggingState.Enabled : JavalinLoggingState.Disabled,
+        Path.of(getEnv("SCHEDULER_LOCAL_STORE", "/usr/src/app/scheduler_file_store")),
+        new PostgresStore(getEnv("SCHEDULER_DB_TYPE", "postgres"),
+                          getEnv("SCHEDULER_DB_USER", "aerie"),
+                          Integer.parseInt(getEnv("SCHEDULER_DB_PORT", "5432")),
+                          getEnv("SCHEDULER_DB_PASSWORD", "aerie"),
+                          getEnv("SCHEDULER_DB", "aerie_scheduler")),
         URI.create(getEnv("MERLIN_GRAPHQL_URL", "http://localhost:8080/v1/graphql")),
         Path.of(getEnv("MERLIN_LOCAL_STORE", "/usr/src/app/merlin_file_store")),
-        Path.of(getEnv("SCHED_RULES_JAR", "/usr/src/app/merlin_file_store/sched_rules.jar")),
-        PlanOutputMode.valueOf((getEnv("SCHED_OUTPUT_MODE", "CreateNewOutputPlan")))
+        Path.of(getEnv("SCHEDULER_RULES_JAR", "/usr/src/app/merlin_file_store/scheduler_rules.jar")),
+        PlanOutputMode.valueOf((getEnv("SCHEDULER_OUTPUT_MODE", "CreateNewOutputPlan")))
     );
   }
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
@@ -135,7 +135,7 @@ public final class SchedulerAppDriver {
                           getEnv("SCHED_DB_USER", "aerie"),
                           Integer.parseInt(getEnv("SCHED_DB_PORT", "5432")),
                           getEnv("SCHED_DB_PASSWORD", "aerie"),
-                          getEnv("SCHED_DB", "aerie_sched")),
+                          getEnv("SCHED_DB", "aerie_scheduler")),
         URI.create(getEnv("MERLIN_GRAPHQL_URL", "http://localhost:8080/v1/graphql")),
         Path.of(getEnv("MERLIN_LOCAL_STORE", "/usr/src/app/merlin_file_store")),
         Path.of(getEnv("SCHED_RULES_JAR", "/usr/src/app/merlin_file_store/sched_rules.jar")),

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
@@ -1,14 +1,27 @@
 package gov.nasa.jpl.aerie.scheduler.server;
 
+import com.impossibl.postgres.jdbc.PGDataSource;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import gov.nasa.jpl.aerie.scheduler.server.config.InMemoryStore;
+import gov.nasa.jpl.aerie.scheduler.server.config.PostgresStore;
 import gov.nasa.jpl.aerie.scheduler.server.config.AppConfiguration;
 import gov.nasa.jpl.aerie.scheduler.server.config.JavalinLoggingState;
 import gov.nasa.jpl.aerie.scheduler.server.config.PlanOutputMode;
+import gov.nasa.jpl.aerie.scheduler.server.config.Store;
 import gov.nasa.jpl.aerie.scheduler.server.http.SchedulerBindings;
+import gov.nasa.jpl.aerie.scheduler.server.mocks.InMemorySpecificationRepository;
+import gov.nasa.jpl.aerie.scheduler.server.mocks.InMemoryResultsCellRepository;
+import gov.nasa.jpl.aerie.scheduler.server.remotes.ResultsCellRepository;
+import gov.nasa.jpl.aerie.scheduler.server.remotes.SpecificationRepository;
+import gov.nasa.jpl.aerie.scheduler.server.remotes.postgres.PostgresSpecificationRepository;
+import gov.nasa.jpl.aerie.scheduler.server.remotes.postgres.PostgresResultsCellRepository;
 import gov.nasa.jpl.aerie.scheduler.server.services.GraphQLMerlinService;
 import gov.nasa.jpl.aerie.scheduler.server.services.LocalSpecificationService;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleAction;
 import gov.nasa.jpl.aerie.scheduler.server.services.SynchronousSchedulerAgent;
 import gov.nasa.jpl.aerie.scheduler.server.services.UncachedSchedulerService;
+import gov.nasa.jpl.aerie.scheduler.server.services.UnexpectedSubtypeError;
 import io.javalin.Javalin;
 
 import java.net.URI;
@@ -33,14 +46,14 @@ public final class SchedulerAppDriver {
   public static void main(final String[] args) {
     //load the service configuration options
     final var config = loadConfiguration();
+    final var stores = loadStores(config);
 
     //create objects in each service abstraction layer (mirroring MerlinApp)
     final var merlinService = new GraphQLMerlinService(config.merlinGraphqlURI());
-    final var specificationService = new LocalSpecificationService();
-    final var scheduleAgent = new SynchronousSchedulerAgent(
-        specificationService, merlinService, config.missionModelJarsDir(), config.missionRuleJarPath(),
-        config.outputMode());
-    final var schedulerService = new UncachedSchedulerService(scheduleAgent);
+    final var specificationService = new LocalSpecificationService(stores.specifications());
+    final var scheduleAgent = new SynchronousSchedulerAgent(specificationService, merlinService,
+        config.merlinFileStore(), config.missionRuleJarPath(), config.outputMode());
+    final var schedulerService = new UncachedSchedulerService(stores.results(), scheduleAgent);
     final var scheduleAction = new ScheduleAction(specificationService, schedulerService);
 
     //establish bindings to the service layers
@@ -61,23 +74,36 @@ public final class SchedulerAppDriver {
     javalin.start(config.httpPort());
   }
 
-  /**
-   * collects configuration options from the environment
-   *
-   * any options not specified in the input stream fall back to the hard-coded defaults here
-   *
-   * @return a complete configuration object reflecting choices elected in the environment or the defaults
-   */
-  private static AppConfiguration loadConfiguration() {
-    return new AppConfiguration(
-        Integer.parseInt(getEnvOrFallback("SCHED_PORT", "27193")),
-        Boolean.parseBoolean(getEnvOrFallback("SCHED_LOGGING", "true")) ?
-            JavalinLoggingState.Enabled : JavalinLoggingState.Disabled,
-        URI.create(getEnvOrFallback("MERLIN_GRAPHQL_URL", "http://localhost:8080/v1/graphql")),
-        Path.of(getEnvOrFallback("MERLIN_LOCAL_STORE", "/usr/src/app/merlin_file_store")),
-        Path.of(getEnvOrFallback("SCHED_RULES_JAR", "/usr/src/app/merlin_file_store/sched_rules.jar")),
-        PlanOutputMode.valueOf((getEnvOrFallback("SCHED_OUTPUT_MODE", "CreateNewOutputPlan")))
-    );
+  private record Stores(SpecificationRepository specifications, ResultsCellRepository results) { }
+
+  private static Stores loadStores(final AppConfiguration config) {
+    final var store = config.store();
+    if (store instanceof final PostgresStore pgStore) {
+      final var pgDataSource = new PGDataSource();
+      pgDataSource.setServerName(pgStore.server());
+      pgDataSource.setPortNumber(pgStore.port());
+      pgDataSource.setDatabaseName(pgStore.database());
+      pgDataSource.setApplicationName("Scheduler Server");
+
+      final var hikariConfig = new HikariConfig();
+      hikariConfig.setUsername(pgStore.user());
+      hikariConfig.setPassword(pgStore.password());
+      hikariConfig.setDataSource(pgDataSource);
+
+      final var hikariDataSource = new HikariDataSource(hikariConfig);
+
+      return new Stores(
+          new PostgresSpecificationRepository(hikariDataSource),
+          new PostgresResultsCellRepository(hikariDataSource));
+    } else if (store instanceof InMemoryStore) {
+      final var inMemorySchedulerRepository = new InMemorySpecificationRepository();
+      return new Stores(
+          inMemorySchedulerRepository,
+          new InMemoryResultsCellRepository(inMemorySchedulerRepository));
+
+    } else {
+      throw new UnexpectedSubtypeError(Store.class, store);
+    }
   }
 
   /**
@@ -88,9 +114,32 @@ public final class SchedulerAppDriver {
    * @return the value of the requested environment variable if it exists in the environment (even if it is the empty
    *     string), otherwise the specified fallback value
    */
-  private static String getEnvOrFallback(final String key, final String fallback) {
+  private static String getEnv(final String key, final String fallback) {
     final var env = System.getenv(key);
     return env == null ? fallback : env;
   }
 
+  /**
+   * collects configuration options from the environment
+   *
+   * any options not specified in the input stream fall back to the hard-coded defaults here
+   *
+   * @return a complete configuration object reflecting choices elected in the environment or the defaults
+   */
+  private static AppConfiguration loadConfiguration() {
+    return new AppConfiguration(
+        Integer.parseInt(getEnv("SCHED_PORT", "27193")),
+        Boolean.parseBoolean(getEnv("SCHED_LOGGING", "true")) ? JavalinLoggingState.Enabled : JavalinLoggingState.Disabled,
+        Path.of(getEnv("SCHED_LOCAL_STORE", "/usr/src/app/sched_file_store")),
+        new PostgresStore(getEnv("SCHED_DB_TYPE", "postgres"),
+                          getEnv("SCHED_DB_USER", "aerie"),
+                          Integer.parseInt(getEnv("SCHED_DB_PORT", "5432")),
+                          getEnv("SCHED_DB_PASSWORD", "aerie"),
+                          getEnv("SCHED_DB", "aerie_sched")),
+        URI.create(getEnv("MERLIN_GRAPHQL_URL", "http://localhost:8080/v1/graphql")),
+        Path.of(getEnv("MERLIN_LOCAL_STORE", "/usr/src/app/merlin_file_store")),
+        Path.of(getEnv("SCHED_RULES_JAR", "/usr/src/app/merlin_file_store/sched_rules.jar")),
+        PlanOutputMode.valueOf((getEnv("SCHED_OUTPUT_MODE", "CreateNewOutputPlan")))
+    );
+  }
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/config/AppConfiguration.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/config/AppConfiguration.java
@@ -18,6 +18,8 @@ import java.util.Objects;
 public record AppConfiguration(
     int httpPort,
     JavalinLoggingState javalinLogging,
+    Path schedFileStore,
+    Store store,
     URI merlinGraphqlURI,
     Path merlinFileStore,
     Path missionRuleJarPath,
@@ -26,21 +28,12 @@ public record AppConfiguration(
 {
   public AppConfiguration {
     Objects.requireNonNull(javalinLogging);
+    Objects.requireNonNull(schedFileStore);
+    Objects.requireNonNull(store);
     Objects.requireNonNull(merlinGraphqlURI);
     Objects.requireNonNull(merlinFileStore);
     Objects.requireNonNull(missionRuleJarPath);
     Objects.requireNonNull(outputMode);
     //NB: ok if the merlin file store not created yet at app init; just needs to exist by first use
   }
-
-  /**
-   * @return path to the mounted merlin file store subdirectory that houses mission model jar files
-   */
-  public Path missionModelJarsDir() {
-    //TODO: some cross-module synchronization of these magic path terms (if this backdoor persists)
-    //NB: merlin seems to not actually use the .resolve("jars") subpath despite its mention in merlin...AppConfiguration
-    //    (ref PostgresMissionModelRepository where the jar prefix path is hardcoded to just "merlin_file_store")
-    return merlinFileStore;
-  }
-
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/mocks/InMemoryResultsCellRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/mocks/InMemoryResultsCellRepository.java
@@ -1,0 +1,28 @@
+package gov.nasa.jpl.aerie.scheduler.server.mocks;
+
+import java.util.Optional;
+
+import gov.nasa.jpl.aerie.scheduler.server.ResultsProtocol;
+import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
+import gov.nasa.jpl.aerie.scheduler.server.remotes.ResultsCellRepository;
+import gov.nasa.jpl.aerie.scheduler.server.remotes.SpecificationRepository;
+
+public record InMemoryResultsCellRepository(SpecificationRepository specificationRepository) implements ResultsCellRepository {
+  @Override
+  public ResultsProtocol.OwnerRole allocate(final SpecificationId specificationId)
+  {
+    throw new UnsupportedOperationException(); // TODO stubbed method must be implemented
+  }
+
+  @Override
+  public Optional<ResultsProtocol.ReaderRole> lookup(final SpecificationId specificationId)
+  {
+    throw new UnsupportedOperationException(); // TODO stubbed method must be implemented
+  }
+
+  @Override
+  public void deallocate(final ResultsProtocol.OwnerRole resultsCell)
+  {
+    throw new UnsupportedOperationException(); // TODO stubbed method must be implemented
+  }
+}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/mocks/InMemorySpecificationRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/mocks/InMemorySpecificationRepository.java
@@ -1,23 +1,22 @@
-package gov.nasa.jpl.aerie.scheduler.server.services;
+package gov.nasa.jpl.aerie.scheduler.server.mocks;
 
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchSpecificationException;
 import gov.nasa.jpl.aerie.scheduler.server.models.Specification;
 import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
 import gov.nasa.jpl.aerie.scheduler.server.remotes.SpecificationRepository;
+import gov.nasa.jpl.aerie.scheduler.server.services.RevisionData;
 
-public record LocalSpecificationService(SpecificationRepository specificationRepository) implements SpecificationService {
+public final class InMemorySpecificationRepository implements SpecificationRepository {
   @Override
   public Specification getSpecification(final SpecificationId specificationId) throws NoSuchSpecificationException
   {
-    // TODO needs to be implemented
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(); // TODO stubbed method must be implemented
   }
 
   @Override
   public RevisionData getSpecificationRevisionData(final SpecificationId specificationId)
   throws NoSuchSpecificationException
   {
-    // TODO needs to be implemented
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(); // TODO stubbed method must be implemented
   }
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -1,0 +1,29 @@
+package gov.nasa.jpl.aerie.scheduler.server.remotes.postgres;
+
+import javax.sql.DataSource;
+
+import java.util.Optional;
+
+import gov.nasa.jpl.aerie.scheduler.server.ResultsProtocol;
+import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
+import gov.nasa.jpl.aerie.scheduler.server.remotes.ResultsCellRepository;
+
+public record PostgresResultsCellRepository(DataSource dataSource) implements ResultsCellRepository {
+  @Override
+  public ResultsProtocol.OwnerRole allocate(final SpecificationId specificationId)
+  {
+    throw new UnsupportedOperationException(); // TODO stubbed method must be implemented
+  }
+
+  @Override
+  public Optional<ResultsProtocol.ReaderRole> lookup(final SpecificationId specificationId)
+  {
+    throw new UnsupportedOperationException(); // TODO stubbed method must be implemented
+  }
+
+  @Override
+  public void deallocate(final ResultsProtocol.OwnerRole resultsCell)
+  {
+    throw new UnsupportedOperationException(); // TODO stubbed method must be implemented
+  }
+}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
@@ -1,23 +1,25 @@
-package gov.nasa.jpl.aerie.scheduler.server.services;
+package gov.nasa.jpl.aerie.scheduler.server.remotes.postgres;
+
+import javax.sql.DataSource;
 
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchSpecificationException;
 import gov.nasa.jpl.aerie.scheduler.server.models.Specification;
 import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
 import gov.nasa.jpl.aerie.scheduler.server.remotes.SpecificationRepository;
+import gov.nasa.jpl.aerie.scheduler.server.services.RevisionData;
 
-public record LocalSpecificationService(SpecificationRepository specificationRepository) implements SpecificationService {
+public record PostgresSpecificationRepository(DataSource dataSource) implements SpecificationRepository {
+
   @Override
   public Specification getSpecification(final SpecificationId specificationId) throws NoSuchSpecificationException
   {
-    // TODO needs to be implemented
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(); // TODO stubbed method must be implemented
   }
 
   @Override
   public RevisionData getSpecificationRevisionData(final SpecificationId specificationId)
   throws NoSuchSpecificationException
   {
-    // TODO needs to be implemented
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(); // TODO stubbed method must be implemented
   }
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/UncachedSchedulerService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/UncachedSchedulerService.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.scheduler.server.services;
 
 import gov.nasa.jpl.aerie.scheduler.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.scheduler.server.remotes.InMemoryResultsCell;
+import gov.nasa.jpl.aerie.scheduler.server.remotes.ResultsCellRepository;
 
 import java.util.Objects;
 
@@ -10,7 +11,7 @@ import java.util.Objects;
  *
  * @param agent the agent that can be used to carry out scheduling requests
  */
-public record UncachedSchedulerService(SchedulerAgent agent) implements SchedulerService {
+public record UncachedSchedulerService(ResultsCellRepository results, SchedulerAgent agent) implements SchedulerService {
   public UncachedSchedulerService {
     Objects.requireNonNull(agent);
   }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1651
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

- Adds `aerie_sched` database to deployed and local Docker stack.
  - All tables are required to have a `scheduling_` prefix for now until the Hasura issue described below is resolved or documented.
- Updates Hasura Docker image to v2.2.0
  - Encountered duplicate table name in Hasura: https://github.com/hasura/graphql-engine/issues/7895
  - When using v2.2.0 the issue is still present. The closing comment for the PR above does not offer an explanation of how  namespaces work or should be used.
  - https://github.com/hasura/graphql-engine/issues/6974 implements namespaces, but it's still not clear how to use them without an example or user-facing documentation.
- Connects scheduler app driver to `aerie_sched` DB and `AERIE_SCHED_*` environment variables.
- Renames `*SCHED_*` env. variables to `*SCHEDULER_*`.

## Verification
- Tested with local inspection of SQL tables in `tablePlus`.
- Tested with local inspection of Hasura through locally-deployed instance.
- All tests passing in `scheduler-server`.

## Documentation
None.

## Future work
@kroffo will implement `PostgresSpecificationRepository` and `PostgresResultsCellRepository`. @adrienmaillard will work on integrating those with the existing scheduler framework.