### PR TITLE
[REFACTOR] Open debug ports on java servers in dev docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,9 @@ services:
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
       MERLIN_LOGGING: "true"
       MERLIN_PORT: 27183
+      JAVA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
     image: aerie_merlin
-    ports: ["27183:27183"]
+    ports: ["27183:27183", "5005:5005"]
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store
@@ -81,8 +82,9 @@ services:
       SCHEDULER_OUTPUT_MODE: UpdateInputPlanWithNewActivities
       SCHEDULER_PORT: 27193
       SCHEDULER_RULES_JAR: /usr/src/app/merlin_file_store/scheduler_rules.jar
+      JAVA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
     image: aerie_scheduler
-    ports: ["27193:27193"]
+    ports: ["27193:27193", "5006:5005"]
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR sets the `JAVA_OPTS` environment variables for both the merlin server and the scheduler server.

Both servers will be listening for incoming debugger connections. `aerie_merlin` is listening at port `5005`, and `aerie_scheduler` is listening at port `5006`.

To connect IntelliJ to these ports, go to "Edit Configurations", hit the plus button at the top left, and select "Remote JVM Debug". I recommend adding one configuration for merlin (set the port to 5005) and a separate configuration for the scheduler (set the port to 5006). You can actually run both at the same time, as I just discovered!

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I followed the above steps and connected to both the scheduler and merlin. I placed a breakpoint in the simulation code before running a simulation to make sure the `aerie_merlin` connection worked. I placed a breakpoint in the scheduler-server code and ran scheduling to make sure that the `aerie_scheduler` connection worked.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Some dev documentation is probably in order here.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None off the top of my head.
