### PR TITLE
[AERIE-1695] Use properties with defaults for Gradle publish

### DIFF
--- a/contrib/build.gradle
+++ b/contrib/build.gradle
@@ -39,11 +39,11 @@ publishing {
   publishing {
     repositories {
       maven {
-        name = "GitHubPackages"
-        url = "https://maven.pkg.github.com/nasa-ammos/aerie"
+        name = findProperty("publishing.name")
+        url = findProperty("publishing.url")
         credentials {
-          username = System.getenv("GITHUB_ACTOR")
-          password = System.getenv("GITHUB_TOKEN")
+          username = System.getenv(findProperty("publishing.usernameEnvironmentVariable"))
+          password = System.getenv(findProperty("publishing.passwordEnvironmentVariable"))
         }
       }
     }

--- a/examples/banananation/build.gradle
+++ b/examples/banananation/build.gradle
@@ -37,11 +37,11 @@ publishing {
   publishing {
     repositories {
       maven {
-        name = "GitHubPackages"
-        url = "https://maven.pkg.github.com/nasa-ammos/aerie"
+        name = findProperty("publishing.name")
+        url = findProperty("publishing.url")
         credentials {
-          username = System.getenv("GITHUB_ACTOR")
-          password = System.getenv("GITHUB_TOKEN")
+          username = System.getenv(findProperty("publishing.usernameEnvironmentVariable"))
+          password = System.getenv(findProperty("publishing.passwordEnvironmentVariable"))
         }
       }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+# Properties for configuring the publish task.
+publishing.name=GitHubPackages
+publishing.url=https://maven.pkg.github.com/nasa-ammos/aerie
+publishing.usernameEnvironmentVariable=GITHUB_ACTOR
+publishing.passwordEnvironmentVariable=GITHUB_TOKEN

--- a/merlin-driver/build.gradle
+++ b/merlin-driver/build.gradle
@@ -48,11 +48,11 @@ publishing {
   publishing {
     repositories {
       maven {
-        name = "GitHubPackages"
-        url = "https://maven.pkg.github.com/nasa-ammos/aerie"
+        name = findProperty("publishing.name")
+        url = findProperty("publishing.url")
         credentials {
-          username = System.getenv("GITHUB_ACTOR")
-          password = System.getenv("GITHUB_TOKEN")
+          username = System.getenv(findProperty("publishing.usernameEnvironmentVariable"))
+          password = System.getenv(findProperty("publishing.passwordEnvironmentVariable"))
         }
       }
     }

--- a/merlin-framework-junit/build.gradle
+++ b/merlin-framework-junit/build.gradle
@@ -33,11 +33,11 @@ publishing {
   publishing {
     repositories {
       maven {
-        name = "GitHubPackages"
-        url = "https://maven.pkg.github.com/nasa-ammos/aerie"
+        name = findProperty("publishing.name")
+        url = findProperty("publishing.url")
         credentials {
-          username = System.getenv("GITHUB_ACTOR")
-          password = System.getenv("GITHUB_TOKEN")
+          username = System.getenv(findProperty("publishing.usernameEnvironmentVariable"))
+          password = System.getenv(findProperty("publishing.passwordEnvironmentVariable"))
         }
       }
     }

--- a/merlin-framework-processor/build.gradle
+++ b/merlin-framework-processor/build.gradle
@@ -28,11 +28,11 @@ publishing {
   publishing {
     repositories {
       maven {
-        name = "GitHubPackages"
-        url = "https://maven.pkg.github.com/nasa-ammos/aerie"
+        name = findProperty("publishing.name")
+        url = findProperty("publishing.url")
         credentials {
-          username = System.getenv("GITHUB_ACTOR")
-          password = System.getenv("GITHUB_TOKEN")
+          username = System.getenv(findProperty("publishing.usernameEnvironmentVariable"))
+          password = System.getenv(findProperty("publishing.passwordEnvironmentVariable"))
         }
       }
     }

--- a/merlin-framework/build.gradle
+++ b/merlin-framework/build.gradle
@@ -40,11 +40,11 @@ publishing {
   publishing {
     repositories {
       maven {
-        name = "GitHubPackages"
-        url = "https://maven.pkg.github.com/nasa-ammos/aerie"
+        name = findProperty("publishing.name")
+        url = findProperty("publishing.url")
         credentials {
-          username = System.getenv("GITHUB_ACTOR")
-          password = System.getenv("GITHUB_TOKEN")
+          username = System.getenv(findProperty("publishing.usernameEnvironmentVariable"))
+          password = System.getenv(findProperty("publishing.passwordEnvironmentVariable"))
         }
       }
     }

--- a/merlin-sdk/build.gradle
+++ b/merlin-sdk/build.gradle
@@ -49,11 +49,11 @@ publishing {
   publishing {
     repositories {
       maven {
-        name = "GitHubPackages"
-        url = "https://maven.pkg.github.com/nasa-ammos/aerie"
+        name = findProperty("publishing.name")
+        url = findProperty("publishing.url")
         credentials {
-          username = System.getenv("GITHUB_ACTOR")
-          password = System.getenv("GITHUB_TOKEN")
+          username = System.getenv(findProperty("publishing.usernameEnvironmentVariable"))
+          password = System.getenv(findProperty("publishing.passwordEnvironmentVariable"))
         }
       }
     }

--- a/parsing-utilities/build.gradle
+++ b/parsing-utilities/build.gradle
@@ -30,11 +30,11 @@ publishing {
   publishing {
     repositories {
       maven {
-        name = "GitHubPackages"
-        url = "https://maven.pkg.github.com/nasa-ammos/aerie"
+        name = findProperty("publishing.name")
+        url = findProperty("publishing.url")
         credentials {
-          username = System.getenv("GITHUB_ACTOR")
-          password = System.getenv("GITHUB_TOKEN")
+          username = System.getenv(findProperty("publishing.usernameEnvironmentVariable"))
+          password = System.getenv(findProperty("publishing.passwordEnvironmentVariable"))
         }
       }
     }


### PR DESCRIPTION
* **Tickets addressed:** part of AERIE-1695
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This is a part of AERIE-1695, which replaces the four following strings used in the `./gradlew publish` tasks in all subprojects with a property:

Original String | Property Name
---|---
"GithubPackages" | `publishConfig.name`
"https://maven.pkg.github.com/nasa-ammos/aerie" | `publishConfig.url`
"GITHUB_ACTOR" | `publishConfig.usernameEnvironmentVariable`
"GITHUB_TOKEN" | `publishConfig.passwordEnvironmentVariable`

The default values of the properties are unchanged, so the github workflow is unaffected.

## Verification
Testing was performed on [a fork](https://github.com/JoelCourtney/aerie). I tested the default publishing procedure by changing the `publishConfig.url` property in `gradle.properties` to point to JoelCourtney/aerie instead of NASA-AMMOS/aerie, and ran `./gradlew publish`. The maven libraries were correctly published to my fork's packages.

I also tested that the properties can be changed on the command line like so: `./gradlew publish -PpublishConfig.usernameEnvironmentVariable=SOME_OTHER_VAR`.

## Documentation
[This portion of the release checklist](https://github.com/NASA-AMMOS/aerie/blob/develop/docs/release-checklist.md#mavenartifacory) is out of date. (Not because of this PR; it was already out of date.)

## Future work
The rest of the work will be done in the internal Aerie/aerie-artifactory-mirror repo, to use this change for publishing to artifactory.