### PR TITLE
[AERIE-1756] Initial barebones coexistence goal

### DIFF
--- a/scheduler-server/scheduling-dsl-compiler/package-lock.json
+++ b/scheduler-server/scheduling-dsl-compiler/package-lock.json
@@ -8,7 +8,7 @@
       "name": "typescript-compiler",
       "version": "1.0.0",
       "dependencies": {
-        "@nasa-jpl/aerie-ts-user-code-runner": "^0.2.5",
+        "@nasa-jpl/aerie-ts-user-code-runner": "^0.2.6",
         "source-map": "^0.7.3",
         "typescript": "^4.5.5",
         "typescript-json-schema": "^0.53.0"
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@nasa-jpl/aerie-ts-user-code-runner": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-ts-user-code-runner/-/aerie-ts-user-code-runner-0.2.5.tgz",
-      "integrity": "sha512-pisGo+Dn8paELm2cG2MiSleUzNnQDC+Cn/OgaqDwODvRfDB1IlyDX6sCOqXMd5vxcN3pU4PJpfyR0P4o1viOvg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-ts-user-code-runner/-/aerie-ts-user-code-runner-0.2.6.tgz",
+      "integrity": "sha512-Rkv9vpd6saWM5zdDGJlL0Pgjp53wv1HSMt1lFlcGzaaeDg+BS7qnX+PheulyqMxPtHCGCBGTbyMva9rHajMFIA==",
       "dependencies": {
         "lru-cache": "^7.7.1",
         "source-map": "^0.7.3",
@@ -596,9 +596,9 @@
       }
     },
     "@nasa-jpl/aerie-ts-user-code-runner": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-ts-user-code-runner/-/aerie-ts-user-code-runner-0.2.5.tgz",
