### PR TITLE
[ARIE-1687]  Setup Database Schema Initialization for the Command Expansion Server

### DIFF
--- a/command-expansion-server/sql/commanding/init.sql
+++ b/command-expansion-server/sql/commanding/init.sql
@@ -1,0 +1,13 @@
+-- The order of inclusion is important! Tables referenced by foreign keys must be loaded before their dependants.
+
+begin;
+
+  -- Command Expansion Tables.
+  \ir tables/command_dictionary.sql
+  \ir tables/expansion_set.sql
+  \ir tables/expansion_rules.sql
+  \ir tables/expansion_set_to_rule.sql
+  \ir tables/expansion_run.sql
+  \ir tables/activity_instance_commands.sql
+
+end;

--- a/command-expansion-server/sql/commanding/tables/activity_instance_commands.sql
+++ b/command-expansion-server/sql/commanding/tables/activity_instance_commands.sql
@@ -1,0 +1,20 @@
+create table activity_instance_commands (
+  activity_instance_id integer not null,
+  commands jsonb not null,
+  expansion_run_id integer not null,
+
+  constraint activity_instance_primary_key
+    primary key (activity_instance_id),
+
+  foreign key (expansion_run_id)
+  references expansion_run (id)
+);
+
+comment on table activity_instance_commands is e''
+  'The commands generated from activities instances in the plan.';
+comment on column activity_instance_commands.activity_instance_id is e''
+  'The activity_instance in the plan.';
+comment on column activity_instance_commands.commands is e''
+  'Commands generated for the activity_instance.';
+comment on column activity_instance_commands.expansion_run_id is e''
+  'The configuration used during command generation';

--- a/command-expansion-server/sql/commanding/tables/command_dictionary.sql
+++ b/command-expansion-server/sql/commanding/tables/command_dictionary.sql
@@ -1,0 +1,21 @@
+create table command_dictionary (
+  id integer generated always as identity,
+
+  command_types text not null,
+  mission text not null,
+  version text not null,
+
+  constraint command_dictionary_primary_key
+      primary key (id)
+);
+
+comment on table command_dictionary is e''
+  'A Command Dictionary for a mission.';
+comment on column command_dictionary.id is e''
+  'The synthetic identifier for this command dictionary.';
+comment on column command_dictionary.command_types is e''
+  'The location of command dictionary types (.ts) on the filesystem';
+comment on column command_dictionary.mission is e''
+  'A human-meaningful identifier for the mission described by the command dictionary';
+comment on column command_dictionary.version is e''
+  'A human-meaningful version qualifier.';

--- a/command-expansion-server/sql/commanding/tables/expansion_rules.sql
+++ b/command-expansion-server/sql/commanding/tables/expansion_rules.sql
@@ -1,0 +1,17 @@
+create table expansion_rules (
+  id integer generated always as identity,
+
+  activity_type text not null,
+  expansion_logic text not null,
+
+  constraint expansion_rules_primary_key
+  primary key (id)
+);
+comment on table expansion_rules is e''
+  'The user defined logic to expand an activity type.';
+comment on column expansion_rules.id is e''
+  'The synthetic identifier for this expansion rule.';
+comment on column expansion_rules.activity_type is e''
+  'The user selected activity type.';
+comment on column expansion_rules.expansion_logic is e''
+  'The expansion logic used to generate commands.';

--- a/command-expansion-server/sql/commanding/tables/expansion_run.sql
+++ b/command-expansion-server/sql/commanding/tables/expansion_run.sql
@@ -1,0 +1,20 @@
+create table expansion_run (
+  id integer generated always as identity,
+
+  simulation_id integer not null,
+  expansion_set_id integer not null,
+
+  constraint expansion_run_primary_key
+    primary key (id),
+
+  foreign key (expansion_set_id)
+  references expansion_set (id)
+);
+comment on table expansion_run is e''
+  'The configuration for an expansion run for a plan.';
+comment on column expansion_run.id is e''
+  'The synthetic identifier for this expansion run.';
+comment on column expansion_run.simulation_id is e''
+  'The simulation results for the plan.';
+comment on column expansion_run.expansion_set_id is e''
+  'The command dictionary and mission model set';

--- a/command-expansion-server/sql/commanding/tables/expansion_set.sql
+++ b/command-expansion-server/sql/commanding/tables/expansion_set.sql
@@ -1,0 +1,21 @@
+create table expansion_set (
+  id integer generated always as identity,
+
+  command_dict_id integer not null,
+  mission_model_id integer not null,
+
+  constraint expansion_set_primary_key
+    primary key (id),
+
+  foreign key (command_dict_id)
+  references command_dictionary (id)
+);
+
+comment on table expansion_set is e''
+  'A binding of a command dictionary to a mission model.';
+comment on column expansion_set.id is e''
+  'The synthetic identifier for the set.';
+comment on column expansion_set.command_dict_id is e''
+  'The ID of a command dictionary.';
+comment on column expansion_set.mission_model_id is e''
+  'The ID of a mission model.';

--- a/command-expansion-server/sql/commanding/tables/expansion_set_to_rule.sql
+++ b/command-expansion-server/sql/commanding/tables/expansion_set_to_rule.sql
@@ -1,0 +1,19 @@
+create table expansion_set_to_rule (
+  set_id integer not null,
+  rule_id integer not null,
+
+  constraint expansion_set_to_rule_primary_key
+  primary key (set_id,rule_id),
+
+  foreign key (set_id)
+  references expansion_set (id),
+
+  foreign key (rule_id)
+  references expansion_rules (id)
+);
+comment on table expansion_set_to_rule is e''
+  'The join table between expansion_set and expansion_rules';
+comment on column expansion_set_to_rule.set_id is e''
+  'The id for an expansion_set.';
+comment on column expansion_set_to_rule.rule_id is e''
+  'the id for an expansion_rule.';

