### PR TITLE
Add name column to scheduling_goal table

### DIFF
--- a/scheduler-server/sql/scheduler/tables/scheduling_goal.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_goal.sql
@@ -1,6 +1,7 @@
 create table scheduling_goal (
   id integer generated always as identity,
   revision integer not null default 0,
+  name text not null,
   definition text not null,
 
   model_id integer not null,
@@ -24,8 +25,10 @@ comment on column scheduling_goal.definition is e''
   'The source code for a Typescript module defining this scheduling goal';
 comment on column scheduling_goal.model_id is e''
   'The mission model used to which this scheduling goal is associated.';
+comment on column scheduling_goal.name is e''
+  'A short human readable name for this goal';
 comment on column scheduling_goal.description is e''
-  'A text description of this scheduling goal.';
+  'A longer text description of this scheduling goal.';
 comment on column scheduling_goal.author is e''
   'The original user who authored this scheduling goal.';
 comment on column scheduling_goal.last_modified_by is e''


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Scheduling goals should have both a short human-readable name and a longer text description. Neither of these is required to be unique, since the unique identifier for scheduling goals is an integer autogenerated by postgres.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I opened hasura and saw that the name field was available via GraphQL.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No documentation exists for scheduling goals yet.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
No next steps.