### PR TITLE
[HOTFIX] `MerlinBindingsTest`: use likely unused port to avoid port clashes

### DIFF
--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindingsTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindingsTest.java
@@ -48,7 +48,7 @@ public final class MerlinBindingsTest {
       config.registerPlugin(new MerlinBindings(missionModelApp, planApp, simulationAction));
     });
 
-    SERVER.start();
+    SERVER.start(54321); // Use likely unused port to avoid clash with any currently hosted port 80 services
   }
 
   @AfterAll


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
When testing `merlin-server` you currently have to make sure that `localhost:80` is unoccupied. This has bitten me a few times so I've changed the bindings test to use a likely unused port.

## Verification
Tested locally.