### PR TITLE
[AERIE-1726]  Activity Typescript Types Generation

### DIFF
--- a/command-expansion-server/package-lock.json
+++ b/command-expansion-server/package-lock.json
@@ -13,7 +13,7 @@
         "@nasa-jpl/aerie-ampcs": "^1.0.0",
         "body-parser": "^1.19.2",
         "express": "^4.17.2",
-        "graphql": "^16.3.0",
+        "graphql-request": "^4.0.0",
         "pg": "^8.7.3",
         "reserved-words": "^0.1.2",
         "typescript": "^4.5.5"
@@ -1339,8 +1339,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -1689,7 +1688,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1771,6 +1769,14 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1885,7 +1891,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2159,6 +2164,17 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
+      "engines": {
+        "node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2226,7 +2242,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2371,8 +2386,22 @@
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
       "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
+      }
+    },
+    "node_modules/graphql-request": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-4.0.0.tgz",
+      "integrity": "sha512-cdqQLCXlBGkaLdkLYRl4LtkwaZU6TfpE7/tnUQFl3wXfUPWN74Ov+Q61VuIh+AltS789YfGB6whghmCmeXLvTw==",
+      "dependencies": {
+        "cross-fetch": "^3.0.6",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
       }
     },
     "node_modules/has": {
@@ -3726,6 +3755,44 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-int64": {
@@ -6214,8 +6281,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -6488,7 +6554,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -6554,6 +6619,14 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "requires": {
+        "node-fetch": "2.6.7"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -6647,8 +6720,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -6851,6 +6923,11 @@
         "vary": "~1.1.2"
       }
     },
