### PR TITLE
[HOTFIX] Fix bugs surfaced by api tests

### DIFF
--- a/scheduler-server/sql/scheduler/tables/scheduling_goal.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_goal.sql
@@ -1,7 +1,7 @@
 create table scheduling_goal (
   id integer generated always as identity,
   revision integer not null default 0,
-  definition jsonb not null,
+  definition text not null,
 
   model_id integer not null,
   description text null,
@@ -21,7 +21,7 @@ comment on column scheduling_goal.id is e''
 comment on column scheduling_goal.revision is e''
   'A monotonic clock that ticks for every change to this scheduling goal.';
 comment on column scheduling_goal.definition is e''
-  'A JSON representation of this goal''s structure';
+  'The source code for a Typescript module defining this scheduling goal';
 comment on column scheduling_goal.model_id is e''
   'The mission model used to which this scheduling goal is associated.';
 comment on column scheduling_goal.description is e''

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -300,7 +300,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements MerlinServic
               .getJsonObject("plan_by_pk")
               .getJsonNumber("id")
               .longValueExact());
-      if (id.equals(planId)) {
+      if (!id.equals(planId)) {
         throw exceptionFactory.get();
       }
     } catch (ClassCastException | ArithmeticException e) {

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -126,7 +126,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements MerlinServic
         + "  } "
         + "  simulations(limit:1, order_by:{revision:desc} ) { arguments }"
         + "} }"
-    ).formatted(planId);
+    ).formatted(planId.id());
     final var response = postRequest(request).orElseThrow(() -> new NoSuchPlanException(planId));
     try {
       //TODO: elevate and then leverage existing MerlinParsers (after updating them to match current db!)

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -290,7 +290,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements MerlinServic
   public void ensurePlanExists(final PlanId planId) throws IOException, NoSuchPlanException {
     final Supplier<NoSuchPlanException> exceptionFactory = () -> new NoSuchPlanException(planId);
     final var request = "query ensurePlanExists { plan_by_pk( id: %s ) { id } }"
-        .formatted(planId);
+        .formatted(planId.id());
     final var response = postRequest(request).orElseThrow(exceptionFactory);
     try {
       final var id =

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -100,7 +100,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements MerlinServic
   @Override
   public long getPlanRevision(final PlanId planId) throws IOException, NoSuchPlanException {
     final var request = "query getPlanRevision { plan_by_pk( id: %s ) { revision } }"
-        .formatted(planId);
+        .formatted(planId.id());
     final var response = postRequest(request).orElseThrow(() -> new NoSuchPlanException(planId));
     try {
       return response.getJsonObject("data").getJsonObject("plan_by_pk").getJsonNumber("revision").longValueExact();

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -353,7 +353,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements MerlinServic
     var orderedActivities = plan.getActivities().stream().toList();
 
     for (final var act : orderedActivities) {
-      requestSB.append(actPre.formatted(planId, act.getType().getName(), act.getStartTime().toString()));
+      requestSB.append(actPre.formatted(planId.id(), act.getType().getName(), act.getStartTime().toString()));
       if (act.getDuration() != null) {
         requestSB.append(argFormat.formatted("duration", getGraphQLValueString(act.getDuration())));
       }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -378,7 +378,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements MerlinServic
           .getJsonObject("data").getJsonObject("insert_activity").getJsonArray("returning");
       //make sure we associate the right id with the right activity
       for(int i = 0; i < ids.size(); i++) {
-        instanceToInstanceId.put(orderedActivities.get(i), new ActivityInstanceId(ids.getInt(i)));
+        instanceToInstanceId.put(orderedActivities.get(i), new ActivityInstanceId(ids.getJsonObject(i).getInt("id")));
       }
     } catch (ClassCastException | ArithmeticException e) {
       throw new NoSuchPlanException(planId);

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -140,10 +140,11 @@ public record SynchronousSchedulerAgent(
 
     final var loadedGoals = new ArrayList<GoalRecord>(dbLoadedSpec.goalsByPriority().size());
     for (final var dbGoal : dbLoadedSpec.goalsByPriority()) {
-      boolean definitionFound = false;
+      var definitionFound = false;
       for (final var jarGoal : jarGoals) {
         if (dbGoal.definition().getName().equals(jarGoal.getName())) {
           loadedGoals.add(new GoalRecord(dbGoal.id(), jarGoal));
+          definitionFound = true;
           break;
         }
       }


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR contains a set of fixes for issues that came up during api testing of the scheduler server. Every commit contains a tiny one-line fix.

The most common issue was that `planId`'s default `toString` method returns the string `"PlanId[ id=1 ]"` instead of `"1"`, so the code responsible for constructing a graphql query needs to extract the long from the planId by calling `planId.id()`.

The change from representing goal definitions as `jsonb` to `text` was motivated by the fact that the string matching logic (for correlating goal names in the `scheduling_rules.jar` workaround) assumed that the definitions were strings. (so I would get errors like "no goal found with name `"\"goaldefinition\""`" - note the extra quotes added by the `jsonb` type). My choice was either to add json parsing to the definition matching (which we're going to throw away as soon as we can), or to update the column type to text, which we were planning to do anyways. Let me know if anyone thinks that update is out of place in this PR, and I can split it out.

Other errors were simple logic errors / typos.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
1. Check out develop
2. merge #52 
3. merge #61 
4. merge `prototype/api-tests` (and update paths/user/pass)
5. `./gradlew assemble` followed by `docker-compose build` and `docker-compose up -d`
6. run `./gradlew :api-tests:npm_test`. Observe errors.
7. merge this PR
8. Update api.test.ts to use `String` instead of `jsonb` in the `MakeSchedulingGoal` mutation
9. `./gradlew assemble` followed by `docker-compose build` and `docker-compose up -d`
10. run `./gradlew :api-tests:npm_test`. Observe no errors.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
This PR does not affect any existing documentation. The change of the `scheduling_goal.sql` definition field from `jsonb` to `text` will affect the API, so when we get around to documenting the scheduling API, we'll need to include info about that field.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
No future work, aside from merging the above mentioned PRs.

