### PR TITLE
[AERIE-1798]  Fix JSON parse errors in scheduling dsl compiler

### DIFF
--- a/scheduler-server/scheduling-dsl-compiler/src/main.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/main.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import * as readline from 'readline';
 import ts from 'typescript';
 import { UserCodeRunner } from '@nasa-jpl/aerie-ts-user-code-runner';
 import type { Goal } from './libs/scheduler-edsl-fluent-api.js';
@@ -7,8 +8,10 @@ const codeRunner = new UserCodeRunner();
 const schedulerEDSL = fs.readFileSync(`${process.env.SCHEDULING_DSL_COMPILER_ROOT}/src/libs/scheduler-edsl-fluent-api.ts`, 'utf8');
 const schedulerAST = fs.readFileSync(`${process.env.SCHEDULING_DSL_COMPILER_ROOT}/src/libs/scheduler-ast.ts`, 'utf8');
 
+const input = readline.createInterface(process.stdin);
+
 function registerInputCallback(callback: (data: string) => void) {
-  process.stdin.once('data', data => callback(data.toString()));
+  input.once('line', callback);
 }
 
 function writeOutputOneLine(data: string) {

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
@@ -241,4 +241,44 @@ class SchedulingDSLCompilationServiceTests {
                     .anyMatch(e -> e.message().contains("TypeError: TS2322 Incorrect return type. Expected: 'Goal', Actual: 'number'."))
     );
   }
