### PR TITLE
Adjust expansion_run columns

### DIFF
--- a/command-expansion-server/sql/commanding/tables/expansion_run.sql
+++ b/command-expansion-server/sql/commanding/tables/expansion_run.sql
@@ -1,7 +1,7 @@
 create table expansion_run (
   id integer generated always as identity,
 
-  simulation_id integer not null,
+  dataset_id integer not null,
   expansion_set_id integer not null,
 
   constraint expansion_run_primary_key
@@ -14,7 +14,7 @@ comment on table expansion_run is e''
   'The configuration for an expansion run for a plan.';
 comment on column expansion_run.id is e''
   'The synthetic identifier for this expansion run.';
-comment on column expansion_run.simulation_id is e''
-  'The simulation results for the plan.';
+comment on column expansion_run.dataset_id is e''
+  'The dataset id used to generate this expansion run.';
 comment on column expansion_run.expansion_set_id is e''
-  'The command dictionary and mission model set';
+  'The command dictionary, mission model, and expansion set';

--- a/command-expansion-server/sql/commanding/tables/expansion_run.sql
+++ b/command-expansion-server/sql/commanding/tables/expansion_run.sql
@@ -17,4 +17,4 @@ comment on column expansion_run.id is e''
 comment on column expansion_run.dataset_id is e''
   'The dataset id used to generate this expansion run.';
 comment on column expansion_run.expansion_set_id is e''
-  'The command dictionary, mission model, and expansion set';
+  'The command dictionary, mission model, and expansion set id.';


### PR DESCRIPTION
* **Tickets addressed:** ARIE-1687
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

We need to swap out simulation_id with dataset_id in the expansion_run
table so that we are locked to a particular run of the simulation for
traceability. We should still be able to attain all of the simulation
information from the dataset through the GraphQL API.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Deployed locally with no issues

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
We should update the diagram for command expansion workflow to properly reflect the table update @goetzrrGit 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Ensure future PRs adhere to the new column