### PR TITLE
[HOTFIX] Gave aerie user permission to command expansion db

### DIFF
--- a/deployment/postgres-init-db/init-aerie.sh
+++ b/deployment/postgres-init-db/init-aerie.sh
@@ -29,7 +29,7 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
 
   \echo 'Initializing aerie_commanding database...'
   CREATE DATABASE aerie_commanding;
-  GRANT ALL PRIVILEGES ON DATABASE aerie_ui TO aerie;
+  GRANT ALL PRIVILEGES ON DATABASE aerie_commanding TO aerie;
   \echo 'Done!'
 
 EOSQL


### PR DESCRIPTION

## Description
I noticed that we didn't give the aerie user permission to access the command expansion database. Right now that isn't a problem but we should probably set up the permissions so we don't run into any issues in the future.

## Verification
Nuke everything and verified the command expansion database was created with all its tables.


