### PR TITLE
[HOTFIX] Add quotes around docker arg

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       context: ./merlin-server
       dockerfile: Dockerfile
       args:
-        IMAGE_INCLUDE_JDK: true
+        IMAGE_INCLUDE_JDK: "true"
     container_name: aerie_merlin
     depends_on: ["postgres"]
     environment:
@@ -77,7 +77,7 @@ services:
       context: ./scheduler-server
       dockerfile: Dockerfile
       args:
-        IMAGE_INCLUDE_JDK: true
+        IMAGE_INCLUDE_JDK: "true"
     container_name: aerie_scheduler
     depends_on: ["aerie_merlin", "postgres"]
     environment:
@@ -121,7 +121,7 @@ services:
       context: ./merlin-worker
       dockerfile: Dockerfile
       args:
-        IMAGE_INCLUDE_JDK: true
+        IMAGE_INCLUDE_JDK: "true"
     container_name: aerie_merlin_worker_1
     depends_on: ["postgres"]
     environment:
@@ -145,7 +145,7 @@ services:
       context: ./merlin-worker
       dockerfile: Dockerfile
       args:
-        IMAGE_INCLUDE_JDK: true
+        IMAGE_INCLUDE_JDK: "true"
     container_name: aerie_merlin_worker_2
     depends_on: ["postgres"]
     environment:


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Fix for when using `docker-compose` instead of `docker compose`. Boolean arguments in `docker-compose.yml` should include quotes around boolean values.

## Verification
Verified that `docker-compose` works now.
