### PR TITLE
Support Hasura v2.2 action JSON `request_query` field

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
@@ -89,24 +89,25 @@ public abstract class MerlinParsers {
           untuple((role, userId) -> new HasuraAction.Session(role, userId.orElse(""))),
           $ -> tuple($.hasuraRole(), Optional.ofNullable($.hasuraUserId()))));
 
-  private static <S> JsonParser<Pair<Pair<String, S>, HasuraAction.Session>> hasuraActionP(final JsonParser<S> inputP) {
+  private static <I> JsonParser<Pair<Pair<Pair<String, I>, HasuraAction.Session>, String>> hasuraActionP(final JsonParser<I> inputP) {
     return productP
-        .  field("action", productP.field("name", stringP))
-        .  field("input", inputP)
-        .  field("session_variables", hasuraActionSessionP);
+        .field("action", productP.field("name", stringP))
+        .field("input", inputP)
+        .field("session_variables", hasuraActionSessionP)
+        .field("request_query", stringP);
   }
 
   public static final JsonParser<HasuraAction<HasuraAction.MissionModelInput>> hasuraMissionModelActionP
       = hasuraActionP(productP.field("missionModelId", stringP))
       . map(Iso.of(
-          untuple((name, missionModelId, session) -> new HasuraAction<>(name, new HasuraAction.MissionModelInput(missionModelId), session)),
-          $ -> tuple($.name(), $.input().missionModelId(), $.session())));
+          untuple((name, missionModelId, session, requestQuery) -> new HasuraAction<>(name, new HasuraAction.MissionModelInput(missionModelId), session)),
+          $ -> tuple($.name(), $.input().missionModelId(), $.session(), "")));
 
   public static final JsonParser<HasuraAction<HasuraAction.PlanInput>> hasuraPlanActionP
       = hasuraActionP(productP.field("planId", planIdP))
       . map(Iso.of(
-          untuple((name, planId, session) -> new HasuraAction<>(name, new HasuraAction.PlanInput(planId), session)),
-          $ -> tuple($.name(), $.input().planId(), $.session())));
+          untuple((name, planId, session, requestQuery) -> new HasuraAction<>(name, new HasuraAction.PlanInput(planId), session)),
+          $ -> tuple($.name(), $.input().planId(), $.session(), "")));
 
   public static final JsonParser<HasuraMissionModelEvent> hasuraMissionModelEventTriggerP
       = productP
@@ -136,8 +137,8 @@ public abstract class MerlinParsers {
   public static final JsonParser<HasuraAction<HasuraAction.MissionModelArgumentsInput>> hasuraMissionModelArgumentsActionP
       = hasuraActionP(hasuraMissionModelArgumentsInputP)
       .map(Iso.of(
-          untuple(HasuraAction::new),
-          $ -> tuple($.name(), $.input(), $.session())));
+          untuple((name, input, session, requestQuery) -> new HasuraAction<>(name, input, session)),
+          $ -> tuple($.name(), $.input(), $.session(), "")));
 
   private static final JsonParser<HasuraAction.ActivityInput> hasuraActivityInputP
       = productP
@@ -151,8 +152,8 @@ public abstract class MerlinParsers {
   public static final JsonParser<HasuraAction<HasuraAction.ActivityInput>> hasuraActivityActionP
       = hasuraActionP(hasuraActivityInputP)
       . map(Iso.of(
-          untuple(HasuraAction::new),
-          $ -> tuple($.name(), $.input(), $.session())));
+          untuple((name, input, session, requestQuery) -> new HasuraAction<>(name, input, session)),
+          $ -> tuple($.name(), $.input(), $.session(), "")));
 
   public static final JsonParser<HasuraAction.UploadExternalDatasetInput> hasuraUploadExternalDatasetActionP
       = productP
@@ -167,6 +168,6 @@ public abstract class MerlinParsers {
   public static final JsonParser<HasuraAction<HasuraAction.UploadExternalDatasetInput>> hasuraExternalDatasetActionP
       = hasuraActionP(hasuraUploadExternalDatasetActionP)
       . map(Iso.of(
-          untuple(HasuraAction::new),
-          $ -> tuple($.name(), $.input(), $.session())));
+          untuple((name, input, session, requestQuery) -> new HasuraAction<>(name, input, session)),
+          $ -> tuple($.name(), $.input(), $.session(), "")));
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsersTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsersTest.java
@@ -105,6 +105,7 @@ public final class MerlinParsersTest {
               .createObjectBuilder()
               .add("x-hasura-role", "admin")
               .build())
+          .add("request_query", "query { someValue }")
           .build();
 
       final var expected = new HasuraAction<>(
@@ -131,6 +132,7 @@ public final class MerlinParsersTest {
               .add("x-hasura-role", "admin")
               .add("x-hasura-user-id", "userId")
               .build())
+          .add("request_query", "query { someValue }")
           .build();
 
       final var expected = new HasuraAction<>(

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
@@ -49,11 +49,12 @@ public class SchedulerParsers {
    * @return a parser that accepts hasura action / session details along with specified input type into a tuple
    *     of the form (name,input,session) ready for application of a mapping
    */
-  private static <I> JsonParser<Pair<Pair<String, I>, HasuraAction.Session>> hasuraActionP(final JsonParser<I> inputP) {
+  private static <I> JsonParser<Pair<Pair<Pair<String, I>, HasuraAction.Session>, String>> hasuraActionP(final JsonParser<I> inputP) {
     return productP
         .field("action", productP.field("name", stringP))
         .field("input", inputP)
-        .field("session_variables", hasuraActionSessionP);
+        .field("session_variables", hasuraActionSessionP)
+        .field("request_query", stringP);
   }
 
   /**
@@ -62,6 +63,6 @@ public class SchedulerParsers {
   public static final JsonParser<HasuraAction<HasuraAction.SpecificationInput>> hasuraSpecificationActionP
       = hasuraActionP(productP.field("specificationId", specificationIdP))
       .map(Iso.of(
-          untuple((name, specificationId, session) -> new HasuraAction<>(name, new HasuraAction.SpecificationInput(specificationId), session)),
-          action -> tuple(action.name(), action.input().specificationId(), action.session())));
+          untuple((name, specificationId, session, requestQuery) -> new HasuraAction<>(name, new HasuraAction.SpecificationInput(specificationId), session)),
+          action -> tuple(action.name(), action.input().specificationId(), action.session(), "")));
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/HasuraAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/HasuraAction.java
@@ -1,9 +1,5 @@
 package gov.nasa.jpl.aerie.scheduler.server.models;
 
-import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
-
-import java.util.Map;
-
 public record HasuraAction<I extends HasuraAction.Input>(String name, I input, Session session)
 {
   public record Session(String hasuraRole, String hasuraUserId) { }


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Supports new Hasura action handler fields (mainly `request_query`): https://hasura.io/docs/latest/graphql/core/actions/action-handlers.html#http-handler

## Verification
Simulation run through UI runs without issue. This serves as a decent end-to-end test for this PR.

## Documentation
None.

## Future work
None.
