### PR TITLE
[Aerie-1686]  Setup JS Command Expansion Server

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,3 +22,5 @@ jobs:
         run: ./gradlew test
       - name: Assemble
         run: ./gradlew assemble
+      - name: Assemble Node Project
+        run: ./gradlew command-expansion-server:build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,8 @@ jobs:
           reporter: java-junit
       - name: Assemble
         run: ./gradlew assemble
+      - name: Assemble Node Project
+        run: ./gradlew command-expansion-server:build
       - name: Login to the Container Registry
         uses: docker/login-action@v1
         with:
@@ -70,6 +72,19 @@ jobs:
           push: true
           tags: ${{ steps.aerieScheduler.outputs.tags }}
           labels: ${{ steps.aerieScheduler.outputs.labels }}
+      # Build aerie-commanding Docker artifacts.
+      - name: Extract metadata (tags, labels) for aerie-commanding Docker image
+          id: aerieCommanding
+          uses: docker/metadata-action@v3
+          with:
+            images: ${{ env.REGISTRY }}/nasa-ammos/aerie-commanding
+      - name: Build and push aerie-commanding Docker image
+          uses: docker/build-push-action@v2
+          with:
+            context: ./command-expansion-server
+            push: true
+            tags: ${{ steps.aerieCommanding.outputs.tags }}
+            labels: ${{ steps.aerieCommanding.outputs.labels }}
       # Publish via Gradle.
       - name: Publish Package
         run: ./gradlew publish

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 /nbbuild/
 /nbdist/
 /nbproject/private/
+node_modules
 
 # Ignore any SQL files copied from build tasks
 deployment/postgres-init-db/sql/**/*.sql

