### PR TITLE
[HOTFIX] Fix `distributeSql` task erroneous "up to date" state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,25 +10,32 @@ task archiveDeployment(type: Tar) {
 }
 
 // Add `distributeSql` task to all subprojects with `sql/` child directory
-configure(subprojects.findAll { it.projectDir.toPath().resolve('sql').toFile().exists() }) {
+configure(subprojects.findAll { it.projectDir.toPath().resolve('sql').toFile().exists() }) { sp ->
   // Specify only subprojects with `processResources` tasks,
   // otherwise Gradle cannot see `processResources` as a valid task
   ['java', 'com.github.node-gradle.node'].each { pluginId ->
     plugins.withId(pluginId) {
 
-    task distributeSql {
-      copy {
+      task distributeSql(type: Copy) {
         into "$rootDir/deployment/postgres-init-db/sql"
-        from fileTree(dir: 'sql', include: '**/*.sql')
+        from fileTree(dir: "${sp.projectDir}/sql", include: '**/*.sql')
       }
-    }
 
-    // Distribute SQL prior to any resource processing.
-    // This ensures `test` and `build` tasks will distribute SQL
-    processResources.dependsOn distributeSql
+      task undoDistributeSql(type: Delete) {
+        file("${sp.projectDir}/sql").list().each {
+          delete "$rootDir/deployment/postgres-init-db/sql/$it"
+        }
+      }
 
-    // Distribute SQL prior to creating deployment archive
-    archiveDeployment.dependsOn distributeSql
+      // Distribute SQL prior to any resource processing.
+      // This ensures `test` and `build` tasks will distribute SQL
+      processResources.dependsOn distributeSql
+
+      // Distribute SQL prior to creating deployment archive
+      archiveDeployment.dependsOn distributeSql
+
+      // Remove distributed SQL as part of `clean` task
+      clean.dependsOn undoDistributeSql
     }
   }
 }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1666
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

- Inheriting `Copy` task correctly marks the task as "incomplete", therefore avoiding unwanted task skips
- Use absolutized subproject path to `sql/` directory
- Add `undoDistributeSql` to run as part of `clean` task

## Verification
Tested locally, seeing SQL copied properly after a `gradle processResources`. When testing yesterday I must've been doing `gradle merlin-server:processResources` instead of a top-level one, in which case the relative `sql/` path worked. 