+
+  @Test
+  void testHugeGoal()
+  {
+    // This test is intended to create a Goal that is bigger than the node subprocess's standard input buffer
+    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult result;
+    result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+        PLAN_ID, """
+                export default function myGoal() {
+                  return Goal.ActivityRecurrenceGoal({
+                    activityTemplate: ActivityTemplates.SampleActivity1({
+                      variant: 'option2',
+                      fancy: { subfield1: 'value1', subfield2: [{subsubfield1: 2}]},
+                      duration: 60 * 60 * 1000 * 1000 // 1 hour in microseconds
+                    }),
+                    interval: 60 * 60 * 1000 * 1000 // 1 hour in microseconds
+                  })
+                }
+            """ + " ".repeat(9001), "goalfile");
+    final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.GoalDefinition(
+        SchedulingDSL.GoalKinds.ActivityRecurrenceGoal,
+        new SchedulingDSL.ActivityTemplate(
+            "SampleActivity1",
+            Map.ofEntries(
+                Map.entry("variant", SerializedValue.of("option2")),
+                Map.entry("fancy", SerializedValue.of(Map.ofEntries(
+                    Map.entry("subfield1", SerializedValue.of("value1")),
+                    Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2)))))
+                    )))),
+                Map.entry("duration", SerializedValue.of(60L * 60 * 1000 * 1000))
+            )
+        ),
+        Duration.HOUR
+    );
+    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
+      assertEquals(expectedGoalDefinition, r.goalSpecifier());
+    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+      fail(r.toString());
+    }
+  }
 }

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
@@ -127,8 +127,8 @@ class SchedulingDSLCompilationServiceTests {
         PLAN_ID, """
                 export default function myGoal() {
                   return Goal.ActivityRecurrenceGoal({
-                    activityTemplate: ActivityTemplates.PeelBanana({
-                      peelDirection: 'fromStem',
+                    activityTemplate: ActivityTemplates.SampleActivity1({
+                      variant: 'option2',
                       fancy: { subfield1: 'value1', subfield2: [{subsubfield1: 2}]},
                       duration: 60 * 60 * 1000 * 1000 // 1 hour in microseconds
                     }),
@@ -139,9 +139,9 @@ class SchedulingDSLCompilationServiceTests {
     final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.GoalDefinition(
         SchedulingDSL.GoalKinds.ActivityRecurrenceGoal,
         new SchedulingDSL.ActivityTemplate(
-            "PeelBanana",
+            "SampleActivity1",
             Map.ofEntries(
-                Map.entry("peelDirection", SerializedValue.of("fromStem")),
+                Map.entry("variant", SerializedValue.of("option2")),
                 Map.entry("fancy", SerializedValue.of(Map.ofEntries(
                     Map.entry("subfield1", SerializedValue.of("value1")),
                     Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2)))))
@@ -165,8 +165,8 @@ class SchedulingDSLCompilationServiceTests {
     result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
         PLAN_ID, """
                 export default function myGoal() {
-                  return myHelper(ActivityTemplates.PeelBanana({
-                    peelDirection: 'fromStem',
+                  return myHelper(ActivityTemplates.SampleActivity1({
+                    variant: 'option2',
                     fancy: { subfield1: 'value1', subfield2: [{subsubfield1: 2}]},
                     duration: 60 * 60 * 1000 * 1000 // 1 hour in microseconds
                   }))
@@ -181,9 +181,9 @@ class SchedulingDSLCompilationServiceTests {
     final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.GoalDefinition(
         SchedulingDSL.GoalKinds.ActivityRecurrenceGoal,
         new SchedulingDSL.ActivityTemplate(
-            "PeelBanana",
+            "SampleActivity1",
             Map.ofEntries(
-                Map.entry("peelDirection", SerializedValue.of("fromStem")),
+                Map.entry("variant", SerializedValue.of("option2")),
                 Map.entry("fancy", SerializedValue.of(Map.ofEntries(
                     Map.entry("subfield1", SerializedValue.of("value1")),
                     Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2)))))
@@ -206,8 +206,8 @@ class SchedulingDSLCompilationServiceTests {
           PLAN_ID, """
                 export default function myGoal() {
                   const x = 4 - 2
-                  return myHelper(ActivityTemplates.PeelBanana({
-                    peelDirection: 'fromStem',
+                  return myHelper(ActivityTemplates.SampleActivity1({
+                    variant: 'option2',
                     fancy: { subfield1: 'value1', subfield2: [{subsubfield1: 2}]},
                     duration: 60 * 60 * 1000 * 1000 // 1 hour in microseconds
                   }))

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
@@ -13,16 +13,16 @@ class TypescriptCodeGenerationServiceTest {
   public static final TypescriptCodeGenerationService.MissionModelTypes MISSION_MODEL_TYPES =
       new TypescriptCodeGenerationService.MissionModelTypes(
           List.of(new TypescriptCodeGenerationService.ActivityType(
-              "PeelBanana",
+              "SampleActivity1",
               Map.of(
-                  "peelDirection",
+                  "variant",
                   ValueSchema.ofVariant(List.of(
                       new ValueSchema.Variant(
-                          "fromTip", "fromTip"
+                          "option1", "option1"
                       ),
                       new ValueSchema.Variant(
-                          "fromStem",
-                          "fromStem"))),
+                          "option2",
+                          "option2"))),
                   "duration",
                   ValueSchema.DURATION,
                   "fancy",
@@ -41,25 +41,25 @@ class TypescriptCodeGenerationServiceTest {
         """
             /** Start Codegen */
             import type { ActivityTemplate } from './scheduler-edsl-fluent-api.js';
-            interface PeelBanana extends ActivityTemplate {}
+            interface SampleActivity1 extends ActivityTemplate {}
             export const ActivityTemplates = {
-              PeelBanana: function PeelBanana(
+              SampleActivity1: function SampleActivity1(
                 args: {
                   duration: Duration,
                   fancy: { subfield1: string, subfield2: { subsubfield1: Double, }[], },
-                  peelDirection: ("fromTip" | "fromStem"),
-                }): PeelBanana {
-                  return { activityType: 'PeelBanana', args };
+                  variant: ("option1" | "option2"),
+                }): SampleActivity1 {
+                  return { activityType: 'SampleActivity1', args };
                 },
             }
             declare global {
               var ActivityTemplates: {
-                PeelBanana: (
+                SampleActivity1: (
                   args: {
                     duration: Duration,
                     fancy: { subfield1: string, subfield2: { subsubfield1: Double, }[], },
-                    peelDirection: ("fromTip" | "fromStem"),
-                  }) => PeelBanana
+                    variant: ("option1" | "option2"),
+                  }) => SampleActivity1
               }
             };
             // Make ActivityTemplates available on the global object


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1798
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
While writing e2e tests for the scheduler, @adrienmaillard observed a periodic test failure. We did not observe a pattern at the time - but in hindsight, I think every 12 (or so) successful test runs, there would be two test failures. Both would be "panics" of the scheduling dsl compiler, as it failed to parse JSON. The first would be an "Unexpected end of JSON input", and the second would be "Illegal character in JSON" (paraphrasing).

What I believe is happening is that the buffer allocated for standard input on the node subprocess is filling up mid-message, and calling our message handler twice, each time with half a message. This happens periodically because our banananation messages are much smaller than the buffer. (Attempted illustration below - note that Message 3 is split across the two buffers).

```mermaid
gantt
Buffer 1 :done,    des1, 2014-01-06,2014-01-11
Buffer 2 :done,    des1, 2014-01-11,2014-01-16
Message 1   :         des3, 2014-01-06, 2d
Message 2   :         des4, after des3, 2d
Message 3   :         des5, after des4, 2d
```

I would expect this to happen much more often with a larger mission model, since the size of the messages scales with the number of activity types in the mission model. (The generated typescript library has a function for every activity type).

Why does our handler get called twice? I _think_ it's because the `process.stdin.on('data', ...)` triggers the callback every time the buffer is written to. If the buffer fills up, it calls our callback, and continues writing from the beginning of a new buffer.

Why do we get two test failures in a row? Since our handler is called twice, it writes two messages to standard output. The Java code only reads one of those messages every time. So, the first time, it sees the failure that resulted from the handler being called on the first half of the message. The next time the tests are run, the error from the handler being called on the second half of the message is still sitting in standard output, patiently waiting to be read. **This means that all subsequent runs of the tests will be reading the result of the previous test** 😱 (that didn't dawn on me until writing this up just now)

The fix is to call our callback every time we get a complete message, to avoid calling it with partial messages. Our protocol demarcates the end of messages with a newline. The fix in this PR is to use the `readline` module from the node standard library. This abstracts away the buffer, and allows us to register a callback on the `'line'` event.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Once I had a hunch that there was a buffering issue, I decided to try to force the error by passing the scheduling dsl compiler a very large message that would not fit into the buffer. If my mental model of the problem was correct, this would cause our handler to be called on a partial message. Indeed, it failed with an `Unexpected end of JSON` error. 

![Screen Shot 2022-04-15 at 7 31 52 AM](https://user-images.githubusercontent.com/1189602/163583372-4fe572d7-4b67-4a68-b7dd-e4da417bf211.png)

(Screenshot taken from this run: https://github.com/NASA-AMMOS/aerie/runs/6039227681#r20)

After making the `readline` change described above, this test no longer fails.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
I think this PR write-up as well as the git history serves as documentation of this fix.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
We need to avoid making the same mistake on the constraints dsl compiler (cc: @JoelCourtney )