### PR TITLE
refactor: add more Hasura metadata for scheduling

### DIFF
--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal.yaml
@@ -1,3 +1,11 @@
 table:
   name: scheduling_goal
   schema: public
+array_relationships:
+- name: analyses
+  using:
+    foreign_key_constraint_on:
+      column: goal_id
+      table:
+        name: scheduling_goal_analysis
+        schema: public

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal_analysis.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal_analysis.yaml
@@ -1,3 +1,24 @@
 table:
   name: scheduling_goal_analysis
   schema: public
+object_relationships:
+- name: request
+  using:
+    manual_configuration:
+      remote_table:
+        schema: public
+        name: scheduling_request
+      insertion_order: null
+      column_mapping:
+        analysis_id: analysis_id
+array_relationships:
+- name: satisfying_activities
+  using:
+    manual_configuration:
+      remote_table:
+        schema: public
+        name: scheduling_goal_analysis_satisfying_activities
+      insertion_order: null
+      column_mapping:
+        goal_id: goal_id
+        analysis_id: analysis_id


### PR DESCRIPTION
## Description

- add goal relationship to analyses
- add goal analysis relationship to request and satisfying activities

## Example

The following query gets all spec goals for a given spec id. Then for each goal it gets the last two analyses based on the scheduling request spec revision. It also demonstrates how to get a count of satisfying activities in an analysis using an aggregate query.

```gql
query SchedulingSpecGoals($specification_id: Int!) {
  scheduling_specification_goals(where: { specification_id: { _eq: $specification_id } }) {
    goal {
      name
      analyses(order_by: { request: { specification_revision: desc } }, limit: 2) {
        request {
          specification_revision
        }
        satisfied
        satisfying_activities {
          activity_id
        }
        satisfying_activities_aggregate {
          aggregate {
            count
          }
        }
      }
    }
  }
}
```
