### PR TITLE
Upgrade all components to Java 18

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,12 +40,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        distribution: "temurin"
-        java-version: "18"
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
@@ -60,8 +54,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -69,8 +63,13 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
-    #- run: |
-    #    ./gradlew testClasses
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: "temurin"
+        java-version: "18"
+    - run: |
+        ./gradlew testClasses
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,10 +42,11 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         queries: +security-extended
+        tools: latest
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
@@ -53,8 +54,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -62,10 +63,13 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: "temurin"
+        java-version: "18"
+    - run: |
+        ./gradlew testClasses
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: "temurin"
+        java-version: "18"
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
@@ -54,8 +60,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v1
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -63,13 +69,8 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        distribution: "temurin"
-        java-version: "18"
-    - run: |
-        ./gradlew testClasses
+    #- run: |
+    #    ./gradlew testClasses
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "18"
       - uses: gradle/wrapper-validation-action@v1
       - uses: gradle/gradle-build-action@v2
       - name: Build Classes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "18"
       - name: Setup Postgres Client (psql)
         run: sudo apt-get install --yes postgresql-client
       - name: Validate Gradle Wrapper

--- a/constraints/build.gradle
+++ b/constraints/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 }
 

--- a/contrib/build.gradle
+++ b/contrib/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 
   withJavadocJar()

--- a/db-tests/build.gradle
+++ b/db-tests/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 }
 

--- a/examples/banananation/build.gradle
+++ b/examples/banananation/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 }
 

--- a/examples/config-with-defaults/build.gradle
+++ b/examples/config-with-defaults/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 }
 

--- a/examples/config-without-defaults/build.gradle
+++ b/examples/config-without-defaults/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 }
 

--- a/examples/foo-missionmodel/build.gradle
+++ b/examples/foo-missionmodel/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/merlin-driver/build.gradle
+++ b/merlin-driver/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 
   withJavadocJar()

--- a/merlin-framework-junit/build.gradle
+++ b/merlin-framework-junit/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 
   withJavadocJar()

--- a/merlin-framework-processor/build.gradle
+++ b/merlin-framework-processor/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 }
 

--- a/merlin-framework/build.gradle
+++ b/merlin-framework/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 
   withJavadocJar()

--- a/merlin-sdk/build.gradle
+++ b/merlin-sdk/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 
   withJavadocJar()

--- a/merlin-server/Dockerfile
+++ b/merlin-server/Dockerfile
@@ -4,7 +4,7 @@ COPY build/distributions/*.tar /usr/src/app/server.tar
 RUN mkdir /usr/src/app/extracted
 RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 
-FROM eclipse-temurin:17-jre-focal
+FROM eclipse-temurin:18-focal
 
 ARG IMAGE_INCLUDE_JDK=false
 RUN if [ $IMAGE_INCLUDE_JDK = "true" ] ; then \

--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 }
 

--- a/merlin-worker/Dockerfile
+++ b/merlin-worker/Dockerfile
@@ -4,7 +4,7 @@ COPY build/distributions/*.tar /usr/src/app/server.tar
 RUN mkdir /usr/src/app/extracted
 RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 
-FROM eclipse-temurin:17-jre-focal
+FROM eclipse-temurin:18-focal
 
 ARG IMAGE_INCLUDE_JDK=false
 RUN if [ $IMAGE_INCLUDE_JDK = "true" ] ; then \

--- a/merlin-worker/build.gradle
+++ b/merlin-worker/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 
   withJavadocJar()

--- a/merlin-worker/build.gradle
+++ b/merlin-worker/build.gradle
@@ -6,7 +6,6 @@ plugins {
 java {
   toolchain {
     languageVersion = JavaLanguageVersion.of(17)
-    vendor = JvmVendorSpec.ADOPTOPENJDK
   }
 
   withJavadocJar()

--- a/parsing-utilities/build.gradle
+++ b/parsing-utilities/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 }
 

--- a/scheduler-server/Dockerfile
+++ b/scheduler-server/Dockerfile
@@ -4,7 +4,7 @@ COPY build/distributions/*.tar /usr/src/app/server.tar
 RUN mkdir /usr/src/app/extracted
 RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 
-FROM eclipse-temurin:17-jre-focal
+FROM eclipse-temurin:18-focal
 
 ARG IMAGE_INCLUDE_JDK=false
 RUN if [ $IMAGE_INCLUDE_JDK = "true" ] ; then \

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 }
 

--- a/scheduler/build.gradle
+++ b/scheduler/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(18)
   }
 }
 


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Traditionally, Aerie has kept up with the latest release of the JDK. There is little benefit to sticking to a single LTS; as [Ron Pressler says](https://www.reddit.com/r/java/comments/nc1fz2/comment/gy501o7/) (and has been saying for years):

> The safest, most secure version is always the most recent one. Old releases with LTS -- a new path to stay on old feature releases that didn't exist under the old model -- are better-suited for legacy codebases.

(Ron is a key contributor to OpenJDK; you may recognize him as the lead on Project Loom.)

[OpenJDK 18](https://openjdk.java.net/projects/jdk/18/) was released on March 22nd, [Adoptium Temurin](https://adoptium.net/temurin/releases) now has distributions available, and [base images](https://hub.docker.com/_/eclipse-temurin) have been uploaded to Docker Hub. Gradle has supported building with arbitrary JDK toolchains (i.e. separated from the JVM Gradle *itself* runs on) since around the time JDK 17 was released.

It's a great time to move to Java 18.

I recommend skimming [the list of features](https://openjdk.java.net/projects/jdk/18/) included in Java 18. It's a fairly incremental release (that's good!), but JEPs 400, 408, and 413 are nice to have, and 420 marks the second preview of the much-awaited pattern-matching for `switch`.

I've updated the following file types in the repository for this change:
* All `build.gradle` files
* Most `Dockerfile`s
* GitHub CI configuration
* `gradle-wrapper.properties` (since Gradle *only just recently* addressed the relocation of AdoptOpenJDK to the Eclipse foundation as Temurin Adoptium.)

## Verification
I've build the codebase successfully with a Java 18 distribution installed locally, and I expect (hope?) that the GitHub CI actions on this PR will confirm that the CI and Docker-related changes are sound.

## Documentation
Customers need to be informed that Java 18 is now required. In particular (to my knowledge), mission models will need to be built with Java 18.

## Future work
Look forward to Java 19 (and pattern-matching!!) in September!