-      "integrity": "sha512-pisGo+Dn8paELm2cG2MiSleUzNnQDC+Cn/OgaqDwODvRfDB1IlyDX6sCOqXMd5vxcN3pU4PJpfyR0P4o1viOvg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-ts-user-code-runner/-/aerie-ts-user-code-runner-0.2.6.tgz",
+      "integrity": "sha512-Rkv9vpd6saWM5zdDGJlL0Pgjp53wv1HSMt1lFlcGzaaeDg+BS7qnX+PheulyqMxPtHCGCBGTbyMva9rHajMFIA==",
       "requires": {
         "lru-cache": "^7.7.1",
         "source-map": "^0.7.3",

--- a/scheduler-server/scheduling-dsl-compiler/package.json
+++ b/scheduler-server/scheduling-dsl-compiler/package.json
@@ -10,7 +10,7 @@
   },
   "author": "",
   "dependencies": {
-    "@nasa-jpl/aerie-ts-user-code-runner": "^0.2.5",
+    "@nasa-jpl/aerie-ts-user-code-runner": "^0.2.6",
     "source-map": "^0.7.3",
     "typescript": "^4.5.5",
     "typescript-json-schema": "^0.53.0"

--- a/scheduler-server/scheduling-dsl-compiler/src/libs/mission-model-generated-code.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/mission-model-generated-code.ts
@@ -1,0 +1,11 @@
+/**
+ *
+ * This is just a placeholder to placate the type checker for our node process.
+ * At runtime, this file is replaced with the real generated code.
+ *
+ */
+
+export enum ActivityType {
+  // This indicates to the compiler that we are using a string enum so we can assign it to string for our AST
+  _ = '_',
+}

--- a/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-ast.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-ast.ts
@@ -5,6 +5,7 @@ export interface ActivityTemplate {
 
 export enum NodeKind {
   ActivityRecurrenceGoal = 'ActivityRecurrenceGoal',
+  ActivityCoexistenceGoal = 'ActivityCoexistenceGoal',
   GoalAnd = 'GoalAnd',
   GoalOr = 'GoalOr'
 }
@@ -18,14 +19,24 @@ export enum NodeKind {
  */
 export type Goal =
   | ActivityRecurrenceGoal
+  | ActivityCoexistenceGoal
   ;
-// TODO coexistence goal
 // TODO cardinality goal
 
 export interface ActivityRecurrenceGoal {
   kind: NodeKind.ActivityRecurrenceGoal,
   activityTemplate: ActivityTemplate,
   interval: number,
+}
+
+export interface ActivityExpression {
+  type: string
+}
+
+export interface ActivityCoexistenceGoal {
+  kind: NodeKind.ActivityCoexistenceGoal,
+  activityTemplate: ActivityTemplate,
+  forEach: ActivityExpression
 }
 
 export type GoalSpecifier =

--- a/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-ast.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-ast.ts
@@ -3,6 +3,12 @@ export interface ActivityTemplate {
   args: {[key: string]: any},
 }
 
+export enum NodeKind {
+  ActivityRecurrenceGoal = 'ActivityRecurrenceGoal',
+  GoalAnd = 'GoalAnd',
+  GoalOr = 'GoalOr'
+}
+
 /**
  * Goal
  *
@@ -17,7 +23,7 @@ export type Goal =
 // TODO cardinality goal
 
 export interface ActivityRecurrenceGoal {
-  kind: 'ActivityRecurrenceGoal',
+  kind: NodeKind.ActivityRecurrenceGoal,
   activityTemplate: ActivityTemplate,
   interval: number,
 }
@@ -39,12 +45,12 @@ export type GoalComposition =
   ;
 
 export interface GoalAnd {
-  kind: 'GoalAnd',
+  kind: NodeKind.GoalAnd,
   goals: GoalSpecifier[],
 }
 
 export interface GoalOr {
-  kind: 'GoalOr',
+  kind: NodeKind.GoalOr,
   goals: GoalSpecifier[],
 }
 

--- a/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
@@ -1,6 +1,9 @@
 import * as AST from './scheduler-ast.js';
+import { ActivityType } from "./mission-model-generated-code";
 
 interface ActivityRecurrenceGoal extends Goal {}
+interface ActivityCoexistenceGoal extends Goal {}
+
 export class Goal {
   private readonly goalSpecifier: AST.GoalSpecifier;
 
@@ -43,6 +46,15 @@ export class Goal {
       interval: opts.interval,
     });
   }
+  public static CoexistenceGoal(opts: { activityTemplate: ActivityTemplate, forEach: ActivityType }): ActivityCoexistenceGoal {
+    return Goal.new({
+      kind: AST.NodeKind.ActivityCoexistenceGoal,
+      activityTemplate: opts.activityTemplate,
+      forEach: {
+        type: opts.forEach
+      },
+    });
+  }
 }
 
 declare global {
@@ -52,6 +64,8 @@ declare global {
     public or(...others: Goal[]): Goal
 
     public static ActivityRecurrenceGoal(opts: { activityTemplate: ActivityTemplate, interval: Duration }): ActivityRecurrenceGoal
+
+    public static CoexistenceGoal(opts: { activityTemplate: ActivityTemplate, forEach: ActivityType }): ActivityCoexistenceGoal
   }
   type Duration = number;
   type Double = number;

--- a/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
@@ -1,4 +1,4 @@
-import type * as AST from './scheduler-ast.js';
+import * as AST from './scheduler-ast.js';
 
 interface ActivityRecurrenceGoal extends Goal {}
 export class Goal {
@@ -18,7 +18,7 @@ export class Goal {
 
   public and(...others: Goal[]): Goal {
     return Goal.new({
-      kind: 'GoalAnd',
+      kind: AST.NodeKind.GoalAnd,
       goals: [
         this.goalSpecifier,
         ...others.map(other => other.goalSpecifier),
@@ -28,7 +28,7 @@ export class Goal {
 
   public or(...others: Goal[]): Goal {
     return Goal.new({
-      kind: 'GoalOr',
+      kind: AST.NodeKind.GoalOr,
       goals: [
         this.goalSpecifier,
         ...others.map(other => other.goalSpecifier),
@@ -38,7 +38,7 @@ export class Goal {
 
   public static ActivityRecurrenceGoal(opts: { activityTemplate: ActivityTemplate, interval: Duration }): ActivityRecurrenceGoal {
     return Goal.new({
-      kind: 'ActivityRecurrenceGoal',
+      kind: AST.NodeKind.ActivityRecurrenceGoal,
       activityTemplate: opts.activityTemplate,
       interval: opts.interval,
     });

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/SchedulingDSL.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/SchedulingDSL.java
@@ -2,17 +2,15 @@ package gov.nasa.jpl.aerie.scheduler.server.models;
 
 import gov.nasa.jpl.aerie.json.Iso;
 import gov.nasa.jpl.aerie.json.JsonParser;
-import gov.nasa.jpl.aerie.json.Unit;
+import gov.nasa.jpl.aerie.json.ProductParsers;
+import gov.nasa.jpl.aerie.json.SumParsers;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.util.List;
 import java.util.Map;
 
-import static gov.nasa.jpl.aerie.json.BasicParsers.chooseP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.enumP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.listP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.literalP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.longP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.mapP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
@@ -39,53 +37,48 @@ public class SchedulingDSL {
           microseconds -> Duration.of(microseconds, Duration.MICROSECONDS),
           duration -> duration.in(Duration.MICROSECONDS)));
 
-  private static final JsonParser<GoalSpecifier.GoalDefinition> goalDefinitionP =
+  private static final ProductParsers.JsonObjectParser<GoalSpecifier.RecurrenceGoalDefinition>
+      recurrenceGoalDefinitionP =
       productP
-          .field("kind", enumP(GoalKinds.class, Enum::name))
           .field("activityTemplate", activityTemplateP)
           .field("interval", durationP)
           .map(Iso.of(
-              untuple(GoalSpecifier.GoalDefinition::new),
+              untuple(GoalSpecifier.RecurrenceGoalDefinition::new),
               goalDefinition -> tuple(
-                  goalDefinition.kind(),
                   goalDefinition.activityTemplate(),
                   goalDefinition.interval())));
 
-  private static JsonParser<GoalSpecifier.GoalAnd> goalAndF(final JsonParser<GoalSpecifier> goalSpecifierP) {
+  private static ProductParsers.JsonObjectParser<GoalSpecifier.GoalAnd> goalAndF(final JsonParser<GoalSpecifier> goalSpecifierP) {
     return productP
-        .field("kind", literalP("GoalAnd"))
         .field("goals", listP(goalSpecifierP))
-        .map(Iso.of(untuple(($, goals) -> new GoalSpecifier.GoalAnd(goals)),
-                    $ -> tuple(Unit.UNIT, $.goals())));
+        .map(Iso.of(untuple(GoalSpecifier.GoalAnd::new),
+                    GoalSpecifier.GoalAnd::goals));
   }
 
-  private static JsonParser<GoalSpecifier.GoalOr> goalOrF(final JsonParser<GoalSpecifier> goalSpecifierP) {
+  private static ProductParsers.JsonObjectParser<GoalSpecifier.GoalOr> goalOrF(final JsonParser<GoalSpecifier> goalSpecifierP) {
     return productP
-        .field("kind", literalP("GoalOr"))
         .field("goals", listP(goalSpecifierP))
-        .map(Iso.of(untuple(($, goals) -> new GoalSpecifier.GoalOr(goals)),
-                    $ -> tuple(Unit.UNIT, $.goals())));
+        .map(Iso.of(untuple(GoalSpecifier.GoalOr::new),
+                    GoalSpecifier.GoalOr::goals));
   }
 
 
   private static final JsonParser<GoalSpecifier> goalSpecifierP =
-      recursiveP(self -> chooseP(goalAndF(self), goalOrF(self), goalDefinitionP));
+      recursiveP(self -> SumParsers.sumP("kind", GoalSpecifier.class, List.of(
+          SumParsers.variant("ActivityRecurrenceGoal", GoalSpecifier.RecurrenceGoalDefinition.class, recurrenceGoalDefinitionP),
+          SumParsers.variant("GoalAnd", GoalSpecifier.GoalAnd.class, goalAndF(self)),
+          SumParsers.variant("GoalOr", GoalSpecifier.GoalOr.class, goalOrF(self))
+      )));
 
 
   public static final JsonParser<GoalSpecifier> schedulingJsonP = goalSpecifierP;
 
 
-  public enum GoalKinds {
-    ActivityRecurrenceGoal
-  }
-
   public sealed interface GoalSpecifier {
-    record GoalDefinition(
-        GoalKinds kind,
+    record RecurrenceGoalDefinition(
         ActivityTemplate activityTemplate,
         Duration interval
-    ) implements GoalSpecifier {
-    }
+    ) implements GoalSpecifier {}
     record GoalAnd(List<GoalSpecifier> goals) implements GoalSpecifier {}
     record GoalOr(List<GoalSpecifier> goals) implements GoalSpecifier {}
   }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
@@ -1,6 +1,9 @@
 package gov.nasa.jpl.aerie.scheduler.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate;
+import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
+import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.TimeAnchor;
+import gov.nasa.jpl.aerie.scheduler.goals.CoexistenceGoal;
 import gov.nasa.jpl.aerie.scheduler.goals.CompositeAndGoal;
 import gov.nasa.jpl.aerie.scheduler.goals.Goal;
 import gov.nasa.jpl.aerie.scheduler.goals.OptionGoal;
@@ -9,7 +12,6 @@ import gov.nasa.jpl.aerie.scheduler.model.ActivityType;
 import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
 import gov.nasa.jpl.aerie.scheduler.server.models.SchedulingDSL;
 import gov.nasa.jpl.aerie.scheduler.server.models.Timestamp;
-import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.function.Function;
 
@@ -31,7 +33,12 @@ public class GoalBuilder {
           .thereExistsOne(makeActivityTemplate(g.activityTemplate(), lookupActivityType))
           .build();
     } else if (goalSpecifier instanceof SchedulingDSL.GoalSpecifier.CoexistenceGoalDefinition g) {
-      throw new NotImplementedException("Working on coexistence goal");
+      return new CoexistenceGoal.Builder()
+          .forAllTimeIn(hor)
+          .forEach(ActivityExpression.ofType(lookupActivityType.apply(g.forEach().type())))
+          .thereExistsOne(makeActivityTemplate(g.activityTemplate(), lookupActivityType))
+          .startsAt(TimeAnchor.END)
+          .build();
     } else if (goalSpecifier instanceof SchedulingDSL.GoalSpecifier.GoalAnd g) {
       var builder = new CompositeAndGoal.Builder();
       for (final var subGoalSpecifier : g.goals()) {

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
@@ -9,6 +9,7 @@ import gov.nasa.jpl.aerie.scheduler.model.ActivityType;
 import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
 import gov.nasa.jpl.aerie.scheduler.server.models.SchedulingDSL;
 import gov.nasa.jpl.aerie.scheduler.server.models.Timestamp;
+import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.function.Function;
 
@@ -29,6 +30,8 @@ public class GoalBuilder {
           .repeatingEvery(g.interval())
           .thereExistsOne(makeActivityTemplate(g.activityTemplate(), lookupActivityType))
           .build();
+    } else if (goalSpecifier instanceof SchedulingDSL.GoalSpecifier.CoexistenceGoalDefinition g) {
+      throw new NotImplementedException("Working on coexistence goal");
     } else if (goalSpecifier instanceof SchedulingDSL.GoalSpecifier.GoalAnd g) {
       var builder = new CompositeAndGoal.Builder();
       for (final var subGoalSpecifier : g.goals()) {

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
@@ -50,7 +50,7 @@ public class TypescriptCodeGenerationService {
     for (final var activityTypeCode : activityTypeCodes) {
       result.add("interface %s extends ActivityTemplate {}".formatted(activityTypeCode.activityTypeName()));
     }
-    result.add("export const ActivityTemplates = {");
+    result.add("const ActivityTemplates = {");
     result.add(indent(generateActivityTemplates(activityTypeCodes)));
     result.add("}");
     result.add("declare global {");

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
@@ -47,18 +47,31 @@ public class TypescriptCodeGenerationService {
     final var result = new ArrayList<String>();
     result.add("/** Start Codegen */");
     result.add("import type { ActivityTemplate } from './scheduler-edsl-fluent-api.js';");
+    result.add(generateActivityTypeEnum(activityTypeCodes));
     for (final var activityTypeCode : activityTypeCodes) {
       result.add("interface %s extends ActivityTemplate {}".formatted(activityTypeCode.activityTypeName()));
     }
     result.add(generateActivityTemplateConstructors(activityTypeCodes));
     result.add("declare global {");
     result.add(indent("var ActivityTemplates: typeof ActivityTemplateConstructors;"));
+    result.add(indent("var ActivityTypes: typeof ActivityType;"));
     result.add("}");
-    result.add("// Make ActivityTemplates available on the global object");
+    result.add("// Make ActivityTemplates and ActivityTypes available on the global object");
     result.add("Object.assign(globalThis, {");
     result.add(indent("ActivityTemplates: ActivityTemplateConstructors,"));
+    result.add(indent("ActivityTypes: ActivityType,"));
     result.add("});");
     result.add("/** End Codegen */");
+    return joinLines(result);
+  }
+
+  private static String generateActivityTypeEnum(ArrayList<ActivityTypeCode> activityTypeCodes) {
+    final var result = new ArrayList<String>();
+    result.add("export enum ActivityType {");
+    for (final var activityTypeCode : activityTypeCodes) {
+      result.add(indent("%s = '%s',".formatted(activityTypeCode.activityTypeName(), activityTypeCode.activityTypeName())));
+    }
+    result.add("}");
     return joinLines(result);
   }
 
@@ -69,7 +82,7 @@ public class TypescriptCodeGenerationService {
       result.add(indent("%s: function %sConstructor(args: {".formatted(activityTypeCode.activityTypeName(), activityTypeCode.activityTypeName())));
       result.add(indent(indent(generateActivityArgumentTypes(activityTypeCode.parameterTypes()))));
       result.add(indent("}): %s {".formatted(activityTypeCode.activityTypeName())));
-      result.add(indent(indent("return { activityType: '%s', args };".formatted(activityTypeCode.activityTypeName()))));
+      result.add(indent(indent("return { activityType: ActivityType.%s, args };".formatted(activityTypeCode.activityTypeName()))));
       result.add(indent("},"));
     }
     result.add("};");

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
@@ -136,8 +136,7 @@ class SchedulingDSLCompilationServiceTests {
                   })
                 }
             """, "goalfile");
-    final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.GoalDefinition(
-        SchedulingDSL.GoalKinds.ActivityRecurrenceGoal,
+    final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
         new SchedulingDSL.ActivityTemplate(
             "SampleActivity1",
             Map.ofEntries(
@@ -178,8 +177,7 @@ class SchedulingDSLCompilationServiceTests {
                   })
                 }
             """, "goalfile");
