### PR TITLE
[AERIE-1772] Add a merlin worker to the deployment docker-compose file

### DIFF
--- a/deployment/.env
+++ b/deployment/.env
@@ -1,0 +1,2 @@
+DOCKER_TAG=latest
+REPOSITORY_DOCKER_URL=ghcr.io/nasa-ammos

--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -41,6 +41,18 @@ This document provides detailed information about environment variables for each
 | `MERLIN_DB_PASSWORD` | Password of the DB instance                               | `string` | aerie                          |
 | `MERLIN_DB`          | The DB for Merlin.                                        | `string` | aerie_merlin                   |
 
+## Aerie Merlin Worker
+
+| Name                        | Description                                                                              | Type     | Default                        |
+|-----------------------------|------------------------------------------------------------------------------------------| -------- | ------------------------------ |
+| `JAVA_OPTS`                 | Configuration for Merlin's logging level and output file                                 | `string` | log level: warn. output: stderr|
+| `MERLIN_WORKER_LOCAL_STORE` | The local storage as for the Merlin container (this must the same as the Merlin container)                                      | `string` | /usr/src/app/merlin_file_store |
+| `MERLIN_WORKER_DB_SERVER`   | The DB instance that Merlin will connect with (this must the same as the Merlin container) | `string` | postgres                       |
+| `MERLIN_WORKER_DB_PORT`     | The DB instance port number that Merlin will connect with (this must the same as the Merlin container)                               | `number` | 5432                           |
+| `MERLIN_WORKER_DB_USER`     | Username of the DB instance (this must the same as the Merlin container)                                                             | `string` | aerie                          |
+| `MERLIN_WORKER_DB_PASSWORD` | Password of the DB instance (this must the same as the Merlin container)                                                             | `string` | aerie                          |
+| `MERLIN_WORKER_DB`          | The DB for Merlin. (this must the same as the Merlin container)                                                                     
+
 ## Aerie Scheduler
 
 | Name                    | Description                                                           | Type     | Default                                            |

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -19,6 +19,15 @@ Before you can deploy Aerie, you must install and configure the following produc
 
 Each container has environment variables that can be used to fine-tune your deployment. See the [environment variable documentation](./Environment.md) for the complete set of variables. See the example [docker-compose.yml](./docker-compose.yml) file for examples on how to set the environment variables. **We highly recommend changing the default environment variable passwords before deploying Aerie**.
 
+## Configuring Merlin Simulation Workers
+A Merlin simulation is executed by an aerie-merlin-worker. An Aerie deployment can configure one or 
+more workers to provide an Aerie deployment with the ability to execute multiple concurrent 
+simulations. Without a worker Aerie will not execute any simulations. Workers are declared by adding
+a worker container definition in your docker-compose file for each worker. The default docker-compose.yml
+contained in this directory declares a single worker. The worker must configured to access the same 
+postgresql instance and database as the Merlin server. It is recommended that the number of workers 
+does not exceed the host's remaining available cores (considering other processes running on the host). 
+
 ## Starting the Services
 
 Download and unzip the latest [Deployment.zip](https://github.com/NASA-AMMOS/aerie/releases) file onto your local machine, then do:

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       POSTGRES_PASSWORD: aerie
       POSTGRES_PORT: 5432
       POSTGRES_USER: aerie
-    image: "ghcr.io/nasa-ammos/aerie-gateway:latest"
+    image: "${REPOSITORY_DOCKER_URL}/aerie-gateway:${DOCKER_TAG}"
     ports: ["9000:9000"]
     restart: always
     volumes:
@@ -35,11 +35,29 @@ services:
       JAVA_OPTS: >
         -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
         -Dorg.slf4j.simpleLogger.logFile=System.err
-    image: "ghcr.io/nasa-ammos/aerie-merlin:latest"
+    image: "${REPOSITORY_DOCKER_URL}/aerie-merlin:${DOCKER_TAG}"
     ports: ["27183:27183"]
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store
+  aerie_merlin_worker_1:
+    container_name: aerie_merlin_worker
+    depends_on: ["postgres"]
+    environment:
+      MERLIN_WORKER_DB: "aerie_merlin"
+      MERLIN_WORKER_DB_PASSWORD: "aerie"
+      MERLIN_WORKER_DB_PORT: 5432
+      MERLIN_WORKER_DB_SERVER: "postgres"
+      MERLIN_WORKER_DB_USER: "aerie"
+      MERLIN_WORKER_LOCAL_STORE: /usr/src/app/merlin_file_store
+      JAVA_OPTS: >
+        -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+        -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=WARN
+        -Dorg.slf4j.simpleLogger.logFile=System.err
+    image: "${REPOSITORY_DOCKER_URL}/aerie-merlin-worker:${DOCKER_TAG}"
+    restart: always
+    volumes:
+      - aerie_file_store:/usr/src/app/merlin_file_store:ro
   aerie_scheduler:
     container_name: aerie_scheduler
     depends_on: ["aerie_merlin", "postgres"]
@@ -58,7 +76,7 @@ services:
       JAVA_OPTS: >
         -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
         -Dorg.slf4j.simpleLogger.logFile=System.err
-    image: "ghcr.io/nasa-ammos/aerie-scheduler:latest"
+    image: "${REPOSITORY_DOCKER_URL}/aerie-scheduler:${DOCKER_TAG}"
     ports: ["27193:27193"]
     restart: always
     volumes:
@@ -72,7 +90,7 @@ services:
       GATEWAY_SERVER_URL: http://aerie_gateway:9000
       HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
       HASURA_SERVER_URL: http://hasura:8080/v1/graphql
-    image: "ghcr.io/nasa-ammos/aerie-ui:latest"
+    image: "${REPOSITORY_DOCKER_URL}/aerie-ui:${DOCKER_TAG}"
     ports: ["80:80"]
     restart: always
   hasura:


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1772
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR parameterizes the image tag and repository URL for the docker-compose file. Certain users may have a local repository to which the ghcr images are mirrored. This parameterisation allows them to change the .env to point to that location.

## Verification
Tested and run locally. Used DOCKER_TAG=develop and REPOSITORY_DOCKER_URL=ghcr.io/nasa-ammos

## Documentation
Updated the README.md to describe the required inclusion of a merlin-worker container(s) in a deployment.

## Future work
None
