### PR TITLE
Simplify `scheduler-server` Gradle logic

### DIFF
--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -41,15 +41,12 @@ assemble {
 test {
   dependsOn(assembleSchedulingDSLCompiler)
   useJUnitPlatform()
-  def architectureSpecificDir = new ByteArrayOutputStream()
-  exec{
-    commandLine "ls", projectDir.toPath().resolve(".gradle/nodejs")
-    standardOutput = architectureSpecificDir;
-    ignoreExitValue true
+
+  // Add node bin directory to PATH, helps CI/CD services without node installed
+  projectDir.toPath().resolve('.gradle/nodejs').toFile().listFiles().each {
+    environment 'PATH', "${System.env.PATH}${System.getProperty('path.separator')}$it/bin"
   }
 
-  def nodePath = projectDir.toPath().resolve(".gradle/nodejs").resolve("$architectureSpecificDir".trim()).resolve("bin")
-  environment "PATH", "$System.env.PATH" + System.getProperty("path.separator") + nodePath
   environment "SCHEDULING_DSL_COMPILER_ROOT", projectDir.toPath().resolve('scheduling-dsl-compiler')
   environment "SCHEDULING_DSL_COMPILER_COMMAND", './build/main.js'
 }


### PR DESCRIPTION
## Description

1. Simplifies `node` path env. setting for `test` task.
1. Simplifies & generalizes `processResources` task dependencies.

## Verification

Item 1 will be tested when running through GH actions.
Item 2 has been tested manually with `gradle undoDistributeSql` followed by `gradle scheduler-server:processResources`.