### PR TITLE
docs: remove internal docs and deployment variables 

### DIFF
--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -11,25 +11,22 @@ This document provides detailed information about environment variables for each
 
 ## Aerie Gateway
 
-| Name                          | Description                                                            | Type     | Default                                        |
-| ----------------------------- | ---------------------------------------------------------------------- | -------- | ---------------------------------------------- |
-| `AUTH_TYPE`                   | Mode of authentication. Set to `none` to fully disable authentication. | `string` | cam                                            |
-| `AUTH_URL`                    | URL of authentication API for the given `AUTH_TYPE`.                   | `string` | https://atb-ocio-12b.jpl.nasa.gov:8443/cam-api |
-| `GQL_API_URL`                 | URL of GraphQL API for the GraphQL Playground.                         | `string` | http://localhost:8080/v1/graphql               |
-| `PORT`                        | Port the Gateway server listens on.                                    | `number` | 9000                                           |
-| `POSTGRES_AERIE_MERLIN_DB`    | Name of Merlin Postgres database.                                      | `string` | aerie_merlin                                   |
-| `POSTGRES_AERIE_SCHEDULER_DB` | Name of scheduler Postgres database.                                   | `string` | aerie_scheduler                                |
-| `POSTGRES_AERIE_UI_DB`        | Name of UI Postgres database.                                          | `string` | aerie_ui                                       |
-| `POSTGRES_HOST`               | Hostname of Postgres instance.                                         | `string` | localhost                                      |
-| `POSTGRES_PASSWORD`           | Password of Postgres instance.                                         | `string` | aerie                                          |
-| `POSTGRES_PORT`               | Port of Postgres instance.                                             | `number` | 5432                                           |
-| `POSTGRES_USER`               | User of Postgres instance.                                             | `string` | aerie                                          |
+| Name                          | Description                                    | Type     | Default                          |
+| ----------------------------- | ---------------------------------------------- | -------- | -------------------------------- |
+| `GQL_API_URL`                 | URL of GraphQL API for the GraphQL Playground. | `string` | http://localhost:8080/v1/graphql |
+| `PORT`                        | Port the Gateway server listens on.            | `number` | 9000                             |
+| `POSTGRES_AERIE_MERLIN_DB`    | Name of Merlin Postgres database.              | `string` | aerie_merlin                     |
+| `POSTGRES_AERIE_SCHEDULER_DB` | Name of scheduler Postgres database.           | `string` | aerie_scheduler                  |
+| `POSTGRES_AERIE_UI_DB`        | Name of UI Postgres database.                  | `string` | aerie_ui                         |
+| `POSTGRES_HOST`               | Hostname of Postgres instance.                 | `string` | localhost                        |
+| `POSTGRES_PASSWORD`           | Password of Postgres instance.                 | `string` | aerie                            |
+| `POSTGRES_PORT`               | Port of Postgres instance.                     | `number` | 5432                             |
+| `POSTGRES_USER`               | User of Postgres instance.                     | `string` | aerie                            |
 
 ## Aerie UI
 
 | Name                   | Description                                                                    | Type     | Default                          |
 | ---------------------- | ------------------------------------------------------------------------------ | -------- | -------------------------------- |
-| `AUTH_TYPE`            | Mode of authentication. Set to `none` to fully disable authentication.         | `string` | cam                              |
 | `GATEWAY_CLIENT_URL`   | Url of the Gateway as called from the client (i.e. web browser)                | `string` | http://localhost:9000            |
 | `GATEWAY_SERVER_URL`   | Url of the Gateway as called from the server (i.e. Node.js container)          | `string` | http://localhost:9000            |
 | `HASURA_CLIENT_URL`    | Url of Hasura as called from the client (i.e. web browser)                     | `string` | http://localhost:8080/v1/graphql |