--- a/deployment/hasura/metadata/databases/AerieCommanding/tables/public_activity_instance_commands.yaml
+++ b/deployment/hasura/metadata/databases/AerieCommanding/tables/public_activity_instance_commands.yaml
@@ -1,0 +1,3 @@
+table:
+  name: activity_instance_commands
+  schema: public

--- a/deployment/hasura/metadata/databases/AerieCommanding/tables/public_command_dictionary.yaml
+++ b/deployment/hasura/metadata/databases/AerieCommanding/tables/public_command_dictionary.yaml
@@ -1,0 +1,3 @@
+table:
+  name: command_dictionary
+  schema: public

--- a/deployment/hasura/metadata/databases/AerieCommanding/tables/public_expansion_rules.yaml
+++ b/deployment/hasura/metadata/databases/AerieCommanding/tables/public_expansion_rules.yaml
@@ -1,0 +1,3 @@
+table:
+  name: expansion_rules
+  schema: public

--- a/deployment/hasura/metadata/databases/AerieCommanding/tables/public_expansion_run.yaml
+++ b/deployment/hasura/metadata/databases/AerieCommanding/tables/public_expansion_run.yaml
@@ -1,0 +1,3 @@
+table:
+  name: expansion_run
+  schema: public

--- a/deployment/hasura/metadata/databases/AerieCommanding/tables/public_expansion_set.yaml
+++ b/deployment/hasura/metadata/databases/AerieCommanding/tables/public_expansion_set.yaml
@@ -1,0 +1,3 @@
+table:
+  name: expansion_set
+  schema: public

--- a/deployment/hasura/metadata/databases/AerieCommanding/tables/public_expansion_set_to_rule.yaml
+++ b/deployment/hasura/metadata/databases/AerieCommanding/tables/public_expansion_set_to_rule.yaml
@@ -1,0 +1,3 @@
+table:
+  name: expansion_set_to_rule
+  schema: public

--- a/deployment/hasura/metadata/databases/AerieCommanding/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieCommanding/tables/tables.yaml
@@ -1,0 +1,6 @@
+- "!include public_activity_instance_commands.yaml"
+- "!include public_command_dictionary.yaml"
+- "!include public_expansion_rules.yaml"
+- "!include public_expansion_run.yaml"
+- "!include public_expansion_set_to_rule.yaml"
+- "!include public_expansion_set.yaml"

--- a/deployment/hasura/metadata/databases/databases.yaml
+++ b/deployment/hasura/metadata/databases/databases.yaml
@@ -16,3 +16,12 @@
       isolation_level: read-committed
       use_prepared_statements: false
   tables: "!include AerieScheduler/tables/tables.yaml"
+- name: AerieCommanding
+  kind: postgres
+  configuration:
+    connection_info:
+      database_url:
+        from_env: AERIE_COMMANDING_DATABASE_URL
+      isolation_level: read-committed
+      use_prepared_statements: false
+  tables: "!include AerieCommanding/tables/tables.yaml"

--- a/deployment/postgres-init-db/init-aerie.sh
+++ b/deployment/postgres-init-db/init-aerie.sh
@@ -26,6 +26,12 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
   CREATE DATABASE aerie_ui;
   GRANT ALL PRIVILEGES ON DATABASE aerie_ui TO aerie;
   \echo 'Done!'
+
+  \echo 'Initializing aerie_commanding database...'
+  CREATE DATABASE aerie_commanding;
+  GRANT ALL PRIVILEGES ON DATABASE aerie_ui TO aerie;
+  \echo 'Done!'
+
 EOSQL
 
 export PGPASSWORD=aerie
@@ -45,5 +51,11 @@ EOSQL
 psql -v ON_ERROR_STOP=1 --username "aerie" --dbname "aerie_ui" <<-EOSQL
   \echo 'Initializing aerie_ui database objects...'
   \ir /docker-entrypoint-initdb.d/sql/ui/init.sql
+  \echo 'Done!'
+EOSQL
+
+psql -v ON_ERROR_STOP=1 --username "aerie" --dbname "aerie_commanding" <<-EOSQL
+  \echo 'Initializing aerie_commanding database objects...'
+  \ir /docker-entrypoint-initdb.d/sql/commanding/init.sql
   \echo 'Done!'
 EOSQL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,7 @@ services:
     environment:
       AERIE_MERLIN_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_merlin
       AERIE_SCHEDULER_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_scheduler
+      AERIE_COMMANDING_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_commanding
       AERIE_UI_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_ui
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1687
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Add the SQL tables to Postgres under the `aerie-commanding` db and enable them to be visible to Hasura.

Waiting on 2 PRs

- https://github.com/NASA-AMMOS/aerie/pull/49 - Merged
- https://github.com/NASA-AMMOS/aerie/pull/51 - Merged


## Verification
- Nuke everything:
`docker system prune --all --volumes`
- build and run
`./gradlew clean; ./gradlew assemble ; docker compose -f docker-compose.yml build; docker compose -f docker-compose.yml up
`

I have tested this locally and the tables are created in Postgres and viewable in Hasura

## Documentation
None that I can think of

## Future work
Now the infrastructure is in place we can start hooking up all the business logic