### PR TITLE
[AERIE-1716] Add git hash to snapshot version tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,8 @@ subprojects {
   }
 
   group = 'gov.nasa.jpl.aerie'
-  version = '0.10.0-SNAPSHOT'
+  def hash = 'git rev-parse --short HEAD'.execute().text.trim()
+  version = "0.10.0-SNAPSHOT-$hash"
 
   tasks.withType(JavaCompile) {
     options.compilerArgs << '-Xlint:deprecation' << '-Xlint:unchecked'


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1716
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds git hash to snapshot version tag to sidestep JARs with identical versions not being re-published.

### Alternatives Explored

We could use [this action](https://github.com/actions/delete-package-versions) to remove all versions with the same name as the version about to be published. This does add some complexity and another action dep. to our publish workflow.

We could also use GQL to do the package deletion logic: [https://docs.github.com/en/packages/learn-github-packages/deleting-and-restoring-a-package#deleting-a-version-of-a-rep[…]scoped-package-with-graphql](https://docs.github.com/en/packages/learn-github-packages/deleting-and-restoring-a-package#deleting-a-version-of-a-repository-scoped-package-with-graphql).

Both of these approaches are limited to working on packages that have < 5,000 downloads. See https://docs.github.com/en/packages/learn-github-packages/deleting-and-restoring-a-package#package-deletion-and-restoration-support-on-github:
>You cannot delete a public package if any version of the package has more than 5000 downloads. In this scenario, contact [GitHub support](https://support.github.com/contact?tags=docs-packages) for further assistance.

For simplicity and avoiding the 5k limit we're going with adding the latest git commit hash to `version` for now.

## Verification
Verification will ultimately take place when monitoring the `publish` workflow output and the https://github.com/NASA-AMMOS/aerie/packages page upon merging this PR.

## Documentation
None.

## Future work
None.