### PR TITLE
build: remove env vars from docker-compose

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -68,8 +68,6 @@ services:
       GATEWAY_SERVER_URL: http://aerie_gateway:9000
       HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
       HASURA_SERVER_URL: http://hasura:8080/v1/graphql
-      SCHEDULER_CLIENT_URL: http://localhost:27193
-      SCHEDULER_SERVER_URL: http://scheduler:27193
     image: "ghcr.io/nasa-ammos/aerie-ui:latest"
     ports: ["80:80"]
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,8 +100,6 @@ services:
       HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
       HASURA_SERVER_URL: http://hasura:8080/v1/graphql
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
-      SCHEDULER_CLIENT_URL: http://localhost:27193
-      SCHEDULER_SERVER_URL: http://scheduler:27193
     image: "ghcr.io/nasa-ammos/aerie-ui:develop"
     ports: ["80:80"]
     restart: always


### PR DESCRIPTION
- UI scheduler env vars are obsolete

