### PR TITLE
[AERIE-1717]  Upload a command dictionary

### DIFF
--- a/command-expansion-server/package.json
+++ b/command-expansion-server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "build": "tsc;",
+    "build": "rm -rf ./build/packages/lib/CommandEDSLPreface.ts; tsc; cp ./src/packages/lib/CommandEDSLPreface.ts ./build/packages/lib/CommandEDSLPreface.ts;",
     "start": "node ./build/app.js",
     "ts-watch": "tsc --watch",
     "dev-server": "supervisor -- --inspect=0.0.0.0 ./build/app.js",

--- a/command-expansion-server/sql/commanding/tables/command_dictionary.sql
+++ b/command-expansion-server/sql/commanding/tables/command_dictionary.sql
@@ -5,9 +5,9 @@ create table command_dictionary (
   mission text not null,
   version text not null,
 
-  constraint command_dictionary_primary_key
+  constraint command_dictionary_synthetic_key
       primary key (id),
-  constraint pair unique (mission,version)
+  constraint command_dictionary_natural_key unique (mission,version)
 );
 
 comment on table command_dictionary is e''

--- a/command-expansion-server/src/app.ts
+++ b/command-expansion-server/src/app.ts
@@ -47,9 +47,12 @@ app.post("/dictionary", async (req, res) => {
 
   if (rows.length < 0) {
     console.error(`POST /dictionary: No command dictionary was updated in the database`);
+    res.status(400).json({ message: `POST /dictionary: No command dictionary was updated in the database` });
+  } else {
+    const id = rows[0].id;
+    res.status(200).json({ id });
   }
-  const id = rows[0].id;
-  res.status(200).json({ id });
+  return;
 });
 
 app.put("/expansion/:activityTypeName", async (req, res) => {

--- a/command-expansion-server/src/app.ts
+++ b/command-expansion-server/src/app.ts
@@ -9,35 +9,35 @@ import { processDictionary } from "./packages/lib/CommandTypeCodegen.js";
 const PORT: number = parseInt(getEnv().PORT, 10) ?? 3000;
 
 const app: Application = express();
-app.use(bodyParser.json({ limit: '25mb' }));
+app.use(bodyParser.json({ limit: "25mb" }));
 
 DbExpansion.init();
 const db = DbExpansion.getDb();
-
 
 app.get("/", (req: Request, res: Response) => {
   res.send("Aerie Command Service");
 });
 
-app.put("/dictionary", async (req, res) => {
-  const dictionary = Buffer.from(req.body.input.dictionary, 'base64').toString();
-
-
+app.post("/dictionary", async (req, res) => {
+  const base64Dictionary: string = req.body.input.dictionary;
+  const dictionary = Buffer.from(base64Dictionary, "base64").toString("utf8");
   console.log(`Dictionary received`);
+
   const parsedDictionary = ampcs.parse(dictionary);
   console.log(
     `Dictionary parsed - version: ${parsedDictionary.header.version}, mission: ${parsedDictionary.header.mission_name}`
   );
+
   const commandDictionaryPath = await processDictionary(parsedDictionary);
   console.log(`command-lib generated - path: ${commandDictionaryPath}`);
 
   const sqlExpression = `
-    insert into command_dictionary (command_types, mission, version)
-    values ($1, $2, $3)
-    on conflict (mission, version) do update
-    set command_types = $1
-    returning id;
-  `;
+      insert into command_dictionary (command_types, mission, version)
+      values ($1, $2, $3)
+      on conflict (mission, version) do update
+      set command_types = $1
+      returning id;
+    `;
 
   const { rows } = await db.query(sqlExpression, [
     commandDictionaryPath,
@@ -45,57 +45,52 @@ app.put("/dictionary", async (req, res) => {
     parsedDictionary.header.version,
   ]);
 
-
-
   if (rows.length < 0) {
     console.error(`POST /dictionary: No command dictionary was updated in the database`);
-    res.status(500).send(`POST /dictionary: No command dictionary was updated in the database`);
-    return;
   }
   const id = rows[0].id;
   res.status(200).json({ id });
+});
+
+app.put("/expansion/:activityTypeName", async (req, res) => {
+  res.status(501).send("PUT /expansion: Not implemented");
   return;
 });
 
-app.put('/expansion/:activityTypeName', async (req, res) => {
-  res.status(501).send('PUT /expansion: Not implemented');
+app.get("/expansion/:expansionId(\\d+)", async (req, res) => {
+  res.status(501).send("GET /expansion: Not implemented");
   return;
 });
 
-app.get('/expansion/:expansionId(\\d+)', async (req, res) => {
-  res.status(501).send('GET /expansion: Not implemented');
+app.put("/expansion-set", async (req, res) => {
+  res.status(501).send("PUT /expansion-set: Not implemented");
   return;
 });
 
-app.put('/expansion-set', async (req, res) => {
-  res.status(501).send('PUT /expansion-set: Not implemented');
-    return;
-});
-
-app.get('/command-types/:dictionaryId(\\d+)', async (req, res) => {
-  res.status(501).send('GET /command-types: Not implemented');
+app.get("/command-types/:dictionaryId(\\d+)", async (req, res) => {
+  res.status(501).send("GET /command-types: Not implemented");
   return;
 });
 
-app.get('/activity-types/:missionModelId(\\d+)/:activityTypeName', async (req, res) => {
-  res.status(501).send('GET /activity-types: Not implemented');
+app.get("/activity-types/:missionModelId(\\d+)/:activityTypeName", async (req, res) => {
+  res.status(501).send("GET /activity-types: Not implemented");
   return;
 });
 
-app.get('/commands/:expansionRunId(\\d+)/:activityInstanceId(\\d+)', async (req, res) => {
+app.get("/commands/:expansionRunId(\\d+)/:activityInstanceId(\\d+)", async (req, res) => {
   // Pull existing expanded commands for an activity instance of an expansion run
-  res.status(501).send('GET /commands: Not implemented');
+  res.status(501).send("GET /commands: Not implemented");
   return;
 });
 
-app.post('/expand-all-activity-instances/:simulationId(\\d+)/:expansionSetId(\\d+)', async (req, res) => {
-    res.status(501).send('POST /expand-all-activity-instances: Not implemented');
-    return;
+app.post("/expand-all-activity-instances/:simulationId(\\d+)/:expansionSetId(\\d+)", async (req, res) => {
+  res.status(501).send("POST /expand-all-activity-instances: Not implemented");
+  return;
 });
 
 app.use((err: any, req: Request, res: Response, _next: NextFunction) => {
-  console.error(err)
-  res.status(err.status ?? err.statusCode ?? 500).send(err.message)
+  console.error(err);
+  res.status(err.status ?? err.statusCode ?? 500).send(err.message);
 });
 
 app.listen(PORT, () => {

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -9,9 +9,6 @@ type Mutation {
 type Mutation {
   uploadDictionary(dictionary: String!): CommandDictionaryResponse
 }
-type CommandDictionaryResponse {
-  id: Int!
-}
 
 type Query {
   getModelEffectiveArguments(
@@ -96,6 +93,10 @@ type AddExternalDatasetResponse {
 type SchedulingResponse {
   status: SchedulingStatus!
   reason: SchedulingFailureReason
+}
+
+type CommandDictionaryResponse {
+  id: Int!
 }
 
 enum SchedulingStatus {


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1717
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The first part of the command expansion servicer. This will allow the user to upload a command dictionary, parse, and create the command-lib.ts. The path to this file will be saved in the command_dictionary table. 

There will be a separate PR for the Aerie-Gateway, which you can use to upload the command dictionary via the gateway. It will not affect this PR though.

- [x] Add endpoint to upload the command dictionary. Future work: move to the Aerie Gateway
- [x] Import command dictionary parse library to parse the command dictionary
- [x] Generate command-lib.ts and save to the filesystem
- [x] Save (path, version, and mission) to Postgres
- [x] Support upload of the same command dictionary file

## Verification

1.  ` docker system prune --all --volumes`
2.  `./gradlew clean; ./gradlew assemble;  docker compose -f docker-compose.yml build; docker compose -f docker-compose.yml up`
3.  Download the command dictionary: https://jira.jpl.nasa.gov/browse/AERIE-1633
4.  Copy the XML content to https://www.base64encode.org/ and encode to `base64`
5.  In Hasura use the graphQL to send the command dictionary to the command service

Take the base64 string and add it to the call at `<INSERT>`
```
mutation MyMutation {
  uploadDictionary(dictionary: "<INSERT>") {
    id
  }
}
```
6.  Verify the query returns an ID to the Postgres table
7.  Look at Hasura and verify you see the entries in the command-dictionary table

## Documentation
I will have to add these steps to the User Guide that we will be giving the users

## Future work
[AERIE-1718](https://jira.jpl.nasa.gov/browse/AERIE-1718) Create an activity-type library from a mission model. 
