### PR TITLE
[AERIE-1727] Add `put-expansion` endpoint

### DIFF
--- a/command-expansion-server/src/app.ts
+++ b/command-expansion-server/src/app.ts
@@ -8,11 +8,12 @@ import * as ampcs from "@nasa-jpl/aerie-ampcs";
 import { processDictionary } from "./packages/lib/CommandTypeCodegen.js";
 import { getActivityTypescript } from "./getActivityTypescript.js";
 import { getCommandTypescriptTypes } from "./getCommandTypescriptTypes.js";
+import { ErrorWithStatusCode } from "./utils/ErrorWithStatusCode.js";
 
 const PORT: number = parseInt(getEnv().PORT, 10) ?? 3000;
 
 const app: Application = express();
-app.use(bodyParser.json({ limit: "25mb" }));
+app.use(bodyParser.json({ limit: '25mb' }));
 
 DbExpansion.init();
 const db = DbExpansion.getDb();
@@ -36,12 +37,12 @@ app.post("/put-dictionary", async (req, res) => {
   console.log(`command-lib generated - path: ${commandDictionaryPath}`);
 
   const sqlExpression = `
-      insert into command_dictionary (command_types, mission, version)
-      values ($1, $2, $3)
-      on conflict (mission, version) do update
-      set command_types = $1
-      returning id;
-    `;
+    insert into command_dictionary (command_types, mission, version)
+    values ($1, $2, $3)
+    on conflict (mission, version) do update
+    set command_types = $1
+    returning id;
+  `;
 
   const { rows } = await db.query(sqlExpression, [
     commandDictionaryPath,
@@ -49,28 +50,41 @@ app.post("/put-dictionary", async (req, res) => {
     parsedDictionary.header.version,
   ]);
 
-  if (rows.length < 0) {
+  if (rows.length < 1) {
     console.error(`POST /dictionary: No command dictionary was updated in the database`);
-    res.status(400).json({ message: `POST /dictionary: No command dictionary was updated in the database` });
-  } else {
-    const id = rows[0].id;
-    res.status(200).json({ id });
+    res.status(500).send(`POST /dictionary: No command dictionary was updated in the database`);
+    return;
   }
+  const id = rows[0].id;
+  res.status(200).json({ id });
   return;
 });
 
-app.put("/expansion/:activityTypeName", async (req, res) => {
-  res.status(501).send("PUT /expansion: Not implemented");
+app.post('/put-expansion', async (req, res) => {
+  const activityTypeName = req.body.input.activityTypeName as string;
+  const expansionLogicBase64 = req.body.input.expansionLogic as string;
+
+  const { rows } = await db.query(`
+    INSERT INTO expansion_rules (activity_type, expansion_logic)
+    VALUES ($1, $2)
+    RETURNING id;
+  `, [
+    activityTypeName,
+    expansionLogicBase64,
+  ]);
+
+  if (rows.length < 1) {
+    throw new Error(`POST /put-expansion: No expansion was updated in the database`);
+  }
+
+  const id = rows[0].id;
+  console.log(`POST /put-expansion: Updated expansion in the database: id=${id}`);
+  res.status(200).json({ id });
   return;
 });
 
-app.get("/expansion/:expansionId(\\d+)", async (req, res) => {
-  res.status(501).send("GET /expansion: Not implemented");
-  return;
-});
-
-app.put("/expansion-set", async (req, res) => {
-  res.status(501).send("PUT /expansion-set: Not implemented");
+app.put('/expansion-set', async (req, res) => {
+  res.status(501).send('PUT /expansion-set: Not implemented');
   return;
 });
 
@@ -82,7 +96,6 @@ app.post("/get-command-typescript", async (req, res) => {
   res.status(200).json({
     typescript: commandTypescriptBase64,
   });
-
   return;
 });
 
@@ -101,12 +114,12 @@ app.post("/get-activity-typescript", async (req, res) => {
 
 app.get("/commands/:expansionRunId(\\d+)/:activityInstanceId(\\d+)", async (req, res) => {
   // Pull existing expanded commands for an activity instance of an expansion run
-  res.status(501).send("GET /commands: Not implemented");
+  res.status(501).send('GET /commands: Not implemented');
   return;
 });
 
-app.post("/expand-all-activity-instances/:simulationId(\\d+)/:expansionSetId(\\d+)", async (req, res) => {
-  res.status(501).send("POST /expand-all-activity-instances: Not implemented");
+app.post('/expand-all-activity-instances/:simulationId(\\d+)/:expansionSetId(\\d+)', async (req, res) => {
+  res.status(501).send('POST /expand-all-activity-instances: Not implemented');
   return;
 });
 

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -10,6 +10,13 @@ type Mutation {
   uploadDictionary(dictionary: String!): CommandDictionaryResponse
 }
 
+type Mutation {
+  addCommandExpansionTypeScript(
+    activityTypeName: String!
+    expansionLogic: String!
+  ): AddCommandExpansionResponse
+}
+
 type Query {
   getModelEffectiveArguments(
     missionModelId: ID!
@@ -115,6 +122,10 @@ type SchedulingResponse {
 
 type CommandDictionaryResponse {
   id: Int!
+}
+
+type AddCommandExpansionResponse {
+  expansionId: Int!
 }
 
 type TypeScriptResponse {

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -44,6 +44,12 @@ type Query {
 }
 
 type Query {
+  schedule(
+    specificationId: Int!
+  ): SchedulingResponse
+}
+
+type Query {
   simulate(
     planId: Int!
   ): MerlinSimulationResponse
@@ -64,13 +70,13 @@ type Query {
   ): ValidationResponse
 }
 
-type Query {
-  schedule(
-    specificationId: Int!
-  ): SchedulingResponse
+enum MerlinSimulationStatus {
+  complete
+  failed
+  incomplete
 }
 
-enum MerlinSimulationStatus {
+enum SchedulingStatus {
   complete
   failed
   incomplete
@@ -113,12 +119,6 @@ type CommandDictionaryResponse {
 
 type TypeScriptResponse {
   typescript: String!
-}
-
-enum SchedulingStatus {
-  complete
-  failed
-  incomplete
 }
 
 scalar ResourceSchema

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -74,6 +74,9 @@ custom_types:
     - name: ValidationResponse
     - name: EffectiveArgumentsResponse
     - name: AddExternalDatasetResponse
+    - name: SchedulingResponse
+    - name: CommandDictionaryResponse
+    - name: TypeScriptResponse
   scalars:
     - name: ResourceSchema
     - name: MerlinSimulationResults
@@ -81,3 +84,4 @@ custom_types:
     - name: ModelArguments
     - name: ActivityArguments
     - name: ProfileSet
+    - name: SchedulingFailureReason

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -7,6 +7,10 @@ actions:
     definition:
       kind: synchronous
       handler: http://aerie_commanding:3000/put-dictionary
+  - name: addCommandExpansionTypeScript
+    definition:
+      kind: synchronous
+      handler: http://aerie_commanding:3000/put-expansion
   - name: getModelEffectiveArguments
     definition:
       kind: ""
@@ -76,6 +80,7 @@ custom_types:
     - name: AddExternalDatasetResponse
     - name: SchedulingResponse
     - name: CommandDictionaryResponse
+    - name: AddCommandExpansionResponse
     - name: TypeScriptResponse
   scalars:
     - name: ResourceSchema


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1727
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds `put-expansion` endpoint and Hasura action.
Initially a `get-expansion` endpoint & action was implemented but it was decided that this is unneeded right now and the UI/clients can simply look inside the `expansion_rules.expansion_logic` column and deserialize the text as base64.

From Dylan's https://github.com/NASA-AMMOS/aerie/pull/82.

## Verification

1. Start with a clean slate: `docker system prune --all --volumes`
1. Start the Docker stack: `./gradlew clean; ./gradlew assemble; docker compose -f docker-compose.yml build; docker compose -f docker-compose.yml up`
1. Run `echo 'hello world' | base64 | pbcopy` to encode a message in base 64 and copy to your clipboard.
1. Run
```graphql
mutation Test {
  addCommandExpansionTypeScript(activityTypeName: "Test", expansionLogic: "aGVsbG8gd29ybGQK") {
    expansionId
  }
}
```
→
```json
{
  "data": {
    "addCommandExpansionTypeScript": {
      "expansionId": 34
    }
  }
}
```
To retrieve the stored expansion logic inspect the `expansion_rules` table and find `"aGVsbG8gd29ybGQK"` under the `expansion_logic` column for id `34`.

<!---
1. Download the command dictionary: https://jira.jpl.nasa.gov/browse/AERIE-1633
1. Run `cat <command_xml_file> | base64 | pbcopy` to encode in base 64 and copy to your clipboard.
    Take the base64 string and paste it as `<INSERT>`
    ```gql
    mutation MyMutation {
      uploadDictionary(dictionary: "<INSERT>") {
        id
      }
    }
    ```
6.  Verify the query returns an ID to the Postgres table
7.  Look at Hasura and verify you see the entries in the command-dictionary table
-->
## Documentation

I will have to add these steps to the User Guide that we will be giving the users

## Future work

Implement the `expand` endpoint (AERIE-1741 & AERIE-1729) to actually evaluate the expansion logic.