### PR TITLE
[AERIE-1676] Look up ActivityTypes from Problem when building Goals

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GoalRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GoalRecord.java
@@ -1,5 +1,3 @@
 package gov.nasa.jpl.aerie.scheduler.server.models;
 
-import gov.nasa.jpl.aerie.scheduler.Goal;
-
-public final record GoalRecord(GoalId id, Goal definition) {}
+public final record GoalRecord(GoalId id, SchedulingDSL.GoalSpecifier definition) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
@@ -8,43 +8,11 @@ import gov.nasa.jpl.aerie.scheduler.OptionGoal;
 import gov.nasa.jpl.aerie.scheduler.PlanningHorizon;
 import gov.nasa.jpl.aerie.scheduler.RecurrenceGoal;
 import gov.nasa.jpl.aerie.scheduler.Time;
-import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
-import gov.nasa.jpl.aerie.scheduler.server.models.GoalRecord;
-import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
 import gov.nasa.jpl.aerie.scheduler.server.models.SchedulingDSL;
 import gov.nasa.jpl.aerie.scheduler.server.models.Timestamp;
-import gov.nasa.jpl.aerie.scheduler.server.services.SchedulingDSLCompilationService;
 
 public class GoalBuilder {
-  sealed interface GoalBuildResult {
-    record Success(GoalRecord goalRecord) implements GoalBuildResult {}
-    record Failure(String reason) implements GoalBuildResult {}
-  }
-  static GoalBuildResult buildGoalRecord(
-      final PlanId planId,
-      final PostgresGoalRecord pgGoal,
-      final Timestamp horizonStartTimestamp,
-      final Timestamp horizonEndTimestamp,
-      final SchedulingDSLCompilationService schedulingDSLCompilationService)
-  {
-    final SchedulingDSL.GoalSpecifier goalSpecifier;
-    try {
-      goalSpecifier = schedulingDSLCompilationService.compileSchedulingGoalDSL(
-          planId,
-          pgGoal.definition(),
-          pgGoal.name());
-    } catch (SchedulingDSLCompilationService.SchedulingDSLCompilationException e) {
-      return new GoalBuildResult.Failure(e.getMessage());
-    }
-    final var goalId = new GoalId(pgGoal.id());
-
-    final var goal = goalOfGoalSpecifier(
-        goalSpecifier,
-        horizonStartTimestamp,
-        horizonEndTimestamp);
-
-    return new GoalBuildResult.Success(new GoalRecord(goalId, goalSpecifier));
-  }
+  private GoalBuilder() {}
 
   public static Goal goalOfGoalSpecifier(
       final SchedulingDSL.GoalSpecifier goalSpecifier,

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
@@ -43,10 +43,10 @@ public class GoalBuilder {
         horizonStartTimestamp,
         horizonEndTimestamp);
 
-    return new GoalBuildResult.Success(new GoalRecord(goalId, goal));
+    return new GoalBuildResult.Success(new GoalRecord(goalId, goalSpecifier));
   }
 
-  private static Goal goalOfGoalSpecifier(
+  public static Goal goalOfGoalSpecifier(
       final SchedulingDSL.GoalSpecifier goalSpecifier,
       final Timestamp horizonStartTimestamp,
       final Timestamp horizonEndTimestamp) {

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -105,7 +105,8 @@ public record SynchronousSchedulerAgent(
             .goalOfGoalSpecifier(
                 goalRecord.definition(),
                 specification.horizonStartTimestamp(),
-                specification.horizonEndTimestamp());
+                specification.horizonEndTimestamp(),
+                problem::getActivityType);
         orderedGoals.add(goal);
         goals.put(goal, goalRecord.id());
       }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -24,10 +24,10 @@ import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchSpecificationExcepti
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.ResultsProtocolFailure;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.SpecificationLoadException;
 import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
-import gov.nasa.jpl.aerie.scheduler.server.models.GoalRecord;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanMetadata;
 import gov.nasa.jpl.aerie.scheduler.server.models.Specification;
+import gov.nasa.jpl.aerie.scheduler.server.remotes.postgres.GoalBuilder;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -38,6 +38,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,22 +85,31 @@ public record SynchronousSchedulerAgent(
       //confirm requested plan to schedule from/into still exists at targeted version (request could be stale)
       //TODO: maybe some kind of high level db transaction wrapping entire read/update of target plan revision
 
-      final var specificationWithGoals = specificationService.getSpecification(request.specificationId());
-      final var planMetadata = merlinService.getPlanMetadata(specificationWithGoals.planId());
+      final var specification = specificationService.getSpecification(request.specificationId());
+      final var planMetadata = merlinService.getPlanMetadata(specification.planId());
       ensureRequestIsCurrent(request);
-      ensurePlanRevisionMatch(specificationWithGoals,planMetadata.planRev());
+      ensurePlanRevisionMatch(specification, planMetadata.planRev());
       //create scheduler problem seeded with initial plan
       final var schedulerMissionModel = loadMissionModel(planMetadata);
-      var planningHorizon = new PlanningHorizon(Time.fromInstant(specificationWithGoals.horizonStartTimestamp().toInstant()),Time.fromInstant(specificationWithGoals.horizonEndTimestamp().toInstant())) ;
+      final var planningHorizon = new PlanningHorizon(Time.fromInstant(specification.horizonStartTimestamp().toInstant()), Time.fromInstant(specification.horizonEndTimestamp().toInstant())) ;
       final var problem = new Problem(schedulerMissionModel.missionModel(), planningHorizon, new SimulationFacade(planningHorizon, schedulerMissionModel.missionModel()), schedulerMissionModel.schedulerModel());
       //seed the problem with the initial plan contents
       problem.setInitialPlan(loadInitialPlan(planMetadata, problem));
 
       //apply constraints/goals to the problem
       loadConstraints(planMetadata, schedulerMissionModel.missionModel()).forEach(problem::add);
-      var orderedGoals = specificationWithGoals.goalsByPriority().stream().map(GoalRecord::definition).collect(Collectors.toList());
+      final var orderedGoals = new ArrayList<Goal>();
+      final var goals = new HashMap<Goal, GoalId>();
+      for (final var goalRecord : specification.goalsByPriority()) {
+        final var goal = GoalBuilder
+            .goalOfGoalSpecifier(
+                goalRecord.definition(),
+                specification.horizonStartTimestamp(),
+                specification.horizonEndTimestamp());
+        orderedGoals.add(goal);
+        goals.put(goal, goalRecord.id());
+      }
       problem.setGoals(orderedGoals);
-      var goals = specificationWithGoals.goalsByPriority().stream().collect(Collectors.toMap(GoalRecord::definition, GoalRecord::id));
 
       final var scheduler = createScheduler(planMetadata,problem);
       //run the scheduler to find a solution to the posed problem, if any
@@ -108,8 +118,8 @@ public record SynchronousSchedulerAgent(
 
       //store the solution plan back into merlin (and reconfirm no intervening mods!)
       //TODO: make revision confirmation atomic part of plan mutation (plan might have been modified during scheduling!)
-      ensurePlanRevisionMatch(specificationWithGoals, getMerlinPlanRev(specificationWithGoals.planId()));
-      var instancesToIds = storeFinalPlan(planMetadata, solutionPlan);
+      ensurePlanRevisionMatch(specification, getMerlinPlanRev(specification.planId()));
+      final var instancesToIds = storeFinalPlan(planMetadata, solutionPlan);
 
       //collect results and notify subscribers of success
       final var results = collectResults(solutionPlan,instancesToIds, goals);

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Evaluation.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Evaluation.java
@@ -156,22 +156,26 @@ public class Evaluation {
     return Objects.hash(goalEvals);
   }
 
-  boolean canAssociateMoreToCreatorOf(ActivityInstance instance){
-    Goal creator = getGoalCreator(instance);
-    if(creator instanceof ActivityExistentialGoal activityExistentialCreator) {
+  boolean canAssociateMoreToCreatorOf(final ActivityInstance instance){
+    final var creator = getGoalCreator(instance)
+        .orElseThrow(() -> new IllegalStateException("No goal is referenced as creator for activity " + instance));
+    if (creator instanceof ActivityExistentialGoal activityExistentialCreator) {
       //we can piggyback
       return activityExistentialCreator.childCustody == ChildCustody.Jointly;
     }
     return true;
   }
 
-  Goal getGoalCreator(ActivityInstance instance){
-    for(var goalEval : goalEvals.entrySet()){
+  /**
+   * If an activity instance was already in the plan prior to this run of the scheduler, this method will return Optional.empty()
+   */
+  Optional<Goal> getGoalCreator(final ActivityInstance instance){
+    for(final var goalEval : goalEvals.entrySet()){
       if(goalEval.getValue().getInsertedActivities().contains(instance)){
-        return goalEval.getKey();
+        return Optional.of(goalEval.getKey());
       }
     }
-    throw new IllegalStateException("No goal is referenced as creator for activity " + instance) ;
+    return Optional.empty();
   }
 
 }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Evaluation.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/Evaluation.java
@@ -157,13 +157,12 @@ public class Evaluation {
   }
 
   boolean canAssociateMoreToCreatorOf(final ActivityInstance instance){
-    final var creator = getGoalCreator(instance)
-        .orElseThrow(() -> new IllegalStateException("No goal is referenced as creator for activity " + instance));
-    if (creator instanceof ActivityExistentialGoal activityExistentialCreator) {
-      //we can piggyback
-      return activityExistentialCreator.childCustody == ChildCustody.Jointly;
-    }
-    return true;
+    final var creator$ = getGoalCreator(instance);
+    if (creator$.isEmpty()) return false;
+    final var creator = creator$.get();
+
+    if (!(creator instanceof ActivityExistentialGoal activityExistentialCreator)) return true;
+    return activityExistentialCreator.childCustody == ChildCustody.Jointly; // we can piggyback
   }
 
   /**


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1676
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

If the scheduler is run on a plan that already satisfies its goals, it should not add any new activities to that plan. One of the ways the scheduler determines that an activity satisfies its goal is by checking its activity type. This activity type check uses object equality - so the corresponding `ActivityType` field needs to be identical in order for an `ActivityExpression` to match an `ActivityInstance`.

This PR updates the GoalBuilder to call `problem.getActivityType` with the name of the activity type, rather than construct a `new ActivityType()` itself.

In order to make this change, the GoalBuilder had to be moved later in the workflow, after the `Problem` object is constructed, but before its `setGoals` method is called.

After making this change, I would get `IllegalStateExceptions` because `Evaluation#canAssociateMoreToCreatorOf` assumes that every activity instance was created by a scheduling goal. This assumption is not, in general, true, because there are already activities in the plan before the scheduler is run. I updated `Evaluation#canAssociateMoreToCreatorOf` to return `true` if an activity was not created by any goal.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
1. Fresh `./gradlew assemble` and `docker-compose build` and `docker-compose up -d`
2. Make an empty plan
3. Add the following scheduling goal:
```typescript
export default function myGoal() {
    return Goal.ActivityRecurrenceGoal({
        activityTemplate: ActivityTemplates.BakeBananaBread('My Goal', { temperature: 325.0, tbSugar: 2, glutenFree: false }),
        interval: 12 * 60 * 60 * 1000 * 1000 // 1 day in microseconds
    })
}
```
4. Run the scheduling goal, observe that it places activities in the plan
5. Run the scheduling goal again, observe that it does NOT place any more activities in the plan
6. Delete a few of the activities it placed from the plan
7. Run the scheduler again and observe that it re-creates the activities you deleted :tada:

https://user-images.githubusercontent.com/1189602/159300691-2a412554-b13f-4f22-acff-6a9b2dce7226.mov

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
In the soon-to-be-written scheduling documentation, it may be worth describing how the scheduler identifies activities in the plan that already satisfy its goals.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Implement more Goal types and test with more activity types