### PR TITLE
Feature/Parameterize versioning for releases and snapshots

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
 jobs:
   publish:
@@ -85,7 +86,7 @@ jobs:
           labels: ${{ steps.aerieCommanding.outputs.labels }}
       # Publish via Gradle.
       - name: Publish Package
-        run: ./gradlew publish
+        run: ./gradlew publish -Pversion.isRelease=$IS_RELEASE
         env:
           GITHUB_TOKEN: ${{ github.token }}
       # Publish deployment via action artifact uploader.

--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,15 @@ subprojects {
   }
 
   group = 'gov.nasa.jpl.aerie'
-  def hash = 'git rev-parse --short HEAD'.execute().text.trim()
-  version = "0.10.0-SNAPSHOT-$hash"
+
+  version = {
+    if (findProperty("version.isRelease").toBoolean()) {
+      return "${findProperty("version.number")}"
+    } else {
+      def hash = 'git rev-parse --short HEAD'.execute().text.trim()
+      return "${findProperty("version.number")}-SNAPSHOT-$hash"
+    }
+  }()
 
   tasks.withType(JavaCompile) {
     options.compilerArgs << '-Xlint:deprecation' << '-Xlint:unchecked'

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,11 @@ publishing.name=GitHubPackages
 publishing.url=https://maven.pkg.github.com/nasa-ammos/aerie
 publishing.usernameEnvironmentVariable=GITHUB_ACTOR
 publishing.passwordEnvironmentVariable=GITHUB_TOKEN
+
+# Override for releases
+
+# Change the version number here
+version.number=0.10.1
+# If you are publishing a release *manually* (i.e. not through github actions),
+# override this on the command line with `./gradlew publish -Pversion.isRelease=true`.
+version.isRelease=false // override this on the command line


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Added two properties to `gradle.properties`: `version.number` and `version.isRelease`. `build.gradle` will use these two properties to set the version:

- `version.number`: standard version number
- `version.isRelease`: defaults to `false`. If `true`, the version will be `<version.number>`. If `false`, the version will be `<version.number>-SNAPSHOT-<git commit hash>`.

Github actions will automatically set the `version.isRelease` property to `true` when a tag is pushed.

## Verification
I have manually tested the properties on the command line, making sure that they can be overridden and the correct version string is produced. **I haven't** tested whether the github workflow correctly detects releases and sets the property. Please suggest a way if you think of one.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
