### PR TITLE
Configure Hasura log level through env vars

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -83,6 +83,7 @@ services:
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
+      HASURA_GRAPHQL_LOG_LEVEL: warn
       HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_hasura
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
     image: "hasura/graphql-engine:v2.2.0.cli-migrations-v3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,7 @@ services:
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
+      HASURA_GRAPHQL_LOG_LEVEL: info
       HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_hasura
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
     image: "hasura/graphql-engine:v2.2.0.cli-migrations-v3"


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Add the `HASURA_GRAPHQL_LOG_LEVEL` environment variable to both docker-compose.yml's.

- dev level: info
  - info is the default if unset, so this does not change any behavior
- deploy level: warn
  - this eliminates most of hasura's info output (see verification)

## Verification
I verified that changing this parameter does filter output. It seems there is a bug in hasura where some logs are mislabeled; setting the level to `warn` eliminates most, but not all, of the logs that contain the field `"level": "info"`.

## Documentation
Hasura's usual environment variables (i.e. the ones we didn't make) aren't documented in `deployment/Environment.md`, so I didn't add this one.
