### PR TITLE
[AERIE-1790] Added Relative, Absolute, and Epoch timing.

### DIFF
--- a/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -2,33 +2,99 @@
 export class Command<A extends ArgType[] | { [argName: string]: any } = [] | {}> {
   public readonly stem: string;
   public readonly arguments: A;
+  public readonly absoluteTime: Temporal.Instant | null = null;
+  public readonly epochTime: { epochName: string; time: Temporal.Duration } | null = null;
+  public readonly relativeTime: Temporal.Duration | null = null;
 
-  private constructor(opts: { stem: string; arguments: A }) {
+  private constructor(opts: CommandOptions<A>) {
     this.stem = opts.stem;
     this.arguments = opts.arguments;
+    if ('absoluteTime' in opts) {
+      this.absoluteTime = opts.absoluteTime;
+    } else if ('epochTime' in opts) {
+      this.epochTime = opts.epochTime;
+    } else if ('relativeTime' in opts) {
+      this.relativeTime = opts.relativeTime;
+    }
   }
 
-  public static new<A extends any[] | { [argName: string]: any }>(opts: { stem: string; arguments: A }): Command<A> {
-    return new Command({
-      stem: opts.stem,
-      arguments: opts.arguments,
-    });
+  public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): Command<A> {
+    if ('absoluteTime' in opts) {
+      return new Command<A>({
+        ...opts,
+        absoluteTime: opts.absoluteTime,
+      });
+    } else if ('epochTime' in opts) {
+      return new Command<A>({
+        ...opts,
+        epochTime: opts.epochTime,
+      });
+    } else if ('relativeTime' in opts) {
+      return new Command<A>({
+        ...opts,
+        relativeTime: opts.relativeTime,
+      });
+    } else {
+      return new Command<A>(opts);
+    }
   }
 
   public toSeqJson() {
     return {
       id: 'command',
       metadata: {},
+
       steps: [
         {
           stem: this.stem,
-          time: { type: 'COMPLETE' },
+          time: {
+            tag: this.absoluteTime
+              ? this.absoluteTime.toString()
+              : this.relativeTime
+              ? this.relativeTime.toString()
+              : this.epochTime
+              ? this.epochTime.time.toString()
+              : '',
+            type: this.absoluteTime
+              ? 'ABSOLUTE'
+              : this.relativeTime
+              ? 'COMMAND_RELATIVE'
+              : this.epochTime
+              ? 'EPOCH_RELATIVE'
+              : 'COMMAND_COMPLETE',
+          },
           type: 'command',
           metadata: {},
+          // include epoch field if we have an epoch time
+          ...(this.epochTime !== null ? { epoch: this.epochTime?.epochName } : {}),
           args: typeof this.arguments == 'object' ? Object.values(this.arguments) : this.arguments,
         },
       ],
     };
+  }
+
+  public absoluteTiming(absoluteTime: Temporal.Instant): Command<A> {
+    return Command.new({
+      stem: this.stem,
+      arguments: this.arguments,
+      absoluteTime: absoluteTime,
+    });
+  }
+
+  public epochTiming(epochName: string, epochTime: Temporal.Duration): Command<A> {
+    return Command.new({
+      stem: this.stem,
+      arguments: this.arguments,
+      epochTime: { epochName, time: epochTime },
+    });
+  }
+
+  public relativeTiming(relativeTime: Temporal.Duration): Command<A> {
+    return Command.new({
+      stem: this.stem,
+      arguments: this.arguments,
+      relativeTime: relativeTime,
+    });
   }
 }
 
@@ -36,12 +102,21 @@ declare global {
   export class Command<A extends ArgType[] | { [argName: string]: any } = [] | {}> {
     public readonly stem: string;
     public readonly arguments: A;
+    public readonly absoluteTime: Temporal.Instant | null;
+    public readonly epochTime: { epochName: string; time: Temporal.Duration } | null;
+    public readonly relativeTime: Temporal.Duration | null;
 
-    private constructor(opts: { stem: string; arguments: A });
+    private constructor(opts: CommandOptions<A>);
 
-    public static new<A extends any[] | { [argName: string]: any }>(opts: { stem: string; arguments: A }): Command<A>;
+    public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): Command<A>;
 
     public toSeqJson(): any;
+
+    public absoluteTiming(absoluteTime: Temporal.Instant): Command<A>;
+
+    public epochTiming(epochName: string, epochTime: Temporal.Duration): Command<A>;
+
+    public relativeTiming(relativeTime: Temporal.Duration): Command<A>;
   }
   type Context = {};
   type ArgType = boolean | string | number;
@@ -62,5 +137,18 @@ declare global {
   type F<BitLength extends 32 | 64> = number;
   type F32 = F<32>;
   type F64 = F<64>;
+  type CommandOptions<A> = { stem: string; arguments: A } & (
+    | {
+        absoluteTime: Temporal.Instant;
+      }
+    | {
+        epochTime: { epochName: string; time: Temporal.Duration };
+      }
+    | {
+        relativeTime: Temporal.Duration;
+      }
+    // CommandComplete
+    | {}
+  );
 }
 /** END Preface */


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1790
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

I added these timing options to the seqJson generated during expansion runs:

“ABSOLUTE”,
“COMMAND_RELATIVE”,
“EPOCH_RELATIVE”,
“COMMAND_COMPLETE”

The time values use [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) and follow the stage 3 proposal for [Temporal](https://tc39.es/proposal-temporal/docs/)

I am using this spec file here as a reference: [spec](https://github.jpl.nasa.gov/Aerie/aerie-seq-schema/blob/develop/schema.json)

Here is an example of expansion logic:

```
    BAKE_BREAD.relativeTiming(Temporal.Duration.from({ minutes: 5 })),
    BAKE_BREAD.absoluteTiming(Temporal.Instant.from("2022-04-20T20:17:13Z")),
    BAKE_BREAD.epochTiming("starPoch", Temporal.Duration.from({ minutes: 15 })),
```
Absolute time is not a duration but rather a [Temporal.Instant](https://tc39.es/proposal-temporal/docs/instant.html) as you will need to provide an exact time of when you will like to run the command.

You will notice the `epochTiming` will require an epoch name. From what I gathered, epoch names are global so the user should provide a valid name. I am storing the epochName in the `epoch : {} `field in the generated seqJson.

Here is the output from the expansion run

```
    {
        "id": "command",
        "steps": [
            {
                "args": [],
                "stem": "BAKE_BREAD",
                "time": {
                    "tag": "PT5M",
                    "type": "COMMAND_RELATIVE"
                },
                "type": "command",
                "metadata": {}
            }
        ],
        "metadata": {}
    },
    {
        "id": "command",
        "steps": [
            {
                "args": [],
                "stem": "BAKE_BREAD",
                "time": {
                    "tag": "2022-04-20T20:17:13Z",
                    "type": "ABSOLUTE"
                },
                "type": "command",
                "metadata": {}
            }
        ],
        "metadata": {}
    },
    {
        "id": "command",
        "steps": [
            {
                "args": [],
                "stem": "BAKE_BREAD",
                "time": {
                    "tag": "PT15M",
                    "type": "EPOCH_RELATIVE"
                },
                "type": "command",
                "epoch": "Nova",
                "metadata": {}
            }
        ],
        "metadata": {}
    }
```

## Verification
I ran through the whole expansion process to generate the above seqJson. 

## Documentation
none

## Future work
Continue to add missing fields in the seqJson generated by sequence expansions.
