### PR TITLE
[REFACTOR] Correctly implement `distributeSql` and `undoDistributeSql` tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,21 +12,35 @@ task archiveDeployment(type: Tar) {
 // Add `distributeSql` task to all subprojects with `sql/` child directory
 configure(subprojects.findAll { it.projectDir.toPath().resolve('sql').toFile().exists() }) { sp ->
 
-  // Distribute SQL as part of resource processing
-  task distributeSql(type: Copy, dependsOn: 'processResources') {
+  task distributeSql(type: Copy) {
     into "$rootDir/deployment/postgres-init-db/sql"
     from fileTree(dir: "${sp.projectDir}/sql", include: '**/*.sql')
   }
 
   // Remove distributed SQL as part of `clean` task
   task undoDistributeSql(type: Delete) {
-    file("${sp.projectDir}/sql").list().each {
-      delete "$rootDir/deployment/postgres-init-db/sql/$it"
+    doLast { // Explicity do last to avoid running during configuration step
+      file("${sp.projectDir}/sql").list().each {
+        delete "$rootDir/deployment/postgres-init-db/sql/$it"
+      }
     }
   }
 
-  // Remove distributed SQL as part of `clean` tasks
-  tasks.findAll { it.name == 'clean' }.each { t -> t.dependsOn undoDistributeSql }
+  // For all Java subprojects
+  sp.plugins.withId('java') {
+    // Distribute SQL as part of resource processing
+    processResources.dependsOn distributeSql
+    // Remove distributed SQL as part of `clean` tasks
+    clean.dependsOn undoDistributeSql
+  }
+
+  // For all Node subprojects
+  sp.plugins.withId('com.github.node-gradle.node') {
+    // Distribute SQL as part of resource processing
+    tasks.findAll { it.name == 'processResources' }.each { it.dependsOn distributeSql }
+    // Remove distributed SQL as part of `clean` tasks
+    tasks.findAll { it.name == 'clean' }.each { it.dependsOn undoDistributeSql }
+  }
 
   // Distribute SQL prior to creating deployment archive
   archiveDeployment.dependsOn distributeSql


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1666
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Distributed SQL was being automatically removed when running `gradle build`. This was because there was a missing `doLast` closure to prevent the task from automatically running during the Gradle "configuration" step. I've been bitten forgetting to keep a task out of the "configuration" phase quite a few times. 

## Verification
- Ran `gradle clean`.
- Checked and saw no distributed SQL under `deployment/postgres-init-db/sql`.
- Created a mock `command-expansion-server/sql/test/t.sql`.
- Ran `gradle processResources`.
- Checked and saw all expected SQL distributed correctly, including the `test/t.sql` created above.
- Ran `gradle build`.
- Checked and saw that the distributed SQL persists.
 
## Documentation
None.

## Future work
None.