-    final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.GoalDefinition(
-        SchedulingDSL.GoalKinds.ActivityRecurrenceGoal,
+    final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
         new SchedulingDSL.ActivityTemplate(
             "SampleActivity1",
             Map.ofEntries(
@@ -260,8 +258,7 @@ class SchedulingDSLCompilationServiceTests {
                   })
                 }
             """ + " ".repeat(9001), "goalfile");
-    final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.GoalDefinition(
-        SchedulingDSL.GoalKinds.ActivityRecurrenceGoal,
+    final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
         new SchedulingDSL.ActivityTemplate(
             "SampleActivity1",
             Map.ofEntries(

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
@@ -42,7 +42,7 @@ class TypescriptCodeGenerationServiceTest {
             /** Start Codegen */
             import type { ActivityTemplate } from './scheduler-edsl-fluent-api.js';
             interface SampleActivity1 extends ActivityTemplate {}
-            export const ActivityTemplates = {
+            const ActivityTemplates = {
               SampleActivity1: function SampleActivity1(
                 args: {
                   duration: Duration,

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
@@ -48,6 +48,10 @@ class TypescriptCodeGenerationServiceTest {
         """
             /** Start Codegen */
             import type { ActivityTemplate } from './scheduler-edsl-fluent-api.js';
+            export enum ActivityType {
+              SampleActivity1 = 'SampleActivity1',
+              SampleActivity2 = 'SampleActivity2',
+            }
             interface SampleActivity1 extends ActivityTemplate {}
             interface SampleActivity2 extends ActivityTemplate {}
             const ActivityTemplateConstructors = {
@@ -56,20 +60,22 @@ class TypescriptCodeGenerationServiceTest {
                 fancy: { subfield1: string, subfield2: { subsubfield1: Double, }[], },
                 variant: ("option1" | "option2"),
               }): SampleActivity1 {
-                return { activityType: 'SampleActivity1', args };
+                return { activityType: ActivityType.SampleActivity1, args };
               },
               SampleActivity2: function SampleActivity2Constructor(args: {
                 quantity: Double,
               }): SampleActivity2 {
-                return { activityType: 'SampleActivity2', args };
+                return { activityType: ActivityType.SampleActivity2, args };
               },
             };
             declare global {
               var ActivityTemplates: typeof ActivityTemplateConstructors;
+              var ActivityTypes: typeof ActivityType;
             }
