### PR TITLE
Correctly register `command-expansion-server` with SQL distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,40 +11,32 @@ task archiveDeployment(type: Tar) {
 
 // Add `distributeSql` task to all subprojects with `sql/` child directory
 configure(subprojects.findAll { it.projectDir.toPath().resolve('sql').toFile().exists() }) { sp ->
-  // Specify only subprojects with `processResources` tasks,
-  // otherwise Gradle cannot see `processResources` as a valid task
-  ['java', 'com.github.node-gradle.node'].each { pluginId ->
-    plugins.withId(pluginId) {
 
-      task distributeSql(type: Copy) {
-        into "$rootDir/deployment/postgres-init-db/sql"
-        from fileTree(dir: "${sp.projectDir}/sql", include: '**/*.sql')
-      }
+  // Distribute SQL as part of resource processing
+  task distributeSql(type: Copy, dependsOn: 'processResources') {
+    into "$rootDir/deployment/postgres-init-db/sql"
+    from fileTree(dir: "${sp.projectDir}/sql", include: '**/*.sql')
+  }
 
-      task undoDistributeSql(type: Delete) {
-        file("${sp.projectDir}/sql").list().each {
-          delete "$rootDir/deployment/postgres-init-db/sql/$it"
-        }
-      }
-
-      // Distribute SQL prior to any resource processing.
-      // This ensures `test` and `build` tasks will distribute SQL
-      processResources.dependsOn distributeSql
-
-      // Distribute SQL prior to creating deployment archive
-      archiveDeployment.dependsOn distributeSql
-
-      // Remove distributed SQL as part of `clean` task
-      clean.dependsOn undoDistributeSql
+  // Remove distributed SQL as part of `clean` task
+  task undoDistributeSql(type: Delete) {
+    file("${sp.projectDir}/sql").list().each {
+      delete "$rootDir/deployment/postgres-init-db/sql/$it"
     }
   }
+
+  // Remove distributed SQL as part of `clean` tasks
+  tasks.findAll { it.name == 'clean' }.each { t -> t.dependsOn undoDistributeSql }
+
+  // Distribute SQL prior to creating deployment archive
+  archiveDeployment.dependsOn distributeSql
 }
 
 subprojects {
   apply plugin: 'com.github.ben-manes.versions'
 
   repositories {
-    // Search the local filesystem before attempting remote repositories.
+    // Search the local filesystem before attempting remote repositories
     flatDir { dirs "$rootDir/third-party" }
     mavenCentral()
   }

--- a/command-expansion-server/build.gradle
+++ b/command-expansion-server/build.gradle
@@ -1,6 +1,5 @@
-
 plugins {
-  id "com.github.node-gradle.node" version "3.1.1"
+  id 'com.github.node-gradle.node' version '3.1.1'
 }
 
 node {
@@ -9,11 +8,22 @@ node {
   download = true
 }
 
+task processResources {
+  // Currently does nothing, exists as a hook for `distributeSql`
+}
+
 task build(type: NpmTask) {
+  dependsOn processResources
   dependsOn npmInstall
-  args = ['run','build']
+  args = ['run', 'build']
+}
+
+task test(type: NpmTask) {
+  dependsOn processResources
+  dependsOn npmInstall
+  args = ['run', 'test']
 }
 
 task clean(type: Delete) {
-  delete 'build','node_modules', 'package-lock.json'
+  delete 'build', 'node_modules', 'package-lock.json'
 }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1686
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Supports SQL distribution for node project.

## Verification
Tested locally with `gradle distributeSql`, `gradle undoDistributeSql`. Must run `mkdir command-expansion-server/sql` prior to either of these for things to work. I'd suggest testing this with some mock `.sql` files under `command-expansion-server/sql/<table_name>/` and making sure they're correctly distributed and cleaned.

Works with `command-expansion-server/sql/paul/p.sql`:
```
feature/AERIE-1686--setup-js-command-expansion-server-rosemurg:aerie$ gradle undoDistributeSql

BUILD SUCCESSFUL in 903ms
3 actionable tasks: 3 up-to-date
^[[A^[[Afeature/AERIE-1686--setup-js-command-expansion-server-rosemurg:aerie$ t deployment/postgres-init-db/sql/
deployment/postgres-init-db/sql/
└── ui
    ├── tables
    │   └── view.sql
    └── init.sql

2 directories, 2 files
feature/AERIE-1686--setup-js-command-expansion-server-rosemurg:aerie$ gradle distributeSql

BUILD SUCCESSFUL in 1s
3 actionable tasks: 3 executed
feature/AERIE-1686--setup-js-command-expansion-server-rosemurg:aerie$ t deployment/postgres-init-db/sql/
deployment/postgres-init-db/sql/
├── merlin
│   ├── domain-types
│   │   └── merlin-arguments.sql
│   ├── tables
│   │   ├── activity.sql
│   │   ├── activity_type.sql
│   │   ├── condition.sql
│   │   ├── dataset.sql
│   │   ├── event.sql
│   │   ├── mission_model.sql
│   │   ├── mission_model_parameters.sql
│   │   ├── plan.sql
│   │   ├── plan_dataset.sql
│   │   ├── profile.sql
│   │   ├── profile_request.sql
│   │   ├── profile_segment.sql
│   │   ├── simulation.sql
│   │   ├── simulation_dataset.sql
│   │   ├── simulation_template.sql
│   │   ├── span.sql
│   │   ├── topic.sql
│   │   └── uploaded_file.sql
│   └── init.sql
├── paul
│   └── p.sql
├── scheduler
│   ├── tables
│   │   ├── scheduling_analysis.sql
│   │   ├── scheduling_goal.sql
│   │   ├── scheduling_goal_analysis.sql
│   │   ├── scheduling_goal_analysis_created_activities.sql
│   │   ├── scheduling_goal_analysis_satisfying_activities.sql
│   │   ├── scheduling_request.sql
│   │   ├── scheduling_rule.sql
│   │   ├── scheduling_spec.sql
│   │   ├── scheduling_spec_goals.sql
│   │   ├── scheduling_template.sql
│   │   └── scheduling_template_goals.sql
│   └── init.sql
└── ui
    ├── tables
    │   └── view.sql
    └── init.sql
```