### PR TITLE
[HOTFIX] Update AerieLander scheduler tests

### DIFF
--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlinSightTestUtility.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlinSightTestUtility.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.scheduler;
 
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.util.List;
 
@@ -24,7 +25,7 @@ public class MerlinSightTestUtility {
 
   public static MissionModelWrapper getMerlinSightMissionModel(final PlanningHorizon horizon){
     final var builder = new MissionModelBuilder();
-    final var configuration = new gov.nasa.jpl.aerielander.mappers.config.ConfigurationValueMapper().serializeValue(gov.nasa.jpl.aerielander.config.Configuration.defaultConfiguration());
+    final var configuration = SerializedValue.of(new gov.nasa.jpl.aerielander.generated.config.ConfigurationMapper().getArguments(gov.nasa.jpl.aerielander.config.Configuration.defaultConfiguration()));
     final var factory = new gov.nasa.jpl.aerielander.generated.GeneratedMissionModelFactory();
     final var model = factory.instantiate(configuration, builder);
     final var mission = builder.build(model, factory.getTaskSpecTypes());


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Recent updates to the way mission model configuration works (notably #20) required changes to the aerie lander mission model. The scheduler tests were not updated to match, and this eluded notice because they are excluded from compilation. This PR brings them back into compatibility with aerie lander.

~The second commit of this PR renames the tests to use "AerieLander" instead of deprecated terminology.~

## Verification
I'm still not 100% sure what the proper workflow is for running tests against the aerielander repository. I cloned it and saved it in its own subproject of aerie, and updated `settings.gradle` as well as `scheduler/build.gradle` to depend on it. I then commented out the compile exclusions in `scheduler/build.gradle` and ran the tests, and saw that they passed.

## Documentation
No documentation is necessary for these changes at this time, in my opinion.

## Future work
- use the name AerieLander consistently
- streamline the process for running these tests, so we can detect these regressions sooner

