### PR TITLE
[AERIE-1783] Add commanding container to the deployment docker compose

### DIFF
--- a/command-expansion-server/src/app.ts
+++ b/command-expansion-server/src/app.ts
@@ -22,7 +22,7 @@ import { mapGraphQLActivityInstance } from './lib/mapGraphQLActivityInstance.js'
 
 const logger = getLogger("app");
 
-const PORT: number = parseInt(getEnv().PORT, 10) ?? 3000;
+const PORT: number = parseInt(getEnv().PORT, 10) ?? 27184;
 
 const app: Application = express();
 // WARNING: bodyParser.json() is vulnerable to a string too long issue. Iff that occurs,

--- a/command-expansion-server/src/env.ts
+++ b/command-expansion-server/src/env.ts
@@ -15,7 +15,7 @@ export const defaultEnv: Env = {
   LOG_FILE: 'console',
   LOG_LEVEL: 'info',
   MERLIN_GRAPHQL_URL: 'http://hasura:8080/v1/graphql',
-  PORT: '3000',
+  PORT: '27184',
   POSTGRES_AERIE_EXPANSION_DB: 'aerie_commanding',
   POSTGRES_HOST: 'localhost',
   POSTGRES_PASSWORD: 'aerie',

--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -2,12 +2,28 @@
 
 This document provides detailed information about environment variables for each service in Aerie.
 
+- [Aerie Commanding](#aerie-commanding)
 - [Aerie Gateway](#aerie-gateway)
 - [Aerie Merlin](#aerie-merlin)
 - [Aerie Scheduler](#aerie-scheduler)
 - [Aerie UI](#aerie-ui)
 - [Hasura](#hasura)
 - [Postgres](#postgres)
+
+## Aerie Commanding
+
+| Name                          | Description                                       | Type     | Default                             |
+|-------------------------------|---------------------------------------------------| -------- |-------------------------------------|
+| `LOG_FILE`                    | Either an output filepath to log to, or 'console' | `string` | console                             |
+| `LOG_LEVEL`                   | Logging level for filtering logs                  | `string` | warn                                |
+| `MERLIN_GRAPHQL_URL`          | URI of the Aerie GraphQL API                      | `string` | http://hasura:8080/v1/graphql       |
+| `COMMANDING_SERVER_PORT`      | Port the server listens on                        | `number` | 27184                               |
+| `COMMANDING_DB`               | Name of Commanding Postgres database              | `string` | aerie_commanding                    |
+| `COMMANDING_DB_SERVER`        | Hostname of Postgres instance                     | `string` | postgres                            |
+| `COMMANDING_DB_PASSWORD`      | Password of Postgres instance                     | `string` | aerie                               |
+| `COMMANDING_DB_PORT`          | Port of Postgres instance                         | `number` | 5432                                |
+| `COMMANDING_DB_USER`          | User of Postgres instance                         | `string` | aerie                               |
+| `COMMANDING_LOCAL_STORE`      | Local storage file storage in the container       | `string` | /usr/src/app/commanding_file_store  |
 
 ## Aerie Gateway
 
@@ -43,15 +59,15 @@ This document provides detailed information about environment variables for each
 
 ## Aerie Merlin Worker
 
-| Name                        | Description                                                                              | Type     | Default                        |
-|-----------------------------|------------------------------------------------------------------------------------------| -------- | ------------------------------ |
-| `JAVA_OPTS`                 | Configuration for Merlin's logging level and output file                                 | `string` | log level: warn. output: stderr|
-| `MERLIN_WORKER_LOCAL_STORE` | The local storage as for the Merlin container (this must the same as the Merlin container)                                      | `string` | /usr/src/app/merlin_file_store |
-| `MERLIN_WORKER_DB_SERVER`   | The DB instance that Merlin will connect with (this must the same as the Merlin container) | `string` | postgres                       |
-| `MERLIN_WORKER_DB_PORT`     | The DB instance port number that Merlin will connect with (this must the same as the Merlin container)                               | `number` | 5432                           |
-| `MERLIN_WORKER_DB_USER`     | Username of the DB instance (this must the same as the Merlin container)                                                             | `string` | aerie                          |
-| `MERLIN_WORKER_DB_PASSWORD` | Password of the DB instance (this must the same as the Merlin container)                                                             | `string` | aerie                          |
-| `MERLIN_WORKER_DB`          | The DB for Merlin. (this must the same as the Merlin container)                                                                     
+| Name                        | Description                                               | Type     | Default                                      |
+|-----------------------------|-----------------------------------------------------------| -------- |----------------------------------------------|
+| `JAVA_OPTS`                 | Configuration for Merlin's logging level and output file  | `string` | log level: warn. output: stderr              |
+| `MERLIN_WORKER_LOCAL_STORE` | The local storage as for the Merlin container             | `string` | /usr/src/app/merlin_file_store               |
+| `MERLIN_WORKER_DB_SERVER`   | The DB instance that Merlin will connect with             | `string` | (this must the same as the Merlin container) |
+| `MERLIN_WORKER_DB_PORT`     | The DB instance port number that Merlin will connect with | `number` | (this must the same as the Merlin container) |
+| `MERLIN_WORKER_DB_USER`     | Username of the DB instance                               | `string` | (this must the same as the Merlin container) |
+| `MERLIN_WORKER_DB_PASSWORD` | Password of the DB instance                               | `string` | (this must the same as the Merlin container) |
+| `MERLIN_WORKER_DB`          | The DB for Merlin.                                        | `string` | (this must the same as the Merlin container) |                                                             
 
 ## Aerie Scheduler
 
@@ -68,7 +84,7 @@ This document provides detailed information about environment variables for each
 | `SCHEDULER_LOCAL_STORE` | Local storage for scheduler in the container                          | `string` | /usr/src/app/scheduler_file_store                  |
 | `SCHEDULER_LOGGING`     | Whether or not you want Javalin to log server information             | `string` | true                                               |
 | `SCHEDULER_OUTPUT_MODE` | how scheduler output is sent back to aerie                            | `string` | UpdateInputPlanWithNewActivities                   |
-| `SCHEDULER_PORT`        | Port number for the scheduler server                                  | `number` | 27193                                              |
+| `SCHEDULER_PORT`        | Port number for the scheduler server                                  | `number` | 27185                                              |
 | `SCHEDULER_RULES_JAR`   | Jar file to load scheduling rules from (until user input to database) | `string` | /usr/src/app/merlin_file_store/scheduler_rules.jar |
 
 ## Aerie UI

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -90,13 +90,13 @@ services:
       SCHEDULER_DB_USER: "aerie"
       SCHEDULER_LOCAL_STORE: /usr/src/app/scheduler_file_store
       SCHEDULER_OUTPUT_MODE: UpdateInputPlanWithNewActivities
-      SCHEDULER_PORT: 27193
+      SCHEDULER_PORT: 27185
       SCHEDULER_RULES_JAR: /usr/src/app/merlin_file_store/scheduler_rules.jar
       JAVA_OPTS: >
         -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
         -Dorg.slf4j.simpleLogger.logFile=System.err
     image: "${REPOSITORY_DOCKER_URL}/aerie-scheduler:${DOCKER_TAG}"
-    ports: ["27193:27193"]
+    ports: ["27185:27185"]
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,5 +1,24 @@
 version: "3.7"
 services:
+  aerie_commanding:
+    container_name: aerie_commanding
+    depends_on: ["postgres"]
+    environment:
+      LOG_FILE: console
+      LOG_LEVEL: warn
+      MERLIN_GRAPHQL_URL: http://hasura:8080/v1/graphql
+      COMMANDING_SERVER_PORT: 27184
+      COMMANDING_DB: aerie_commanding
+      COMMANDING_DB_PASSWORD: aerie
+      COMMANDING_DB_PORT: 5432
+      COMMANDING_DB_SERVER: postgres
+      COMMANDING_DB_USER: aerie
+      COMMANDING_LOCAL_STORE: /usr/src/app/commanding_file_store
+    image: "${REPOSITORY_DOCKER_URL}/aerie-commanding:${DOCKER_TAG}"
+    ports: ["27184:27184"]
+    restart: always
+    volumes:
+      - aerie_file_store:/usr/src/app/commanding_file_store
   aerie_gateway:
     container_name: aerie_gateway
     depends_on: ["postgres"]
@@ -97,6 +116,7 @@ services:
     container_name: hasura
     depends_on: ["postgres"]
     environment:
+      AERIE_COMMANDING_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_commanding
       AERIE_MERLIN_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_merlin
       AERIE_SCHEDULER_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_scheduler
       AERIE_UI_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_ui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       LOG_FILE: console
       LOG_LEVEL: debug
       MERLIN_GRAPHQL_URL: http://hasura:8080/v1/graphql
-      COMMANDING_SERVER_PORT: 3000
+      COMMANDING_SERVER_PORT: 27184
       COMMANDING_DB: aerie_commanding
       COMMANDING_DB_PASSWORD: aerie
       COMMANDING_DB_PORT: 5432
@@ -18,7 +18,7 @@ services:
       COMMANDING_DB_USER: aerie
       COMMANDING_LOCAL_STORE: /usr/src/app/commanding_file_store
     image: aerie_commanding
-    ports: ["3000:3000"]
+    ports: ["27184:27184"]
     restart: always
     volumes:
       - ./command-expansion-server:/app:cached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       SCHEDULER_LOCAL_STORE: /usr/src/app/scheduler_file_store
       SCHEDULER_LOGGING: "true"
       SCHEDULER_OUTPUT_MODE: UpdateInputPlanWithNewActivities
-      SCHEDULER_PORT: 27193
+      SCHEDULER_PORT: 27185
       SCHEDULER_RULES_JAR: /usr/src/app/merlin_file_store/scheduler_rules.jar
       JAVA_OPTS: >
         -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
@@ -99,7 +99,7 @@ services:
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
     image: aerie_scheduler
-    ports: ["27193:27193", "5006:5005"]
+    ports: ["27185:27185", "5006:5005"]
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
@@ -147,7 +147,7 @@ public final class SchedulerAppDriver {
   private static AppConfiguration loadConfiguration() {
     final var logger = LoggerFactory.getLogger(SchedulerAppDriver.class);
     return new AppConfiguration(
-        Integer.parseInt(getEnv("SCHEDULER_PORT", "27193")),
+        Integer.parseInt(getEnv("SCHEDULER_PORT", "27185")),
         logger.isDebugEnabled(),
         Path.of(getEnv("SCHEDULER_LOCAL_STORE", "/usr/src/app/scheduler_file_store")),
         new PostgresStore(getEnv("SCHEDULER_DB_SERVER", "postgres"),


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1783
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Added commanding container to deployment docker compose.

## Verification
Ran `docker compose up` and uploaded a command dictionary and received a dict ID of 1 and no errors. Used upload query as defined in the test file https://github.com/NASA-AMMOS/aerie/blob/fca42c28f23488d97506dd798070d879ae284f3b/command-expansion-server/test/utils/CommandDictionary.ts#L3

## Documentation
None required and no new documentation needed.

## Future work
None