-            // Make ActivityTemplates available on the global object
+            // Make ActivityTemplates and ActivityTypes available on the global object
             Object.assign(globalThis, {
               ActivityTemplates: ActivityTemplateConstructors,
+              ActivityTypes: ActivityType,
             });
             /** End Codegen */""",
         TypescriptCodeGenerationService.generateTypescriptTypesFromMissionModel(MISSION_MODEL_TYPES));

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
@@ -50,38 +50,27 @@ class TypescriptCodeGenerationServiceTest {
             import type { ActivityTemplate } from './scheduler-edsl-fluent-api.js';
             interface SampleActivity1 extends ActivityTemplate {}
             interface SampleActivity2 extends ActivityTemplate {}
-            const ActivityTemplates = {
-              SampleActivity1: function SampleActivity1(
-                args: {
-                  duration: Duration,
-                  fancy: { subfield1: string, subfield2: { subsubfield1: Double, }[], },
-                  variant: ("option1" | "option2"),
-                }): SampleActivity1 {
-                  return { activityType: 'SampleActivity1', args };
-                },
-              SampleActivity2: function SampleActivity2(
-                args: {
-                  quantity: Double,
-                }): SampleActivity2 {
-                  return { activityType: 'SampleActivity2', args };
-                },
-            }
-            declare global {
-              var ActivityTemplates: {
-                SampleActivity1: (
-                  args: {
-                    duration: Duration,
-                    fancy: { subfield1: string, subfield2: { subsubfield1: Double, }[], },
-                    variant: ("option1" | "option2"),
-                  }) => SampleActivity1
-                SampleActivity2: (
-                  args: {
-                    quantity: Double,
-                  }) => SampleActivity2
-              }
+            const ActivityTemplateConstructors = {
+              SampleActivity1: function SampleActivity1Constructor(args: {
+                duration: Duration,
+                fancy: { subfield1: string, subfield2: { subsubfield1: Double, }[], },
+                variant: ("option1" | "option2"),
+              }): SampleActivity1 {
+                return { activityType: 'SampleActivity1', args };
+              },
+              SampleActivity2: function SampleActivity2Constructor(args: {
+                quantity: Double,
+              }): SampleActivity2 {
+                return { activityType: 'SampleActivity2', args };
+              },
             };
+            declare global {
+              var ActivityTemplates: typeof ActivityTemplateConstructors;
+            }
             // Make ActivityTemplates available on the global object
-            Object.assign(globalThis, { ActivityTemplates });
+            Object.assign(globalThis, {
+              ActivityTemplates: ActivityTemplateConstructors,
+            });
             /** End Codegen */""",
         TypescriptCodeGenerationService.generateTypescriptTypesFromMissionModel(MISSION_MODEL_TYPES));
   }

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
@@ -31,7 +31,14 @@ class TypescriptCodeGenerationServiceTest {
                       ValueSchema.STRING,
                       "subfield2",
                       ValueSchema.ofSeries(ValueSchema.ofStruct(Map.of("subsubfield1", ValueSchema.REAL)))
-                  ))))),
+                  )))),
+                  new TypescriptCodeGenerationService.ActivityType(
+                      "SampleActivity2",
+                      Map.of(
+                          "quantity",
+                          ValueSchema.REAL
+                      )
+                  )),
           null
       );
 
