### PR TITLE
[AERIE-1782] Scheduler integration tests

### DIFF
--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -53,6 +53,9 @@ test {
 
   environment "SCHEDULING_DSL_COMPILER_ROOT", projectDir.toPath().resolve('scheduling-dsl-compiler')
   environment "SCHEDULING_DSL_COMPILER_COMMAND", './build/main.js'
+
+  dependsOn ":examples:banananation:assemble"
+  environment 'AERIE_ROOT', rootDir.toString()
 }
 
 application {

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -60,7 +60,7 @@ import java.util.stream.Collectors;
 //TODO: will eventually need scheduling goal service arg to pull goals from scheduler's own data store
 public record SynchronousSchedulerAgent(
     SpecificationService specificationService,
-    GraphQLMerlinService merlinService,
+    MerlinService merlinService,
     Path modelJarsDir,
     Path goalsJarPath,
     PlanOutputMode outputMode

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockMerlinService.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockMerlinService.java
@@ -1,0 +1,177 @@
+package gov.nasa.jpl.aerie.scheduler.server.services;
+
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.scheduler.TimeUtility;
+import gov.nasa.jpl.aerie.scheduler.model.ActivityInstance;
+import gov.nasa.jpl.aerie.scheduler.model.Plan;
+import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
+import gov.nasa.jpl.aerie.scheduler.model.Problem;
+import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityInstanceId;
+import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchActivityInstanceException;
+import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchMissionModelException;
+import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.scheduler.server.models.MerlinActivityInstance;
+import gov.nasa.jpl.aerie.scheduler.server.models.MerlinPlan;
+import gov.nasa.jpl.aerie.scheduler.server.models.MissionModelId;
+import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
+import gov.nasa.jpl.aerie.scheduler.server.models.PlanMetadata;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class MockMerlinService implements MerlinService {
+
+  private final Path modelPath;
+  private final String modelName;
+  private List<PlannedActivityInstance> initialPlan;
+  Collection<PlannedActivityInstance> updatedPlan;
+
+  MockMerlinService(final Path modelPath, final String modelName) {
+    this.modelPath = modelPath;
+    this.modelName = modelName;
+    this.initialPlan = List.of();
+  }
+
+  void setInitialPlan(final List<PlannedActivityInstance> initialPlan) {
+    this.initialPlan = initialPlan;
+  }
+
+  @Override
+  public long getPlanRevision(final PlanId planId) {
+    return 1L;
+  }
+
+  @Override
+  public PlanMetadata getPlanMetadata(final PlanId planId)
+  throws IOException, NoSuchPlanException, MerlinServiceException
+  {
+    // Checked that revision matches
+    // Uses model version info to load mission model jar
+    // The PlanningHorizon here is not used for scheduling (at least not directly)
+    return new PlanMetadata(
+        new PlanId(1L),
+        1L,
+        new PlanningHorizon(
+            TimeUtility.fromDOY("2021-001T00:00:00"),
+            TimeUtility.fromDOY("2021-005T00:00:00")),
+        1L,
+        modelPath,
+        modelName,
+        "1.0.0",
+        Map.of("initialDataPath", SerializedValue.of("/etc/hosts")));
+  }
+
+  @Override
+  public MerlinPlan getPlanActivities(final PlanMetadata planMetadata, final Problem mission)
+  {
+    // TODO this gets the planMetadata from above
+
+    return makePlan(initialPlan, mission);
+  }
+
+  @Override
+  public Pair<PlanId, Map<ActivityInstance, ActivityInstanceId>> createNewPlanWithActivities(
+      final PlanMetadata planMetadata,
+      final Plan plan) throws IOException, NoSuchPlanException, MerlinServiceException
+  {
+    return null;
+  }
+
+  @Override
+  public PlanId createEmptyPlan(final String name, final long modelId, final Instant startTime, final Duration duration)
+  throws IOException, NoSuchPlanException, MerlinServiceException
+  {
+    return null;
+  }
+
+  @Override
+  public void createSimulationForPlan(final PlanId planId)
+  throws IOException, NoSuchPlanException, MerlinServiceException
+  {
+
+  }
+
+  @Override
+  public Map<ActivityInstance, ActivityInstanceId> updatePlanActivities(
+      final PlanId planId,
+      final Map<SchedulingActivityInstanceId, ActivityInstanceId> idsFromInitialPlan,
+      final MerlinPlan initialPlan,
+      final Plan plan
+  )
+  throws IOException, NoSuchPlanException, MerlinServiceException, NoSuchActivityInstanceException
+  {
+    this.updatedPlan = extractPlannedActivityInstances(plan);
+    final var res = new HashMap<ActivityInstance, ActivityInstanceId>();
+    for (final var activity : plan.getActivities()) {
+      var id = 0L;
+      res.put(activity, new ActivityInstanceId(id++));
+    }
+    return res;
+  }
+
+  @Override
+  public void ensurePlanExists(final PlanId planId) throws IOException, NoSuchPlanException, MerlinServiceException {
+
+  }
+
+  @Override
+  public void clearPlanActivities(final PlanId planId)
+  throws IOException, NoSuchPlanException, MerlinServiceException
+  {
+
+  }
+
+  @Override
+  public Map<ActivityInstance, ActivityInstanceId> createAllPlanActivities(final PlanId planId, final Plan plan)
+  throws IOException, NoSuchPlanException, MerlinServiceException
+  {
+    return null;
+  }
+
+  @Override
+  public TypescriptCodeGenerationService.MissionModelTypes getMissionModelTypes(final PlanId planId)
+  throws IOException, MerlinServiceException
+  {
+    return SchedulingIntegrationTests.MISSION_MODEL_TYPES;
+  }
+
+  @Override
+  public TypescriptCodeGenerationService.MissionModelTypes getMissionModelTypes(final MissionModelId missionModelId)
+  throws IOException, MerlinServiceException, NoSuchMissionModelException
+  {
+    return SchedulingIntegrationTests.MISSION_MODEL_TYPES;
+  }
+
+  record PlannedActivityInstance(String type, Map<String, SerializedValue> args, Duration startTime) {}
+
+  private static Collection<PlannedActivityInstance> extractPlannedActivityInstances(Plan plan) {
+    final var plannedActivityInstances = new ArrayList<PlannedActivityInstance>();
+    for (final var activity : plan.getActivities()) {
+      plannedActivityInstances.add(new PlannedActivityInstance(
+          activity.getType().getName(),
+          activity.getArguments(),
+          activity.getStartTime()));
+    }
+    return plannedActivityInstances;
+  }
+
+  private static MerlinPlan makePlan(final Iterable<MockMerlinService.PlannedActivityInstance> activities, final Problem problem) {
+    final var initialPlan = new MerlinPlan();
+
+    var id = 0L;
+    for (final var activity : activities) {
+      final var activityInstance = new MerlinActivityInstance(activity.type(), activity.startTime(), activity.args());
+      initialPlan.addActivity(new ActivityInstanceId(id++), activityInstance);
+    }
+    return initialPlan;
+  }
+}

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockResultsProtocolWriter.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockResultsProtocolWriter.java
@@ -1,0 +1,34 @@
+package gov.nasa.jpl.aerie.scheduler.server.services;
+
+import gov.nasa.jpl.aerie.scheduler.server.ResultsProtocol;
+
+import java.util.ArrayList;
+
+class MockResultsProtocolWriter implements ResultsProtocol.WriterRole {
+  final ArrayList<Result> results;
+
+  MockResultsProtocolWriter() {
+    this.results = new ArrayList<>();
+  }
+
+  sealed interface Result {
+    record Success(ScheduleResults results) implements Result {}
+
+    record Failure(String reason) implements Result {}
+  }
+
+  @Override
+  public boolean isCanceled() {
+    return false;
+  }
+
+  @Override
+  public void succeedWith(final ScheduleResults results) {
+    this.results.add(new Result.Success(results));
+  }
+
+  @Override
+  public void failWith(final String reason) {
+    this.results.add(new Result.Failure(reason));
+  }
+}

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockSpecificationService.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockSpecificationService.java
@@ -1,0 +1,32 @@
+package gov.nasa.jpl.aerie.scheduler.server.services;
+
+import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchSpecificationException;
+import gov.nasa.jpl.aerie.scheduler.server.exceptions.SpecificationLoadException;
+import gov.nasa.jpl.aerie.scheduler.server.models.Specification;
+import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
+
+import java.util.Map;
+import java.util.Optional;
+
+class MockSpecificationService implements SpecificationService {
+  Map<SpecificationId, Specification> specifications;
+
+  MockSpecificationService(final Map<SpecificationId, Specification> specifications) {
+    this.specifications = specifications;
+  }
+
+  @Override
+  public Specification getSpecification(final SpecificationId specificationId)
+  throws NoSuchSpecificationException, SpecificationLoadException
+  {
+    return Optional.ofNullable(specifications.get(specificationId))
+                   .orElseThrow(() -> new NoSuchSpecificationException(specificationId));
+  }
+
+  @Override
+  public RevisionData getSpecificationRevisionData(final SpecificationId specificationId)
+  throws NoSuchSpecificationException
+  {
+    return $ -> RevisionData.MatchResult.success();
+  }
+}

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -1,0 +1,207 @@
+package gov.nasa.jpl.aerie.scheduler.server.services;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import gov.nasa.jpl.aerie.scheduler.server.config.PlanOutputMode;
+import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
+import gov.nasa.jpl.aerie.scheduler.server.models.GoalRecord;
+import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
+import gov.nasa.jpl.aerie.scheduler.server.models.Specification;
+import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
+import gov.nasa.jpl.aerie.scheduler.server.models.Timestamp;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SchedulingIntegrationTests {
+
+  public static final TypescriptCodeGenerationService.MissionModelTypes MISSION_MODEL_TYPES =
+      new TypescriptCodeGenerationService.MissionModelTypes(
+          List.of(
+              new TypescriptCodeGenerationService.ActivityType(
+                  "PeelBanana",
+                  Map.of(
+                      "peelDirection",
+                      ValueSchema.ofVariant(List.of(
+                          new ValueSchema.Variant(
+                              "fromTip", "fromTip"
+                          ),
+                          new ValueSchema.Variant(
+                              "fromStem",
+                              "fromStem"))
+                      )
+                  )
+              ),
+              new TypescriptCodeGenerationService.ActivityType(
+                  "GrowBanana",
+                  Map.of(
+                      "growingDuration",
+                      ValueSchema.REAL,
+                      "quantity",
+                      ValueSchema.REAL
+                  )
+              ),
+              new TypescriptCodeGenerationService.ActivityType(
+                  "BiteBanana",
+                  Map.of(
+                      "biteSize",
+                      ValueSchema.REAL
+                  )
+              )
+          ),
+          null
+      );
+
+  private MockMerlinService merlinService;
+  private Path banananationLibPath;
+  private SchedulingDSLCompilationService schedulingDSLCompiler;
+
+  @BeforeAll
+  void setup() throws IOException {
+    banananationLibPath = Path.of(System.getenv("AERIE_ROOT"), "examples", "banananation", "build", "libs");
+    final var files = banananationLibPath.toFile().listFiles(pathname -> pathname.getName().endsWith(".jar"));
+    Arrays.sort(files, Comparator.comparingLong(File::lastModified).reversed());
+    final var banananationJarFile = files[0];
+
+    this.merlinService = new MockMerlinService(Path.of(banananationJarFile.getName()), "some-model-name");
+    this.schedulingDSLCompiler = new SchedulingDSLCompilationService(new TypescriptCodeGenerationService(this.merlinService));
+  }
+
+  @Test
+  void testEmptyPlanEmptySpecification() {
+    final var results = runSchedulerOnBanananation(List.of(), List.of());
+    assertEquals(Map.of(), results.scheduleResults.goalResults());
+  }
+
+  @Test
+  void testEmptyPlanSimpleRecurrenceGoal() {
+    final var results = runSchedulerOnBanananation(
+        List.of(),
+        List.of("""
+          export default () => Goal.ActivityRecurrenceGoal({
+            activityTemplate: ActivityTemplates.PeelBanana({
+              peelDirection: "fromStem",
+            }),
+            interval: 24 * 60 * 60 * 1000 * 1000 // one day in microseconds
+          })
+          """));
+    assertEquals(1, results.scheduleResults.goalResults().size());
+    final var goalResult = results.scheduleResults.goalResults().get(new GoalId(0L));
+    assertTrue(goalResult.satisfied());
+    assertEquals(5, goalResult.createdActivities().size());
+    for (final var activity : goalResult.createdActivities()) {
+      assertNotNull(activity);
+    }
+    for (final var activity : goalResult.satisfyingActivities()) {
+      assertNotNull(activity);
+    }
+    final var updatedPlan = results.updatedPlan();
+    for (final var activity : updatedPlan) {
+      final var arguments = activity.args();
+      assertEquals("PeelBanana", activity.type());
+      assertEquals(SerializedValue.of("fromStem"), arguments.get("peelDirection"));
+    }
+  }
+
+  @Test
+  void testSingleActivityPlanSimpleRecurrenceGoal() {
+    final var results = runSchedulerOnBanananation(
+        List.of(new MockMerlinService.PlannedActivityInstance("BiteBanana", Map.of("biteSize", SerializedValue.of(1)), Duration.ZERO)),
+        List.of("""
+          export default () => Goal.ActivityRecurrenceGoal({
+            activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
+            interval: 24 * 60 * 60 * 1000 * 1000 // one day in microseconds
+          })
+          """));
+
+    assertEquals(1, results.scheduleResults.goalResults().size());
+    final var goalResult = results.scheduleResults.goalResults().get(new GoalId(0L));
+
+    assertTrue(goalResult.satisfied());
+    assertEquals(5, goalResult.createdActivities().size());
+    for (final var activity : goalResult.createdActivities()) {
+      assertNotNull(activity);
+    }
+    for (final var activity : goalResult.satisfyingActivities()) {
+      assertNotNull(activity);
+    }
+
+    final var activitiesByType = partitionByActivityType(results.updatedPlan());
+    final var biteBananas = activitiesByType.get("BiteBanana");
+    assertEquals(1, biteBananas.size());
+
+    final var biteBanana = biteBananas.iterator().next();
+    assertEquals(SerializedValue.of(1), biteBanana.args().get("biteSize"));
+
+    final var peelBananas = activitiesByType.get("PeelBanana");
+    assertEquals(5, peelBananas.size());
+
+    for (final var peelBanana : peelBananas) {
+      assertEquals(SerializedValue.of("fromStem"), peelBanana.args().get("peelDirection"));
+    }
+  }
+
+  private static Map<String, Collection<MockMerlinService.PlannedActivityInstance>> partitionByActivityType(final Iterable<MockMerlinService.PlannedActivityInstance> activities) {
+    final var result = new HashMap<String, Collection<MockMerlinService.PlannedActivityInstance>>();
+    for (final var activity : activities) {
+      result
+          .computeIfAbsent(activity.type(), key -> new ArrayList<>())
+          .add(activity);
+    }
+    return result;
+  }
+
+  private SchedulingRunResults runSchedulerOnBanananation(List<MockMerlinService.PlannedActivityInstance> plannedActivities, final Iterable<String> goals)
+  {
+    this.merlinService.setInitialPlan(plannedActivities);
+    final var planId = new PlanId(1L);
+    final var goalsByPriority = new ArrayList<GoalRecord>();
+    var goalId = 0L;
+    for (final var goal : goals) {
+      final var goalResult = schedulingDSLCompiler.compileSchedulingGoalDSL(planId, goal, "");
+      if (goalResult instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success s) {
+        goalsByPriority.add(new GoalRecord(new GoalId(goalId++), s.goalSpecifier()));
+      } else if (goalResult instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error e) {
+        fail(e.toString());
+      }
+    }
+    final var specificationService = new MockSpecificationService(Map.of(new SpecificationId(1L), new Specification(
+        planId,
+        1L,
+        goalsByPriority,
+        Timestamp.fromString("2021-001T00:00:00"),
+        Timestamp.fromString("2021-005T00:00:00"),
+        Map.of())));
+    final var agent = new SynchronousSchedulerAgent(specificationService, this.merlinService, this.banananationLibPath, Path.of(""), PlanOutputMode.UpdateInputPlanWithNewActivities);
+    // Scheduling Goals -> Scheduling Specification
+    final var writer = new MockResultsProtocolWriter();
+    agent.schedule(new ScheduleRequest(new SpecificationId(1L), $ -> RevisionData.MatchResult.success()), writer);
+    assertEquals(1, writer.results.size());
+    final var result = writer.results.get(0);
+    if (result instanceof MockResultsProtocolWriter.Result.Failure e) {
+      System.err.println(e.reason());
+      fail(e.reason());
+    }
+    return new SchedulingRunResults(((MockResultsProtocolWriter.Result.Success) result).results(), this.merlinService.updatedPlan);
+  }
+
+  record SchedulingRunResults(ScheduleResults scheduleResults, Collection<MockMerlinService.PlannedActivityInstance> updatedPlan) {}
+}


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR is intended to set up follow-up PRs that grow the scheduling DSL. It establishes tests that:
- Exercise code paths that turn the Typescript goal definition into a scheduler Goal object
- Actually run the scheduler
- Make assertions on the post-conditions of a scheduling run
- Do not require a deployment of aerie (no database, no hasura)

The nice thing about testing at this level is that we can express scheduling as a simple function:

```
(Plan x List[Typescript Goal definitions]) => (Plan x Analysis)
```

Tests written in this way become a specification of the semantics of our scheduling DSL. Future PRs that grow the DSL will be expected to update these tests to demonstrate the new semantics.

~This PR will need to be rebased onto #121 , since there are some MerlinService interface changes there.~ Done.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Running `./gradlew :scheduler-server:test` should run these tests, and they should pass.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Some developer documentation might be helpful - perhaps a short checklist of steps to follow when growing the scheduling DSL.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- The MerlinService seems a bit too broad, maybe we can split it up into a set of smaller interfaces
- These tests only work with banananation at the moment. It would be good to figure out how to make them work with aerie-lander
- #121 does not re-write unchanged activities, so these tests will need to be updated to take that into account
- It should be possible to make assertions about the properties of the simulation (perhaps by running another simulation after the scheduling run completes)
