### PR TITLE
[AERIE-1656]  Activities opt-in to controllable duration

### DIFF
--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BakeBananaBreadActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BakeBananaBreadActivity.java
@@ -5,10 +5,9 @@ import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.WithDefaults;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Validation;
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
 @ActivityType("BakeBananaBread")
-public record BakeBananaBreadActivity(double temperature, int tbSugar, boolean glutenFree, Duration duration) {
+public record BakeBananaBreadActivity(double temperature, int tbSugar, boolean glutenFree) {
 
   @Validation("Temperature must be positive")
   public boolean validateTemperature() {

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/GrowBananaActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/GrowBananaActivity.java
@@ -1,11 +1,14 @@
 package gov.nasa.jpl.aerie.banananation.activities;
 
-import gov.nasa.jpl.aerie.banananation.Flag;
 import gov.nasa.jpl.aerie.banananation.Mission;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.ControllableDuration;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Validation;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Template;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 
 /**
  * Monke has evolve. Monke now make banana. Monke is farmer.
@@ -16,10 +19,10 @@ import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Template;
  * @contact John Doe
  */
 @ActivityType("GrowBanana")
-public record GrowBananaActivity(int quantity) {
+public record GrowBananaActivity(int quantity, Duration growingDuration) {
 
   public static @Template GrowBananaActivity defaults() {
-    return new GrowBananaActivity(0);
+    return new GrowBananaActivity(0, Duration.ZERO);
   }
 
   @Validation("Quantity must be positive")
@@ -28,7 +31,9 @@ public record GrowBananaActivity(int quantity) {
   }
 
   @EffectModel
+  @ControllableDuration(parameterName = "growingDuration")
   public void run(final Mission mission) {
+    delay(this.growingDuration());
     mission.plant.add(this.quantity());
   }
 }

--- a/examples/banananation/src/main/resources/META-INF/services/gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin
+++ b/examples/banananation/src/main/resources/META-INF/services/gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin
@@ -1,0 +1,1 @@
+gov.nasa.jpl.aerie.banananation.generated.GeneratedSchedulerPlugin

--- a/examples/config-with-defaults/src/main/resources/META-INF/services/gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin
+++ b/examples/config-with-defaults/src/main/resources/META-INF/services/gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin
@@ -1,0 +1,1 @@
+gov.nasa.jpl.aerie.configwithdefaults.generated.GeneratedSchedulerPlugin

--- a/examples/config-without-defaults/src/main/resources/META-INF/services/gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin
+++ b/examples/config-without-defaults/src/main/resources/META-INF/services/gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin
@@ -1,0 +1,1 @@
+gov.nasa.jpl.aerie.configwithoutdefaults.generated.GeneratedSchedulerPlugin

--- a/examples/foo-missionmodel/src/main/resources/META-INF/services/gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin
+++ b/examples/foo-missionmodel/src/main/resources/META-INF/services/gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin
@@ -1,0 +1,1 @@
+gov.nasa.jpl.aerie.foomissionmodel.generated.GeneratedSchedulerPlugin

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelLoader.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelLoader.java
@@ -33,7 +33,7 @@ public final class MissionModelLoader {
         return loadMissionModel(missionModelConfig, factory, builder);
     }
 
-    private static <Model>
+    public static <Model>
     MissionModel<Model> loadMissionModel(
         final SerializedValue missionModelConfig,
         final MissionModelFactory<Model> factory,

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
@@ -354,12 +354,15 @@ import java.util.function.Predicate;
 
       if (!(element instanceof ExecutableElement executableElement)) continue;
 
+      final var durationTypeAnnotation = element.getAnnotation(ActivityType.ControllableDuration.class);
+      final var durationParameter = Optional.ofNullable(durationTypeAnnotation).map(ActivityType.ControllableDuration::parameterName);
+
       final var returnType = executableElement.getReturnType();
       final var nonVoidReturnType = returnType.getKind() == TypeKind.VOID
           ? Optional.<TypeMirror>empty()
           : Optional.of(returnType);
 
-      return Optional.of(new EffectModelRecord(element.getSimpleName().toString(), executorAnnotation.value(), nonVoidReturnType));
+      return Optional.of(new EffectModelRecord(element.getSimpleName().toString(), executorAnnotation.value(), nonVoidReturnType, durationParameter));
     }
 
     return Optional.empty();

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
@@ -82,7 +82,9 @@ public final class MissionModelProcessor implements Processor {
       try {
         final var missionModelRecord = missionModelParser.parseMissionModel(packageElement);
 
-        final var generatedFiles = new ArrayList<>(List.of(missionModelGen.generateMerlinPlugin(missionModelRecord)));
+        final var generatedFiles = new ArrayList<>(List.of(
+            missionModelGen.generateMerlinPlugin(missionModelRecord),
+            missionModelGen.generateSchedulerPlugin(missionModelRecord)));
 
         missionModelRecord.modelConfigurationType
             .flatMap(configType -> missionModelGen.generateMissionModelConfigurationMapper(missionModelRecord, configType))
@@ -90,6 +92,7 @@ public final class MissionModelProcessor implements Processor {
 
         generatedFiles.addAll(List.of(
             missionModelGen.generateMissionModelFactory(missionModelRecord),
+            missionModelGen.generateSchedulerModel(missionModelRecord),
             missionModelGen.generateActivityActions(missionModelRecord),
             missionModelGen.generateActivityTypes(missionModelRecord)
         ));

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -308,10 +308,14 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                 activityTypeRecord ->
                                     CodeBlock
                                         .builder()
-                                        .addStatement("result.put(\"$L\", $T.$L())",
+                                        .addStatement("result.put(\"$L\", $T.$L)",
                                                       activityTypeRecord.name(),
                                                       DurationType.class,
-                                                      "uncontrollable"))
+                                                      activityTypeRecord
+                                                          .effectModel()
+                                                          .flatMap(EffectModelRecord::durationParameter)
+                                                          .map(durationParameter -> CodeBlock.of("controllable(\"$L\")", durationParameter))
+                                                          .orElse(CodeBlock.of("uncontrollable()"))))
                             .reduce((x, y) -> x.add("$L", y.build()))
                             .orElse(CodeBlock.builder()).build())
                     .addStatement("return result")

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -24,6 +24,9 @@ import gov.nasa.jpl.aerie.merlin.processor.metamodel.ExportTypeRecord;
 import gov.nasa.jpl.aerie.merlin.protocol.model.ConfigurationType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.MerlinPlugin;
 import gov.nasa.jpl.aerie.merlin.protocol.model.MissionModelFactory;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin;
+import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
@@ -46,7 +49,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
 
   /** Generate `GeneratedMerlinPlugin` class. */
   public JavaFile generateMerlinPlugin(final MissionModelRecord missionModel) {
-    final var typeName = missionModel.getPluginName();
+    final var typeName = missionModel.getMerlinPluginName();
 
     final var typeSpec =
         TypeSpec
@@ -67,6 +70,37 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                     .addStatement(
                         "return new $T()",
                         missionModel.getFactoryName())
+                    .build())
+            .build();
+
+    return JavaFile
+        .builder(typeName.packageName(), typeSpec)
+        .skipJavaLangImports(true)
+        .build();
+  }
+
+  /** Generate `GeneratedSchedulerPlugin` class. */
+  public JavaFile generateSchedulerPlugin(final MissionModelRecord missionModel) {
+    final var typeName = missionModel.getSchedulerPluginName();
+
+    final var typeSpec =
+        TypeSpec
+            .classBuilder(typeName)
+            .addAnnotation(
+                AnnotationSpec
+                    .builder(javax.annotation.processing.Generated.class)
+                    .addMember("value", "$S", MissionModelProcessor.class.getCanonicalName())
+                    .build())
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addSuperinterface(SchedulerPlugin.class)
+            .addMethod(
+                MethodSpec
+                    .methodBuilder("getSchedulerModel")
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(missionModel.getSchedulerModelName())
+                    .addStatement("return new $T()",
+                                  missionModel.getSchedulerModelName())
                     .build())
             .build();
 
@@ -236,6 +270,51 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                     .addStatement(
                         "return getConfigurationType().map(configType -> configType.getParameters()).orElseGet(() -> $T.of())",
                         List.class)
+                    .build())
+            .build();
+
+    return JavaFile
+        .builder(typeName.packageName(), typeSpec)
+        .skipJavaLangImports(true)
+        .build();
+  }
+
+  /** Generate `GeneratedSchedulerModel` class. */
+  public JavaFile generateSchedulerModel(final MissionModelRecord missionModel) {
+    final var typeName = missionModel.getSchedulerModelName();
+
+    final var typeSpec =
+        TypeSpec
+            .classBuilder(typeName)
+            .addAnnotation(
+                AnnotationSpec
+                    .builder(javax.annotation.processing.Generated.class)
+                    .addMember("value", "$S", MissionModelProcessor.class.getCanonicalName())
+                    .build())
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addSuperinterface(SchedulerModel.class)
+            .addMethod(
+                MethodSpec
+                    .methodBuilder("getDurationTypes")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addAnnotation(Override.class)
+                    .returns(ParameterizedTypeName.get(Map.class, String.class, DurationType.class))
+                    .addStatement("final var result = new $T()", ParameterizedTypeName.get(HashMap.class, String.class, DurationType.class))
+                    .addCode(
+                        missionModel
+                            .activityTypes
+                            .stream()
+                            .map(
+                                activityTypeRecord ->
+                                    CodeBlock
+                                        .builder()
+                                        .addStatement("result.put(\"$L\", $T.$L())",
+                                                      activityTypeRecord.name(),
+                                                      DurationType.class,
+                                                      "uncontrollable"))
+                            .reduce((x, y) -> x.add("$L", y.build()))
+                            .orElse(CodeBlock.builder()).build())
+                    .addStatement("return result")
                     .build())
             .build();
 

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
@@ -5,5 +5,10 @@ import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import javax.lang.model.type.TypeMirror;
 import java.util.Optional;
 
-public record EffectModelRecord(String methodName, ActivityType.Executor executor, Optional<TypeMirror> returnType) {
+public record EffectModelRecord(
+    String methodName,
+    ActivityType.Executor executor,
+    Optional<TypeMirror> returnType,
+    Optional<String> durationParameter
+) {
 }

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/MissionModelRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/MissionModelRecord.java
@@ -29,12 +29,20 @@ public final class MissionModelRecord {
     this.activityTypes = Objects.requireNonNull(activityTypes);
   }
 
-  public ClassName getPluginName() {
+  public ClassName getMerlinPluginName() {
     return ClassName.get(this.$package.getQualifiedName() + ".generated", "GeneratedMerlinPlugin");
+  }
+
+  public ClassName getSchedulerPluginName() {
+    return ClassName.get(this.$package.getQualifiedName() + ".generated", "GeneratedSchedulerPlugin");
   }
 
   public ClassName getFactoryName() {
     return ClassName.get(this.$package.getQualifiedName() + ".generated", "GeneratedMissionModelFactory");
+  }
+
+  public ClassName getSchedulerModelName() {
+    return ClassName.get(this.$package.getQualifiedName() + ".generated", "GeneratedSchedulerModel");
   }
 
   public ClassName getActivityActionsName() {

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/ActivityType.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/ActivityType.java
@@ -25,4 +25,10 @@ public @interface ActivityType {
   @interface EffectModel {
     Executor value() default Executor.Threaded;
   }
+
+  @Retention(RetentionPolicy.CLASS)
+  @Target(ElementType.METHOD)
+  @interface ControllableDuration {
+    String parameterName();
+  }
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/SchedulerModel.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/SchedulerModel.java
@@ -1,0 +1,9 @@
+package gov.nasa.jpl.aerie.merlin.protocol.model;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
+
+import java.util.Map;
+
+public interface SchedulerModel {
+  Map<String, DurationType> getDurationTypes();
+}

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/SchedulerPlugin.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/SchedulerPlugin.java
@@ -1,0 +1,5 @@
+package gov.nasa.jpl.aerie.merlin.protocol.model;
+
+public interface SchedulerPlugin {
+  SchedulerModel getSchedulerModel();
+}

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/DurationType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/DurationType.java
@@ -1,9 +1,14 @@
 package gov.nasa.jpl.aerie.merlin.protocol.types;
 
 public sealed interface DurationType {
+  record Controllable(String parameterName) implements DurationType {}
   record Uncontrollable() implements DurationType {}
 
   static DurationType uncontrollable() {
     return new Uncontrollable();
+  }
+
+  static DurationType controllable(final String parameterName) {
+    return new Controllable(parameterName);
   }
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/DurationType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/DurationType.java
@@ -1,0 +1,9 @@
+package gov.nasa.jpl.aerie.merlin.protocol.types;
+
+public sealed interface DurationType {
+  record Uncontrollable() implements DurationType {}
+
+  static DurationType uncontrollable() {
+    return new Uncontrollable();
+  }
+}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
@@ -99,7 +99,6 @@ public class GoalBuilder {
     for (final var argument : activityTemplate.arguments().entrySet()) {
       builder = builder.withArgument(argument.getKey(), argument.getValue());
     }
-    builder = builder.duration(Duration.ZERO);
     return builder.build();
   }
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -90,7 +90,7 @@ public record SynchronousSchedulerAgent(
       //create scheduler problem seeded with initial plan
       final var schedulerMissionModel = loadMissionModel(planMetadata);
       var planningHorizon = new PlanningHorizon(Time.fromInstant(specificationWithGoals.horizonStartTimestamp().toInstant()),Time.fromInstant(specificationWithGoals.horizonEndTimestamp().toInstant())) ;
-      final var problem = new Problem(schedulerMissionModel.missionModel(), planningHorizon);
+      final var problem = new Problem(schedulerMissionModel.missionModel(), planningHorizon, schedulerMissionModel.schedulerModel());
       //seed the problem with the initial plan contents
       problem.setInitialPlan(loadInitialPlan(planMetadata, problem));
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -3,6 +3,8 @@ package gov.nasa.jpl.aerie.scheduler.server.services;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelLoader;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.scheduler.ActivityInstance;
 import gov.nasa.jpl.aerie.scheduler.GlobalConstraint;
@@ -25,14 +27,21 @@ import gov.nasa.jpl.aerie.scheduler.server.models.GoalRecord;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanMetadata;
 import gov.nasa.jpl.aerie.scheduler.server.models.Specification;
-import gov.nasa.jpl.aerie.scheduler.server.remotes.postgres.PostgresSpecificationRepository;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 /**
@@ -79,14 +88,14 @@ public record SynchronousSchedulerAgent(
       ensureRequestIsCurrent(request);
       ensurePlanRevisionMatch(specificationWithGoals,planMetadata.planRev());
       //create scheduler problem seeded with initial plan
-      final var mission = loadMissionModel(planMetadata);
+      final var schedulerMissionModel = loadMissionModel(planMetadata);
       var planningHorizon = new PlanningHorizon(Time.fromInstant(specificationWithGoals.horizonStartTimestamp().toInstant()),Time.fromInstant(specificationWithGoals.horizonEndTimestamp().toInstant())) ;
-      final var problem = new Problem(mission, planningHorizon);
+      final var problem = new Problem(schedulerMissionModel.missionModel(), planningHorizon);
       //seed the problem with the initial plan contents
       problem.setInitialPlan(loadInitialPlan(planMetadata, problem));
 
       //apply constraints/goals to the problem
-      loadConstraints(planMetadata, mission).forEach(problem::add);
+      loadConstraints(planMetadata, schedulerMissionModel.missionModel()).forEach(problem::add);
       var orderedGoals = specificationWithGoals.goalsByPriority().stream().map(GoalRecord::definition).collect(Collectors.toList());
       problem.setGoals(orderedGoals);
       var goals = specificationWithGoals.goalsByPriority().stream().collect(Collectors.toMap(GoalRecord::definition, GoalRecord::id));
@@ -200,6 +209,8 @@ public record SynchronousSchedulerAgent(
     }
   }
 
+  record SchedulerMissionModel(MissionModel<?> missionModel, SchedulerModel schedulerModel) {}
+
   /**
    * creates an instance of the mission model referenced by the specified plan
    *
@@ -209,16 +220,91 @@ public record SynchronousSchedulerAgent(
    * @throws ResultsProtocolFailure when the mission model could not be loaded: eg jar file not found, declared
    *     version/name in jar does not match, or aerie filesystem could not be mounted
    */
-  private MissionModel<?> loadMissionModel(final PlanMetadata plan) {
+  private SchedulerMissionModel loadMissionModel(final PlanMetadata plan) {
     try {
       final var missionConfig = SerializedValue.of(plan.modelConfiguration());
       final var modelJarPath = modelJarsDir.resolve(plan.modelPath());
-
-      final var aerieModel = MissionModelLoader.loadMissionModel(
-          missionConfig, modelJarPath, plan.modelName(), plan.modelVersion());
-      return aerieModel;
-    } catch (MissionModelLoader.MissionModelLoadException e) {
+      return new SchedulerMissionModel(
+          MissionModelLoader.loadMissionModel(missionConfig, modelJarPath, plan.modelName(), plan.modelVersion()),
+          loadSchedulerModelProvider(modelJarPath, plan.modelName(), plan.modelVersion()).getSchedulerModel());
+    } catch (MissionModelLoader.MissionModelLoadException | SchedulerModelLoadException e) {
       throw new ResultsProtocolFailure(e);
+    }
+  }
+
+  public static SchedulerPlugin loadSchedulerModelProvider(final Path path, final String name, final String version)
+  throws MissionModelLoader.MissionModelLoadException, SchedulerModelLoadException
+  {
+    // Look for a MerlinMissionModel implementor in the mission model. For correctness, we're assuming there's
+    // only one matching MerlinMissionModel in any given mission model.
+    final var className = getImplementingClassName(path, name, version);
+
+    // Construct a ClassLoader with access to classes in the mission model location.
+    final var parentClassLoader = Thread.currentThread().getContextClassLoader();
+    final URLClassLoader classLoader;
+    try {
+      classLoader = new URLClassLoader(new URL[] {path.toUri().toURL()}, parentClassLoader);
+    } catch (MalformedURLException ex) {
+      throw new Error(ex);
+    }
+
+    try {
+      final var factoryClass$ = classLoader.loadClass(className);
+      if (!SchedulerPlugin.class.isAssignableFrom(factoryClass$)) {
+        throw new SchedulerModelLoadException(path, name, version);
+      }
+
+      // SAFETY: We checked above that SchedulerPlugin is assignable from this type.
+      @SuppressWarnings("unchecked")
+      final var factoryClass = (Class<? extends SchedulerPlugin>) factoryClass$;
+
+      return factoryClass.getConstructor().newInstance();
+    } catch (final ClassNotFoundException | NoSuchMethodException | InstantiationException
+        | IllegalAccessException | InvocationTargetException ex)
+    {
+      throw new SchedulerModelLoadException(path, name, version, ex);
+    }
+  }
+
+  public static String getImplementingClassName(final Path jarPath, final String name, final String version)
+  throws SchedulerModelLoadException
+  {
+    try {
+      final var jarFile = new JarFile(jarPath.toFile());
+      final var jarEntry = jarFile.getEntry("META-INF/services/" + SchedulerPlugin.class.getCanonicalName());
+      if (jarEntry == null) {
+        throw new Error("JAR file `" + jarPath + "` did not declare a service called " + SchedulerPlugin.class.getCanonicalName());
+      }
+      final var inputStream = jarFile.getInputStream(jarEntry);
+
+      final var classPathList = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+          .lines()
+          .collect(Collectors.toList());
+
+      if (classPathList.size() != 1) {
+        throw new SchedulerModelLoadException(jarPath, name, version);
+      }
+
+      return classPathList.get(0);
+    } catch (final IOException ex) {
+      throw new SchedulerModelLoadException(jarPath, name, version, ex);
+    }
+  }
+
+  public static class SchedulerModelLoadException extends Exception {
+    private SchedulerModelLoadException(final Path path, final String name, final String version) {
+      this(path, name, version, null);
+    }
+
+    private SchedulerModelLoadException(final Path path, final String name, final String version, final Throwable cause) {
+      super(
+          String.format(
+              "No implementation found for `%s` at path `%s` wih name \"%s\" and version \"%s\"",
+              SchedulerPlugin.class.getSimpleName(),
+              path,
+              name,
+              version),
+          cause);
     }
   }
 

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/ActivityCreationTemplate.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/ActivityCreationTemplate.java
@@ -131,6 +131,28 @@ public class ActivityCreationTemplate extends ActivityExpression {
         }
         template.parametricDur = this.parametricDur;
       }
+
+      if (this.type.getDurationType() instanceof DurationType.Uncontrollable) {
+        if (this.parametricDur != null) {
+          throw new RuntimeException("Cannot define parametric duration on activity of type "
+                                     + this.type.getName()
+
+                                     + " because its DurationType is Uncontrollable");
+        }
+        if (this.durationIn != null) {
+          throw new RuntimeException("Cannot constrain duration on activity of type "
+                                     + this.type.getName()
+
+                                     + " because its DurationType is Uncontrollable");
+        }
+        if (this.endsIn != null) {
+          throw new RuntimeException("Cannot constrain end time of an activity of type "
+                                     + this.type.getName()
+
+                                     + " because its DurationType is Uncontrollable");
+        }
+      }
+
       template.type = this.type;
 
       if (this.durationIn != null) {

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/ActivityCreationTemplate.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/ActivityCreationTemplate.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.scheduler;
 import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
 
 /**
  * criteria used to identify create activity instances in scheduling goals
@@ -120,26 +121,26 @@ public class ActivityCreationTemplate extends ActivityExpression {
       return this;
     }
 
-    protected ActivityCreationTemplate fill(ActivityCreationTemplate template) {
-      template.startRange = startsIn;
-      template.endRange = endsIn;
-      template.startOrEndRange = startsOrEndsIn;
-      if(parametricDur!=null){
-        if(durationIn!= null){
+    protected ActivityCreationTemplate fill(final ActivityCreationTemplate template) {
+      template.startRange = this.startsIn;
+      template.endRange = this.endsIn;
+      template.startOrEndRange = this.startsOrEndsIn;
+      if (this.parametricDur != null){
+        if (this.durationIn != null){
           throw new RuntimeException("Cannot specify two different types of durations");
         }
-        template.parametricDur = parametricDur;
+        template.parametricDur = this.parametricDur;
       }
-      template.type = type;
+      template.type = this.type;
 
-      if (durationIn != null) {
-        template.durationRange = durationIn;
+      if (this.durationIn != null) {
+        template.durationRange = this.durationIn;
       }
       //REVIEW: probably want to store permissible rane separate from creation
       //        default value
 
-      template.arguments = arguments;
-      template.variableArguments = variableArguments;
+      template.arguments = this.arguments;
+      template.variableArguments = this.variableArguments;
       return template;
     }
 

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/ActivityCreationTemplate.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/ActivityCreationTemplate.java
@@ -196,47 +196,46 @@ public class ActivityCreationTemplate extends ActivityExpression {
 
   }
 
-  private ActivityInstance createInstanceForReal(String name, Window window, boolean instantiateVariableArguments) {
-    final ActivityInstance act = new ActivityInstance(type);
-    act.setArguments(arguments);
-    act.setVariableArguments(variableArguments);
-    TaskNetwork tw = new TaskNetwork();
-    TaskNetworkAdapter tnw = new TaskNetworkAdapter(tw);
+  private ActivityInstance createInstanceForReal(final String name, final Window window, final boolean instantiateVariableArguments) {
+    final var act = new ActivityInstance(this.type);
+    act.setArguments(this.arguments);
+    act.setVariableArguments(this.variableArguments);
+    final var tnw = new TaskNetworkAdapter(new TaskNetwork());
     tnw.addAct(name);
-    if(window != null){
-      tnw.addEnveloppe(name,"window", window.start, window.end);
+    if (window != null) {
+      tnw.addEnveloppe(name, "window", window.start, window.end);
     }
-    if (startRange != null){
-      tnw.addStartInterval(name, startRange.start, startRange.end);
+    if (this.startRange != null) {
+      tnw.addStartInterval(name, this.startRange.start, this.startRange.end);
     }
-    if (endRange != null){
-      tnw.addEndInterval(name, endRange.start, endRange.end);
+    if (this.endRange != null) {
+      tnw.addEndInterval(name, this.endRange.start, this.endRange.end);
     }
-    if(durationRange!=null){
-      tnw.addDurationInterval(name, durationRange.start, durationRange.end);
+    if (this.durationRange != null) {
+      tnw.addDurationInterval(name, this.durationRange.start, this.durationRange.end);
     }
-    var success = tnw.solveConstraints();
-    if(!success){
+    final var success = tnw.solveConstraints();
+    if (!success) {
       System.out.println("Inconsistent temporal constraints, returning empty activity");
       return null;
     }
-    var solved = tnw.getAllData(name);
+    final var solved = tnw.getAllData(name);
     //select earliest start time
-    var earliestStart= solved.start().start;
+    final var earliestStart = solved.start().start;
     act.setStartTime(earliestStart);
-    if(parametricDur==null) {
+    if (this.parametricDur == null) {
       //select smallest duration
       act.setDuration(solved.duration().start);
-    } else{
-      var computedDur = parametricDur.compute(Window.between(earliestStart, earliestStart));
-      if(solved.duration().contains(computedDur)){
+    } else {
+      final var computedDur = this.parametricDur.compute(Window.between(earliestStart, earliestStart));
+      if (solved.duration().contains(computedDur)) {
         act.setDuration(computedDur);
-      } else{
+      } else {
         throw new IllegalArgumentException("Parametric duration is incompatible with temporal constraints");
       }
     }
 
-    for (var param : variableArguments.entrySet()) {
+    for (final var param : this.variableArguments.entrySet()) {
       if (instantiateVariableArguments) {
         act.instantiateVariableArgument(param.getKey());
       }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/ActivityType.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/ActivityType.java
@@ -23,6 +23,21 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class ActivityType {
 
   /**
+   * the identifier associated with this activity type
+   */
+  final String name;
+
+  /**
+   * a list of constraints associated to this activity type
+   */
+  StateConstraintExpression activityConstraints;
+
+  /**
+   * the information required to simulate this activity type
+   */
+  TaskSpecType<?, ?, ?> specType;
+
+  /**
    * ctor creates a new empty activity type container
    *
    * @param name IN the identifier of the activity type
@@ -55,6 +70,16 @@ public class ActivityType {
     this.activityConstraints = constraints;
   }
 
+  public static Parameter getParameterSpecification(List<Parameter> params, String name) {
+    var parameterSpecifications = params.stream()
+        .filter(var -> var.name().equals(name))
+        .collect(Collectors.toList());
+    if(parameterSpecifications.isEmpty()){
+      return null;
+    }
+    assert(parameterSpecifications.size()==1);
+    return parameterSpecifications.get(0);
+  }
 
   /**
    * fetches the identifier associated with this activity type
@@ -91,18 +116,6 @@ public class ActivityType {
     return true;
   }
 
-  public static Parameter getParameterSpecification(List<Parameter> params, String name) {
-    var parameterSpecifications = params.stream()
-        .filter(var -> var.name().equals(name))
-        .collect(Collectors.toList());
-    if(parameterSpecifications.isEmpty()){
-      return null;
-    }
-    assert(parameterSpecifications.size()==1);
-    return parameterSpecifications.get(0);
-  }
-
-
   @Override
   public boolean equals(final Object o) {
     if (this == o) return true;
@@ -112,16 +125,5 @@ public class ActivityType {
            && Objects.equals(activityConstraints, that.activityConstraints)
            && Objects.equals(specType, that.specType);
   }
-
-  /**
-   * the identifier associated with this activity type
-   */
-  final String name;
-  /**
-   * a list of constraints associated to this activity type
-   */
-  StateConstraintExpression activityConstraints;
-
-  TaskSpecType<?, ?, ?> specType;
 
 }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/ActivityType.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/ActivityType.java
@@ -25,26 +25,28 @@ public class ActivityType {
   /**
    * the identifier associated with this activity type
    */
-  final String name;
+  private final String name;
 
   /**
    * a list of constraints associated to this activity type
    */
-  StateConstraintExpression activityConstraints;
+  private final StateConstraintExpression activityConstraints;
 
   /**
    * the information required to simulate this activity type
    */
-  TaskSpecType<?, ?, ?> specType;
+  private final TaskSpecType<?, ?, ?> specType;
 
   /**
    * ctor creates a new empty activity type container
    *
    * @param name IN the identifier of the activity type
    */
-  public ActivityType(String name) {
+  public ActivityType(final String name) {
     checkNotNull(name, "creating activity type with null name");
     this.name = name;
+    this.activityConstraints = null;
+    this.specType = null;
   }
 
   /**
@@ -52,9 +54,10 @@ public class ActivityType {
    *
    * @param name IN the identifier of the activity type
    */
-  public ActivityType(String name, TaskSpecType<?, ?, ?> specType) {
+  public ActivityType(final String name, final TaskSpecType<?, ?, ?> specType) {
     checkNotNull(name, "creating activity type with null name");
     this.name = name;
+    this.activityConstraints = null;
     this.specType = specType;
   }
 
@@ -64,14 +67,16 @@ public class ActivityType {
    * @param name IN the identifier of the activity type
    * @param constraints constraints for the activity type
    */
-  public ActivityType(String name, StateConstraintExpression constraints) {
-    this(name);
+  public ActivityType(final String name, final StateConstraintExpression constraints) {
+    checkNotNull(name, "creating activity type with null name");
     checkNotNull(constraints, "creating activity type with null constraints");
+    this.name = name;
     this.activityConstraints = constraints;
+    this.specType = null;
   }
 
-  public static Parameter getParameterSpecification(List<Parameter> params, String name) {
-    var parameterSpecifications = params.stream()
+  static Parameter getParameterSpecification(final List<Parameter> params, final String name) {
+    final var parameterSpecifications = params.stream()
         .filter(var -> var.name().equals(name))
         .collect(Collectors.toList());
     if(parameterSpecifications.isEmpty()){
@@ -87,7 +92,7 @@ public class ActivityType {
    * @return the identifier associated with this activity type
    */
   public String getName() {
-    return name;
+    return this.name;
   }
 
   /**
@@ -100,17 +105,17 @@ public class ActivityType {
    *     with this activity type and inherited by all matching activity
    *     instances
    */
-  public StateConstraintExpression getStateConstraints() {
-    return activityConstraints;
+  StateConstraintExpression getStateConstraints() {
+    return this.activityConstraints;
   }
 
-  public TaskSpecType<?, ?, ?> getSpecType(){
-    return specType;
+  TaskSpecType<?, ?, ?> getSpecType(){
+    return this.specType;
   }
 
-  public boolean isParamLegal(String name){
-    if(specType!= null){
-      var paramSpec = getParameterSpecification(specType.getParameters(), name);
+  boolean isParamLegal(final String name){
+    if(this.specType != null){
+      final var paramSpec = getParameterSpecification(this.specType.getParameters(), name);
       return paramSpec != null;
     }
     return true;
@@ -120,10 +125,10 @@ public class ActivityType {
   public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    ActivityType that = (ActivityType) o;
-    return Objects.equals(name, that.name)
-           && Objects.equals(activityConstraints, that.activityConstraints)
-           && Objects.equals(specType, that.specType);
+    final var that = (ActivityType) o;
+    return Objects.equals(this.name, that.name)
+           && Objects.equals(this.activityConstraints, that.activityConstraints)
+           && Objects.equals(this.specType, that.specType);
   }
 
 }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/ActivityType.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/ActivityType.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.scheduler;
 
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 
 import java.util.List;
@@ -38,6 +39,11 @@ public class ActivityType {
   private final TaskSpecType<?, ?, ?> specType;
 
   /**
+   * describes the level of control that the scheduler has over the duration of this activity
+   */
+  private final DurationType durationType;
+
+  /**
    * ctor creates a new empty activity type container
    *
    * @param name IN the identifier of the activity type
@@ -47,6 +53,7 @@ public class ActivityType {
     this.name = name;
     this.activityConstraints = null;
     this.specType = null;
+    this.durationType = DurationType.uncontrollable();
   }
 
   /**
@@ -54,11 +61,12 @@ public class ActivityType {
    *
    * @param name IN the identifier of the activity type
    */
-  public ActivityType(final String name, final TaskSpecType<?, ?, ?> specType) {
+  public ActivityType(final String name, final TaskSpecType<?, ?, ?> specType, final DurationType durationType) {
     checkNotNull(name, "creating activity type with null name");
     this.name = name;
     this.activityConstraints = null;
     this.specType = specType;
+    this.durationType = durationType;
   }
 
   /**
@@ -73,6 +81,7 @@ public class ActivityType {
     this.name = name;
     this.activityConstraints = constraints;
     this.specType = null;
+    this.durationType = DurationType.uncontrollable();
   }
 
   static Parameter getParameterSpecification(final List<Parameter> params, final String name) {
@@ -111,6 +120,10 @@ public class ActivityType {
 
   TaskSpecType<?, ?, ?> getSpecType(){
     return this.specType;
+  }
+
+  DurationType getDurationType(){
+    return this.durationType;
   }
 
   boolean isParamLegal(final String name){

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/AerieController.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/AerieController.java
@@ -803,7 +803,7 @@ public class AerieController {
       sbPlanRequest.append("start_offset:\"");
       sbPlanRequest.append(instance.getStartTime());
       sbPlanRequest.append("\", type:\"");
-      sbPlanRequest.append(instance.getType().name);
+      sbPlanRequest.append(instance.getType().getName());
       sbPlanRequest.append("\", plan_id:");
       sbPlanRequest.append(planid);
       sbPlanRequest.append("}){ id }}");

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Problem.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Problem.java
@@ -1,6 +1,8 @@
 package gov.nasa.jpl.aerie.scheduler;
 
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -17,6 +19,11 @@ public class Problem {
    * the mission model that this problem is based on
    */
   private final MissionModel<?> missionModel;
+
+  /**
+   * The scheduler-specific aspects of the mission model
+   */
+  private final SchedulerModel schedulerModel;
 
   private final SimulationFacade simulationFacade;
 
@@ -50,14 +57,15 @@ public class Problem {
    *
    * @param mission IN the mission model that this problem is based on
    */
-  public Problem(MissionModel<?> mission, PlanningHorizon planningHorizon) {
+  public Problem(MissionModel<?> mission, PlanningHorizon planningHorizon, SchedulerModel schedulerModel) {
     this.missionModel = mission;
+    this.schedulerModel = schedulerModel;
     this.initialPlan = new PlanInMemory();
     this.planningHorizon = planningHorizon;
     //add all activity types known to aerie to scheduler index
     if( missionModel != null ) {
       for(var taskType : missionModel.getTaskSpecificationTypes().entrySet()){
-        this.add(new ActivityType(taskType.getKey(), taskType.getValue()));
+        this.add(new ActivityType(taskType.getKey(), taskType.getValue(), schedulerModel.getDurationTypes().get(taskType.getKey())));
       }
     }
     simulationFacade = new SimulationFacade(planningHorizon, missionModel);

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/AerieControllerTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/AerieControllerTest.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.scheduler;
 
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.junit.jupiter.api.Disabled;
@@ -9,9 +10,10 @@ import org.junit.jupiter.api.Test;
 public class AerieControllerTest {
   private final PlanningHorizon horizon = new PlanningHorizon(new Time(0), new Time(100000));
   private final MissionModel<?> missionModel = MerlinSightTestUtility.getMerlinSightMissionModel();
+  private final SchedulerModel schedulerModel = MerlinSightTestUtility.getMerlinSightSchedulerModel();
   private final String URL_AERIE = MerlinSightTestUtility.LOCAL_AERIE;
   private final int MISSION_MODEL_ID = MerlinSightTestUtility.latest;
-  private final Problem problem = new Problem(missionModel, horizon);
+  private final Problem problem = new Problem(missionModel, horizon, schedulerModel);
   /**
    * This test is here as a demonstration of how the AerieController can be used
    * Disabled because you need a local aerie

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlInsightRules.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlInsightRules.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.scheduler;
 import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.apache.commons.lang3.tuple.Pair;
@@ -17,11 +18,11 @@ public class MerlInsightRules extends Problem {
 
   static final PlanningHorizon DEFAULT_PLANNING_HORIZON = new PlanningHorizon(new Time(0), new Time(48 * 3600));
 
-  public MerlInsightRules(MissionModel<?> missionModel) {
-    super(missionModel, DEFAULT_PLANNING_HORIZON);
+  public MerlInsightRules(MissionModel<?> missionModel, SchedulerModel schedulerModel) {
+    super(missionModel, DEFAULT_PLANNING_HORIZON, schedulerModel);
   }
-  public MerlInsightRules(MissionModel<?> missionModel, PlanningHorizon planningHorizon) {
-    super(missionModel, planningHorizon);
+  public MerlInsightRules(MissionModel<?> missionModel, PlanningHorizon planningHorizon, SchedulerModel schedulerModel) {
+    super(missionModel, planningHorizon, schedulerModel);
   }
 
   @Override

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlInsightRulesTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlInsightRulesTest.java
@@ -13,11 +13,12 @@ public class MerlInsightRulesTest {
   void setUp(){
     planningHorizon = new PlanningHorizon(new Time(0), new Time(48*3600));
     MissionModel<?> aerieLanderMissionModel = MerlinSightTestUtility.getMerlinSightMissionModel();
-    rules = new MerlInsightRules(aerieLanderMissionModel, planningHorizon);
+    final var aerieLanderSchedulerModel = MerlinSightTestUtility.getMerlinSightSchedulerModel();
+    rules = new MerlInsightRules(aerieLanderMissionModel, planningHorizon, aerieLanderSchedulerModel);
     rules.getSimulationFacade().simulatePlan(makeEmptyPlan());
     plan = makeEmptyPlan();
     controller = new AerieController(MerlinSightTestUtility.LOCAL_AERIE, MerlinSightTestUtility.latest, false, planningHorizon, rules.getActivityTypes());
-    smallProblem = new Problem(aerieLanderMissionModel, planningHorizon);
+    smallProblem = new Problem(aerieLanderMissionModel, planningHorizon, aerieLanderSchedulerModel);
   }
 
   private PlanningHorizon planningHorizon;

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlinSightTestUtility.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/MerlinSightTestUtility.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.scheduler;
 
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.util.List;
@@ -32,5 +33,9 @@ public class MerlinSightTestUtility {
     final var mission = builder.build(model, factory.getTaskSpecTypes());
     return mission;
    //return null;
+  }
+
+  static SchedulerModel getMerlinSightSchedulerModel() {
+    return new gov.nasa.jpl.aerielander.generated.GeneratedSchedulerModel();
   }
 }

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
@@ -13,7 +13,7 @@ import static com.google.common.truth.Truth8.assertThat;
 
 public class PrioritySolverTest {
   private static PrioritySolver makeEmptyProblemSolver() {
-    return new PrioritySolver(new HuginnConfiguration(), new Problem(null,h));
+    return new PrioritySolver(new HuginnConfiguration(), new Problem(null, h, null));
   }
 
   private static PrioritySolver makeProblemSolver(Problem problem) {
@@ -22,7 +22,7 @@ public class PrioritySolverTest {
 
   @Test
   public void ctor_onEmptyProblemWorks() {
-    new PrioritySolver(new HuginnConfiguration(), new Problem(null,h));
+    new PrioritySolver(new HuginnConfiguration(), new Problem(null,h, null));
   }
 
   @Test
@@ -51,7 +51,7 @@ public class PrioritySolverTest {
 
   //test mission with two primitive activity types
   private static Problem makeTestMissionAB() {
-    final var mission = new Problem(null, h);
+    final var mission = new Problem(null, h, null);
     final var actA = new ActivityType("A");
     mission.add(actA);
     final var actB = new ActivityType("B");
@@ -70,7 +70,7 @@ public class PrioritySolverTest {
 
   private static final NullPointerTester NULL_POINTER_TESTER = new NullPointerTester()
       .setDefault(HuginnConfiguration.class, new HuginnConfiguration())
-      .setDefault(Problem.class, new Problem(null,h));
+      .setDefault(Problem.class, new Problem(null, h, null));
 
 
   private static PlanInMemory makePlanA012(Problem problem) {

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.scheduler;
 import com.google.common.testing.NullPointerTester;
 import com.google.common.truth.Correspondence;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -52,9 +53,9 @@ public class PrioritySolverTest {
   //test mission with two primitive activity types
   private static Problem makeTestMissionAB() {
     final var mission = new Problem(null, h, null);
-    final var actA = new ActivityType("A");
+    final var actA = new ActivityType("A", null, DurationType.controllable("duration"));
     mission.add(actA);
-    final var actB = new ActivityType("B");
+    final var actB = new ActivityType("B", null, DurationType.controllable("duration"));
     mission.add(actB);
     return mission;
   }

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/RadarBeamCalibrationTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/RadarBeamCalibrationTest.java
@@ -24,7 +24,7 @@ public class RadarBeamCalibrationTest {
 
   @BeforeEach
   public void setUp() {
-    problem = new Problem(null, horizon);
+    problem = new Problem(null, horizon, null);
     plan = new PlanInMemory();
   }
 

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
@@ -61,7 +61,8 @@ public class SimulationFacadeTest {
   @BeforeEach
   public void setUp() {
     missionModel = SimulationUtility.getBananaMissionModel();
-    problem = new Problem(missionModel, horizon);
+    final var schedulerModel = SimulationUtility.getBananaSchedulerModel();
+    problem = new Problem(missionModel, horizon, schedulerModel);
     facade = new SimulationFacade(horizon, missionModel);
   }
 

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationUtility.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationUtility.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.banananation.Configuration;
 import gov.nasa.jpl.aerie.banananation.generated.ConfigurationMapper;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.nio.file.Path;
@@ -31,6 +32,10 @@ public final class SimulationUtility {
     final var config = new Configuration(Configuration.DEFAULT_PLANT_COUNT, Configuration.DEFAULT_PRODUCER, Path.of("/etc/hosts"));
     final var serializedConfig = SerializedValue.of(new ConfigurationMapper().getArguments(config));
     return makeMissionModel(new MissionModelBuilder(), serializedConfig);
+  }
+
+  public static SchedulerModel getBananaSchedulerModel(){
+    return new gov.nasa.jpl.aerie.banananation.generated.GeneratedSchedulerModel();
   }
 
 }

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
@@ -48,7 +48,7 @@ public void minimalDef(){
 
         .build();
 
-    Problem problem = new Problem(null, null);
+    Problem problem = new Problem(null, null, null);
 
     problem.setGoals(List.of(goal));
 
@@ -93,7 +93,7 @@ public void minimalDef(){
 
         .build();
 
-    Problem problem = new Problem(null, null);
+    Problem problem = new Problem(null, null, null);
 
     problem.setGoals(List.of(goal));
 

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.scheduler;
 import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -30,7 +31,7 @@ public void minimalDef(){
     var periodTre = new TimeRangeExpression.Builder()
         .from(new Windows(period))
         .build();
-    ActivityType actType = new ActivityType("CardGoalActType");
+    ActivityType actType = new ActivityType("CardGoalActType", null, DurationType.controllable("duration"));
 
 
     CardinalityGoal goal = new CardinalityGoal.Builder()
@@ -75,7 +76,7 @@ public void minimalDef(){
     var periodTre = new TimeRangeExpression.Builder()
         .from(new Windows(List.of(period, period2)))
         .build();
-    ActivityType actType = new ActivityType("CardGoalActType");
+    ActivityType actType = new ActivityType("CardGoalActType", null, DurationType.controllable("duration"));
 
 
     CardinalityGoal goal = new CardinalityGoal.Builder()

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
@@ -22,7 +22,7 @@ public class TestRecurrenceGoal {
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
         .build();
 
-    Problem problem = new Problem(null, planningHorizon);
+    Problem problem = new Problem(null, planningHorizon, null);
 
     problem.setGoals(List.of(goal));
 

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.scheduler;
 
 import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -10,7 +11,7 @@ public class TestRecurrenceGoal {
 
   @Test
   public void testRecurrence() {
-    var actType = new ActivityType("RecGoalActType");
+    var actType = new ActivityType("RecGoalActType", null, DurationType.controllable("duration"));
     var planningHorizon = new PlanningHorizon(new Time(0),new Time(20));
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestStateConstraints.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestStateConstraints.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.scheduler;
 import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -118,7 +119,7 @@ public class TestStateConstraints {
   public void testconstraintgoal() {
 
     final var dur = gov.nasa.jpl.aerie.merlin.protocol.types.Duration.of(1, gov.nasa.jpl.aerie.merlin.protocol.types.Duration.HOUR);
-    final var activityTypeImage = new ActivityType("EISImage");
+    final var activityTypeImage = new ActivityType("EISImage", null, DurationType.controllable("duration"));
 
     final var eisImageAct = new ActivityCreationTemplate.Builder()
         .ofType(activityTypeImage)
@@ -288,7 +289,7 @@ public class TestStateConstraints {
   @Test
   public void testOfEachValue(){
     final var dur = gov.nasa.jpl.aerie.merlin.protocol.types.Duration.of(1, gov.nasa.jpl.aerie.merlin.protocol.types.Duration.HOUR);
-    final var activityTypeImage = new ActivityType("EISImage");
+    final var activityTypeImage = new ActivityType("EISImage", null, DurationType.controllable("duration"));
 
     final var eisImageAct = new ActivityCreationTemplate.Builder()
         .ofType(activityTypeImage)

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestStateConstraints.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestStateConstraints.java
@@ -33,7 +33,7 @@ public class TestStateConstraints {
 
   @BeforeEach
   public void setUp() {
-    problem = new Problem(null, horizon);
+    problem = new Problem(null, horizon, null);
     plan = new PlanInMemory();
   }
 


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1656
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
> Note: this PR does not actually change any functionality, per se. It merely requires activities to explicitly opt-in to having their durations controlled by the scheduler.

Currently, the scheduler assumes that all activities have a `duration` parameter, which can be used to control their duration. This is not, in general, true.

One option to reconcile this is to have the scheduler inspect the parameters of an activity type, and check if there is a `duration` parameter with the correct type. However, this feels wrong to me, since it ascribes a meaning to a particular parameter name - something we've managed to avoid thus far. Parameter names should be completely up to the mission modelers.

The option I chose to pursue is to add an annotation, `@ControllableDuration(parameterName = "myDurationParam")` that allows an activity definition to opt-in to being controllable by the scheduler. I added a `validateControllableDurationParameter` method to the `MissionModelParser` that checks that the string provided:
1. corresponds to an existing parameter name
2. that parameter has type Duration

The scheduler will be able to call `TaskSpecType::getDurationType` on a particular activity's TaskSpecType, and get back whether the activity has opted-in to having a controllable duration:

```java
public sealed interface DurationType {
  record Controllable(String parameterName) implements DurationType {}
  record Uncontrollable() implements DurationType {}
}
```

The contract between the scheduler and the mission model is that after simulating any activity marked with `@ControllableDuration`, its actual duration is expected to be equal to the value of the declared duration parameter. The scheduler will rely on this fact to satisfy certain goals (such as lining up the end time of one activity with the start time of another activity).

I modified the scheduler to use `getDurationType` to look up what parameter to set for a desired duration. For activities with Uncontrollable duration, the scheduler prints a warning, but does not throw an exception. The main reason here is I do not want to impede uncontrollable activities in existing plans. Future work is to test that the scheduler works with an existing plan.

## Verification
I ran the aerie lander tests, and they passed (though they don't seem to have very clear success criteria, so I want to spend some time in a future PR making the tests stricter).

I'll make a corresponding PR to aerielander momentarily.

## Documentation
This will, of course, need to be documented, but it's still in flux. We have a meeting with some stakeholders next week, where we'll get some feedback.

## Future work
- Focused testing of controllable activity durations
- Testing of the scheduler against existing plans (i.e. not just plans generated from procedural rules, as the tests do now)
- It may be desirable to schedule activities whose duration is uncontrollable. This will place restrictions on the kinds of goals that can place this activity.
- There are potential performance benefits from getting more fine grained than `Uncontrollable`. For example, if the scheduler knew that an activity's duration is "Context Independent", it would know that the activity's duration is invariant under translation in time, which could reduce the necessity to re-simulate.
- It may also turn out to be useful to allow gradations of "Controllable". Some activities cannot uphold the contract of matching the requested duration exactly. Perhaps they have a lower bound for how long they will take. Perhaps the activity can only take multiples of a certain amount of time, so requesting a duration between two multiples would require the activity to decide whether to treat the requested duration as a lower or upper bound. (E.g. take "N" pictures takes "N" times the amount of time it takes to take a picture).