### PR TITLE
[AERIE-1685] Validate plan prior to simulating 

### DIFF
--- a/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/activities/ParameterTestActivityTest.java
+++ b/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/activities/ParameterTestActivityTest.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.banananation.activities;
 import gov.nasa.jpl.aerie.banananation.generated.activities.ParameterTestActivityMapper;
 import gov.nasa.jpl.aerie.contrib.serialization.mappers.DurationValueMapper;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.junit.jupiter.api.Test;
 
@@ -26,7 +27,7 @@ public class ParameterTestActivityTest {
   }
 
   @Test
-  public void testDeserialization() throws TaskSpecType.UnconstructableTaskSpecException {
+  public void testDeserialization() throws TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException {
     final Map<String, SerializedValue> sourceActivity = createSerializedArguments();
     final ParameterTestActivity testValues = new ParameterTestActivity();
 
@@ -94,7 +95,7 @@ public class ParameterTestActivityTest {
   }
 
   @Test
-  public void testSerialization() throws TaskSpecType.UnconstructableTaskSpecException {
+  public void testSerialization() throws TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException {
     final ParameterTestActivity sourceActivity = new ParameterTestActivity();
     final Map<String, SerializedValue> activityArgs = this.mapper.getArguments(sourceActivity);
 

--- a/examples/config-with-defaults/src/test/java/gov/nasa/jpl/aerie/configwithdefaults/ConfigurationTest.java
+++ b/examples/config-with-defaults/src/test/java/gov/nasa/jpl/aerie/configwithdefaults/ConfigurationTest.java
@@ -5,6 +5,7 @@ import gov.nasa.jpl.aerie.configwithdefaults.generated.ConfigurationMapper;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinTestContext;
 import gov.nasa.jpl.aerie.merlin.protocol.model.ConfigurationType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -23,7 +24,7 @@ public final class ConfigurationTest {
   private final Mission model;
 
   public ConfigurationTest(final MerlinTestContext<ActivityTypes, Mission> ctx)
-  throws ConfigurationType.UnconstructableConfigurationException
+  throws ConfigurationType.UnconstructableConfigurationException, MissingArgumentsException
   {
     // Rely on config. defaults by instantiating config. with empty argument map
     final var config = new ConfigurationMapper().instantiate(Map.of());

--- a/examples/config-without-defaults/src/test/java/gov/nasa/jpl/aerie/configwithoutdefaults/ConfigurationTest.java
+++ b/examples/config-without-defaults/src/test/java/gov/nasa/jpl/aerie/configwithoutdefaults/ConfigurationTest.java
@@ -5,6 +5,7 @@ import gov.nasa.jpl.aerie.configwithoutdefaults.generated.ConfigurationMapper;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinTestContext;
 import gov.nasa.jpl.aerie.merlin.protocol.model.ConfigurationType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -28,7 +29,7 @@ public final class ConfigurationTest {
   private final Mission model;
 
   public ConfigurationTest(final MerlinTestContext<ActivityTypes, Mission> ctx)
-  throws ConfigurationType.UnconstructableConfigurationException
+  throws ConfigurationType.UnconstructableConfigurationException, MissingArgumentsException
   {
     // Rely on config. defaults by instantiating config. with empty argument map
     final var config = new ConfigurationMapper().instantiate(Map.of(

--- a/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/FooValueMappersTest.java
+++ b/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/FooValueMappersTest.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.foomissionmodel;
 import gov.nasa.jpl.aerie.foomissionmodel.generated.ConfigurationMapper;
 import gov.nasa.jpl.aerie.merlin.driver.json.JsonEncoding;
 import gov.nasa.jpl.aerie.merlin.protocol.model.ConfigurationType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import org.junit.jupiter.api.Test;
 
 import javax.json.Json;
@@ -12,7 +13,9 @@ import static org.assertj.core.api.Assertions.within;
 
 public final class FooValueMappersTest {
   @Test
-  public void testConfigurationMapper() throws ConfigurationType.UnconstructableConfigurationException {
+  public void testConfigurationMapper()
+  throws ConfigurationType.UnconstructableConfigurationException, MissingArgumentsException
+  {
     final var stream = FooValueMappersTest.class.getResourceAsStream("mission_config.json");
     final var serializedConfig = JsonEncoding.decode(Json.createReader(stream).read());
     final var config = new ConfigurationMapper().instantiate(serializedConfig.asMap().get());

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
@@ -8,6 +8,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.ConfigurationType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Resource;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
@@ -58,7 +59,7 @@ public final class MissionModel<Model> {
   }
 
   public Directive<Model, ?, ?> instantiateDirective(final SerializedActivity specification)
-  throws TaskSpecType.UnconstructableTaskSpecException
+  throws TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException
   {
     return Directive.instantiate(this.directiveTypes.taskSpecTypes().get(specification.getTypeName()), specification);
   }

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelLoader.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelLoader.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.driver;
 import gov.nasa.jpl.aerie.merlin.protocol.model.ConfigurationType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.MerlinPlugin;
 import gov.nasa.jpl.aerie.merlin.protocol.model.MissionModelFactory;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.io.BufferedReader;
@@ -47,7 +48,7 @@ public final class MissionModelLoader {
             final var registry = DirectiveTypeRegistry.extract(factory);
             final var model = factory.instantiate(registry.registry(), config, builder);
             return builder.build(model, factory.getConfigurationType(), registry);
-        } catch (final ConfigurationType.UnconstructableConfigurationException ex) {
+        } catch (final ConfigurationType.UnconstructableConfigurationException | MissingArgumentsException ex) {
             throw new MissionModelInstantiationException(ex);
         }
     }

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/Directive.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/Directive.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.driver.engine;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.util.Map;
@@ -16,7 +17,7 @@ public record Directive<Model, DirectiveType, Return> (
 ) {
   public static <Model, DirectiveType, Return> Directive<Model, DirectiveType, Return>
   instantiate(final @Nullable TaskSpecType<Model, DirectiveType, Return> directiveType, final SerializedActivity instance)
-  throws TaskSpecType.UnconstructableTaskSpecException
+  throws TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException
   {
     if (directiveType == null) throw new TaskSpecType.UnconstructableTaskSpecException();
     return new Directive<>(directiveType, instance.getTypeName(), directiveType.instantiate(instance.getArguments()));

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/Directive.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/Directive.java
@@ -19,7 +19,10 @@ public record Directive<Model, DirectiveType, Return> (
   instantiate(final @Nullable TaskSpecType<Model, DirectiveType, Return> directiveType, final SerializedActivity instance)
   throws TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException
   {
-    if (directiveType == null) throw new TaskSpecType.UnconstructableTaskSpecException();
+    if (directiveType == null) {
+      throw new TaskSpecType.UnconstructableTaskSpecException("Nonexistent task spec. type: %s".formatted(instance.getTypeName()));
+    }
+
     return new Directive<>(directiveType, instance.getTypeName(), directiveType.instantiate(instance.getArguments()));
   }
 

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -20,6 +20,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.Resource;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
@@ -76,7 +77,7 @@ public final class SimulationEngine implements AutoCloseable {
   TaskId initiateTaskFromInput(final MissionModel<Model> model, final SerializedActivity input) {
     try {
       return initiateTaskFromInputOrFail(model, input);
-    } catch (final TaskSpecType.UnconstructableTaskSpecException ex) {
+    } catch (final TaskSpecType.UnconstructableTaskSpecException | MissingArgumentsException ex) {
       final var task = TaskId.generate();
 
       // TODO: Provide more information about the failure.
@@ -89,7 +90,7 @@ public final class SimulationEngine implements AutoCloseable {
   /** Construct a task defined by the behavior of a model given a type and arguments. */
   public <Model>
   TaskId initiateTaskFromInputOrFail(final MissionModel<Model> model, final SerializedActivity input)
-  throws TaskSpecType.UnconstructableTaskSpecException
+  throws TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException
   {
     final var directive  = model.instantiateDirective(input);
     final var task = TaskId.generate();

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllDefinedMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllDefinedMethodMaker.java
@@ -69,11 +69,12 @@ import java.util.Optional;
                     .add("case $S:\n", parameter.name)
                     .indent()
                     .addStatement(
-                        "template.$L = this.mapper_$L.deserializeValue($L.getValue()).getSuccessOrThrow($$ -> new $T())",
+                        "template.$L = this.mapper_$L.deserializeValue($L.getValue()).getSuccessOrThrow(failure -> $T.unconstructableArgument(\"$L\", failure))",
                         parameter.name,
                         parameter.name,
                         "entry",
-                        unconstructableInstantiateException)
+                        unconstructableInstantiateException,
+                        parameter.name)
                     .addStatement("break")
                     .unindent())
                 .reduce(CodeBlock.builder(), (x, y) -> x.add(y.build()))
@@ -84,8 +85,9 @@ import java.util.Optional;
                 .add("default:\n")
                 .indent()
                 .addStatement(
-                    "throw new $T()",
-                    unconstructableInstantiateException)
+                    "throw $T.extraneousParameter($L.getKey())",
+                    unconstructableInstantiateException,
+                    "entry")
                 .unindent()
                 .build())
         .endControlFlow()

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllStaticallyDefinedMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllStaticallyDefinedMethodMaker.java
@@ -75,12 +75,13 @@ import java.util.stream.Collectors;
                         .add("case $S:\n", parameter.name)
                         .indent()
                         .addStatement(
-                            "$L = $L(this.mapper_$L.deserializeValue($L.getValue()).getSuccessOrThrow($$ -> new $T()))",
+                            "$L = $L(this.mapper_$L.deserializeValue($L.getValue()).getSuccessOrThrow(failure -> $T.unconstructableArgument(\"$L\", failure)))",
                             parameter.name,
                             "Optional.ofNullable",
                             parameter.name,
                             "entry",
-                            unconstructableInstantiateException)
+                            unconstructableInstantiateException,
+                            parameter.name)
                         .addStatement("break")
                         .unindent())
                     .reduce(CodeBlock.builder(), (x, y) -> x.add(y.build()))
@@ -91,8 +92,9 @@ import java.util.stream.Collectors;
                     .add("default:\n")
                     .indent()
                     .addStatement(
-                        "throw new $T()",
-                        unconstructableInstantiateException)
+                        "throw $T.extraneousParameter($L.getKey())",
+                        unconstructableInstantiateException,
+                        "entry")
                     .unindent()
                     .build())
             .endControlFlow()

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -28,6 +28,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.MissionModelFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin;
 import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/NoneDefinedMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/NoneDefinedMethodMaker.java
@@ -65,11 +65,12 @@ import java.util.stream.Collectors;
                     .add("case $S:\n", parameter.name)
                     .indent()
                     .addStatement(
-                        "$L = Optional.ofNullable(this.mapper_$L.deserializeValue($L.getValue()).getSuccessOrThrow($$ -> new $T()))",
+                        "$L = Optional.ofNullable(this.mapper_$L.deserializeValue($L.getValue()).getSuccessOrThrow(failure -> $T.unconstructableArgument(\"$L\", failure)))",
                         parameter.name,
                         parameter.name,
                         "entry",
-                        unconstructableInstantiateException)
+                        unconstructableInstantiateException,
+                        parameter.name)
                     .addStatement("break")
                     .unindent())
                 .reduce(CodeBlock.builder(), (x, y) -> x.add(y.build()))
@@ -80,8 +81,9 @@ import java.util.stream.Collectors;
                 .add("default:\n")
                 .indent()
                 .addStatement(
-                    "throw new $T()",
-                    unconstructableInstantiateException)
+                    "throw $T.extraneousParameter($L.getKey())",
+                    unconstructableInstantiateException,
+                    "entry")
                 .unindent()
                 .build())
         .endControlFlow()

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/SomeStaticallyDefinedMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/SomeStaticallyDefinedMethodMaker.java
@@ -81,11 +81,12 @@ import java.util.stream.Collectors;
                     .add("case $S:\n", parameter.name)
                     .indent()
                     .addStatement(
-                        "$L = Optional.ofNullable(this.mapper_$L.deserializeValue($L.getValue()).getSuccessOrThrow($$ -> new $T()))",
+                        "$L = Optional.ofNullable(this.mapper_$L.deserializeValue($L.getValue()).getSuccessOrThrow(failure -> $T.unconstructableArgument(\"$L\", failure)))",
                         parameter.name,
                         parameter.name,
                         "entry",
-                        unconstructableInstantiateException)
+                        unconstructableInstantiateException,
+                        parameter.name)
                     .addStatement("break")
                     .unindent())
                 .reduce(CodeBlock.builder(), (x, y) -> x.add(y.build()))
@@ -96,8 +97,9 @@ import java.util.stream.Collectors;
                 .add("default:\n")
                 .indent()
                 .addStatement(
-                    "throw new $T()",
-                    unconstructableInstantiateException)
+                    "throw $T.extraneousParameter($L.getKey())",
+                    unconstructableInstantiateException,
+                    "entry")
                 .unindent()
                 .build())
         .endControlFlow()

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/ConfigurationType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/ConfigurationType.java
@@ -17,5 +17,21 @@ public interface ConfigurationType<Config> {
   Map<String, SerializedValue> getArguments(Config configuration);
   List<String> getValidationFailures(Config configuration);
 
-  final class UnconstructableConfigurationException extends Exception {}
+  final class UnconstructableConfigurationException extends Exception {
+    public UnconstructableConfigurationException() {
+      super();
+    }
+
+    public UnconstructableConfigurationException(final String message) {
+      super(message);
+    }
+
+    public static UnconstructableConfigurationException unconstructableArgument(final String parameterName, final String failure) {
+      return new UnconstructableConfigurationException("Unconstructable argument \"%s\": %s".formatted(parameterName, failure));
+    }
+
+    public static UnconstructableConfigurationException extraneousParameter(final String parameterName) {
+      return new UnconstructableConfigurationException("Extraneous parameter \"%s\"".formatted(parameterName));
+    }
+  }
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
@@ -22,5 +22,17 @@ public interface TaskSpecType<Model, Specification, Return> {
   ValueSchema getReturnValueSchema();
   SerializedValue serializeReturnValue(Return returnValue);
 
-  final class UnconstructableTaskSpecException extends Exception {}
+  final class UnconstructableTaskSpecException extends Exception {
+    public UnconstructableTaskSpecException(final String message) {
+      super(message);
+    }
+
+    public static UnconstructableTaskSpecException unconstructableArgument(final String parameterName, final String failure) {
+      return new UnconstructableTaskSpecException("Unconstructable argument \"%s\": %s".formatted(parameterName, failure));
+    }
+
+    public static UnconstructableTaskSpecException extraneousParameter(final String parameterName) {
+      return new UnconstructableTaskSpecException("Extraneous parameter \"%s\"".formatted(parameterName));
+    }
+  }
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/MissingArgumentsException.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/MissingArgumentsException.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public final class MissingArgumentsException extends RuntimeException {
+public final class MissingArgumentsException extends Exception {
   public final String containerName, metaName;
   public final List<ProvidedArgument> providedArguments;
   public final List<MissingArgument> missingArguments;

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/MissingArgumentsException.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/MissingArgumentsException.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public final class MissingArgumentsException extends RuntimeException {
   public final String containerName, metaName;
@@ -16,6 +17,8 @@ public final class MissingArgumentsException extends RuntimeException {
       final List<ProvidedArgument> providedArguments,
       final List<MissingArgument> missingArguments)
   {
+    super("Missing arguments for %s \"%s\": %s"
+      .formatted(metaName, containerName, missingArguments.stream().map(a -> "\"%s\"".formatted(a.parameterName)).collect(Collectors.joining(", "))));
     this.containerName = containerName;
     this.metaName = metaName;
     this.providedArguments = Collections.unmodifiableList(providedArguments);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.server.http;
 
 import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
+import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.services.GetSimulationResultsAction;
@@ -169,6 +170,9 @@ public final class MerlinBindings implements Plugin {
       final var failures = this.missionModelService.validateActivityArguments(missionModelId, serializedActivity);
 
       ctx.result(ResponseSerializers.serializeFailures(failures).toString());
+    } catch (final TaskSpecType.UnconstructableTaskSpecException | MissingArgumentsException ex) {
+      ctx.status(400)
+         .result(ResponseSerializers.serializeFailures(List.of(ex.getMessage())).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       ctx.status(404);
     } catch (final InvalidJsonException ex) {
@@ -238,7 +242,7 @@ public final class MerlinBindings implements Plugin {
     } catch (final MissingArgumentsException ex) {
       ctx.status(200)
          .result(ResponseSerializers.serializeMissingArgumentsException(ex).toString());
-    } catch (final MissionModelService.NoSuchActivityTypeException | MissionModelService.UnconstructableActivityInstanceException ex) {
+    } catch (final MissionModelService.NoSuchActivityTypeException | TaskSpecType.UnconstructableTaskSpecException ex) {
       ctx.status(400)
          .result(ResponseSerializers.serializeFailures(List.of(ex.getMessage())).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
@@ -50,7 +50,7 @@ public final class MissionModelFacade {
   }
 
   public List<String> validateActivity(final SerializedActivity activity)
-  throws NoSuchActivityTypeException, UnconstructableActivityInstanceException
+  throws NoSuchActivityTypeException, TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException
   {
     final var specType = Optional
         .ofNullable(this.missionModel.getDirectiveTypes().taskSpecTypes().get(activity.getTypeName()))
@@ -62,21 +62,15 @@ public final class MissionModelFacade {
   private <Specification, Return> List<String> getValidationFailures(
       final TaskSpecType<?, Specification, Return> specType,
       final Map<String, SerializedValue> arguments)
-  throws UnconstructableActivityInstanceException
+  throws TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException
   {
-    try {
-      return specType.getValidationFailures(specType.instantiate(arguments));
-    } catch (final TaskSpecType.UnconstructableTaskSpecException | MissingArgumentsException e) {
-      throw new UnconstructableActivityInstanceException(
-          "Unknown failure when deserializing activity -- do the parameters match the schema?",
-          e);
-    }
+    return specType.getValidationFailures(specType.instantiate(arguments));
   }
 
   public Map<String, SerializedValue> getActivityEffectiveArguments(
       final String typeName,
       final Map<String, SerializedValue> arguments)
-  throws NoSuchActivityTypeException, UnconstructableActivityInstanceException, MissingArgumentsException
+  throws NoSuchActivityTypeException, TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException
   {
     final var specType = Optional
         .ofNullable(this.missionModel.getDirectiveTypes().taskSpecTypes().get(typeName))
@@ -88,16 +82,10 @@ public final class MissionModelFacade {
   private static <Specification, Return> Map<String, SerializedValue> getActivityEffectiveArguments(
       final TaskSpecType<?, Specification, Return> specType,
       final Map<String, SerializedValue> arguments)
-  throws UnconstructableActivityInstanceException, MissingArgumentsException
+  throws TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException
   {
-    try {
-      final var activity = specType.instantiate(arguments);
-      return specType.getArguments(activity);
-    } catch (final TaskSpecType.UnconstructableTaskSpecException e) {
-      throw new UnconstructableActivityInstanceException(
-          "Unknown failure when deserializing activity -- do the parameters match the schema?",
-          e);
-    }
+    final var activity = specType.instantiate(arguments);
+    return specType.getArguments(activity);
   }
 
   public List<String> validateConfiguration(final Map<String, SerializedValue> arguments)
@@ -151,7 +139,7 @@ public final class MissionModelFacade {
       try {
         getActivityEffectiveArguments(act.getTypeName(), act.getArguments());
       } catch (final NoSuchActivityTypeException |
-          UnconstructableActivityInstanceException |
+          TaskSpecType.UnconstructableTaskSpecException |
           MissingArgumentsException e)
       {
         failures.put(id, e.toString());
@@ -211,16 +199,6 @@ public final class MissionModelFacade {
     public NoSuchActivityTypeException(final String typeName) {
       super("No such activity type: \"%s\"".formatted(typeName));
       this.typeName = typeName;
-    }
-  }
-
-  public static class UnconstructableActivityInstanceException extends Exception {
-    public UnconstructableActivityInstanceException(final String message) {
-      super(message);
-    }
-
-    public UnconstructableActivityInstanceException(final String message, final Throwable cause) {
-      super(message, cause);
     }
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
@@ -49,14 +49,14 @@ public final class MissionModelFacade {
     return schemas;
   }
 
-  public List<String> validateActivity(final String typeName, final Map<String, SerializedValue> arguments)
+  public List<String> validateActivity(final SerializedActivity activity)
   throws NoSuchActivityTypeException, UnconstructableActivityInstanceException
   {
     final var specType = Optional
-        .ofNullable(this.missionModel.getDirectiveTypes().taskSpecTypes().get(typeName))
+        .ofNullable(this.missionModel.getDirectiveTypes().taskSpecTypes().get(activity.getTypeName()))
         .orElseThrow(NoSuchActivityTypeException::new);
 
-    return getValidationFailures(specType, arguments);
+    return getValidationFailures(specType, activity.getArguments());
   }
 
   private <Specification, Return> List<String> getValidationFailures(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -106,8 +106,7 @@ public final class LocalMissionModelService implements MissionModelService {
   {
     try {
       // TODO: [AERIE-1516] Teardown the missionModel after use to release any system resources (e.g. threads).
-      return this.loadConfiguredMissionModel(missionModelId)
-                 .validateActivity(activity.getTypeName(), activity.getArguments());
+      return this.loadConfiguredMissionModel(missionModelId).validateActivity(activity);
     } catch (final MissionModelFacade.NoSuchActivityTypeException ex) {
       return List.of("unknown activity type");
     } catch (final MissionModelFacade.UnconstructableActivityInstanceException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelLoader;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
+import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
@@ -102,15 +103,14 @@ public final class LocalMissionModelService implements MissionModelService {
    */
   @Override
   public List<String> validateActivityArguments(final String missionModelId, final SerializedActivity activity)
-  throws NoSuchMissionModelException, MissionModelFacade.MissionModelContractException, MissionModelLoadException
+  throws NoSuchMissionModelException, MissionModelLoadException, TaskSpecType.UnconstructableTaskSpecException,
+         MissingArgumentsException
   {
     try {
       // TODO: [AERIE-1516] Teardown the missionModel after use to release any system resources (e.g. threads).
       return this.loadConfiguredMissionModel(missionModelId).validateActivity(activity);
     } catch (final MissionModelFacade.NoSuchActivityTypeException ex) {
       return List.of("unknown activity type");
-    } catch (final MissionModelFacade.UnconstructableActivityInstanceException ex) {
-      return List.of(ex.getMessage());
     }
   }
 
@@ -132,17 +132,15 @@ public final class LocalMissionModelService implements MissionModelService {
   public Map<String, SerializedValue> getActivityEffectiveArguments(final String missionModelId, final SerializedActivity activity)
   throws NoSuchMissionModelException,
          NoSuchActivityTypeException,
-         UnconstructableActivityInstanceException,
          MissingArgumentsException,
-         MissionModelLoadException
+         MissionModelLoadException,
+         TaskSpecType.UnconstructableTaskSpecException
   {
     try {
       return this.loadConfiguredMissionModel(missionModelId)
                  .getActivityEffectiveArguments(activity.getTypeName(), activity.getArguments());
     } catch (final MissionModelFacade.NoSuchActivityTypeException ex) {
       throw new NoSuchActivityTypeException(activity.getTypeName(), ex);
-    } catch (final MissionModelFacade.UnconstructableActivityInstanceException ex) {
-      throw new UnconstructableActivityInstanceException(activity.getTypeName(), ex);
     }
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -114,6 +114,20 @@ public final class LocalMissionModelService implements MissionModelService {
     }
   }
 
+  /**
+   * Validate that a set of activity parameters conforms to the expectations of a named mission model.
+   *
+   * @param missionModelId The ID of the mission model to load.
+   * @param activities The serialized activities to perform instantiation validation against the named mission model.
+   * @return A map of validation errors mapping activity instance ID to failure message. If validation succeeds the map is empty.
+   */
+  @Override
+  public <T> Map<T, String> validateActivityInstantiations(final String missionModelId, final Map<T, SerializedActivity> activities)
+  throws NoSuchMissionModelException, MissionModelFacade.MissionModelContractException, MissionModelLoadException
+  {
+    return this.loadConfiguredMissionModel(missionModelId).validateActivityInstantiations(activities);
+  }
+
   @Override
   public Map<String, SerializedValue> getActivityEffectiveArguments(final String missionModelId, final SerializedActivity activity)
   throws NoSuchMissionModelException,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -32,6 +32,10 @@ public interface MissionModelService {
   List<String> validateActivityArguments(String missionModelId, SerializedActivity activity)
   throws NoSuchMissionModelException;
 
+  <T> Map<T, String> validateActivityInstantiations(String missionModelId, Map<T, SerializedActivity> activities)
+  throws NoSuchMissionModelException, MissionModelFacade.MissionModelContractException,
+         LocalMissionModelService.MissionModelLoadException;
+
   Map<String, SerializedValue> getActivityEffectiveArguments(String missionModelId, SerializedActivity activity)
   throws NoSuchMissionModelException,
          NoSuchActivityTypeException,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelLoader;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
+import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
@@ -30,7 +31,7 @@ public interface MissionModelService {
   throws NoSuchMissionModelException;
   // TODO: Provide a finer-scoped validation return type. Mere strings make all validations equally severe.
   List<String> validateActivityArguments(String missionModelId, SerializedActivity activity)
-  throws NoSuchMissionModelException;
+  throws NoSuchMissionModelException, TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException;
 
   <T> Map<T, String> validateActivityInstantiations(String missionModelId, Map<T, SerializedActivity> activities)
   throws NoSuchMissionModelException, MissionModelFacade.MissionModelContractException,
@@ -39,7 +40,7 @@ public interface MissionModelService {
   Map<String, SerializedValue> getActivityEffectiveArguments(String missionModelId, SerializedActivity activity)
   throws NoSuchMissionModelException,
          NoSuchActivityTypeException,
-         UnconstructableActivityInstanceException,
+         TaskSpecType.UnconstructableTaskSpecException,
          MissingArgumentsException;
 
   List<String> validateModelArguments(String missionModelId, Map<String, SerializedValue> arguments)
@@ -90,15 +91,6 @@ public interface MissionModelService {
     }
 
     public NoSuchActivityTypeException(final String activityTypeId) { this(activityTypeId, null); }
-  }
-
-  class UnconstructableActivityInstanceException extends Exception {
-    public final String activityTypeId;
-
-    public UnconstructableActivityInstanceException(final String activityTypeId, final Throwable cause) {
-      super(cause);
-      this.activityTypeId = activityTypeId;
-    }
   }
 
   class UnconfigurableMissionModelException extends Exception {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ThreadedSimulationAgent.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ThreadedSimulationAgent.java
@@ -66,7 +66,7 @@ public final class ThreadedSimulationAgent implements SimulationAgent {
               this.simulationAgent.simulate(req.planId(), req.revisionData(), req.writer());
             } catch (final Throwable ex) {
               ex.printStackTrace(System.err);
-              req.writer().failWith(ex.getMessage());
+              req.writer().failWith(ex.toString());
             }
             // continue
           } else if (request instanceof SimulationRequest.Terminate) {

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -10,6 +10,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
+import gov.nasa.jpl.aerie.merlin.server.models.MissionModelFacade;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelJar;
 import gov.nasa.jpl.aerie.merlin.server.services.CreateSimulationMessage;
 import gov.nasa.jpl.aerie.merlin.server.services.LocalMissionModelService;
@@ -126,6 +127,15 @@ public final class StubMissionModelService implements MissionModelService {
     } else {
       return Collections.emptyList();
     }
+  }
+
+  @Override
+  public <T> Map<T, String> validateActivityInstantiations(
+      final String missionModelId,
+      final Map<T, SerializedActivity> activities)
+  throws NoSuchMissionModelException, MissionModelFacade.MissionModelContractException, LocalMissionModelService.MissionModelLoadException
+  {
+    return Map.of();
   }
 
   @Override

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
@@ -5,6 +5,7 @@ import gov.nasa.jpl.aerie.foomissionmodel.Configuration;
 import gov.nasa.jpl.aerie.foomissionmodel.generated.GeneratedMissionModelFactory;
 import gov.nasa.jpl.aerie.merlin.driver.DirectiveTypeRegistry;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
+import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.framework.VoidEnum;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
@@ -107,7 +108,7 @@ public final class MissionModelTest {
                                                     "y", SerializedValue.of("test")));
 
         // WHEN
-        final var failures = missionModel.validateActivity(typeName, parameters);
+        final var failures = missionModel.validateActivity(new SerializedActivity(typeName, parameters));
 
         // THEN
         assertThat(failures).isEmpty();
@@ -121,7 +122,7 @@ public final class MissionModelTest {
                                                     "y", SerializedValue.of(1.0)));
 
         // WHEN
-        final Throwable thrown = catchThrowable(() -> missionModel.validateActivity(typeName, parameters));
+        final Throwable thrown = catchThrowable(() -> missionModel.validateActivity(new SerializedActivity(typeName, parameters)));
 
         // THEN
         assertThat(thrown).isInstanceOf(MissionModelFacade.UnconstructableActivityInstanceException.class);
@@ -134,7 +135,7 @@ public final class MissionModelTest {
         final var parameters = new HashMap<>(Map.of("Nonexistent", SerializedValue.of("")));
 
         // WHEN
-        final Throwable thrown = catchThrowable(() -> missionModel.validateActivity(typeName, parameters));
+        final Throwable thrown = catchThrowable(() -> missionModel.validateActivity(new SerializedActivity(typeName, parameters)));
 
         // THEN
         assertThat(thrown).isInstanceOf(MissionModelFacade.UnconstructableActivityInstanceException.class);

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
@@ -7,6 +7,8 @@ import gov.nasa.jpl.aerie.merlin.driver.DirectiveTypeRegistry;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.framework.VoidEnum;
+import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
@@ -100,7 +102,8 @@ public final class MissionModelTest {
 
     @Test
     public void shouldInstantiateActivityInstance()
-        throws MissionModelFacade.NoSuchActivityTypeException, MissionModelFacade.MissionModelContractException, MissionModelFacade.UnconstructableActivityInstanceException
+    throws MissionModelFacade.NoSuchActivityTypeException, MissionModelFacade.MissionModelContractException,
+           TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException
     {
         // GIVEN
         final var typeName = "foo";
@@ -125,7 +128,7 @@ public final class MissionModelTest {
         final Throwable thrown = catchThrowable(() -> missionModel.validateActivity(new SerializedActivity(typeName, parameters)));
 
         // THEN
-        assertThat(thrown).isInstanceOf(MissionModelFacade.UnconstructableActivityInstanceException.class);
+        assertThat(thrown).isInstanceOf(TaskSpecType.UnconstructableTaskSpecException.class);
     }
 
     @Test
@@ -138,6 +141,6 @@ public final class MissionModelTest {
         final Throwable thrown = catchThrowable(() -> missionModel.validateActivity(new SerializedActivity(typeName, parameters)));
 
         // THEN
-        assertThat(thrown).isInstanceOf(MissionModelFacade.UnconstructableActivityInstanceException.class);
+        assertThat(thrown).isInstanceOf(TaskSpecType.UnconstructableTaskSpecException.class);
     }
 }

--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
@@ -75,7 +75,7 @@ public final class MerlinWorkerAppDriver {
         simulationAgent.simulate(planId, revisionData, writer);
       } catch (final Throwable ex) {
         ex.printStackTrace(System.err);
-        writer.failWith(ex.getMessage());
+        writer.failWith(ex.toString());
       }
     }
   }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -143,10 +143,16 @@ public record SynchronousSchedulerAgent(
       writer.succeedWith(results);
     } catch (final SpecificationLoadException e) {
       //unwrap failure message from any anticipated exceptions and forward to subscribers
-      writer.failWith(e.getMessage() + SchedulingCompilationError.schedulingErrorJsonP.unparse(e.errors).toString());
-    } catch (final ResultsProtocolFailure | NoSuchSpecificationException | NoSuchPlanException | IOException | MerlinService.MerlinServiceException e) {
-      //unwrap failure message from any anticipated exceptions and forward to subscribers
-      writer.failWith(e.getMessage());
+      writer.failWith("%s\n%s".formatted(
+          e.toString(),
+          SchedulingCompilationError.schedulingErrorJsonP.unparse(e.errors).toString()));
+    } catch (final ResultsProtocolFailure |
+        NoSuchSpecificationException |
+        NoSuchPlanException |
+        IOException |
+        MerlinService.MerlinServiceException e) {
+      // unwrap failure message from any anticipated exceptions and forward to subscribers
+      writer.failWith(e.toString());
     }
   }
 

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationDriver.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationDriver.java
@@ -10,6 +10,7 @@ import gov.nasa.jpl.aerie.merlin.driver.timeline.LiveCells;
 import gov.nasa.jpl.aerie.merlin.driver.timeline.TemporalEventSource;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.time.Instant;
@@ -104,7 +105,7 @@ public class IncrementalSimulationDriver {
 
 
   public void simulateActivity(SerializedActivity activity, Duration startTime, ActivityInstanceId activityId)
-  throws TaskSpecType.UnconstructableTaskSpecException
+  throws TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException
   {
     final var activityToSimulate = new SimulatedActivity(startTime, activity, activityId);
     if(startTime.noLongerThan(curTime)){
@@ -162,7 +163,7 @@ public class IncrementalSimulationDriver {
   }
 
   private void simulateSchedule(final Map<ActivityInstanceId, Pair<Duration, SerializedActivity>> schedule)
-  throws TaskSpecType.UnconstructableTaskSpecException
+  throws TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException
   {
 
     if(schedule.isEmpty()){

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -15,6 +15,7 @@ import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
@@ -172,7 +173,7 @@ public class SimulationFacade {
 
     try {
       driver.simulateActivity(serializedActivity, activity.getStartTime(), activityIdSim);
-    } catch (TaskSpecType.UnconstructableTaskSpecException e) {
+    } catch (TaskSpecType.UnconstructableTaskSpecException | MissingArgumentsException e) {
       throw new SimulationException("Failed to simulate " + activity + ", possibly because it has invalid arguments", e);
     }
     insertedActivities.put(activity, serializedActivity);

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/IncrementalSimulationTest.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.scheduler.simulation.IncrementalSimulationDriver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,7 @@ public class IncrementalSimulationTest {
   Duration endOfLastAct;
 
   @BeforeEach
-  public void init() throws TaskSpecType.UnconstructableTaskSpecException {
+  public void init() throws TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException {
     final var acts = getActivities();
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     incrementalSimulationDriver = new IncrementalSimulationDriver(fooMissionModel);


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1685
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

This PR adds plan activity instance validation to the simulate workflow.

Some previous discussions:
- Failure cases: https://jpl.slack.com/archives/GHK90JHH8/p1649903505320229
- Broad to-do:   https://jpl.slack.com/archives/GJ07FGRPH/p1649786627113889
- Tickets:       https://jpl.slack.com/archives/GJ07FGRPH/p1649990579962809

Four failure modes are now correctly accumulated within the simulation engine:
  1. Unconstructable argument.
    - **Note:** the use of singular "argument" is intentional here, see future work section.
  2. Extraneous parameter.
    - **Note:** the use of singular "argument" is intentional here, see future work section.
  3. Missing arguments.
  4. Nonexistent activity type.

## Verification

<details>
<summary>Expand</summary>

An activity that will result in an **unconstructable argument** error is inserted with:
```gql
mutation {
  insert_activity_one(object: { plan_id: $plan_id, start_offset: \"300 seconds\", type: \"BiteBanana\", arguments: { biteSize: true } }) {
    id
  }
}
```

An activity that will result in an **extraneous parameter** error is inserted with:
```gql
mutation {
  insert_activity_one(object: { plan_id: $plan_id, start_offset: \"310 seconds\", type: \"BiteBanana\", arguments: { bad: 42 } }) {
    id
  }
}
```

An activity that will result in a **missing arguments** error is inserted with:
```gql
mutation {
  insert_activity_one(object: { plan_id: $plan_id, start_offset: \"320 seconds\", type: \"BakeBananaBread\", arguments: { tbSugar: 42 } }) {
    id
  }
}
```

An activity that will result in a **nonexistent activity type** error is inserted with:
```gql
mutation {
  insert_activity_one(object: { plan_id: $plan_id, start_offset: \"330 seconds\", type: \"BadActivity\", arguments: { } }) {
    id
  }
}
```

To trigger this message a simple `simulate` call is needed:
```gql
query {
  simulate(planId:1) {
    reason
    results
    status
  }
}
```

This results in:
```json
{
  "data": {
    "simulate": {
      "reason": "ActivityInstanceId[id=1]: gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType$UnconstructableTaskSpecException: Unconstructable argument \"biteSize\": Expected real number, got true\nActivityInstanceId[id=2]: gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType$UnconstructableTaskSpecException: Extraneous parameter \"bad\"\nActivityInstanceId[id=3]: gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException: Missing arguments for activity \"BakeBananaBread\": \"glutenFree\"\nActivityInstanceId[id=4]: gov.nasa.jpl.aerie.merlin.server.models.MissionModelFacade$NoSuchActivityTypeException: No such activity type: \"BadActivity\"",
      "status": "failed"
    }
  }
}
```

Note that this string representation is completely structureless, see this PR's future work section.

</details>

## Documentation

Updated simulation results page (commit `c0a8ab7`).

## Future work

- Look into exception `getMessage()` null handling (see [AERIE-1784](https://jira.jpl.nasa.gov/browse/AERIE-1784)).
- Accumulate all invalid/nonexistent argument exceptions within activity/config. mappers (see [AERIE-1826](https://jira.jpl.nasa.gov/browse/AERIE-1826)).
  - This would allow the `UnconstructableTaskSpecException`/`UnconstructableConfigurationException` to not fail-fast during instantiation.
- Structure `simulation_dataset.reason` as a `jsonb` since unconstructable activities currently serve [3 distinct failure modes](https://jpl.slack.com/archives/GHK90JHH8/p1649904711420249?thread_ts=1649903505.320229&cid=GHK90JHH8)  (see [AERIE-1826](https://jira.jpl.nasa.gov/browse/AERIE-1826)).
  - Would likely require splitting `UnconstructableTaskSpecException`/`UnconstructableConfigurationException` up into 3 distinct cases to allow the UI to react appropriately.
  - All depends on if the UI needs to be aware of these different failure modes (which I believe it does).