### PR TITLE
[Command Expansion] Added a basic banananation command dictionary

### DIFF
--- a/command-expansion-server/cdict/command_banananation.xml
+++ b/command-expansion-server/cdict/command_banananation.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<command_dictionary>
+    <header mission_name="AERIE" version="1.0.0.0" schema_version="1.0">
+        <spacecraft_ids>
+            <spacecraft_id value="62" />
+        </spacecraft_ids>
+    </header>
+    <uplink_file_types>
+        <file_type name="generic" id="0" extension="dat" file_format_spec="None" />
+    </uplink_file_types>
+    <enum_definitions>
+        <enum_table name="boolean">
+            <values>
+                <enum symbol="FALSE" numeric="0" />
+                <enum symbol="TRUE" numeric="1" />
+            </values>
+        </enum_table>
+        <enum_table name="string">
+            <values>
+                <enum symbol="fromStem" numeric="0" />
+                <enum symbol="fromBase" numeric="1" />
+                <enum symbol="fromCenter" numeric="2" />
+            </values>
+        </enum_table>
+    </enum_definitions>
+    <command_definitions>
+        <fsw_command opcode="0xFFFF" stem="PREHEAT_OVEN" class="FSW">
+            <arguments>
+                <unsigned_arg name="temperture" bit_length="8" units="none">
+                    <range_of_values>
+                        <include min="0" max="100" />
+                    </range_of_values>
+                    <description>Set the oven temperture</description>
+                </unsigned_arg>
+            </arguments>
+            <categories>
+                <module>shell_ctl</module>
+                <ops_category>FSW</ops_category>
+            </categories>
+            <description>This command will turn on the oven</description>
+            <completion>Oven is preheated</completion>
+            <fsw_specification custom_validation_required="No" command_priority="Nominal" />
+            <restricted_modes>
+                <prime_string_restriction prime_string_only="No" />
+            </restricted_modes>
+        </fsw_command>
+        <fsw_command opcode="0xFFFF" stem="THROW_BANANA" class="FSW">
+            <arguments>
+                <unsigned_arg name="distance" bit_length="8" units="none">
+                    <range_of_values>
+                        <include min="0" max="100" />
+                    </range_of_values>
+                    <description>The distance you throw the bananan</description>
+                </unsigned_arg>
+            </arguments>
+            <categories>
+                <module>shell_ctl</module>
+                <ops_category>FSW</ops_category>
+            </categories>
+            <description>This command will throw a banana</description>
+            <completion>A single banana was thrown</completion>
+            <fsw_specification custom_validation_required="No" command_priority="Nominal" />
+            <restricted_modes>
+                <prime_string_restriction prime_string_only="No" />
+            </restricted_modes>
+        </fsw_command>
+        <fsw_command opcode="0xFFFF" stem="GROW_BANANA" class="FSW">
+            <arguments>
+                <unsigned_arg name="quantity" bit_length="8" units="none">
+                    <range_of_values>
+                        <include min="0" max="100" />
+                    </range_of_values>
+                    <description>Number of bananans to grow</description>
+                </unsigned_arg>
+                <unsigned_arg name="duration" bit_length="8" units="none">
+                    <range_of_values>
+                        <include min="0" max="100" />
+                    </range_of_values>
+                    <description>How many seconds will it take to grow</description>
+                </unsigned_arg>
+            </arguments>
+            <categories>
+                <module>shell_ctl</module>
+                <ops_category>FSW</ops_category>
+            </categories>
+            <description>This command will turn on the oven</description>
+            <completion>Oven is preheated</completion>
+            <fsw_specification custom_validation_required="No" command_priority="Nominal" />
+            <restricted_modes>
+                <prime_string_restriction prime_string_only="No" />
+            </restricted_modes>
+        </fsw_command>
+        <fsw_command opcode="0xFFFF" stem="PREPARE_LOAF" class="FSW">
+            <arguments>
+                <unsigned_arg name="tb_sugar" bit_length="8" units="priority">
+                    <range_of_values>
+                        <include min="0" max="100" />
+                    </range_of_values>
+                    <description>How much sugar is needed</description>
+                </unsigned_arg>
+                <enum_arg name="gluten_free" bit_length="8" enum_name="boolean">
+                    <description>Do you hate flavor</description>
+                </enum_arg>
+            </arguments>
+            <categories>
+                <module>shell_ctl</module>
+                <ops_category>FSW</ops_category>
+            </categories>
+            <description>This command make the banana bread dough</description>
+            <completion>The dough mixture is created</completion>
+            <fsw_specification custom_validation_required="No" command_priority="Nominal" />
+            <restricted_modes>
+                <prime_string_restriction prime_string_only="No" />
+            </restricted_modes>
+        </fsw_command>
+        <fsw_command opcode="0xFFFF" stem="PEEL_BANANA" class="FSW">
+            <arguments>
+                <enum_arg name="peelDirection" bit_length="8" enum_name="string">
+                    <description>Which way do you peel the banana</description>
+                </enum_arg>
+            </arguments>
+            <categories>
+                <module>shell_ctl</module>
+                <ops_category>FSW</ops_category>
+            </categories>
+            <description>This command make the banana bread dough</description>
+            <completion>The dough mixture is created</completion>
+            <fsw_specification custom_validation_required="No" command_priority="Nominal" />
+            <restricted_modes>
+                <prime_string_restriction prime_string_only="No" />
+            </restricted_modes>
+        </fsw_command>
+        <fsw_command opcode="0xFFFE" stem="BAKE_BREAD" class="FSW">
+            <categories>
+                <module>shell_ctl</module>
+                <ops_category>FSW</ops_category>
+            </categories>
+            <description>This command bakes a bananan bread</description>
+            <completion>Banana bread is done baking</completion>
+            <fsw_specification custom_validation_required="No" command_priority="Nominal" />
+            <restricted_modes>
+                <prime_string_restriction prime_string_only="No" />
+            </restricted_modes>
+        </fsw_command>
+        <fsw_command opcode="0xFFFE" stem="ADD_WATER" class="FSW">
+            <categories>
+                <module>shell_ctl</module>
+                <ops_category>FSW</ops_category>
+            </categories>
+            <description>This command waters the banana tree</description>
+            <completion>Done watering the banana tree</completion>
+            <fsw_specification custom_validation_required="No" command_priority="Nominal" />
+            <restricted_modes>
+                <prime_string_restriction prime_string_only="No" />
+            </restricted_modes>
+        </fsw_command>
+        <fsw_command opcode="0xFFFE" stem="PICK_BANANA" class="FSW">
+            <categories>
+                <module>shell_ctl</module>
+                <ops_category>FSW</ops_category>
+            </categories>
+            <description>Pick a banana</description>
+            <completion>You have a single bananana</completion>
+            <fsw_specification custom_validation_required="No" command_priority="Nominal" />
+            <restricted_modes>
+                <prime_string_restriction prime_string_only="No" />
+            </restricted_modes>
+        </fsw_command>
+        <fsw_command opcode="0xFFFE" stem="EAT_BANANA" class="FSW">
+            <categories>
+                <module>shell_ctl</module>
+                <ops_category>FSW</ops_category>
+            </categories>
+            <description>Eat a banana</description>
+            <completion>You ate a single banana</completion>
+            <fsw_specification custom_validation_required="No" command_priority="Nominal" />
+            <restricted_modes>
+                <prime_string_restriction prime_string_only="No" />
+            </restricted_modes>
+        </fsw_command>
+    </command_definitions>
+</command_dictionary>

--- a/command-expansion-server/tsconfig.json
+++ b/command-expansion-server/tsconfig.json
@@ -98,6 +98,6 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "exclude":["commanding_file_store", "build"]
+  "exclude":["commanding_file_store", "build","cdict"]
 
 }


### PR DESCRIPTION

* **Tickets addressed:** AERIE-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Added a very basic command dictionary to the command expansion service.

List of commands:
PREHEAT_OVEN
THROW_BANANA
GROW_BANANA
PREPARE_LOAF
PEEL_BANANA
BAKE_BREAD
ADD_WATER
PICK_BANANA
EAT_BANANA

## Verification
I was able to upload this dictionary to the command expansion service and generate a command typescript library.

## Documentation
This file can be used for https://github.com/NASA-AMMOS/aerie/wiki/Command-Expansion-Guide