--- a/build.gradle
+++ b/build.gradle
@@ -11,40 +11,32 @@ task archiveDeployment(type: Tar) {
 
 // Add `distributeSql` task to all subprojects with `sql/` child directory
 configure(subprojects.findAll { it.projectDir.toPath().resolve('sql').toFile().exists() }) { sp ->
-  // Specify only subprojects with `processResources` tasks,
-  // otherwise Gradle cannot see `processResources` as a valid task
-  ['java', 'com.github.node-gradle.node'].each { pluginId ->
-    plugins.withId(pluginId) {
 
-      task distributeSql(type: Copy) {
-        into "$rootDir/deployment/postgres-init-db/sql"
-        from fileTree(dir: "${sp.projectDir}/sql", include: '**/*.sql')
-      }
+  // Distribute SQL as part of resource processing
+  task distributeSql(type: Copy, dependsOn: 'processResources') {
+    into "$rootDir/deployment/postgres-init-db/sql"
+    from fileTree(dir: "${sp.projectDir}/sql", include: '**/*.sql')
+  }
 
-      task undoDistributeSql(type: Delete) {
-        file("${sp.projectDir}/sql").list().each {
-          delete "$rootDir/deployment/postgres-init-db/sql/$it"
-        }
-      }
-
-      // Distribute SQL prior to any resource processing.
-      // This ensures `test` and `build` tasks will distribute SQL
-      processResources.dependsOn distributeSql
-
-      // Distribute SQL prior to creating deployment archive
-      archiveDeployment.dependsOn distributeSql
-
-      // Remove distributed SQL as part of `clean` task
-      clean.dependsOn undoDistributeSql
+  // Remove distributed SQL as part of `clean` task
+  task undoDistributeSql(type: Delete) {
+    file("${sp.projectDir}/sql").list().each {
+      delete "$rootDir/deployment/postgres-init-db/sql/$it"
     }
   }
+
+  // Remove distributed SQL as part of `clean` tasks
+  tasks.findAll { it.name == 'clean' }.each { t -> t.dependsOn undoDistributeSql }
+
+  // Distribute SQL prior to creating deployment archive
+  archiveDeployment.dependsOn distributeSql
 }
 
 subprojects {
   apply plugin: 'com.github.ben-manes.versions'
 
   repositories {
-    // Search the local filesystem before attempting remote repositories.
+    // Search the local filesystem before attempting remote repositories
     flatDir { dirs "$rootDir/third-party" }
     mavenCentral()
   }

--- a/command-expansion-server/Dockerfile
+++ b/command-expansion-server/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:lts-alpine
+COPY . /app
+WORKDIR /app
+CMD [ "npm", "start" ]

--- a/command-expansion-server/build.gradle
+++ b/command-expansion-server/build.gradle
@@ -18,11 +18,11 @@ task build(type: NpmTask) {
   args = ['run', 'build']
 }
 
-task test(type: NpmTask) {
-  dependsOn processResources
-  dependsOn npmInstall
-  args = ['run', 'test']
-}
+//task test(type: NpmTask) {
+//  dependsOn processResources
+//  dependsOn npmInstall
+//  args = ['run', 'test']
+//}
 
 task clean(type: Delete) {
   delete 'build', 'node_modules', 'package-lock.json'

--- a/command-expansion-server/build.gradle
+++ b/command-expansion-server/build.gradle
@@ -1,0 +1,19 @@
+
+plugins {
+  id "com.github.node-gradle.node" version "3.1.1"
+}
+
+node {
+  version = '16.4.0'
+  npmVersion = '8.5.0'
+  download = true
+}
+
+task build(type: NpmTask) {
+  dependsOn npmInstall
+  args = ['run','build']
+}
+
+task clean(type: Delete) {
+  delete 'build','node_modules', 'package-lock.json'
+}

--- a/command-expansion-server/build.gradle
+++ b/command-expansion-server/build.gradle
@@ -1,6 +1,5 @@
-
 plugins {
-  id "com.github.node-gradle.node" version "3.1.1"
+  id 'com.github.node-gradle.node' version '3.1.1'
 }
 
 node {
@@ -9,11 +8,22 @@ node {
   download = true
 }
 
+task processResources {
+  // Currently does nothing, exists as a hook for `distributeSql`
+}
+
 task build(type: NpmTask) {
+  dependsOn processResources
   dependsOn npmInstall
-  args = ['run','build']
+  args = ['run', 'build']
+}
+
+task test(type: NpmTask) {
+  dependsOn processResources
+  dependsOn npmInstall
+  args = ['run', 'test']
 }
 
 task clean(type: Delete) {
-  delete 'build','node_modules', 'package-lock.json'
+  delete 'build', 'node_modules', 'package-lock.json'
 }

--- a/command-expansion-server/package.json
+++ b/command-expansion-server/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "aerie-command",
+  "version": "1.0.0",
+  "description": "command service for AERIE",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "build": "npx tsc;",
+    "start": "npm run build; node ./build/app.js",
+    "debug": "npm run build; node --inspect=0.0.0.0:9229 ./build/app.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@microsoft/tsdoc": "^0.13.2",
+    "express": "^4.17.2",
+    "multer": "^1.4.4",
+    "pg": "^8.7.3",
+    "typescript": "^4.5.5"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.13",
+    "@types/jest": "^27.4.0",
+    "@types/multer": "^1.4.7",
+    "@types/pg": "^8.6.4",
+    "jest": "^27.5.1",
+    "jest-circus": "^27.5.1",
+    "jest-html-reporters": "^3.0.5",
+    "ts-jest": "^27.1.3"
+  }
+}

--- a/command-expansion-server/src/app.ts
+++ b/command-expansion-server/src/app.ts
@@ -1,0 +1,18 @@
+import express, { Application, Request, Response } from "express";
+
+import { getEnv } from "./env.js";
+import { DbExpansion } from "./packages/db/db.js";
+
+const app: Application = express();
+const PORT: number = parseInt(getEnv().PORT, 10) ?? 3000;
+
+DbExpansion.init();
+const db = DbExpansion.getDb();
+
+app.get("/", (req: Request, res: Response) => {
+  res.send("Aerie Command Service");
+});
+
+app.listen(PORT, () => {
+  console.log(`connected to port ${PORT}`);
+});

--- a/command-expansion-server/src/env.ts
+++ b/command-expansion-server/src/env.ts
@@ -1,0 +1,37 @@
+export type Env = {
+  PORT: string;
+  POSTGRES_AERIE_EXPANSION_DB: string;
+  POSTGRES_HOST: string;
+  POSTGRES_PASSWORD: string;
+  POSTGRES_PORT: string;
+  POSTGRES_USER: string;
+};
+
+export const defaultEnv: Env = {
+  PORT: "3000",
+  POSTGRES_AERIE_EXPANSION_DB: "aerie_expansion",
+  POSTGRES_HOST: "localhost",
+  POSTGRES_PASSWORD: "aerie",
+  POSTGRES_PORT: "5432",
+  POSTGRES_USER: "aerie",
+};
+
+export function getEnv(): Env {
+  const { env } = process;
+
+  const PORT = env["COMMANDING_SERVER_PORT"] ?? defaultEnv.PORT;
+  const POSTGRES_AERIE_EXPANSION_DB = env["COMMANDING_DB"] ?? defaultEnv.POSTGRES_AERIE_EXPANSION_DB;
+  const POSTGRES_HOST = env["POSTGRES_HOST"] ?? defaultEnv.POSTGRES_HOST;
+  const POSTGRES_PASSWORD = env["COMMANDING_DB_PASSWORD"] ?? defaultEnv.POSTGRES_PASSWORD;
+  const POSTGRES_PORT = env["COMMANDING_DB_PORT"] ?? defaultEnv.POSTGRES_PORT;
+  const POSTGRES_USER = env["COMMANDING_DB_USER"] ?? defaultEnv.POSTGRES_USER;
+
+  return {
+    PORT,
+    POSTGRES_AERIE_EXPANSION_DB,
+    POSTGRES_HOST,
+    POSTGRES_PASSWORD,
+    POSTGRES_PORT,
+    POSTGRES_USER,
+  };
+}

--- a/command-expansion-server/src/packages/db/db.ts
+++ b/command-expansion-server/src/packages/db/db.ts
@@ -1,0 +1,40 @@
+import type { Pool, PoolConfig } from "pg";
+import pg from "pg";
+import { getEnv } from "../../env.js";
+
+const { Pool: DbPool } = pg;
+
+const {
+  POSTGRES_AERIE_EXPANSION_DB,
+  POSTGRES_HOST: host,
+  POSTGRES_PASSWORD: password,
+  POSTGRES_PORT: port,
+  POSTGRES_USER: user,
+} = getEnv();
+
+export class DbExpansion {
+  private static pool: Pool;
+
+  static getDb(): Pool {
+    return DbExpansion.pool;
+  }
+
+  static init() {
+    try {
+      const config: PoolConfig = {
+        database: POSTGRES_AERIE_EXPANSION_DB,
+        host,
+        password,
+        port: parseInt(port, 10),
+        user,
+      };
+
+      console.log(`Postgres Config:`);
+      console.log(config);
+
+      DbExpansion.pool = new DbPool(config);
+    } catch (error) {
+      console.log(error);
+    }
+  }
+}

--- a/command-expansion-server/tsconfig.json
+++ b/command-expansion-server/tsconfig.json
@@ -1,0 +1,101 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Enable incremental compilation */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "ES2021",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": ["ES2021"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+
+    /* Modules */
+    "module": "ES2020",                                /* Specify what module code is generated. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    /*"typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+    /*"types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    /*"allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    "resolveJsonModule": true,                        /* Enable importing .json files */
+    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+     "outDir": "./build",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+    // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,24 @@ services:
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store
+  aerie_commanding:
+    build:
+      context: ./command-expansion-server
+      dockerfile: Dockerfile
+    container_name: aerie_commanding
+    depends_on: [ "postgres" ]
+    environment:
+      MERLIN_GRAPHQL_URL: http://hasura:8080/v1/graphql
+      COMMANDING_SERVER_PORT : 3000
+      COMMANDING_DB: "aerie_expansion"
+      COMMANDING_DB_PASSWORD: "aerie"
+      COMMANDING_DB_PORT: 5432
+      COMMANDING_DB_SERVER: "postgres"
+      COMMANDING_DB_USER: "aerie"
+      COMMANDING_LOCAL_STORE: /usr/src/app/commanding_file_store
+    image: aerie_commanding
+    ports: [ "3000:3000" ]
+    restart: always
   aerie_ui:
     container_name: aerie_ui
     depends_on: ["postgres"]

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,7 @@ include 'parsing-utilities'
 // Services for deployment within the Aerie infrastructure
 include 'merlin-server'
 include 'scheduler-server'
+include 'command-expansion-server'
 
 // Command-line interface direct to services
 include 'constraints'


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1686
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

Instead of having another GitHub repo for the command expansion service, it was decided to keep all the Aerie services under one project. I have added a command-expansion-server directory containing a basic node server we can build upon.

- [x] Gradle build processes
- [x] Docker compose and env variables to connect to db
- [x] PR building
- [x] Publishing build products (docker image to ghcr)
- [x] Identify a testing harness (we can chat about this more if you like)

## Verification

- `docker system prune --all --volumes  <-- Nuke everything `
- `./gradlew build; docker compose -f docker-compose.yml build; docker compose -f docker-compose.yml up`
- Verify you have a new docker container `aerie_commanding` running 
- Login to the new container and see that the node server is running
- Enter localhost:3000 on your browser to connect with the server

## Documentation
Added Command Expansion Service -  https://github.com/NASA-AMMOS/aerie/wiki/Product-Guide

## Future work
[AERIE-1687](https://jira.jpl.nasa.gov/browse/AERIE-1687)
Setup database schema intialization for command expansion server
