### PR TITLE
[Hotfix] Don't remove the package-lock.json file when you run ./gradlew clean

### DIFF
--- a/command-expansion-server/build.gradle
+++ b/command-expansion-server/build.gradle
@@ -29,5 +29,5 @@ task build {
 //}
 
 task clean(type: Delete) {
-  delete 'build', 'node_modules', 'package-lock.json'
+  delete 'build', 'node_modules'
 }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1686
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Let's keep the package-lock.json file around

## Verification

## Documentation

## Future work