@@ -42,6 +49,7 @@ class TypescriptCodeGenerationServiceTest {
             /** Start Codegen */
             import type { ActivityTemplate } from './scheduler-edsl-fluent-api.js';
             interface SampleActivity1 extends ActivityTemplate {}
+            interface SampleActivity2 extends ActivityTemplate {}
             const ActivityTemplates = {
               SampleActivity1: function SampleActivity1(
                 args: {
@@ -50,6 +58,12 @@ class TypescriptCodeGenerationServiceTest {
                   variant: ("option1" | "option2"),
                 }): SampleActivity1 {
                   return { activityType: 'SampleActivity1', args };
+                },
+              SampleActivity2: function SampleActivity2(
+                args: {
+                  quantity: Double,
+                }): SampleActivity2 {
+                  return { activityType: 'SampleActivity2', args };
                 },
             }
             declare global {
@@ -60,6 +74,10 @@ class TypescriptCodeGenerationServiceTest {
                     fancy: { subfield1: string, subfield2: { subsubfield1: Double, }[], },
                     variant: ("option1" | "option2"),
                   }) => SampleActivity1
+                SampleActivity2: (
+                  args: {
+                    quantity: Double,
+                  }) => SampleActivity2
               }
             };
             // Make ActivityTemplates available on the global object


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1756
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR adds an _extremely_ simplistic version of the Coexistence goal. This version basically allows the user to specify "clean-up" activities. For example, this goal makes sure that every time a banana is picked, it is then immediately peeled:

```typescript
export default () => Goal.CoexistenceGoal({
  forEach: "PickBanana",
  activityTemplate: ActivityTemplates.PeelBanana({ peelDirection: 'fromStem' })
})
```

The version in this PR hard-codes that the new activity must start at the end time of the old activity.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I've added a unit test to `SchedulingDSLCompilationServiceTests.java` as well as an integration test to `SchedulingIntegrationTests.java`. You can run these with `./gradlew scheduler-server:test`.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
I've updated the [Scheduling Guide](https://github.com/NASA-AMMOS/aerie/wiki/Scheduling-Guide) with the [coexistence goal](https://github.com/NASA-AMMOS/aerie/wiki/Scheduling-Guide#coexistence-goal-coming-soon).

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Flesh out the forEach clause of the CoexistenceGoal to include:
  - Richer ActivityExpressions
  - Resource expressions
  - A way to specify a temporal relationship to the identified windows
- Enforce that the clean-up activity starts causally after the existing activity. The current implementation may have some subtle concurrency issues, since the end time of the existing activity overlaps with the start time of the new activity.