### PR TITLE
[AERIE-1785] Provide default priorities if not provided

### DIFF
--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
@@ -273,6 +273,50 @@ class SchedulerDatabaseTests {
           new int[]{0, 1, 2}
       );
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"specification", "template"})
+    void shouldGeneratePriorityWhenNull(String tableStem) throws SQLException {
+      connection.createStatement().executeUpdate("""
+          insert into scheduling_%s_goals(%s_id, goal_id)
+          values (%d, %d);
+        """.formatted(
+          tableStem, tableStem,
+          specAndTemplateIds.get(tableStem)[0],
+          goalIds[0]
+      ));
+      checkPriorities(
+          tableStem, 0,
+          new int[]{0},
+          new int[]{0}
+      );
+      connection.createStatement().executeUpdate("""
+          insert into scheduling_%s_goals(%s_id, goal_id, priority)
+          values (%d, %d, null);
+        """.formatted(
+          tableStem, tableStem,
+          specAndTemplateIds.get(tableStem)[0],
+          goalIds[2]
+      ));
+      checkPriorities(
+          tableStem, 0,
+          new int[]{0, 2},
+          new int[]{0, 1}
+      );
+      connection.createStatement().executeUpdate("""
+          insert into scheduling_%s_goals(%s_id, goal_id)
+          values (%d, %d);
+        """.formatted(
+          tableStem, tableStem,
+          specAndTemplateIds.get(tableStem)[0],
+          goalIds[1]
+      ));
+      checkPriorities(
+          tableStem, 0,
+          new int[]{0, 2, 1},
+          new int[]{0, 1, 2}
+      );
+    }
   }
 
 }

--- a/scheduler-server/sql/scheduler/tables/scheduling_template_goals.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_template_goals.sql
@@ -1,7 +1,11 @@
 create table scheduling_template_goals (
   template_id integer not null,
   goal_id integer not null,
-  priority integer not null constraint non_negative_template_goal_priority check (priority >= 0),
+  priority integer
+    not null
+    default null -- Nulls are detected and replaced with the next
+                 -- available priority by the insert trigger
+    constraint non_negative_template_goal_priority check (priority >= 0),
 
   constraint scheduling_template_goals_primary_key
     primary key (template_id, goal_id),
@@ -31,7 +35,12 @@ comment on column scheduling_template_goals.priority is e''
 
 create or replace function insert_scheduling_template_goal_func()
   returns trigger as $$begin
-    if NEW.priority > (
+    if NEW.priority IS NULL then
+      NEW.priority = (
+        select coalesce(max(priority), -1) from scheduling_template_goals
+        where template_id = NEW.template_id
+      ) + 1;
+    elseif NEW.priority > (
       select coalesce(max(priority), -1) from scheduling_template_goals
       where template_id = NEW.template_id
     ) + 1 then


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1785
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds functionality to the SQL triggers from #123 to allow inserts to not provide a priority, in which case the trigger will select the next consecutive priority for the relevant specification or template. 

## Verification
I added a test to db-tests for this.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