@@ -69,17 +66,17 @@ The default Aerie deployment uses the default Postgres environment. See the [Doc
 
 ## Scheduler
 
-| Name                     | Description                                                           | Type     | Default                                           |
-| --------------------     | --------------------------------------------------------------------- | -------- | ------------------------------------------------- |
-| `MERLIN_GRAPHQL_URL`     | URI of the Merlin graphql interface to call                           | `string` | http://hasura:8080/v1/graphql                     |
-| `MERLIN_LOCAL_STORE`     | Local storage for Merlin in the container (for backdoor jar access)   | `string` | /usr/src/app/merlin_file_store                    |
-| `SCHEDULER_DB`           | The DB for scheduler                                                  | `string` | aerie_scheduler                                   |
-| `SCHEDULER_DB_PASSWORD`  | Password of the DB instance                                           | `string` | aerie                                             |
-| `SCHEDULER_DB_PORT`      | The DB instance port number that scheduler will connect with          | `number` | 5432                                              |
-| `SCHEDULER_DB_SERVER`    | The DB instance that scheduler will connect with                      | `string` | postgres                                          |
-| `SCHEDULER_DB_USER`      | Username of the DB instance                                           | `string` | aerie                                             |
-| `SCHEDULER_LOCAL_STORE`  | Local storage for scheduler in the container                          | `string` | /usr/src/app/scheduler_file_store                 |
-| `SCHEDULER_LOGGING`      | Whether or not you want Javalin to log server information             | `string` | true                                              |
-| `SCHEDULER_OUTPUT_MODE`  | how scheduler output is sent back to aerie                            | `string` | UpdateInputPlanWithNewActivities                  |
-| `SCHEDULER_PORT`         | Port number for the scheduler server                                  | `number` | 27193                                             |
-| `SCHEDULER_RULES_JAR`    | Jar file to load scheduling rules from (until user input to database) | `string` | /usr/src/app/merlin_file_store/scheduler_rules.jar |
+| Name                    | Description                                                           | Type     | Default                                            |
+| ----------------------- | --------------------------------------------------------------------- | -------- | -------------------------------------------------- |
+| `MERLIN_GRAPHQL_URL`    | URI of the Merlin graphql interface to call                           | `string` | http://hasura:8080/v1/graphql                      |
+| `MERLIN_LOCAL_STORE`    | Local storage for Merlin in the container (for backdoor jar access)   | `string` | /usr/src/app/merlin_file_store                     |
+| `SCHEDULER_DB`          | The DB for scheduler                                                  | `string` | aerie_scheduler                                    |
+| `SCHEDULER_DB_PASSWORD` | Password of the DB instance                                           | `string` | aerie                                              |
+| `SCHEDULER_DB_PORT`     | The DB instance port number that scheduler will connect with          | `number` | 5432                                               |
+| `SCHEDULER_DB_SERVER`   | The DB instance that scheduler will connect with                      | `string` | postgres                                           |
+| `SCHEDULER_DB_USER`     | Username of the DB instance                                           | `string` | aerie                                              |
+| `SCHEDULER_LOCAL_STORE` | Local storage for scheduler in the container                          | `string` | /usr/src/app/scheduler_file_store                  |
+| `SCHEDULER_LOGGING`     | Whether or not you want Javalin to log server information             | `string` | true                                               |
+| `SCHEDULER_OUTPUT_MODE` | how scheduler output is sent back to aerie                            | `string` | UpdateInputPlanWithNewActivities                   |
+| `SCHEDULER_PORT`        | Port number for the scheduler server                                  | `number` | 27193                                              |
+| `SCHEDULER_RULES_JAR`   | Jar file to load scheduling rules from (until user input to database) | `string` | /usr/src/app/merlin_file_store/scheduler_rules.jar |

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -17,7 +17,7 @@ Before you can deploy Aerie, you must install and configure the following produc
 
 ## Environment Variables
 
-Each container has environment variables that can be used to fine-tune your deployment. See the [environment variable documentation](./Environment.md) for the complete set of variables. See the example [docker-compose.yml](./docker-compose.yml) file for examples on how to set the environment variables.
+Each container has environment variables that can be used to fine-tune your deployment. See the [environment variable documentation](./Environment.md) for the complete set of variables. See the example [docker-compose.yml](./docker-compose.yml) file for examples on how to set the environment variables. **We highly recommend changing the default environment variable passwords before deploying Aerie**.
 
 ## Starting the Services
 

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -4,8 +4,7 @@ services:
     container_name: aerie_gateway
     depends_on: ["postgres"]
     environment:
-      AUTH_TYPE: cam
-      AUTH_URL: https://atb-ocio-12b.jpl.nasa.gov:8443/cam-api
+      AUTH_TYPE: none
       GQL_API_URL: http://localhost:8080/v1/graphql
       PORT: 9000
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin
@@ -62,7 +61,7 @@ services:
     container_name: aerie_ui
     depends_on: ["postgres"]
     environment:
-      AUTH_TYPE: cam
+      AUTH_TYPE: none
       GATEWAY_CLIENT_URL: http://localhost:9000
       GATEWAY_SERVER_URL: http://aerie_gateway:9000
       HASURA_CLIENT_URL: http://localhost:8080/v1/graphql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,23 @@
 version: "3.7"
 services:
+  aerie_commanding:
+    build:
+      context: ./command-expansion-server
+      dockerfile: Dockerfile
+    container_name: aerie_commanding
+    depends_on: ["postgres"]
+    environment:
+      MERLIN_GRAPHQL_URL: http://hasura:8080/v1/graphql
+      COMMANDING_SERVER_PORT: 3000
+      COMMANDING_DB: "aerie_expansion"
+      COMMANDING_DB_PASSWORD: "aerie"
+      COMMANDING_DB_PORT: 5432
+      COMMANDING_DB_SERVER: "postgres"
+      COMMANDING_DB_USER: "aerie"
+      COMMANDING_LOCAL_STORE: /usr/src/app/commanding_file_store
+    image: aerie_commanding
+    ports: ["3000:3000"]
+    restart: always
   aerie_gateway:
     container_name: aerie_gateway
     depends_on: ["postgres"]
@@ -7,6 +25,7 @@ services:
       AUTH_TYPE: cam
       AUTH_URL: https://atb-ocio-12b.jpl.nasa.gov:8443/cam-api
       GQL_API_URL: http://localhost:8080/v1/graphql
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
       PORT: 9000
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin
       POSTGRES_AERIE_SCHEDULER_DB: aerie_scheduler
@@ -64,24 +83,6 @@ services:
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store
-  aerie_commanding:
-    build:
-      context: ./command-expansion-server
-      dockerfile: Dockerfile
-    container_name: aerie_commanding
-    depends_on: [ "postgres" ]
-    environment:
-      MERLIN_GRAPHQL_URL: http://hasura:8080/v1/graphql
-      COMMANDING_SERVER_PORT : 3000
-      COMMANDING_DB: "aerie_expansion"
-      COMMANDING_DB_PASSWORD: "aerie"
-      COMMANDING_DB_PORT: 5432
-      COMMANDING_DB_SERVER: "postgres"
-      COMMANDING_DB_USER: "aerie"
-      COMMANDING_LOCAL_STORE: /usr/src/app/commanding_file_store
-    image: aerie_commanding
-    ports: [ "3000:3000" ]
-    restart: always
   aerie_ui:
     container_name: aerie_ui
     depends_on: ["postgres"]
@@ -91,6 +92,7 @@ services:
       GATEWAY_SERVER_URL: http://aerie_gateway:9000
       HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
       HASURA_SERVER_URL: http://hasura:8080/v1/graphql
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
       SCHEDULER_CLIENT_URL: http://localhost:27193
       SCHEDULER_SERVER_URL: http://scheduler:27193
     image: "ghcr.io/nasa-ammos/aerie-ui:develop"


### PR DESCRIPTION
## Description

- Update Environment.md with external deployment vars
- Update docker-compose deployment to have CAM auth OFF by default
- Internal docs are now here: https://github.jpl.nasa.gov/Aerie/aerie-internal-docs
- Add warning to change default passwords to deployment README.md
- Formatting and alphabetization

## Documentation

This PR is primarily documentation updates.

