### PR TITLE
[AERIE-1714] Add `schedule` Hasura action

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -48,6 +48,12 @@ type Query {
   ): ValidationResponse
 }
 
+type Query {
+  schedule(
+    specificationId: Int!
+  ): SchedulingResponse
+}
+
 enum MerlinSimulationStatus {
   complete
   failed
@@ -80,6 +86,17 @@ type AddExternalDatasetResponse {
   datasetId: Int!
 }
 
+type SchedulingResponse {
+  status: SchedulingStatus!
+  reason: SchedulingFailureReason
+}
+
+enum SchedulingStatus {
+  complete
+  failed
+  incomplete
+}
+
 scalar ResourceSchema
 
 scalar MerlinSimulationResults
@@ -91,3 +108,5 @@ scalar ModelArguments
 scalar ActivityArguments
 
 scalar ProfileSet
+
+scalar SchedulingFailureReason

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -15,6 +15,10 @@ actions:
   definition:
     kind: ""
     handler: http://aerie_merlin:27183/resourceTypes
+- name: schedule
+  definition:
+    kind: ""
+    handler: http://aerie_scheduler:27193/schedule
 - name: simulate
   definition:
     kind: ""
@@ -30,6 +34,17 @@ actions:
 custom_types:
   enums:
   - name: MerlinSimulationStatus
+    values:
+    - description: null
+      is_deprecated: null
+      value: complete
+    - description: null
+      is_deprecated: null
+      value: failed
+    - description: null
+      is_deprecated: null
+      value: incomplete
+  - name: SchedulingStatus
     values:
     - description: null
       is_deprecated: null


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1714
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The scheduler-server exposes a `/schedule` REST endpoint. This PR merely exposes that endpoint to the GraphQL API via a hasura action.

I copy/pasted the yaml for the `schedule` action, and tweaked it.

I'm still no good at exporting metadata from Hasura, so I edited the yaml files by hand like a scrub. Please let me know if I messed anything up, or if for consistency's sake I should generate the files by some other method.

## Verification
I wrote a [python script](https://github.com/mattdailis/aerie-api-tests/blob/main/api_tests/scheduler-api-test.py) to help me hit some of these endpoints (I could just as easily have used the Hasura UI, but I wanted to string together a whole workflow).

## Documentation
We'll need to add this to the [Aerie GraphQL API wiki page](https://github.com/NASA-AMMOS/aerie/wiki/Aerie-GraphQL-API-Software-Interface-Specification).

## Future work
<!-- What next steps can we anticipate from here, if any? -->
We'll probably need to handle long-running scheduling runs the same way we handle long-running simulation runs (by returning incomplete). The current scheduler implementation only has a `SynchronousSchedulerAgent`, so all calls to the scheduler are blocking.

Other than that, next steps are to start triggering scheduling from the UI 🚀  And fixing all the bugs that will be exposed in the process.
