### PR TITLE
[REFACTOR] Keep `node_modules/` directory upon `gradle clean`

### DIFF
--- a/command-expansion-server/build.gradle
+++ b/command-expansion-server/build.gradle
@@ -27,5 +27,5 @@ task build {
 
 task clean(type: Delete) {
   dependsOn undoDistributeSql
-  delete 'build', 'node_modules'
+  delete 'build'
 }


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

Keep `node_modules/` directory when running `gradle clean`. This will make node `clean`s similar to Java `clean`s where downloaded dependencies are not removed. Note that Grade caches Java dependencies locally (`$HOME/.gradle`).
