### PR TITLE
[AERIE-1750] Configure gateway logging

### DIFF
--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -12,8 +12,10 @@ This document provides detailed information about environment variables for each
 ## Aerie Gateway
 
 | Name                          | Description                                                | Type     | Default                          |
-| ----------------------------- | ---------------------------------------------------------- | -------- | -------------------------------- |
+|-------------------------------|------------------------------------------------------------| -------- |----------------------------------|
 | `GQL_API_URL`                 | URL of GraphQL API for the GraphQL Playground.             | `string` | http://localhost:8080/v1/graphql |
+| `LOG_FILE`                    | Either an output filepath to log to, or 'console'.         | `string` | console                          |
+| `LOG_LEVEL`                   | Logging level for filtering logs.                          | `string` | warn                             |
 | `PORT`                        | Port the Gateway server listens on.                        | `number` | 9000                             |
 | `POSTGRES_AERIE_MERLIN_DB`    | Name of Merlin Postgres database.                          | `string` | aerie_merlin                     |
 | `POSTGRES_AERIE_SCHEDULER_DB` | Name of scheduler Postgres database.                       | `string` | aerie_scheduler                  |

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       AUTH_TYPE: none
       GQL_API_URL: http://localhost:8080/v1/graphql
+      LOG_FILE: console
+      LOG_LEVEL: warn
       PORT: 9000
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin
       POSTGRES_AERIE_SCHEDULER_DB: aerie_scheduler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       AUTH_TYPE: cam
       AUTH_URL: https://atb-ocio-12b.jpl.nasa.gov:8443/cam-api
       GQL_API_URL: http://localhost:8080/v1/graphql
+      LOG_FILE: console
+      LOG_LEVEL: debug
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
       PORT: 9000
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1750
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Makes use of the logging changes in aerie-gateway from [this pr](https://github.com/NASA-AMMOS/aerie-gateway/pull/2).

- Adds a `LOG_FILE` environment variable
  - default: `console` (special value, does what you think it does)
- Adds a `LOG_LEVEL` environment variable
  - dev default: `debug`
  - deploy default: `warn`
- Adds documentation of this to `deployment/Environment.md`.

## Verification
I manually verified that setting these variables filters / redirects output correctly.

## Documentation
`deployment/Environment.md` is updated.