### PR TITLE
[HotFix] Can't copy sql from node projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,10 @@ configure(subprojects.findAll { it.projectDir.toPath().resolve('sql').toFile().e
   // For all Node subprojects
   sp.plugins.withId('com.github.node-gradle.node') {
     // Distribute SQL as part of resource processing
+    tasks.create('processResources')
     tasks.findAll { it.name == 'processResources' }.each { it.dependsOn distributeSql }
     // Remove distributed SQL as part of `clean` tasks
-    tasks.findAll { it.name == 'clean' }.each { it.dependsOn undoDistributeSql }
+    // 'clean' is not visible here, use the subproject .gradle 'clean' task
   }
 
   // Distribute SQL prior to creating deployment archive

--- a/command-expansion-server/build.gradle
+++ b/command-expansion-server/build.gradle
@@ -8,9 +8,6 @@ node {
   download = true
 }
 
-task processResources {
-  // Currently does nothing, exists as a hook for `distributeSql`
-}
 
 task assemble(type: NpmTask) {
   dependsOn processResources
@@ -29,5 +26,6 @@ task build {
 //}
 
 task clean(type: Delete) {
+  dependsOn undoDistributeSql
   delete 'build', 'node_modules'
 }


### PR DESCRIPTION


* **Tickets addressed:** AERIE-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
For a strange reason, Gradle is unable to see the command-expansion-server's `build.gradle` tasks. This causes the Aerie `build.gradle` to ignore moving the SQL files over. I tweaked Aerie `build.gradle` a little to get it working. 


## Verification
run `./gradlew clean` and verify `aerie/deployment/postgres-init-db/sql/commanding` is removed
run `./gradlew assemble` and verify `aerie/deployment/postgres-init-db/sql/commanding` is added


