### PR TITLE
[AERIE-1733] Set merlin log level and output file in docker-compose

### DIFF
--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -50,15 +50,15 @@ Additionally, Hasura provides documentation on it's own environment variables yo
 ## Merlin
 
 | Name                 | Description                                               | Type     | Default                        |
-| -------------------- | --------------------------------------------------------- | -------- | ------------------------------ |
+|----------------------|-----------------------------------------------------------| -------- | ------------------------------ |
 | `MERLIN_PORT`        | Port number for the Merlin server                         | `number` | 27183                          |
 | `MERLIN_LOCAL_STORE` | Local storage for Merlin in the container                 | `string` | /usr/src/app/merlin_file_store |
-| `MERLIN_LOGGING`     | Whether or not you want Javalin to log server information | `string` | true                           |
 | `MERLIN_DB_SERVER`   | The DB instance that Merlin will connect with             | `string` | postgres                       |
 | `MERLIN_DB_PORT`     | The DB instance port number that Merlin will connect with | `number` | 5432                           |
 | `MERLIN_DB_USER`     | Username of the DB instance                               | `string` | aerie                          |
 | `MERLIN_DB_PASSWORD` | Password of the DB instance                               | `string` | aerie                          |
 | `MERLIN_DB`          | The DB for Merlin.                                        | `string` | aerie_merlin                   |
+| `JAVA_OPTS`          | Configuration for Merlin's logging level and output file  | `string` | aerie_merlin                   |
 
 ## Postgres
 

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -29,8 +29,10 @@ services:
       MERLIN_DB_SERVER: "postgres"
       MERLIN_DB_USER: "aerie"
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
-      MERLIN_LOGGING: "true"
       MERLIN_PORT: 27183
+      JAVA_OPTS: >
+        -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
+        -Dorg.slf4j.simpleLogger.logFile=System.err
     image: "ghcr.io/nasa-ammos/aerie-merlin:latest"
     ports: ["27183:27183"]
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,9 +55,11 @@ services:
       MERLIN_DB_SERVER: "postgres"
       MERLIN_DB_USER: "aerie"
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
-      MERLIN_LOGGING: "true"
       MERLIN_PORT: 27183
-      JAVA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
+      JAVA_OPTS: >
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+        -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+        -Dorg.slf4j.simpleLogger.logFile=System.err
     image: aerie_merlin
     ports: ["27183:27183", "5005:5005"]
     restart: always

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/config/AppConfiguration.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/config/AppConfiguration.java
@@ -2,16 +2,14 @@ package gov.nasa.jpl.aerie.merlin.server.config;
 
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.Optional;
 
 public record AppConfiguration (
     int httpPort,
-    JavalinLoggingState javalinLogging,
+    boolean enableJavalinDevLogging,
     Path merlinFileStore,
     Store store
 ) {
   public AppConfiguration {
-    Objects.requireNonNull(javalinLogging);
     Objects.requireNonNull(merlinFileStore);
     Objects.requireNonNull(store);
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/config/JavalinLoggingState.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/config/JavalinLoggingState.java
@@ -1,9 +1,0 @@
-package gov.nasa.jpl.aerie.merlin.server.config;
-
-public enum JavalinLoggingState {
-  Enabled, Disabled;
-
-  public boolean isEnabled() {
-    return (this == Enabled);
-  }
-}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -17,7 +17,9 @@ import gov.nasa.jpl.aerie.merlin.server.remotes.MissionModelRepository;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implements the missionModel service {@link MissionModelService} interface on a set of local domain objects.
@@ -27,7 +29,7 @@ import java.util.logging.Logger;
  * connected mission model repository.
  */
 public final class LocalMissionModelService implements MissionModelService {
-  private static final Logger log = Logger.getLogger(LocalMissionModelService.class.getName());
+  private static final Logger log = LoggerFactory.getLogger(LocalMissionModelService.class);
 
   private final Path missionModelDataPath;
   private final MissionModelRepository missionModelRepository;
@@ -187,7 +189,7 @@ public final class LocalMissionModelService implements MissionModelService {
   {
     final var config = message.configuration();
     if (config.isEmpty()) {
-      log.warning(
+      log.warn(
           "No mission model configuration defined for mission model. Simulations will receive an empty set of configuration arguments.");
     }
 


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1733
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Merlin server uses Javalin, which is configured to use slf4j for logging. I've added the ability to configure the logging level (default INFO) and output file (default is stderr, but can be set to a file).

Level options (decreasing verbosity):
- TRACE (javalin doesn't output trace logs, so this is meaningless)
- DEBUG
- INFO (dev default)
- WARN (deploy default)
- ERROR
- OFF

Javalin instantiates its logger statically in life-before-main, so the log level and file (which are java system properties) cannot be set by merlin at runtime. `JAVA_OPTS` is the only env variable that can set system properties, and I can't interpolate another variable into it. So the configuration has to go directly in `JAVA_OPTS`, which is terrible, but it works.

Configuration is in the `AERIE_MERLIN: environment: JAVA_OPTS` variable in `docker-compose.yml`. I don't know where I should document that.

## Verification
I've been able to set the log level and verify that merlin's log output matches. When I set the output file, the stderr output disappears, but I don't know much about docker and have no idea where to find that file. As far as I know that output vanished into the aether.

## Documentation
I don't know where to document this, please advise.

## Future work
I'll have to do the same thing to the scheduler server.