### PR TITLE
[HOTFIX] Check activity DurationType before setting its duration parameter

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -72,21 +72,27 @@ public final class SimulationEngine implements AutoCloseable {
   /** Construct a task defined by the behavior of a model given a type and arguments. */
   public <Model>
   TaskId initiateTaskFromInput(final MissionModel<Model> model, final SerializedActivity input) {
-    final var task = TaskId.generate();
-
-    final Directive<Model, ?, ?> directive;
     try {
-      directive = model.instantiateDirective(input);
+      return initiateTaskFromInputOrFail(model, input);
     } catch (final TaskSpecType.UnconstructableTaskSpecException ex) {
+      final var task = TaskId.generate();
+
       // TODO: Provide more information about the failure.
-      this.tasks.put(task, new ExecutionState.IllegalSource());
+      this.tasks.put(task, new ExecutionState.IllegalSource<>());
 
       return task;
     }
+  }
 
+  /** Construct a task defined by the behavior of a model given a type and arguments. */
+  public <Model>
+  TaskId initiateTaskFromInputOrFail(final MissionModel<Model> model, final SerializedActivity input)
+  throws TaskSpecType.UnconstructableTaskSpecException
+  {
+    final var directive  = model.instantiateDirective(input);
+    final var task = TaskId.generate();
     this.tasks.put(task, new ExecutionState.NotStarted<>(() -> directive.createTask(model.getModel())));
     this.taskDirective.put(task, directive);
-
     return task;
   }
 

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationDriver.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationDriver.java
@@ -8,6 +8,7 @@ import gov.nasa.jpl.aerie.merlin.driver.engine.SimulationEngine;
 import gov.nasa.jpl.aerie.merlin.driver.engine.TaskId;
 import gov.nasa.jpl.aerie.merlin.driver.timeline.LiveCells;
 import gov.nasa.jpl.aerie.merlin.driver.timeline.TemporalEventSource;
+import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -102,7 +103,9 @@ public class IncrementalSimulationDriver {
   }
 
 
-  public void simulateActivity(SerializedActivity activity, Duration startTime, ActivityInstanceId activityId){
+  public void simulateActivity(SerializedActivity activity, Duration startTime, ActivityInstanceId activityId)
+  throws TaskSpecType.UnconstructableTaskSpecException
+  {
     final var activityToSimulate = new SimulatedActivity(startTime, activity, activityId);
     if(startTime.noLongerThan(curTime)){
       final var toBeInserted = new ArrayList<>(activitiesInserted);
@@ -158,7 +161,9 @@ public class IncrementalSimulationDriver {
     return lastSimResults;
   }
 
-  private void simulateSchedule(Map<ActivityInstanceId, Pair<Duration, SerializedActivity>> schedule){
+  private void simulateSchedule(final Map<ActivityInstanceId, Pair<Duration, SerializedActivity>> schedule)
+  throws TaskSpecType.UnconstructableTaskSpecException
+  {
 
     if(schedule.isEmpty()){
       throw new IllegalArgumentException("simulateSchedule() called with empty schedule, use simulateUntil() instead");
@@ -169,7 +174,7 @@ public class IncrementalSimulationDriver {
       final var startOffset = entry.getValue().getLeft();
       final var directive = entry.getValue().getRight();
 
-      final var taskId = engine.initiateTaskFromInput(missionModel, directive);
+      final var taskId = engine.initiateTaskFromInputOrFail(missionModel, directive);
       engine.scheduleTask(taskId, startOffset);
       plannedDirectiveToTask.put(directiveId,taskId);
       taskToPlannedDirective.put(taskId, directiveId);

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationBenchmark.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationBenchmark.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.scheduler;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationDriver;
+import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -21,7 +22,7 @@ public class IncrementalSimulationBenchmark {
    * to simulate a plan with a number of _left activities. Note that this is an ideal case for the incremental driver as
    * it never has to reset.
    */
-  public static void main(String[] args){
+  public static void main(String[] args) throws TaskSpecType.UnconstructableTaskSpecException {
     System.out.println("Incremental");
     benchmarkIncrementalSimulationDriver();
     System.out.println("Non-incremental");
@@ -63,7 +64,7 @@ public class IncrementalSimulationBenchmark {
     }
   }
 
-  private static void benchmarkIncrementalSimulationDriver(){
+  private static void benchmarkIncrementalSimulationDriver() throws TaskSpecType.UnconstructableTaskSpecException {
     final var acts = getActivities();
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     final var incrementalSimulationDriver = new IncrementalSimulationDriver(fooMissionModel);

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationTest.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.scheduler;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
+import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,7 @@ public class IncrementalSimulationTest {
   Duration endOfLastAct;
 
   @BeforeEach
-  public void init() {
+  public void init() throws TaskSpecType.UnconstructableTaskSpecException {
     final var acts = getActivities();
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     incrementalSimulationDriver = new IncrementalSimulationDriver(fooMissionModel);

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
@@ -137,21 +137,21 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void getValueAtTimeDoubleOnSimplePlanMidpoint() {
+  public void getValueAtTimeDoubleOnSimplePlanMidpoint() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
     var actual = getFruitRes().getValueAtTime(t1_5);
     assertThat(actual).isEqualTo(SerializedValue.of(3.0));
   }
 
   @Test
-  public void getValueAtTimeDoubleOnSimplePlan() {
+  public void getValueAtTimeDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
     var actual = getFruitRes().getValueAtTime(t2);
     assertThat(actual).isEqualTo(SerializedValue.of(2.9));
   }
 
   @Test
-  public void whenValueAboveDoubleOnSimplePlan() {
+  public void whenValueAboveDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
     var actual = getFruitRes().whenValueAbove(SerializedValue.of(2.9), entireHorizon);
     var expected = new Windows(Window.betweenClosedOpen(t0, t2));
@@ -159,7 +159,7 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void whenValueBelowDoubleOnSimplePlan() {
+  public void whenValueBelowDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
     var actual = getFruitRes().whenValueBelow(SerializedValue.of(3.0), entireHorizon);
     var expected = new Windows(Window.betweenClosedOpen(t2, tEnd));
@@ -167,7 +167,7 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void whenValueBetweenDoubleOnSimplePlan() {
+  public void whenValueBetweenDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
     var actual = getFruitRes().whenValueBetween(SerializedValue.of(3.00), SerializedValue.of(3.99), entireHorizon);
     var expected = new Windows(Window.betweenClosedOpen(t1, t2));
@@ -175,7 +175,7 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void whenValueEqualDoubleOnSimplePlan() {
+  public void whenValueEqualDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
     var actual = getFruitRes().whenValueEqual(SerializedValue.of(3.00), entireHorizon);
     var expected = new Windows(Window.betweenClosedOpen(t1, t2));
@@ -183,7 +183,7 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void whenValueNotEqualDoubleOnSimplePlan() {
+  public void whenValueNotEqualDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
     var actual = getFruitRes().whenValueNotEqual(SerializedValue.of(3.00), entireHorizon);
     var expected = new Windows(List.of(Window.betweenClosedOpen(t0, t1), Window.betweenClosedOpen(t2, tEnd)));


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
When combining #71  with #54 , we didn't re-implement the checks for an activity's DurationType. Thus, we were attempting to instantiate activities with an extraneous duration parameter.

The new simulation driver loops until the activity completes. If an activity failed to be instantiated, rather than throw an exception, it will be placed in the `IllegalSource` state. Thus, it will never reach the `Terminated` state, so the simulation driver will loop forever. This is the behavior that @camargo observed.

With @adrienmaillard 's help, we identified this issue and implemented the fix - prior to adding a duration parameter, the driver will check that an activity's `DurationType` is `Controllable`.

In addition to implementing the fix, we added a method called `initiateTaskOrFail` to the simulation engine, whose job it is to propagate the `UnconstructableTaskException` to the caller.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
We reproduced Chris's issue by running the api-tests:
```
git checkout prototype/api-tests settings.gradle api-tests
./gradlew :api-tests:run
```
We observed that the tests were timing out.

We then made our fix, and re-ran the tests, and saw that they did not time out.

We also ran the tests without the fix, but with our additional exception logging, and saw in the logs that the errors were reported correctly.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No scheduler docs... yet

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- @adrienmaillard and I discussed that the scheduler lacks a unified error handling strategy. We should decide on a strategy, standardize it across the scheduler-server and the scheduler, and figure out how to display those errors to users. Adrien proposed some sort of console pane in the UI - we would need to do some UX design on this topic.