### PR TITLE
[AERIE-1725]  get command typescript types

### DIFF
--- a/command-expansion-server/src/app.ts
+++ b/command-expansion-server/src/app.ts
@@ -7,6 +7,7 @@ import { DbExpansion } from "./packages/db/db.js";
 import * as ampcs from "@nasa-jpl/aerie-ampcs";
 import { processDictionary } from "./packages/lib/CommandTypeCodegen.js";
 import { getActivityTypescript } from "./getActivityTypescript.js";
+import { getCommandTypescriptTypes } from "./getCommandTypescriptTypes.js";
 
 const PORT: number = parseInt(getEnv().PORT, 10) ?? 3000;
 
@@ -73,8 +74,15 @@ app.put("/expansion-set", async (req, res) => {
   return;
 });
 
-app.get("/command-types/:dictionaryId(\\d+)", async (req, res) => {
-  res.status(501).send("GET /command-types: Not implemented");
+app.post("/get-command-typescript", async (req, res) => {
+  const commandDictionaryId: string = req.body.input.commandDictionaryId;
+  const commandTypescript = await getCommandTypescriptTypes(db, parseInt(commandDictionaryId, 10));
+  const commandTypescriptBase64 = Buffer.from(commandTypescript).toString("base64");
+
+  res.status(200).json({
+    typescript: commandTypescriptBase64,
+  });
+
   return;
 });
 

--- a/command-expansion-server/src/getCommandTypescriptTypes.ts
+++ b/command-expansion-server/src/getCommandTypescriptTypes.ts
@@ -1,0 +1,21 @@
+import type {Pool} from 'pg';
+import fs from 'fs';
+import { ErrorWithStatusCode } from './utils/ErrorWithStatusCode.js';
+
+export async function getCommandTypescriptTypes(db: Pool, dictionaryId: number): Promise<string> {
+
+  const {rowCount, rows} = await db.query(`
+    SELECT command_types
+    FROM command_dictionary
+    WHERE id = $1;
+  `, [
+    dictionaryId
+  ]);
+
+
+  const [row] = rows;
+  if (rowCount < 1) {
+    throw new ErrorWithStatusCode(`No dictionary with id: ${dictionaryId}`, 404);
+  }
+  return fs.promises.readFile(row.command_types, 'utf8');
+}

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -33,6 +33,11 @@ type Query {
 }
 
 type Query {
+  getCommandTypeScript(
+  commandDictionaryId: ID!): TypeScriptResponse
+}
+
+type Query {
   resourceTypes(
     missionModelId: ID!
   ): [ResourceType!]!
@@ -129,4 +134,3 @@ scalar ActivityArguments
 scalar ProfileSet
 
 scalar SchedulingFailureReason
-

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -1,79 +1,83 @@
 actions:
-- name: addExternalDataset
-  definition:
-    kind: synchronous
-    handler: http://aerie_merlin:27183/addExternalDataset
-- name: uploadDictionary
-  definition:
-    kind: synchronous
-    handler: http://aerie_commanding:3000/put-dictionary
-- name: getModelEffectiveArguments
-  definition:
-    kind: ""
-    handler: http://aerie_merlin:27183/getModelEffectiveArguments
-- name: getActivityEffectiveArguments
-  definition:
-    kind: ""
-    handler: http://aerie_merlin:27183/getActivityEffectiveArguments
-- name: getActivityTypeScript
-  definition:
-    kind: ""
-    handler: http://aerie_commanding:3000/get-activity-typescript
-- name: resourceTypes
-  definition:
-    kind: ""
-    handler: http://aerie_merlin:27183/resourceTypes
-- name: schedule
-  definition:
-    kind: ""
-    handler: http://aerie_scheduler:27193/schedule
-- name: simulate
-  definition:
-    kind: ""
-    handler: http://aerie_merlin:27183/getSimulationResults
-- name: validateActivityArguments
-  definition:
-    kind: ""
-    handler: http://aerie_merlin:27183/validateActivityArguments
-- name: validateModelArguments
-  definition:
-    kind: ""
-    handler: http://aerie_merlin:27183/validateModelArguments
+  - name: addExternalDataset
+    definition:
+      kind: synchronous
+      handler: http://aerie_merlin:27183/addExternalDataset
+  - name: uploadDictionary
+    definition:
+      kind: synchronous
+      handler: http://aerie_commanding:3000/put-dictionary
+  - name: getModelEffectiveArguments
+    definition:
+      kind: ""
+      handler: http://aerie_merlin:27183/getModelEffectiveArguments
+  - name: getActivityEffectiveArguments
+    definition:
+      kind: ""
+      handler: http://aerie_merlin:27183/getActivityEffectiveArguments
+  - name: getActivityTypeScript
+    definition:
+      kind: ""
+      handler: http://aerie_commanding:3000/get-activity-typescript
+  - name: getCommandTypeScript
+    definition:
+      kind: ""
+      handler: http://aerie_commanding:3000/get-command-typescript
+  - name: resourceTypes
+    definition:
+      kind: ""
+      handler: http://aerie_merlin:27183/resourceTypes
+  - name: schedule
+    definition:
+      kind: ""
+      handler: http://aerie_scheduler:27193/schedule
+  - name: simulate
+    definition:
+      kind: ""
+      handler: http://aerie_merlin:27183/getSimulationResults
+  - name: validateActivityArguments
+    definition:
+      kind: ""
+      handler: http://aerie_merlin:27183/validateActivityArguments
+  - name: validateModelArguments
+    definition:
+      kind: ""
+      handler: http://aerie_merlin:27183/validateModelArguments
 custom_types:
   enums:
-  - name: MerlinSimulationStatus
-    values:
-    - description: null
-      is_deprecated: null
-      value: complete
-    - description: null
-      is_deprecated: null
-      value: failed
-    - description: null
-      is_deprecated: null
-      value: incomplete
-  - name: SchedulingStatus
-    values:
-    - description: null
-      is_deprecated: null
-      value: complete
-    - description: null
-      is_deprecated: null
-      value: failed
-    - description: null
-      is_deprecated: null
-      value: incomplete
+    - name: MerlinSimulationStatus
+      values:
+        - description: null
+          is_deprecated: null
+          value: complete
+        - description: null
+          is_deprecated: null
+          value: failed
+        - description: null
+          is_deprecated: null
+          value: incomplete
+    - name: SchedulingStatus
+      values:
+        - description: null
+          is_deprecated: null
+          value: complete
+        - description: null
+          is_deprecated: null
+          value: failed
+        - description: null
+          is_deprecated: null
+          value: incomplete
   input_objects: []
   objects:
-  - name: ResourceType
-  - name: MerlinSimulationResponse
-  - name: ValidationResponse
-  - name: EffectiveArgumentsResponse
-  - name: AddExternalDatasetResponse
+    - name: ResourceType
+    - name: MerlinSimulationResponse
+    - name: ValidationResponse
+    - name: EffectiveArgumentsResponse
+    - name: AddExternalDatasetResponse
   scalars:
-  - name: ResourceSchema
-  - name: MerlinSimulationResults
-  - name: MerlinSimulationFailureReason
-  - name: ModelArguments
-  - name: ActivityArguments
-  - name: ProfileSet
+    - name: ResourceSchema
+    - name: MerlinSimulationResults
+    - name: MerlinSimulationFailureReason
+    - name: ModelArguments
+    - name: ActivityArguments
+    - name: ProfileSet


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1725
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

This PR will retrieve the command typescript Library used to author the command expansions.  Here is the workflow:

1. Use a Hasura action and provide the `commandDictionaryID`. 
2. The commanding server will retrieve the command typescript from the filesystem. Note: this was generated when the command dictionary was uploaded 
4. The library is base64 encoded and sent back as the response to the Hasura action

## Verification
I tested this locally

1. `docker system prune --all --volumes` nuke everything 
2. `./gradlew clean; ./gradlew assemble; docker compose -f docker-compose.yml build; docker compose -f docker-compose.yml up` 
3. Follow the step in this PR to upload the command dictionary. Start at step 3: https://github.com/NASA-AMMOS/aerie/pull/70
5. Run the action below. 

```
query commandTypescript {
  getCommandTypeScript(commandDictionaryId: "1") {
    typescript
  }
}
```
6. Verify that you receive `base64` string back from the action.
7. Take the string and convert it with this URL: https://www.base64decode.org/


## Documentation
I will have to add these steps to the User Guide that we will be giving the users

## Future work
Creating Hasura action for the other endpoints in the commanding server and hooking up the rest of the commanding server. 