### PR TITLE
[HOTFIX] Boolean enums should be type `boolean`

### DIFF
--- a/command-expansion-server/src/packages/lib/CommandTypeCodegen.ts
+++ b/command-expansion-server/src/packages/lib/CommandTypeCodegen.ts
@@ -174,7 +174,16 @@ ${doc}
 function mapArgumentType(argument: ampcs.FswCommandArgument, enumMap: ampcs.EnumMap): string {
   switch (argument.arg_type) {
     case "enum":
-      return enumMap[argument.enum_name].values.map((value) => `'${value.symbol}'`).join(" | ");
+      // boolean enum shouldn't be "TRUE | FALSE" but of `boolean` type
+      if (
+        enumMap[argument.enum_name].values.length === 2 &&
+        enumMap[argument.enum_name].values.some(({ symbol, numeric }) => symbol.toLocaleLowerCase() === "true") &&
+        enumMap[argument.enum_name].values.some(({ symbol, numeric }) => symbol.toLocaleLowerCase() === "false")
+      ) {
+        return "boolean";
+      } else {
+        return enumMap[argument.enum_name].values.map((value) => `'${value.symbol}'`).join(" | ");
+      }
     case "boolean":
       return "boolean";
     case "float":


### PR DESCRIPTION

* **Tickets addressed:** AERIE-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Converting the command_dictionary boolean enums to typescript yields "TRUE | FALSE" enum, which isn't usable in the authoring part of command expansion. This code change allows you to do the following below

ex.

BAKE_BANANA_BREAD(activity.glutenFree)
BAKE_BANANA_BREAD(!activity.glutenFree)

