### PR TITLE
[AERIE-1711] Replace DB_TYPE env vars with DB_SERVER env vars

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
@@ -109,7 +109,7 @@ public final class AerieAppDriver {
         Integer.parseInt(getEnv("MERLIN_PORT","27183")),
         logger.isDebugEnabled(),
         Path.of(getEnv("MERLIN_LOCAL_STORE","/usr/src/app/merlin_file_store")),
-        new PostgresStore(getEnv("MERLIN_DB_TYPE","postgres"),
+        new PostgresStore(getEnv("MERLIN_DB_SERVER","postgres"),
                           getEnv("MERLIN_DB_USER","aerie"),
                           Integer.parseInt(getEnv("MERLIN_DB_PORT","5432")),
                           getEnv("MERLIN_DB_PASSWORD","aerie"),

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
@@ -147,7 +147,7 @@ public final class SchedulerAppDriver {
         Integer.parseInt(getEnv("SCHEDULER_PORT", "27193")),
         logger.isDebugEnabled(),
         Path.of(getEnv("SCHEDULER_LOCAL_STORE", "/usr/src/app/scheduler_file_store")),
-        new PostgresStore(getEnv("SCHEDULER_DB_TYPE", "postgres"),
+        new PostgresStore(getEnv("SCHEDULER_DB_SERVER", "postgres"),
                           getEnv("SCHEDULER_DB_USER", "aerie"),
                           Integer.parseInt(getEnv("SCHEDULER_DB_PORT", "5432")),
                           getEnv("SCHEDULER_DB_PASSWORD", "aerie"),


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1711
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This allows users to set the URL for postgres instances through the
MERLIN_DB_SERVER and SCHEDULER_DB_SERVER environment variables. It
also removes the DB_TYPE env vars, which are no longer required as we
only use one type of database.

## Verification
Since this affects the area of the system that tells Merlin how to communicate with the database, I spun up the system, and simulated a plan through the UI to make sure that Merlin was putting the results into the database. I verified this was the case via TablePlus. I don't think we can create scheduling goals in the UI yet, so I couldn't test that, but I did verify that SCHEDULER_DB_SERVER is indeed the environment variable as set in the top-level docker-compose.yml file, so this should be good.

## Documentation
The documentation does not mention the DB_TYPE env vars already, so nothing needs to be removed. The documentation for the DB_SERVER env vars is also already correct, so nothing needs to be added either. See here: https://github.com/NASA-AMMOS/aerie/blob/develop/deployment/Environment.md

## Future work
None.
