### PR TITLE
[AERIE-1673]  Compute Scheduling Results

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/MerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/MerlinService.java
@@ -1,14 +1,18 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.scheduler.ActivityInstance;
 import gov.nasa.jpl.aerie.scheduler.Plan;
 import gov.nasa.jpl.aerie.scheduler.Problem;
 import gov.nasa.jpl.aerie.scheduler.Time;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanMetadata;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * interface for retrieving / storing details to merlin
@@ -54,7 +58,7 @@ public interface MerlinService {
    * @return the database id of the newly created aerie plan container
    * @throws NoSuchPlanException when the plan container could not be found in aerie after creation
    */
-  PlanId createNewPlanWithActivities(final PlanMetadata planMetadata, final Plan plan)
+  Pair<PlanId, Map<ActivityInstance, ActivityInstanceId>> createNewPlanWithActivities(final PlanMetadata planMetadata, final Plan plan)
   throws IOException, NoSuchPlanException;
 
   /**
@@ -89,8 +93,9 @@ public interface MerlinService {
    * @param planId aerie database identifier of the target plan to synchronize into
    * @param plan plan with all activity instances that should be stored to target merlin plan container
    * @throws NoSuchPlanException when the plan container does not exist in aerie
+   * @return
    */
-  void updatePlanActivities(final PlanId planId, final Plan plan) throws IOException, NoSuchPlanException;
+  Map<ActivityInstance, ActivityInstanceId> updatePlanActivities(final PlanId planId, final Plan plan) throws IOException, NoSuchPlanException;
 
   /**
    * confirms that the specified plan exists in the aerie database, throwing exception if not
@@ -121,8 +126,9 @@ public interface MerlinService {
    * @param planId the database id of the plan container to populate with new activity instances
    * @param plan the plan from which to copy all activity instances into aerie
    * @throws NoSuchPlanException when the plan container does not exist in aerie
+   * @return
    */
-  void createAllPlanActivities(final PlanId planId, final Plan plan) throws IOException, NoSuchPlanException;
+  Map<ActivityInstance, ActivityInstanceId> createAllPlanActivities(final PlanId planId, final Plan plan) throws IOException, NoSuchPlanException;
 
 
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleResults.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleResults.java
@@ -1,10 +1,10 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
-import java.util.Collection;
-import java.util.Map;
-
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
+
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * summary of results from running the scheduler, including goal satisfaction metrics and changes made

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -254,15 +254,7 @@ public record SynchronousSchedulerAgent(
    */
   private ScheduleResults collectResults(final Plan plan) {
     final var activityCount = plan.getActivities().size();
-
-    final var goalScores = plan
-        .getEvaluations()
-        .stream().flatMap(eval -> eval.getGoalEvaluations().entrySet().stream())
-        .collect(Collectors.toMap(
-            e -> e.getKey().getName(), //create score map keyed by goal name
-            e -> e.getValue().getScore(),
-            (a, b) -> a)); //just replace any duplicate goal name scores
-
+    //TODO: complete stub
     return new ScheduleResults(Map.of()); // TODO Adrien: complete this stubbed instance
   }
 

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Goal.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Goal.java
@@ -55,25 +55,6 @@ public class Goal {
     protected String name;
 
     /**
-     * sets the priority rank of the goal with respect to other goals
-     *
-     * more important goals have larger positive priority
-     *
-     * this specifier is optional (the default is 0.0). it replaces any
-     * previous specification.
-     *
-     * @param priority IN the new priority rank to assign to this goal
-     * @return this builder, ready for additional specification
-     */
-    //TODO: externalize prioritization from goal specification
-    public T withPriority(double priority) {
-      this.priority = priority;
-      return getThis();
-    }
-
-    protected double priority = 0.0;
-
-    /**
      * sets the beginning of the time interval over which the goal is relevant
      *
      * this specifier is required unless a forAllTimeIn() is specified. it
@@ -184,8 +165,6 @@ public class Goal {
       }
       goal.name = name;
 
-      goal.priority = priority;
-
       goal.partialSatisfaction = true;
 
       goal.stateConstraints = null;
@@ -226,28 +205,6 @@ public class Goal {
    */
   public String getName() {
     return name;
-  }
-
-  /**
-   * assigns the priority rank of the goal with respect to other goals
-   *
-   * more important goals have larger positive priority
-   *
-   * @param newPriority IN the new priority rank to assign to this goal
-   */
-  public void setPriority(double newPriority) {
-    priority = newPriority;
-  }
-
-  /**
-   * fetches the priority rank of the goal with respect to other goals
-   *
-   * more important goals have larger positive priority
-   *
-   * @return the priority rank of the goal with respect to other goals
-   */
-  public double getPriority() {
-    return priority;
   }
 
   /**
@@ -303,13 +260,6 @@ public class Goal {
    * never null
    */
   protected String name;
-
-  /**
-   * the priority rank of the goal with respect to other goals
-   *
-   * more important goals have larger positive priority
-   */
-  protected double priority = 0.0;
 
   /**
    * the contiguous range of time over which the goal applies

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/MissingAssociationConflict.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/MissingAssociationConflict.java
@@ -1,0 +1,29 @@
+package gov.nasa.jpl.aerie.scheduler;
+
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+
+import java.util.Collection;
+
+public class MissingAssociationConflict extends Conflict {
+  private final Collection<ActivityInstance> instances;
+
+  /**
+   * ctor creates a new conflict
+   *
+   * @param goal IN STORED the dissatisfied goal that issued the conflict
+   * @param instancesToChooseFrom IN the list of instances to choose from to perform the association
+   */
+  public MissingAssociationConflict(final Goal goal, final Collection<ActivityInstance> instancesToChooseFrom) {
+    super(goal);
+    this.instances = instancesToChooseFrom;
+  }
+
+  public Collection<ActivityInstance> getActivityInstancesToChooseFrom(){
+    return instances;
+  }
+
+  @Override
+  public Windows getTemporalContext() {
+    return null;
+  }
+}

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Plan.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Plan.java
@@ -91,6 +91,6 @@ public interface Plan {
    *
    * @return container of all evaluations posted to the plan
    */
-  java.util.Collection<Evaluation> getEvaluations();
+  Evaluation getEvaluation();
 
 }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/PlanInMemory.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/PlanInMemory.java
@@ -172,15 +172,15 @@ public class PlanInMemory implements Plan {
    */
   @Override
   public void addEvaluation(Evaluation eval) {
-    evals.add(eval);
+    evaluation = eval;
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public Collection<Evaluation> getEvaluations() {
-    return java.util.Collections.unmodifiableCollection(evals);
+  public Evaluation getEvaluation() {
+    return evaluation;
   }
 
   /**
@@ -188,7 +188,7 @@ public class PlanInMemory implements Plan {
    *
    * note that different solvers may evaluate the same plan differently
    */
-  protected final java.util.List<Evaluation> evals = new java.util.LinkedList<>();
+  protected Evaluation evaluation;
 
 
 }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/PrioritySolver.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/PrioritySolver.java
@@ -393,6 +393,26 @@ private void satisfyOptionGoal(OptionGoal goal) {
               //    at next constraint query, if relevant
             }
           }
+        } else if(missing instanceof MissingAssociationConflict missingAssociationConflict){
+          var actToChooseFrom = missingAssociationConflict.getActivityInstancesToChooseFrom();
+          //no act type constraint to consider as the activities have been scheduled
+          //no global constraint for the same reason above mentioned
+          //only the target goal state constraints to consider
+          for(var act : actToChooseFrom){
+            var actWindow = new Windows();
+            actWindow.add(Window.between(act.getStartTime(), act.getEndTime()));
+            var stateConstraints = goal.getStateConstraints();
+            var narrowed = actWindow;
+            if(stateConstraints!= null) {
+              narrowed = narrowByStateConstraints(actWindow, List.of(stateConstraints));
+            }
+            if(narrowed.includes(actWindow)){
+              //decision-making here, we choose the first satisfying activity
+              evaluation.forGoal(goal).associate(act, false);
+              madeProgress = true;
+              break;
+            }
+          }
         }
       }//for(missing)
 

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Problem.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Problem.java
@@ -4,6 +4,9 @@ import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * description of a planning problem to be solved
@@ -33,6 +36,7 @@ public class Problem {
   /**
    * container of all goals in the problem, indexed by name
    */
+  protected final List<Goal> goalsOrderedByPriority = new ArrayList<>();
   private final java.util.HashMap<String, Goal> goalsByName = new java.util.HashMap<>();
 
   /**
@@ -103,29 +107,9 @@ public class Problem {
     initialPlan = plan;
   }
 
-  public void addAll(Collection<Goal> goals){
-    for(var goal:goals){
-      add(goal);
-    }
-  }
-
-  /**
-   * adds a new goal to the problem specification
-   *
-   * @param goal IN the new goal to add to the problem
-   */
-  public void add(Goal goal) {
-    if (goal == null) {
-      throw new IllegalArgumentException(
-          "inserting null goal into problem");
-    }
-    final var goalName = goal.getName();
-    assert goalName != null;
-    if (goalsByName.containsKey(goalName)) {
-      throw new IllegalArgumentException(
-          "inserting goal with duplicate name=" + goalName + " into problem");
-    }
-    goalsByName.put(goalName, goal);
+  public void setGoals(List<Goal> goals){
+    goalsOrderedByPriority.clear();
+    goalsOrderedByPriority.addAll(goals);
   }
 
   /**
@@ -138,8 +122,8 @@ public class Problem {
    *
    * @return an un-modifiable container of the goals requested for this plan
    */
-  public java.util.Collection<Goal> getGoals() {
-    return java.util.Collections.unmodifiableCollection(goalsByName.values());
+  public List<Goal> getGoals() {
+    return Collections.unmodifiableList(goalsOrderedByPriority);
   }
 
   private void failIfActivityTypeAbsent(String name){

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/RecurrenceGoal.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/RecurrenceGoal.java
@@ -4,6 +4,8 @@ import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
+import java.util.List;
+
 /**
  * describes the desired recurrence of an activity every time period
  */
@@ -125,10 +127,12 @@ public class RecurrenceGoal extends ActivityTemplateGoal {
         conflicts.addAll(makeRecurrenceConflicts(prevStartT, actStartT, plan));
 
       } else {
-        //REVIEW: will need to record associations to check for joint/sole
-        //        ownership, but that assignment will itself be combinatoric
-        //REVIEW: should record determined associations more permanently, eg
-        //        for UI
+        /*TODO: right now, we associate with all the activities that are satisfying but we should aim for the minimum
+        set which itself is a combinatoric problem */
+        var planEval = plan.getEvaluation();
+        if(!planEval.forGoal(this).getAssociatedActivities().contains(act) && planEval.canAssociateMoreToCreatorOf(act)) {
+          conflicts.add(new MissingAssociationConflict(this, List.of(act)));
+        }
       }
 
       prevStartT = actStartT;

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Time.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Time.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.scheduler;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -171,6 +172,10 @@ public class Time implements Comparable<Time> {
    */
   public java.time.Instant toInstant() {
     return java.time.Instant.ofEpochMilli((long) (jplET_s * 1000.0));
+  }
+
+  public static Time fromInstant(Instant instant){
+    return new Time(instant.toEpochMilli()/1000.0);
   }
 
   /**

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlInsightRules.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlInsightRules.java
@@ -5,10 +5,13 @@ import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 public class MerlInsightRules extends Problem {
 
@@ -22,16 +25,17 @@ public class MerlInsightRules extends Problem {
   }
 
   @Override
-  public java.util.Collection<Goal> getGoals() {
-    Collection<Goal> goals = new ArrayList<>();
-    goals.add(generateDSNVisibilityAllocationGoal());
-    goals.addAll(getFirstRuleGoals());
-    goals.addAll(getSecondRuleGoals());
-    goals.addAll(getThirdRuleGoals());
-    return goals;
+  public List<Goal> getGoals() {
+    SortedMap<Integer, Goal> goals = new TreeMap<>(Collections.reverseOrder());
+    var dsnVisibilities = generateDSNVisibilityAllocationGoal();
+    goals.put(dsnVisibilities.getKey(), dsnVisibilities.getValue());
+    goals.putAll(getFirstRuleGoals());
+    goals.putAll(getSecondRuleGoals());
+    goals.putAll(getThirdRuleGoals());
+    return new ArrayList<>(goals.values());
   }
 
-  public Goal generateDSNVisibilityAllocationGoal(){
+  public Pair<Integer, Goal> generateDSNVisibilityAllocationGoal(){
     var actType1 = getActivityType("AllocateDSNStation");
     var actType2 = getActivityType("SetDSNStationVisibility");
     final var period = Duration.of(8, Duration.HOURS);
@@ -69,18 +73,17 @@ public class MerlInsightRules extends Problem {
 
     ProceduralCreationGoal dsnGoal = new ProceduralCreationGoal.Builder()
         .named("Schedule DSN contacts for initial setup")
-        .withPriority(50)
-        .forAllTimeIn(DEFAULT_PLANNING_HORIZON.getHor())
+        .forAllTimeIn(planningHorizon.getHor())
         .generateWith((plan) -> actList)
         .build();
 
-    return dsnGoal;
+    return Pair.of(50,dsnGoal);
   }
 
 
-  public Collection<Goal> getFirstRuleGoals(){
+  public SortedMap<Integer, Goal> getFirstRuleGoals(){
 
-    List<Goal> goals = new ArrayList<>();
+    var goals = new TreeMap<Integer, Goal>(Collections.reverseOrder());
 
   /**
    *
@@ -107,12 +110,11 @@ public class MerlInsightRules extends Problem {
                              Duration.of(1,Duration.MINUTE)));
     ProceduralCreationGoal pro = new ProceduralCreationGoal.Builder()
         .named("TurnOnAndOFFMonitoring")
-        .withPriority(10)
-        .forAllTimeIn(DEFAULT_PLANNING_HORIZON.getHor())
+        .forAllTimeIn(planningHorizon.getHor())
         .generateWith((plan) -> turnONFFMonitoring)
         .owned(ChildCustody.Jointly)
         .build();
-    goals.add(pro);
+    goals.put(10, pro);
 
     var sce = new StateConstraintExpression.Builder()
         .equal(getResource("/hp3/ssaState"), SerializedValue.of("Monitoring"))
@@ -128,14 +130,13 @@ public class MerlInsightRules extends Problem {
 
     RecurrenceGoal goal1a = new RecurrenceGoal.Builder()
         .named("1a")
-        .withPriority(9)
         .repeatingEvery(Duration.of(60, Duration.MINUTE))
         .attachStateConstraint(sce)
         .forAllTimeIn(DEFAULT_PLANNING_HORIZON.getHor())
         .thereExistsOne(HP3Acts)
         .owned(ChildCustody.Jointly)
         .build();
-    goals.add(goal1a);
+    goals.put(9,goal1a);
 
 
     /*
@@ -149,22 +150,21 @@ public class MerlInsightRules extends Problem {
 
     CardinalityGoal goal1c = new CardinalityGoal.Builder()
         .named("1c")
-        .inPeriod(new TimeRangeExpression.Builder().from(new Windows(DEFAULT_PLANNING_HORIZON.getHor())).build())
-        .forAllTimeIn(DEFAULT_PLANNING_HORIZON.getHor())
-        .withPriority(8)
+        .inPeriod(new TimeRangeExpression.Builder().from(new Windows(planningHorizon.getHor())).build())
+        .forAllTimeIn(planningHorizon.getHor())
         .thereExistsOne(HP3Acts)
         .attachStateConstraint(sce)
         .owned(ChildCustody.Jointly)
         .duration(Window.between(Duration.of(3, Duration.HOUR), Duration.MAX_VALUE))
         .build();
 
-    goals.add(goal1c);
+    goals.put(8,goal1c);
     return goals;
   }
 
 
-  public Collection<Goal> getSecondRuleGoals(){
-    var goals = new ArrayList<Goal>();
+  public SortedMap<Integer, Goal> getSecondRuleGoals(){
+    var goals = new TreeMap<Integer,Goal>(Collections.reverseOrder());
 
   /**
    *
@@ -190,13 +190,11 @@ public class MerlInsightRules extends Problem {
 
   ProceduralCreationGoal goal2a = new ProceduralCreationGoal.Builder()
       .named("SchedIDAMoveArm")
-      .forAllTimeIn(DEFAULT_PLANNING_HORIZON.getHor())
-      .withPriority(10)
-      .forAllTimeIn(DEFAULT_PLANNING_HORIZON.getHor())
+      .forAllTimeIn(planningHorizon.getHor())
       .generateWith((plan) -> List.of(new ActivityInstance(actTypeIDAMoveArm,stMoveArm, duroveArm)))
       .build();
 
-  goals.add(goal2a);
+  goals.put(30, goal2a);
 
   /*
    * Rule 2b: pick up the device from its stowed location
@@ -214,10 +212,9 @@ public class MerlInsightRules extends Problem {
                           .duration(Duration.of(20, Duration.MINUTE))
                           .build())
       .forEach(ActivityExpression.ofType(actTypeIDAMoveArm))
-      .withPriority(9)
       .startsAt(TimeAnchor.END)
       .build();
-    goals.add(goal2b);
+    goals.put(29,goal2b);
 
   /*
    * Rule 2c: relocate the device from its stowed location to the target location
@@ -232,10 +229,9 @@ public class MerlInsightRules extends Problem {
                           .duration(Duration.of(1, Duration.HOUR))
                           .build())
       .forEach(ActivityExpression.ofType(atGrapple))
-      .withPriority(8)
       .startsAt(TimeAnchor.END)
       .build();
-  goals.add(goal2c);
+  goals.put(28, goal2c);
 
   /*
    * Rule 2d: release the device at its target location
@@ -256,11 +252,10 @@ public class MerlInsightRules extends Problem {
                             .duration(Duration.of(20, Duration.MINUTE))
                             .build())
         .forEach(secondIdaMoveArm)
-        .withPriority(7)
         .startsAt(TimeAnchor.END)
         .build();
 
-    goals.add(goal2d);
+    goals.put(27,goal2d);
 
 
   /*
@@ -289,11 +284,10 @@ public class MerlInsightRules extends Problem {
                           .duration(Duration.of(3, Duration.MINUTE))
                           .build())
       .forEach(enveloppeAllGrappleMove)
-      .withPriority(6)
       .endsBefore(TimeExpression.offsetByBeforeStart(Duration.of(30, Duration.MINUTE)))
       .build();
 
-  goals.add(goal2e);
+  goals.put(26,goal2e);
 
 
   /*
@@ -314,11 +308,10 @@ public class MerlInsightRules extends Problem {
                           .duration(Duration.of(3, Duration.MINUTE))
                           .build())
       .forEach(enveloppeAllGrappleMove)
-      .withPriority(6)
       .startsAfterEnd()
       .build();
 
-  goals.add(goal2f);
+  goals.put(25,goal2f);
 
   /*
    * Rule 2g: image from arm just before each grapple operation
@@ -340,11 +333,10 @@ public class MerlInsightRules extends Problem {
                           .withArgument("compQuality", SerializedValue.of(97))
                           .build())
       .forEach(ActivityExpression.ofType(atGrapple))
-      .withPriority(6)
       .endsAt(TimeAnchor.START)
       .build();
 
-  goals.add(goal2g);
+  goals.put(24,goal2g);
 
 
   /*
@@ -363,11 +355,10 @@ public class MerlInsightRules extends Problem {
                           .withArgument("compQuality", SerializedValue.of(97))
                           .build())
       .forEach(ActivityExpression.ofType(atGrapple))
-      .withPriority(6)
       .startsAt(TimeAnchor.END)
       .build();
 
-  goals.add(goal2h);
+  goals.put(23,goal2h);
 
 
   /*
@@ -397,11 +388,10 @@ public class MerlInsightRules extends Problem {
                           .duration(Duration.of(15, Duration.MINUTE))
                           .build())
       .forEach(enveloppeAllIDCImage)
-      .withPriority(5)
       .endsBefore(TimeExpression.offsetByBeforeStart(Duration.of(30, Duration.MINUTE)))
       .build();
 
-  goals.add(goal2i);
+  goals.put(22,goal2i);
 
 
   /*
@@ -423,11 +413,10 @@ public class MerlInsightRules extends Problem {
                           .duration(Duration.of(15, Duration.MINUTE))
                           .build())
       .forEach(enveloppeAllIDCImage)
-      .withPriority(5)
       .startsAfterEnd()
       .build();
 
-  goals.add(goal2j);
+  goals.put(21, goal2j);
 
   /*
    * Rule 2k: image stowed device in context before pickup
@@ -454,11 +443,10 @@ public class MerlInsightRules extends Problem {
                           .withArgument("compQuality", SerializedValue.of(95))
                           .build())
       .forEach(firstIdaMoveArm)
-      .withPriority(4)
       .endsAt(TimeAnchor.START)
       .build();
 
-  goals.add(goal2k);
+  goals.put(20,goal2k);
 
 
   /*
@@ -478,11 +466,10 @@ public class MerlInsightRules extends Problem {
                           .withArgument("compQuality", SerializedValue.of(95))
                           .build())
       .forEach(secondIdaMoveArm)
-      .withPriority(4)
       .startsAt(TimeExpression.offsetByAfterEnd(Duration.of(2, Duration.MINUTE)))
       .build();
 
-  goals.add(goal2l);
+  goals.put(19,goal2l);
 
   /*
    * Rule 2m: preheat for ICC image
@@ -506,11 +493,10 @@ public class MerlInsightRules extends Problem {
                           .duration(Duration.of(15, Duration.MINUTE))
                           .build())
       .forEach(firstICCImages)
-      .withPriority(4)
       .endsAt(TimeAnchor.START)
       .build();
 
-  goals.add(goal2m);
+  goals.put(18, goal2m);
 
 
   /*
@@ -536,16 +522,15 @@ public class MerlInsightRules extends Problem {
                           .duration(Duration.of(10, Duration.SECONDS))
                           .build())
       .forEach(lastICCImages)
-      .withPriority(4)
       .endsAfterEnd()
       .build();
 
-  goals.add(goal2n);
+  goals.put(17, goal2n);
   return goals;
 }
-  public Collection<Goal> getThirdRuleGoals(){
+  public SortedMap<Integer, Goal> getThirdRuleGoals(){
 
-    var goals = new ArrayList<Goal>();
+    var goals = new TreeMap<Integer, Goal>(Collections.reverseOrder());
 
     //the dsn visibility activities from generateDSNVisibilityAllocationGoal are required for the following goals
 
@@ -610,14 +595,13 @@ public class MerlInsightRules extends Problem {
                           .ofType(actTypeXbandActive)
                           .build())
       .forEach(expr)
-      .withPriority(7)
       .startsAt(TimeExpression.offsetByAfterStart(prepDur))
       .durationIn(DurationExpressions.max(
           DurationExpressions.constant(Duration.of(2, Duration.HOUR)),
           DurationExpressions.windowDuration().minus(DurationExpressions.constant(cleanupDur)).minus(DurationExpressions.constant(prepDur))))
       .build();
 
-    goals.add(goal3a);
+    goals.put(37, goal3a);
 
   /*
    * Rule 3b: comm prep
@@ -641,11 +625,10 @@ public class MerlInsightRules extends Problem {
                             .duration(prepDur)
                             .build())
         .forEach(ActivityExpression.ofType(actTypeXbandActive))
-        .withPriority(6)
         .endsAt(TimeAnchor.START)
         .build();
 
-    goals.add(goal3b);
+    goals.put(36, goal3b);
 
   /*
    * Rule 3c: comm cleanup
@@ -669,11 +652,10 @@ public class MerlInsightRules extends Problem {
                             .duration(cleanupDur)
                             .build())
         .forEach(ActivityExpression.ofType(actTypeXbandActive))
-        .withPriority(6)
         .startsAt(TimeAnchor.END)
         .build();
 
-    goals.add(goal3c);
+    goals.put(35,goal3c);
   /*
    * Rule 3d: comm summary wrapper
    - schedule XBandCommND activity
@@ -712,12 +694,11 @@ public class MerlInsightRules extends Problem {
                             .withArgument("xbandAntSel", SerializedValue.of("EAST_MGA"))
                             .build())
         .forEach(tre2)
-        .withPriority(3)
         .startsAt(TimeAnchor.START)
         .endsAt(TimeAnchor.END)
         .build();
 
-    goals.add(goal3d);
+    goals.put(33, goal3d);
     return(goals);
   }
 

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlInsightRules.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlInsightRules.java
@@ -110,6 +110,7 @@ public class MerlInsightRules extends Problem {
         .withPriority(10)
         .forAllTimeIn(DEFAULT_PLANNING_HORIZON.getHor())
         .generateWith((plan) -> turnONFFMonitoring)
+        .owned(ChildCustody.Jointly)
         .build();
     goals.add(pro);
 
@@ -132,6 +133,7 @@ public class MerlInsightRules extends Problem {
         .attachStateConstraint(sce)
         .forAllTimeIn(DEFAULT_PLANNING_HORIZON.getHor())
         .thereExistsOne(HP3Acts)
+        .owned(ChildCustody.Jointly)
         .build();
     goals.add(goal1a);
 
@@ -152,6 +154,7 @@ public class MerlInsightRules extends Problem {
         .withPriority(8)
         .thereExistsOne(HP3Acts)
         .attachStateConstraint(sce)
+        .owned(ChildCustody.Jointly)
         .duration(Window.between(Duration.of(3, Duration.HOUR), Duration.MAX_VALUE))
         .build();
 

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlInsightRulesTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlInsightRulesTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+
 public class MerlInsightRulesTest {
 
   @BeforeEach
@@ -46,19 +48,21 @@ public class MerlInsightRulesTest {
 
   @Test
   public void firstRule() {
-    smallProblem.addAll(rules.getFirstRuleGoals());
+    smallProblem.setGoals(new ArrayList<>(rules.getFirstRuleGoals().values()));
     schedule();
   }
   @Test
   public void secondRule() {
-    smallProblem.addAll(rules.getSecondRuleGoals());
+    smallProblem.setGoals(new ArrayList<>(rules.getSecondRuleGoals().values()));
     schedule();
   }
 
   @Test
   public void thirdRule() {
-    smallProblem.add(rules.generateDSNVisibilityAllocationGoal());
-    smallProblem.addAll(rules.getThirdRuleGoals());
+    var goals = new ArrayList<Goal>();
+    goals.add(rules.generateDSNVisibilityAllocationGoal().getValue());
+    goals.addAll(rules.getThirdRuleGoals().values());
+    smallProblem.setGoals(goals);
     schedule();
   }
 

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
@@ -2,8 +2,10 @@ package gov.nasa.jpl.aerie.scheduler;
 
 import com.google.common.testing.NullPointerTester;
 import com.google.common.truth.Correspondence;
-import org.junit.jupiter.api.Test;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
 import java.util.Objects;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -135,7 +137,7 @@ public class PrioritySolverTest {
         .generateWith((plan) -> expectedPlan.getActivitiesByTime())
         .forAllTimeIn(h.getHor())
         .build();
-    problem.add(goal);
+    problem.setGoals(List.of(goal));
     final var solver = makeProblemSolver(problem);
 
     final var plan = solver.getNextSolution().orElseThrow();
@@ -154,7 +156,7 @@ public class PrioritySolverTest {
         .generateWith((plan) -> expectedPlan.getActivitiesByTime())
         .forAllTimeIn(h.getHor())
         .build();
-    problem.add(goal);
+    problem.setGoals(List.of(goal));
     final var solver = makeProblemSolver(problem);
 
     final var plan = solver.getNextSolution().orElseThrow();
@@ -179,7 +181,7 @@ public class PrioritySolverTest {
                             .duration(d1min)
                             .build())
         .build();
-    problem.add(goal);
+    problem.setGoals(List.of(goal));
     final var solver = makeProblemSolver(problem);
 
     final var plan = solver.getNextSolution().orElseThrow();
@@ -213,7 +215,7 @@ public class PrioritySolverTest {
                             .build())
         .startsAt(TimeAnchor.START)
         .build();
-    problem.add(goal);
+    problem.setGoals(List.of(goal));
     final var solver = makeProblemSolver(problem);
 
     final var plan = solver.getNextSolution().orElseThrow();

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
@@ -34,7 +34,7 @@ public class PrioritySolverTest {
     final var plan = solver.getNextSolution();
 
     assertThat(plan).isPresent();
-    assertThat(plan.get().getEvaluations()).containsExactly(new Evaluation());
+    assertThat(plan.get().getEvaluation()).isEqualTo(new Evaluation());
     assertThat(plan.get().getActivitiesByTime()).isEmpty();
   }
 
@@ -159,8 +159,8 @@ public class PrioritySolverTest {
 
     final var plan = solver.getNextSolution().orElseThrow();
 
-    assertThat(plan.getEvaluations()).hasSize(1);
-    final var eval = plan.getEvaluations().stream().findFirst().orElseThrow().forGoal(goal);
+    assertThat(plan.getEvaluation()).isNotNull();
+    final var eval = plan.getEvaluation().forGoal(goal);
     assertThat(eval).isNotNull();
     assertThat(eval.getAssociatedActivities())
         .comparingElementsUsing(equalExceptInName)

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
@@ -9,6 +9,19 @@ import java.util.List;
 
 public class TestCardinalityGoal {
 
+@Test
+public void minimalDef(){
+  CardinalityGoal goal = new CardinalityGoal.Builder()
+      .inPeriod(ActivityExpression.ofType(new ActivityType("")))
+      .thereExistsOne(new ActivityCreationTemplate.Builder()
+                          .ofType(new ActivityType(""))
+                          .build())
+      .named("TestCardGoal")
+      .forAllTimeIn(Window.at(Duration.SECONDS))
+      .owned(ChildCustody.Jointly)
+      .build();
+
+}
 
   @Test
   public void testone() {
@@ -31,13 +44,13 @@ public class TestCardinalityGoal {
         .named("TestCardGoal")
         .forAllTimeIn(period)
         .owned(ChildCustody.Jointly)
-        .withPriority(7.0)
+        //.withPriority(7.0)
 
         .build();
 
     Problem problem = new Problem(null, null);
 
-    problem.add(goal);
+    problem.setGoals(List.of(goal));
 
     HuginnConfiguration huginn = new HuginnConfiguration();
     final var solver = new PrioritySolver(huginn, problem);
@@ -76,13 +89,13 @@ public class TestCardinalityGoal {
         .named("TestCardGoal")
         .forAllTimeIn(period)
         .owned(ChildCustody.Jointly)
-        .withPriority(7.0)
+        //.withPriority(7.0)
 
         .build();
 
     Problem problem = new Problem(null, null);
 
-    problem.add(goal);
+    problem.setGoals(List.of(goal));
 
     HuginnConfiguration huginn = new HuginnConfiguration();
     final var solver = new PrioritySolver(huginn, problem);

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
@@ -3,6 +3,9 @@ package gov.nasa.jpl.aerie.scheduler;
 import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
 public class TestRecurrenceGoal {
 
   @Test
@@ -21,7 +24,7 @@ public class TestRecurrenceGoal {
 
     Problem problem = new Problem(null, planningHorizon);
 
-    problem.add(goal);
+    problem.setGoals(List.of(goal));
 
     HuginnConfiguration huginn = new HuginnConfiguration();
     final var solver = new PrioritySolver(huginn, problem);

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestStateConstraints.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestStateConstraints.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -138,10 +139,11 @@ public class TestStateConstraints {
         .forEach(approachStateConstraint1)
         .owned(ChildCustody.Jointly)
         .startsAt(TimeAnchor.START)
-        .withPriority(7.0)
+        //.withPriority(7.0)
         .build();
 
-    this.problem.add(cg);
+    Problem problem = new Problem(null, horizon);
+    problem.addAll(List.of(cg));
     HuginnConfiguration huginn = new HuginnConfiguration();
     final var solver = new PrioritySolver(huginn, this.problem);
     final var plan = solver.getNextSolution().orElseThrow();
@@ -188,10 +190,11 @@ public class TestStateConstraints {
         .attachStateConstraint(approachStateConstraint)
         .generateWith(fixedGenerator)
         .owned(ChildCustody.Jointly)
-        .withPriority(7.0)
+        //.withPriority(7.0)
         .build();
 
-    this.problem.add(proceduralGoalWithConstraints);
+    Problem problem = new Problem(null, horizon);
+    problem.addAll(List.of(proceduralGoalWithConstraints));
     HuginnConfiguration huginn = new HuginnConfiguration();
     final var solver = new PrioritySolver(huginn, this.problem);
     final var plan = solver.getNextSolution().orElseThrow();
@@ -265,10 +268,11 @@ public class TestStateConstraints {
         .forAllTimeIn(horizon.getHor())
         .generateWith(fixedGenerator)
         .owned(ChildCustody.Jointly)
-        .withPriority(7.0)
+        //.withPriority(7.0)
         .build();
 
-    this.problem.add(proceduralgoalwithoutconstraints);
+    Problem problem = new Problem(null, horizon);
+    problem.addAll(List.of(proceduralgoalwithoutconstraints));
     HuginnConfiguration huginn = new HuginnConfiguration();
     final var solver = new PrioritySolver(huginn, this.problem);
     final var plan = solver.getNextSolution().orElseThrow();
@@ -305,10 +309,11 @@ public class TestStateConstraints {
         .forEach(tre)
         .owned(ChildCustody.Jointly)
         .startsAt(TimeAnchor.START)
-        .withPriority(7.0)
+        //.withPriority(7.0)
         .build();
 
-    this.problem.add(cg);
+    Problem problem = new Problem(null, horizon);
+    problem.addAll(List.of(cg));
     HuginnConfiguration huginn = new HuginnConfiguration();
     final var solver = new PrioritySolver(huginn, this.problem);
     final var plan = solver.getNextSolution().orElseThrow();

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestStateConstraints.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestStateConstraints.java
@@ -142,8 +142,7 @@ public class TestStateConstraints {
         //.withPriority(7.0)
         .build();
 
-    Problem problem = new Problem(null, horizon);
-    problem.addAll(List.of(cg));
+    problem.setGoals(List.of(cg));
     HuginnConfiguration huginn = new HuginnConfiguration();
     final var solver = new PrioritySolver(huginn, this.problem);
     final var plan = solver.getNextSolution().orElseThrow();
@@ -193,8 +192,7 @@ public class TestStateConstraints {
         //.withPriority(7.0)
         .build();
 
-    Problem problem = new Problem(null, horizon);
-    problem.addAll(List.of(proceduralGoalWithConstraints));
+    problem.setGoals(List.of(proceduralGoalWithConstraints));
     HuginnConfiguration huginn = new HuginnConfiguration();
     final var solver = new PrioritySolver(huginn, this.problem);
     final var plan = solver.getNextSolution().orElseThrow();
@@ -271,10 +269,9 @@ public class TestStateConstraints {
         //.withPriority(7.0)
         .build();
 
-    Problem problem = new Problem(null, horizon);
-    problem.addAll(List.of(proceduralgoalwithoutconstraints));
+    problem.setGoals(List.of(proceduralgoalwithoutconstraints));
     HuginnConfiguration huginn = new HuginnConfiguration();
-    final var solver = new PrioritySolver(huginn, this.problem);
+    final var solver = new PrioritySolver(huginn, problem);
     final var plan = solver.getNextSolution().orElseThrow();
     assert (TestUtility.containsExactlyActivity(plan, act1));
     assert (TestUtility.doesNotContainActivity(plan, act2));
@@ -312,8 +309,7 @@ public class TestStateConstraints {
         //.withPriority(7.0)
         .build();
 
-    Problem problem = new Problem(null, horizon);
-    problem.addAll(List.of(cg));
+    problem.setGoals(List.of(cg));
     HuginnConfiguration huginn = new HuginnConfiguration();
     final var solver = new PrioritySolver(huginn, this.problem);
     final var plan = solver.getNextSolution().orElseThrow();


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1673
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
In this draft PR, I am exposing the current changes I am making to the scheduler to accommodate the new types of scheduling results that we have to provide. 

The main challenge is to implement and track which goals create which activities because a distinction between the two is made in the results. 

To do that, I had to make this distinction in the `Evaluation` object, which tracks the progress and success of scheduling goals. 

Before, we did not track associations when activity A created by goal G1 were satisfying goal G2. We only tracked that A was created by G1. It also gave me the opportunity to actually start enforcing the ownership relationship that exists between activities and goals. A goal can decide that the activities it has created cannot be used to satisfy other goals. 

To track both creations and associations, I have created a new conflict that a goal can produce when an existing activity satisfies this goal but is not yet associated with this goal. The goals must check beforehand that they actually can piggyback on the existing activity. Then, the solver proceeds to associate the activity to the goal.

All the goals had to be modified to produce these conflicts. 

Then, when all the information had been made available, I have changed the server so it can package it. Because we have to return maps of `GoalId` to `ActivityInstanceId`, I had to make the server keep track of the created/associated activity instances in the plans we send/receive from Merlin.  

Note that the server gets rules from the database but actually still loads the Merlinsight/AerieLander jar. This will have to be finished later when we actually store goals in the database and we can translate them to objects. 

This work is evolving with the changes that @kroffo and @pcrosemurgy are making to the server. I also have to write some new tests for the scheduler. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
All tests pass including AerieLander tests 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None
## Future work
<!-- What next steps can we anticipate from here, if any? -->
None