### PR TITLE
[HOTFIX] Fix Typo in scheduling_specification Table

### DIFF
--- a/scheduler-server/sql/scheduler/tables/scheduling_specification.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_specification.sql
@@ -41,7 +41,7 @@ create function increment_revision_on_goal_update()
 language plpgsql as $$begin
   with goals as (
     select g.specification_id from scheduling_specification_goals as g
-    where g.goalification_id = new.id
+    where g.specification_id = new.id
   )
   update scheduling_specification set revision = revision + 1
   where exists(select 1 from goals where specification_id = id);


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
A typo that looks like a find-and-replace mistake made it into the scheduling_specification table. This fixes it! 

## Verification
As @camargo found the bug, I would like for him to test that this fixes it and the operation he was trying to perform when he found the issue now works as expected.

## Documentation
No documentation update needed, this was just a typo in our database table code.

## Future work
None.
