### PR TITLE
[AERIE-1779] Reduce docker image sizes.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,8 @@ services:
     build:
       context: ./merlin-server
       dockerfile: Dockerfile
+      args:
+        IMAGE_INCLUDE_JDK: true
     container_name: aerie_merlin
     depends_on: ["postgres"]
     environment:
@@ -74,6 +76,8 @@ services:
     build:
       context: ./scheduler-server
       dockerfile: Dockerfile
+      args:
+        IMAGE_INCLUDE_JDK: true
     container_name: aerie_scheduler
     depends_on: ["aerie_merlin", "postgres"]
     environment:
@@ -116,6 +120,8 @@ services:
     build:
       context: ./merlin-worker
       dockerfile: Dockerfile
+      args:
+        IMAGE_INCLUDE_JDK: true
     container_name: aerie_merlin_worker_1
     depends_on: ["postgres"]
     environment:
@@ -138,6 +144,8 @@ services:
     build:
       context: ./merlin-worker
       dockerfile: Dockerfile
+      args:
+        IMAGE_INCLUDE_JDK: true
     container_name: aerie_merlin_worker_2
     depends_on: ["postgres"]
     environment:

--- a/merlin-server/Dockerfile
+++ b/merlin-server/Dockerfile
@@ -6,6 +6,11 @@ RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 
 FROM eclipse-temurin:17-jre-focal
 
+ARG IMAGE_INCLUDE_JDK=false
+RUN if [ $IMAGE_INCLUDE_JDK = "true" ] ; then \
+        apt update && apt install openjdk-17-jdk-headless -y; \
+    fi ;
+
 COPY --from=extractor /usr/src/app/extracted /usr/src/app
 
 WORKDIR /usr/src/app

--- a/merlin-server/Dockerfile
+++ b/merlin-server/Dockerfile
@@ -1,7 +1,12 @@
-FROM eclipse-temurin:17-focal
+FROM alpine:3.15 AS extractor
 
 COPY build/distributions/*.tar /usr/src/app/server.tar
-RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar
+RUN mkdir /usr/src/app/extracted
+RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
+
+FROM eclipse-temurin:17-jre-focal
+
+COPY --from=extractor /usr/src/app/extracted /usr/src/app
 
 WORKDIR /usr/src/app
 ENTRYPOINT ["/usr/src/app/bin/merlin-server"]

--- a/merlin-worker/Dockerfile
+++ b/merlin-worker/Dockerfile
@@ -6,6 +6,11 @@ RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 
 FROM eclipse-temurin:17-jre-focal
 
+ARG IMAGE_INCLUDE_JDK=false
+RUN if [ $IMAGE_INCLUDE_JDK = "true" ] ; then \
+        apt update && apt install openjdk-17-jdk-headless -y; \
+    fi ;
+
 COPY --from=extractor /usr/src/app/extracted /usr/src/app
 
 WORKDIR /usr/src/app

--- a/merlin-worker/Dockerfile
+++ b/merlin-worker/Dockerfile
@@ -1,7 +1,12 @@
-FROM eclipse-temurin:17-focal
+FROM alpine:3.15 AS extractor
 
-COPY build/distributions/*.tar /usr/src/app/worker.tar
-RUN cd /usr/src/app && tar --strip-components 1 -xf worker.tar
+COPY build/distributions/*.tar /usr/src/app/server.tar
+RUN mkdir /usr/src/app/extracted
+RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
+
+FROM eclipse-temurin:17-jre-focal
+
+COPY --from=extractor /usr/src/app/extracted /usr/src/app
 
 WORKDIR /usr/src/app
 ENTRYPOINT ["/usr/src/app/bin/merlin-worker"]

--- a/scheduler-server/Dockerfile
+++ b/scheduler-server/Dockerfile
@@ -1,4 +1,10 @@
-FROM eclipse-temurin:17-focal
+FROM alpine:3.15 AS extractor
+
+COPY build/distributions/*.tar /usr/src/app/server.tar
+RUN mkdir /usr/src/app/extracted
+RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
+
+FROM eclipse-temurin:17-jre-focal
 
 ENV NODE_VERSION=16.14.0
 RUN apt install -y curl
@@ -11,8 +17,7 @@ ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN node --version
 RUN npm --version
 
-COPY build/distributions/*.tar /usr/src/app/server.tar
-RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar
+COPY --from=extractor /usr/src/app/extracted /usr/src/app
 
 COPY scheduling-dsl-compiler /usr/src/app/scheduling-dsl-compiler
 ENV SCHEDULING_DSL_COMPILER_ROOT="/usr/src/app/scheduling-dsl-compiler/"

--- a/scheduler-server/Dockerfile
+++ b/scheduler-server/Dockerfile
@@ -6,6 +6,11 @@ RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 
 FROM eclipse-temurin:17-jre-focal
 
+ARG IMAGE_INCLUDE_JDK=false
+RUN if [ $IMAGE_INCLUDE_JDK = "true" ] ; then \
+        apt update && apt install openjdk-17-jdk-headless -y; \
+    fi ;
+
 ENV NODE_VERSION=16.14.0
 RUN apt install -y curl
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1779
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

### Commit 1

This makes two changes to the merlin, scheduler, and worker dockerfiles:

1. Change eclipse-temurin:17-focal base image to eclipse-temurin:17-jre-focal
    - This leaves only the JRE, not the full JDK available to the container.
    - This makes the following commands unavailable in the container (found using `compgen -c`):
        - jdeprscan
        - jconsole
        - jinfo
        - **javadoc**
        - **jar**
        - jarsigner
        - jhsdb
        - jstatd
        - **jdb**
        - jlink
        - jmod
        - jmap
        - jstat
        - **javac**
        - serialver
        - jimage
        - jstack
        - jshell
        - javap
        - jcmd
        - jdeps
        - jps
        - jpackage
    - This removes about 190 MB from the container sizes.
2. Add an extra build stage for extracting the `server.tar` file, so that the tar can be left behind (we only need the extracted contents).
    - This can't be accomplished with a simple `rm server.tar` because docker build layers are append-only operations (`rm` removes the file from the filesystem, but the COPY build layer remains)
    - Roughly 40-50 MB size reduction, depending on the image.

In total, the size changes are:
- **aerie_merlin**: 544MB -> 308MB (236MB reduction)
- **aerie_scheduler**: 823MB -> 578MB (245MB reduction)
- **aerie_merlin_worker**: 545MB -> 309MB (236MB reduction)

### Commit 2

This adds a step to the Dockerfiles that conditionally installs openjdk-17 if the docker ARG `IMAGE_INCLUDE_JDK` is `true`. This arg is set to `true` in the root-level docker-compose.yml.

This way the full jdk will be available in locally-built development images, but will not be included/downloaded in the published images created by the `publish` github action.

A downside is that the dev images built with `IMAGE_INCLUDE_JDK=true` are even larger than they were before, but that is acceptable because they will not be pushed or pulled by either devs or users.

## Verification
There are no behavioral changes to the code itself, so as long as the e2e tests pass, the only extra verification should be reviewer approval that the removed commands are not needed for debugging.

## Future Work
~~Another possibility for reducing size would be to combine the java-based containers into one, and our node-based containers into another. This would obviously be a large change (and probably not desirable), but I estimate this could save about a gigabyte, because java and node both take about 250 MB in their respective containers. But I doubt the reduced flexibility would be worth the size reduction.~~

edit: this would not actually be helpful, see discussion below.