+    "extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -6909,7 +6986,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -7010,7 +7086,18 @@
     "graphql": {
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
-      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A=="
+      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
+      "peer": true
+    },
+    "graphql-request": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-4.0.0.tgz",
+      "integrity": "sha512-cdqQLCXlBGkaLdkLYRl4LtkwaZU6TfpE7/tnUQFl3wXfUPWN74Ov+Q61VuIh+AltS789YfGB6whghmCmeXLvTw==",
+      "requires": {
+        "cross-fetch": "^3.0.6",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -8048,6 +8135,35 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",

--- a/command-expansion-server/package.json
+++ b/command-expansion-server/package.json
@@ -21,6 +21,7 @@
     "body-parser": "^1.19.2",
     "express": "^4.17.2",
     "graphql": "^16.3.0",
+    "graphql-request": "^4.0.0",
     "pg": "^8.7.3",
     "reserved-words": "^0.1.2",
     "typescript": "^4.5.5"

--- a/command-expansion-server/package.json
+++ b/command-expansion-server/package.json
@@ -20,7 +20,6 @@
     "@nasa-jpl/aerie-ampcs": "^1.0.0",
     "body-parser": "^1.19.2",
     "express": "^4.17.2",
-    "graphql": "^16.3.0",
     "graphql-request": "^4.0.0",
     "pg": "^8.7.3",
     "reserved-words": "^0.1.2",

--- a/command-expansion-server/src/env.ts
+++ b/command-expansion-server/src/env.ts
@@ -1,4 +1,5 @@
 export type Env = {
+  MERLIN_GRAPHQL_URL: string;
   PORT: string;
   POSTGRES_AERIE_EXPANSION_DB: string;
   POSTGRES_HOST: string;
@@ -9,6 +10,7 @@ export type Env = {
 };
 
 export const defaultEnv: Env = {
+  MERLIN_GRAPHQL_URL: 'http://hasura:8080/v1/graphql',
   PORT: "3000",
   POSTGRES_AERIE_EXPANSION_DB: "aerie_commanding",
   POSTGRES_HOST: "localhost",
@@ -21,14 +23,16 @@ export const defaultEnv: Env = {
 export function getEnv(): Env {
   const { env } = process;
 
-  const PORT = env["COMMANDING_SERVER_PORT"] ?? defaultEnv.PORT;
-  const POSTGRES_AERIE_EXPANSION_DB = env["COMMANDING_DB"] ?? defaultEnv.POSTGRES_AERIE_EXPANSION_DB;
-  const POSTGRES_HOST = env["COMMANDING_DB_SERVER"] ?? defaultEnv.POSTGRES_HOST;
-  const POSTGRES_PASSWORD = env["COMMANDING_DB_PASSWORD"] ?? defaultEnv.POSTGRES_PASSWORD;
-  const POSTGRES_PORT = env["COMMANDING_DB_PORT"] ?? defaultEnv.POSTGRES_PORT;
-  const POSTGRES_USER = env["COMMANDING_DB_USER"] ?? defaultEnv.POSTGRES_USER;
-  const STORAGE = env["COMMANDING_LOCAL_STORE"] ?? defaultEnv.STORAGE;
+  const MERLIN_GRAPHQL_URL = env.MERLIN_GRAPHQL_URL ?? defaultEnv.MERLIN_GRAPHQL_URL;
+  const PORT = env.COMMANDING_SERVER_PORT ?? defaultEnv.PORT;
+  const POSTGRES_AERIE_EXPANSION_DB = env.COMMANDING_DB ?? defaultEnv.POSTGRES_AERIE_EXPANSION_DB;
+  const POSTGRES_HOST = env.COMMANDING_DB_SERVER ?? defaultEnv.POSTGRES_HOST;
+  const POSTGRES_PASSWORD = env.COMMANDING_DB_PASSWORD ?? defaultEnv.POSTGRES_PASSWORD;
+  const POSTGRES_PORT = env.COMMANDING_DB_PORT ?? defaultEnv.POSTGRES_PORT;
+  const POSTGRES_USER = env.COMMANDING_DB_USER ?? defaultEnv.POSTGRES_USER;
+  const STORAGE = env.COMMANDING_LOCAL_STORE ?? defaultEnv.STORAGE;
   return {
+    MERLIN_GRAPHQL_URL,
     PORT,
     POSTGRES_AERIE_EXPANSION_DB,
     POSTGRES_HOST,

--- a/command-expansion-server/src/getActivityTypescript.ts
+++ b/command-expansion-server/src/getActivityTypescript.ts
@@ -1,0 +1,126 @@
+import { GraphQLClient, gql } from "graphql-request";
+import { globalDeclaration, indent, interfaceDeclaration } from "./packages/lib/CodegenHelpers.js";
+import { ErrorWithStatusCode } from "./utils/ErrorWithStatusCode.js";
+
+enum SchemaTypes {
+  Int = "int",
+  Real = "real",
+  Duration = "duration",
+  Boolean = "boolean",
+  String = "string",
+  Series = "series",
+  Struct = "struct",
+  Variant = "variant",
+}
+
+type Schema =
+  | IntSchema
+  | RealSchema
+  | DurationSchema
+  | BooleanSchema
+  | StringSchema
+  | SeriesSchema
+  | StructSchema
+  | VariantSchema;
+
+interface BaseSchema<T extends SchemaTypes | unknown> {
+  type: T;
+}
+
+type StringSchema = BaseSchema<SchemaTypes.String>;
+type BooleanSchema = BaseSchema<SchemaTypes.Boolean>;
+type IntSchema = BaseSchema<SchemaTypes.Int>;
+type RealSchema = BaseSchema<SchemaTypes.Real>;
+type DurationSchema = BaseSchema<SchemaTypes.Duration>;
+
+interface SeriesSchema extends BaseSchema<SchemaTypes.Series> {
+  items: Schema;
+}
+
+interface StructSchema extends BaseSchema<SchemaTypes.Struct> {
+  items: {
+    [key: string]: Schema;
+  };
+}
+
+interface VariantSchema extends BaseSchema<SchemaTypes.Variant> {
+  variants: {
+    key: string;
+    label: string;
+  }[];
+}
+
+interface GraphQLActivityParameter {
+  order: number;
+  schema: Schema;
+}
+
+interface GraphQLActivity {
+  name: string;
+  parameters: GraphQLActivityParameter[];
+  requiredParameters: string[];
+}
+
+export async function getActivityTypescript(
+  graphqlClient: GraphQLClient,
+  missionModelId: number,
+  activityTypeName: string
+): Promise<string> {
+  console.log(`query parameters from ${activityTypeName} with missionModelId: ${missionModelId}`);
+  const response = await graphqlClient.request<{
+    activity_type: GraphQLActivity[];
+  }>(
+    gql`
+      query GetParameters($missionModelId: Int!, $activityTypeName: String!) {
+        activity_type(where: { model_id: { _eq: $missionModelId }, name: { _eq: $activityTypeName } }) {
+          name
+          parameters
+        }
+      }
+    `,
+    { missionModelId, activityTypeName }
+  );
+
+  if (response.activity_type.length === 0) {
+    throw new ErrorWithStatusCode(`Activity type ${activityTypeName} not found`, 404);
+  }
+
+  const activity = response.activity_type[0];
+
+  return generateTypescriptForGraphQLActivitySchema(activity);
+}
+
+function generateTypescriptForGraphQLActivitySchema(activitySchema: GraphQLActivity): string {
+  const propertyDeclarations = Object.entries(activitySchema.parameters)
+    .map(([parameterName, parameterValue]) => `readonly ${parameterName}: ${convertSchemaType(parameterValue.schema)};`)
+    .join("\n");
+  const activityTypeAlias = `type ActivityType = ${activitySchema.name};`;
+
+  return globalDeclaration(`${interfaceDeclaration(activitySchema.name, propertyDeclarations)}\n${activityTypeAlias}`);
+}
+
+function convertSchemaType(schema: Schema): string {
+  const objectDeclaration = (content: string) => `{\n${indent(content)}\n}`;
+  switch (schema.type) {
+    case SchemaTypes.Int:
+    case SchemaTypes.Real:
+    case SchemaTypes.Duration:
+      return "number";
+    case SchemaTypes.Boolean:
+      return "boolean";
+    case SchemaTypes.String:
+      return "string";
+    case SchemaTypes.Series:
+      return `${convertSchemaType(schema.items)}[]`;
+    case SchemaTypes.Struct:
+      return objectDeclaration(
+        Object.entries(schema.items)
+          .map(([key, value]) => `${key}: ${convertSchemaType(value)};`)
+          .join("\n")
+      );
+    case SchemaTypes.Variant:
+      return `(${schema.variants.map((variant) => `'${variant.label}'`).join(" | ")})`;
+    default:
+      return "any";
+  }
+}

--- a/command-expansion-server/src/packages/lib/CodegenHelpers.ts
+++ b/command-expansion-server/src/packages/lib/CodegenHelpers.ts
@@ -1,0 +1,11 @@
+export function globalDeclaration(declarations: string):string {
+  return `declare global {\n${indent(declarations)}\n}`;
+}
+
+export function interfaceDeclaration(name: string,  interfaceContents: string): string {
+  return `interface ${name} {\n${indent(interfaceContents)}\n}`;
+}
+
+export function indent(text:string): string {
+  return text.split("\n").map(line => `\t${line}`).join("\n");
+}

--- a/command-expansion-server/src/utils/ErrorWithStatusCode.ts
+++ b/command-expansion-server/src/utils/ErrorWithStatusCode.ts
@@ -1,0 +1,7 @@
+export class ErrorWithStatusCode extends Error {
+    public readonly statusCode: number;
+    constructor(message: string, statusCode: number) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+}

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -32,10 +32,6 @@ type Query {
   ): TypeScriptResponse
 }
 
-type TypeScriptResponse {
-  typescript: String!
-}
-
 type Query {
   resourceTypes(
     missionModelId: ID!
@@ -108,6 +104,10 @@ type SchedulingResponse {
 
 type CommandDictionaryResponse {
   id: Int!
+}
+
+type TypeScriptResponse {
+  typescript: String!
 }
 
 enum SchedulingStatus {

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -26,6 +26,17 @@ type Query {
 }
 
 type Query {
+  getActivityTypeScript(
+    missionModelId: ID!
+    activityTypeName: String!
+  ): TypeScriptResponse
+}
+
+type TypeScriptResponse {
+  typescript: String!
+}
+
+type Query {
   resourceTypes(
     missionModelId: ID!
   ): [ResourceType!]!

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -15,6 +15,10 @@ actions:
   definition:
     kind: ""
     handler: http://aerie_merlin:27183/getActivityEffectiveArguments
+- name: getActivityTypeScript
+  definition:
+    kind: ""
+    handler: http://aerie_commanding:3000/activity-typescript
 - name: resourceTypes
   definition:
     kind: ""


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1726
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

This PR will generate the activity_type's typescript Library used to author the command expansions.  Here is the workflow:

1. Use a Hasura action and provide the `missionModelID` and `Activity_Type's` name. The action will provide this information to the commanding server
2. The commanding server will retrieve the parameters from the activity_type
3. Once the parameters are queried, a typescript library is generated
4. The library is base64 encoded and sent back as the response to the Hasura action

## Verification
I test locally without any issues using `ParmeterTest` activity_type, which has very complicated parameters objects. 

1. `docker system prune --all --volumes` nuke everything 
2. `./gradlew clean; ./gradlew assemble; docker compose -f docker-compose.yml build; docker compose -f docker-compose.yml up` 
3. Add a mission model jar
4. Run the action which has the activity_type name and mission model 

```
query MyQuery {
  getActivityTypeScript(activityTypeName: "BakeBananaBread", missionModelId: "1") {
    typescript
  }
}
```
5. Verify that you receive `base64` string back from the action.
6. Take the string and convert it with this URL: https://www.base64decode.org/


## Documentation
I will have to add these steps to the User Guide that we will be giving the users

## Future work
Creating Hasura action for the other endpoints in the commanding server and hooking up the rest of the commanding server. 
