### PR TITLE
[HOTFIX] Hasura CommandExpansionResponse should return id.

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -125,7 +125,7 @@ type CommandDictionaryResponse {
 }
 
 type AddCommandExpansionResponse {
-  expansionId: Int!
+  id: Int!
 }
 
 type TypeScriptResponse {


### PR DESCRIPTION

## Description
The server returns json `{id:number}`, but the hasura action was expecting `{expansionID:number}`. This causes an error when running the Hasura mutation.

## Verification
I tested locally with this hasura query:

```
mutation Test {
  addCommandExpansionTypeScript(activityTypeName: "BakeBananaBread", expansionLogic: "aGVsbG8gd29ybGQK") {
  id
  }
}
```

