### PR TITLE
[AERIE-1814] Optimize computations of constraints

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfile.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfile.java
@@ -18,11 +18,17 @@ public final class DiscreteProfile implements Profile<DiscreteProfile> {
     this(List.of(profilePieces));
   }
 
+  private static boolean profileOutsideBounds(final DiscreteProfilePiece piece, final Window bounds){
+    return piece.window.isStrictlyBefore(bounds) || piece.window.isStrictlyAfter(bounds);
+  }
+
   @Override
   public Windows notEqualTo(final DiscreteProfile other, final Window bounds) {
     final var windows = new Windows(bounds);
     for (final var profilePiece : this.profilePieces) {
+      if(profileOutsideBounds(profilePiece, bounds)) continue;
       for (final var otherPiece : other.profilePieces) {
+        if(profileOutsideBounds(otherPiece, bounds)) continue;
         if (profilePiece.value.equals(otherPiece.value)) {
           windows.subtractAll(
               Windows.intersection(
@@ -41,7 +47,9 @@ public final class DiscreteProfile implements Profile<DiscreteProfile> {
   public Windows equalTo(final DiscreteProfile other, final Window bounds) {
     final var windows = new Windows();
     for (final var profilePiece : this.profilePieces) {
+      if(profileOutsideBounds(profilePiece, bounds)) continue;
       for (final var otherPiece : other.profilePieces) {
+        if(profileOutsideBounds(otherPiece, bounds)) continue;
         if (profilePiece.value.equals(otherPiece.value)) {
           windows.addAll(
               Windows.intersection(
@@ -67,6 +75,8 @@ public final class DiscreteProfile implements Profile<DiscreteProfile> {
 
     while (iter.hasNext()) {
       final var curr = iter.next();
+      //avoid adding transition points for profiles outside of bounds
+      if(profileOutsideBounds(prev, bounds) || profileOutsideBounds(curr, bounds)) {prev = curr; continue;}
 
       if (Window.meets(prev.window, curr.window)) {
         if (prev.value != curr.value) changePoints.add(Window.at(prev.window.end));
@@ -92,6 +102,8 @@ public final class DiscreteProfile implements Profile<DiscreteProfile> {
 
     while (iter.hasNext()) {
       final var curr = iter.next();
+      //avoid adding transition points for profiles outside of bounds
+      if(profileOutsideBounds(prev, bounds) || profileOutsideBounds(curr, bounds)) {prev = curr; continue;}
 
       if (Window.meets(prev.window, curr.window)) {
         if (prev.value.equals(oldState) && curr.value.equals(newState)) {

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/And.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/And.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.List;
@@ -22,11 +23,11 @@ public final class And implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    Windows windows = new Windows(results.bounds);
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    Windows windows = new Windows(bounds);
     for (final var expression : this.expressions) {
       windows.intersectWith(
-          expression.evaluate(results, environment)
+          expression.evaluate(results, bounds, environment)
       );
     }
     return windows;

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Changed.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Changed.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.Profile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.Map;
@@ -17,8 +18,8 @@ public final class Changed<P extends Profile<P>> implements Expression<Windows> 
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    return this.expression.evaluate(results, environment).changePoints(results.bounds);
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    return this.expression.evaluate(results, bounds, environment).changePoints(bounds);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteParameter.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteParameter.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 
 import java.util.List;
 import java.util.Map;
@@ -20,11 +21,11 @@ public final class DiscreteParameter implements Expression<DiscreteProfile> {
   }
 
   @Override
-  public DiscreteProfile evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+  public DiscreteProfile evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
     final var activity = environment.get(this.activityAlias);
     return new DiscreteProfile(
         List.of(
-            new DiscreteProfilePiece(results.bounds, activity.parameters.get(this.parameterName))));
+            new DiscreteProfilePiece(bounds, activity.parameters.get(this.parameterName))));
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteResource.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteResource.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.constraints.InputMismatchException;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 
 import java.util.Map;
 import java.util.Objects;
@@ -17,7 +18,7 @@ public final class DiscreteResource implements Expression<DiscreteProfile> {
   }
 
   @Override
-  public DiscreteProfile evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+  public DiscreteProfile evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
     if (results.discreteProfiles.containsKey(this.name)) {
       return results.discreteProfiles.get(this.name);
     } else if (results.realProfiles.containsKey(this.name)) {

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteValue.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteValue.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.util.List;
@@ -19,8 +20,8 @@ public final class DiscreteValue implements Expression<DiscreteProfile> {
   }
 
   @Override
-  public DiscreteProfile evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    return new DiscreteProfile(List.of(new DiscreteProfilePiece(results.bounds, this.value)));
+  public DiscreteProfile evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    return new DiscreteProfile(List.of(new DiscreteProfilePiece(bounds, this.value)));
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/During.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/During.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.Map;
@@ -16,7 +17,7 @@ public final class During implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
     final var activity = environment.get(this.activityAlias);
     return new Windows(activity.window);
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/EndOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/EndOf.java
@@ -17,7 +17,7 @@ public final class EndOf implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
     final var activity = environment.get(this.activityAlias);
     return new Windows(Window.at(activity.window.end));
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Equal.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Equal.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.Profile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.Map;
@@ -19,11 +20,11 @@ public final class Equal<P extends Profile<P>> implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    final var leftProfile = this.left.evaluate(results, environment);
-    final var rightProfile = this.right.evaluate(results, environment);
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    final var leftProfile = this.left.evaluate(results, bounds, environment);
+    final var rightProfile = this.right.evaluate(results, bounds, environment);
 
-    return leftProfile.equalTo(rightProfile, results.bounds);
+    return leftProfile.equalTo(rightProfile, bounds);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Expression.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Expression.java
@@ -2,16 +2,20 @@ package gov.nasa.jpl.aerie.constraints.tree;
 
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 
 import java.util.Map;
 import java.util.Set;
 
 public interface Expression<T> {
-  T evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment);
+  T evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment);
   String prettyPrint(final String prefix);
   /** Add the resources referenced by this expression to the given set. **/
   void extractResources(Set<String> names);
 
+  default T evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment){
+    return this.evaluate(results, results.bounds, environment);
+  }
   default T evaluate(final SimulationResults results) {
     return this.evaluate(results, Map.of());
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivity.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivity.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.model.Violation;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,7 +28,7 @@ public final class ForEachActivity implements Expression<List<Violation>> {
   }
 
   @Override
-  public List<Violation> evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+  public List<Violation> evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
     final var violations = new ArrayList<Violation>();
     for (final var activity : results.activities) {
       if (activity.type.equals(this.activityType)) {
@@ -35,7 +36,7 @@ public final class ForEachActivity implements Expression<List<Violation>> {
         newEnvironment.put(this.alias, activity);
         newEnvironment.putAll(environment);
 
-        final var expressionViolations = this.expression.evaluate(results, newEnvironment);
+        final var expressionViolations = this.expression.evaluate(results, bounds, newEnvironment);
         for (final var violation : expressionViolations) {
           if (!violation.violationWindows.isEmpty()) {
             final var newViolation = violation.clone();

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForbiddenActivityOverlap.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForbiddenActivityOverlap.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.model.Violation;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 
 import java.util.List;
 import java.util.Map;
@@ -19,7 +20,7 @@ public final class ForbiddenActivityOverlap implements Expression<List<Violation
   }
 
   @Override
-  public List<Violation> evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+  public List<Violation> evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
     final var expansion =
         new ForEachActivity(
             this.activityType1,
@@ -30,7 +31,7 @@ public final class ForbiddenActivityOverlap implements Expression<List<Violation
                 new ViolationsOf(
                     new Not(new And(new During("act1"), new During("act2"))))));
 
-    return expansion.evaluate(results, environment);
+    return expansion.evaluate(results, bounds, environment);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/GreaterThan.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/GreaterThan.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.Map;
@@ -19,11 +20,11 @@ public final class GreaterThan implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    final var leftProfile = this.left.evaluate(results, environment);
-    final var rightProfile = this.right.evaluate(results, environment);
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    final var leftProfile = this.left.evaluate(results, bounds, environment);
+    final var rightProfile = this.right.evaluate(results, bounds, environment);
 
-    return leftProfile.greaterThan(rightProfile, results.bounds);
+    return leftProfile.greaterThan(rightProfile, bounds);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/GreaterThanOrEqual.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/GreaterThanOrEqual.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.Map;
@@ -19,11 +20,11 @@ public final class GreaterThanOrEqual implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    final var leftProfile = this.left.evaluate(results, environment);
-    final var rightProfile = this.right.evaluate(results, environment);
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    final var leftProfile = this.left.evaluate(results, bounds, environment);
+    final var rightProfile = this.right.evaluate(results, bounds, environment);
 
-    return leftProfile.greaterThanOrEqualTo(rightProfile, results.bounds);
+    return leftProfile.greaterThanOrEqualTo(rightProfile, bounds);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/IfThen.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/IfThen.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.Map;
@@ -17,8 +18,8 @@ public final class IfThen implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    return new Or(new Not(this.condition), this.expression).evaluate(results, environment);
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    return new Or(new Not(this.condition), this.expression).evaluate(results, bounds, environment);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LessThan.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LessThan.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.Map;
@@ -19,11 +20,11 @@ public final class LessThan implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    LinearProfile leftProfile = this.left.evaluate(results, environment);
-    LinearProfile rightProfile = this.right.evaluate(results, environment);
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    LinearProfile leftProfile = this.left.evaluate(results, bounds, environment);
+    LinearProfile rightProfile = this.right.evaluate(results, bounds, environment);
 
-    return leftProfile.lessThan(rightProfile, results.bounds);
+    return leftProfile.lessThan(rightProfile, bounds);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LessThanOrEqual.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LessThanOrEqual.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.Map;
@@ -19,11 +20,11 @@ public final class LessThanOrEqual implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    final var leftProfile = this.left.evaluate(results, environment);
-    final var rightProfile = this.right.evaluate(results, environment);
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    final var leftProfile = this.left.evaluate(results, bounds, environment);
+    final var rightProfile = this.right.evaluate(results, bounds, environment);
 
-    return leftProfile.lessThanOrEqualTo(rightProfile, results.bounds);
+    return leftProfile.lessThanOrEqualTo(rightProfile, bounds);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Not.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Not.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.Map;
@@ -16,10 +17,10 @@ public final class Not implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
     return Windows.minus(
-        new Windows(results.bounds),
-        this.expression.evaluate(results, environment));
+        new Windows(bounds),
+        this.expression.evaluate(results, bounds, environment));
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/NotEqual.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/NotEqual.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.Profile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.Map;
@@ -19,11 +20,11 @@ public final class NotEqual<P extends Profile<P>> implements Expression<Windows>
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    final var leftProfile = this.left.evaluate(results, environment);
-    final var rightProfile = this.right.evaluate(results, environment);
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    final var leftProfile = this.left.evaluate(results, bounds, environment);
+    final var rightProfile = this.right.evaluate(results, bounds, environment);
 
-    return leftProfile.notEqualTo(rightProfile, results.bounds);
+    return leftProfile.notEqualTo(rightProfile, bounds);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Or.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Or.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.List;
@@ -21,14 +22,14 @@ public final class Or implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
     Windows windows = new Windows();
     for (final var expression : this.expressions) {
       windows.addAll(
-          expression.evaluate(results, environment)
+          expression.evaluate(results, bounds, environment)
       );
     }
-    return Windows.intersection(windows, new Windows(results.bounds));
+    return Windows.intersection(windows, new Windows(bounds));
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Plus.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Plus.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 
 import java.util.Map;
 import java.util.Objects;
@@ -18,9 +19,9 @@ public final class Plus implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    return left.evaluate(results, environment)
-               .plus(right.evaluate(results, environment));
+  public LinearProfile evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    return left.evaluate(results, bounds, environment)
+               .plus(right.evaluate(results, bounds, environment));
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ProfileExpression.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ProfileExpression.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.Profile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 
 import java.util.Map;
 import java.util.Objects;
@@ -16,8 +17,8 @@ public final class ProfileExpression<P extends Profile<P>> implements Expression
   }
 
   @Override
-  public Profile<P> evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    return this.expression.evaluate(results, environment);
+  public Profile<P> evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    return this.expression.evaluate(results, bounds, environment);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Rate.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Rate.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 
 import java.util.Map;
 import java.util.Objects;
@@ -17,8 +18,8 @@ public final class Rate implements Expression<LinearProfile> {
 
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    return this.profile.evaluate(results, environment).rate();
+  public LinearProfile evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    return this.profile.evaluate(results, bounds, environment).rate();
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealParameter.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealParameter.java
@@ -5,6 +5,7 @@ import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 
 import java.util.List;
 import java.util.Map;
@@ -21,7 +22,7 @@ public final class RealParameter implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+  public LinearProfile evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
     final var activity = environment.get(this.activityAlias);
     final var parameter = activity.parameters.get(this.parameterName);
     final var value = parameter.asReal().orElseThrow(
@@ -32,7 +33,7 @@ public final class RealParameter implements Expression<LinearProfile> {
 
     return new LinearProfile(
         List.of(
-            new LinearProfilePiece(results.bounds, value, 0)));
+            new LinearProfilePiece(bounds, value, 0)));
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealResource.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealResource.java
@@ -6,6 +6,7 @@ import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -20,7 +21,7 @@ public final class RealResource implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+  public LinearProfile evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
     if (results.realProfiles.containsKey(this.name)) {
       return results.realProfiles.get(this.name);
     } else if (results.discreteProfiles.containsKey(this.name)) {

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealValue.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealValue.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 
 import java.util.List;
 import java.util.Map;
@@ -18,10 +19,10 @@ public final class RealValue implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+  public LinearProfile evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
     return new LinearProfile(
         List.of(
-            new LinearProfilePiece(results.bounds, this.value, 0.0)
+            new LinearProfilePiece(bounds, this.value, 0.0)
         )
     );
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/StartOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/StartOf.java
@@ -17,7 +17,7 @@ public final class StartOf implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
     final var activity = environment.get(this.activityAlias);
     return new Windows(Window.at(activity.window.start));
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Times.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Times.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 
 import java.util.Map;
 import java.util.Objects;
@@ -18,8 +19,8 @@ public final class Times implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    return this.profile.evaluate(results, environment).times(this.multiplier);
+  public LinearProfile evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    return this.profile.evaluate(results, bounds, environment).times(this.multiplier);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Transition.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Transition.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
@@ -22,8 +23,8 @@ public final class Transition implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
-    return this.profile.evaluate(results, environment).transitions(oldState, newState, results.bounds);
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    return this.profile.evaluate(results, bounds, environment).transitions(oldState, newState, bounds);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/True.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/True.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.List;
@@ -23,6 +24,14 @@ public final class True implements Expression<Windows> {
 
   @Override
   public void extractResources(final Set<String> names) {
+  }
+
+  @Override
+  public Windows evaluate(
+      final SimulationResults results,
+      final Window bounds,
+      final Map<String, ActivityInstance> environment) {
+    return new Windows(bounds);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ViolationsOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ViolationsOf.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.model.Violation;
+import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.List;
@@ -18,10 +19,10 @@ public final class ViolationsOf implements Expression<List<Violation>> {
   }
 
   @Override
-  public List<Violation> evaluate(SimulationResults results, Map<String, ActivityInstance> environment) {
-    final var bounds = new Windows(results.bounds);
-    final var satisfiedWindows = this.expression.evaluate(results, environment);
-    return List.of(new Violation(Windows.minus(bounds, satisfiedWindows)));
+  public List<Violation> evaluate(SimulationResults results, final Window bounds, Map<String, ActivityInstance> environment) {
+    final var boundsW = new Windows(bounds);
+    final var satisfiedWindows = this.expression.evaluate(results, bounds, environment);
+    return List.of(new Violation(Windows.minus(boundsW, satisfiedWindows)));
   }
 
   @Override

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfileTimeDomainTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfileTimeDomainTest.java
@@ -1,0 +1,97 @@
+package gov.nasa.jpl.aerie.constraints.model;
+
+import gov.nasa.jpl.aerie.constraints.time.Window;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static gov.nasa.jpl.aerie.constraints.Assertions.assertEquivalent;
+import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Exclusive;
+import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Inclusive;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
+public class DiscreteProfileTimeDomainTest {
+  @Test
+  public void testEqualToDomain() {
+    final var profile = new DiscreteProfile(List.of(
+        new DiscreteProfilePiece(Window.between(0, Inclusive, 5, Exclusive, SECONDS), SerializedValue.of(true)),
+        new DiscreteProfilePiece(Window.between(5, Inclusive, 10, Exclusive, SECONDS), SerializedValue.of(false)),
+        new DiscreteProfilePiece(Window.between(10, Inclusive, 15, Exclusive, SECONDS), SerializedValue.of(true)),
+        new DiscreteProfilePiece(Window.between(15, Inclusive, 20, Inclusive, SECONDS), SerializedValue.of(false))
+    ));
+
+    final var other = new DiscreteProfile(List.of(
+        new DiscreteProfilePiece(Window.between(0, Inclusive, 5, Exclusive, SECONDS), SerializedValue.of(true)),
+        new DiscreteProfilePiece(Window.between(5, Inclusive, 10, Exclusive, SECONDS), SerializedValue.of(true)),
+        new DiscreteProfilePiece(Window.between(10, Inclusive, 15, Exclusive, SECONDS), SerializedValue.of(false)),
+        new DiscreteProfilePiece(Window.between(15, Inclusive, 20, Inclusive, SECONDS), SerializedValue.of(false))
+    ));
+
+    final var result = profile.equalTo(other, Window.between(6, 14, SECONDS));
+
+    final var expected = new Windows();
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testNotEqualToDomain() {
+    final var profile = new DiscreteProfile(List.of(
+        new DiscreteProfilePiece(Window.between(0, Inclusive, 5, Exclusive, SECONDS), SerializedValue.of(true)),
+        new DiscreteProfilePiece(Window.between(5, Inclusive, 10, Exclusive, SECONDS), SerializedValue.of(false)),
+        new DiscreteProfilePiece(Window.between(10, Inclusive, 15, Exclusive, SECONDS), SerializedValue.of(true)),
+        new DiscreteProfilePiece(Window.between(15, Inclusive, 20, Inclusive, SECONDS), SerializedValue.of(false))
+    ));
+
+    final var other = new DiscreteProfile(List.of(
+        new DiscreteProfilePiece(Window.between(0, Inclusive, 5, Exclusive, SECONDS), SerializedValue.of(true)),
+        new DiscreteProfilePiece(Window.between(5, Inclusive, 10, Exclusive, SECONDS), SerializedValue.of(true)),
+        new DiscreteProfilePiece(Window.between(10, Inclusive, 15, Exclusive, SECONDS), SerializedValue.of(false)),
+        new DiscreteProfilePiece(Window.between(15, Inclusive, 20, Inclusive, SECONDS), SerializedValue.of(false))
+    ));
+
+    final var result = profile.notEqualTo(other, Window.between(6, 14, SECONDS));
+
+    final var expected = new Windows();
+    expected.add(Window.between(6, Inclusive, 14, Inclusive, SECONDS));
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testChangePointsDomain() {
+    final var profile = new DiscreteProfile(List.of(
+        new DiscreteProfilePiece(Window.between(0, Inclusive, 5, Exclusive, SECONDS), SerializedValue.of(true)),
+        new DiscreteProfilePiece(Window.between(5, Inclusive, 10, Exclusive, SECONDS), SerializedValue.of(false)),
+        new DiscreteProfilePiece(Window.between(10, Inclusive, 15, Exclusive, SECONDS), SerializedValue.of(true)),
+        new DiscreteProfilePiece(Window.between(15, Inclusive, 20, Inclusive, SECONDS), SerializedValue.of(false))
+    ));
+
+    final var result = profile.changePoints(Window.between(6, 14, SECONDS));
+
+    final var expected = new Windows();
+    expected.add(Window.at(10, SECONDS));
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testTransitionDomain() {
+    final var profile = new DiscreteProfile(List.of(
+        new DiscreteProfilePiece(Window.between(0, Inclusive, 5, Exclusive, SECONDS), SerializedValue.of(true)),
+        new DiscreteProfilePiece(Window.between(5, Inclusive, 10, Exclusive, SECONDS), SerializedValue.of(false)),
+        new DiscreteProfilePiece(Window.between(10, Inclusive, 15, Exclusive, SECONDS), SerializedValue.of(true)),
+        new DiscreteProfilePiece(Window.between(15, Inclusive, 20, Inclusive, SECONDS), SerializedValue.of(false))
+    ));
+
+    final var result = profile.transitions(
+        SerializedValue.of(true),
+        SerializedValue.of(false),
+        Window.between(6, 16, SECONDS));
+
+    final var expected = new Windows();
+    expected.add(Window.at(15, SECONDS));
+
+    assertEquivalent(expected, result);
+  }
+}

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/LinearProfileBenchmark.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/LinearProfileBenchmark.java
@@ -1,0 +1,88 @@
+package gov.nasa.jpl.aerie.constraints.model;
+
+import gov.nasa.jpl.aerie.constraints.time.Window;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Exclusive;
+import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Inclusive;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
+
+public class LinearProfileBenchmark {
+
+  private static List<LinearProfilePiece> getSubSequenceP1(final long start){
+    return List.of(
+        new LinearProfilePiece(Window.between(start, Inclusive, start + 4, Exclusive, SECONDS), 0, 1),
+        new LinearProfilePiece(Window.between( start + 4, Inclusive,  start + 8, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between( start + 8, Inclusive, start + 12, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(start + 12, Inclusive, start + 16, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between(start + 16, Inclusive, start + 20, Inclusive, SECONDS),  0,  0)
+    );
+  }
+
+  private static List<LinearProfilePiece> getSubSequenceP2(final long start){
+    return List.of(
+        new LinearProfilePiece(Window.between(start, Inclusive, start + 2, Exclusive, SECONDS), 0, 1),
+        new LinearProfilePiece(Window.between( start + 2, Inclusive,  start + 4, Exclusive, SECONDS),  2,  0),
+        new LinearProfilePiece(Window.between( start + 4, Inclusive,  start + 6, Exclusive, SECONDS),  2,  1),
+        new LinearProfilePiece(Window.between( start + 6, Inclusive, start + 12, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between(start + 12, Inclusive, start + 16, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(start + 16, Inclusive, start + 20, Inclusive, SECONDS),  0,  0)
+    );
+  }
+
+  public static void firstMethod(LinearProfile profile1, LinearProfile profile2, int times, long durationSequence){
+    //test at the middle of the profile
+    final var testAt = times / 2;
+    profile1.greaterThan(profile2, Window.between(testAt * durationSequence, (testAt + 1) * durationSequence, SECONDS));
+  }
+
+  public static void secondMethod(final LinearProfile profile1, final LinearProfile profile2, final long start, final int times, final long durationSequence){
+    profile1.greaterThan(profile2, Window.between(start, times * durationSequence, SECONDS));
+  }
+
+
+  public static void main(String[] args){
+    //number of times the sub-sequences are repeated
+    final var times = 1000;
+    final var start = 0L;
+    //duration of a sub-sequence
+    final var durationSequence = 20;
+    //number of runs
+    final var nbRuns = 30;
+
+    final var list1 = new ArrayList<LinearProfilePiece>();
+    final var list2 = new ArrayList<LinearProfilePiece>();
+
+    for(var i = 0; i < times; i++){
+      long startsub = start + (i * durationSequence);
+      list1.addAll(getSubSequenceP1(startsub));
+      list2.addAll(getSubSequenceP2(startsub));
+    }
+    final var profile1 = new LinearProfile(list1);
+    final var profile2 = new LinearProfile(list2);
+
+    var totalTimeFirstMethod = 0L;
+    for(int i = 0; i < nbRuns ; i++) {
+      final var before = System.nanoTime();
+      firstMethod(profile1, profile2, times, durationSequence);
+      totalTimeFirstMethod += (System.nanoTime() - before);
+    }
+
+    var totalTimeSecondMethod = 0L;
+
+    for(int i = 0; i < nbRuns ; i++) {
+      final var before2 = System.nanoTime();
+      secondMethod(profile1, profile2, start, times, durationSequence);
+      totalTimeSecondMethod += (System.nanoTime() - before2);
+    }
+
+    final var timePerRun1 = (float) totalTimeFirstMethod/nbRuns;
+    final var timePerRun2 = (float) totalTimeSecondMethod/nbRuns;
+
+    //When first comparing, testing on restricted bounds was about 100 times faster than without bounds
+    System.out.println( timePerRun1+ " "  + timePerRun2  + " ratio = " + (timePerRun1/timePerRun2));
+  }
+
+}

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/LinearProfileTimeDomainTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/LinearProfileTimeDomainTest.java
@@ -1,0 +1,199 @@
+package gov.nasa.jpl.aerie.constraints.model;
+
+import gov.nasa.jpl.aerie.constraints.time.Window;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import org.junit.jupiter.api.Test;
+
+import static gov.nasa.jpl.aerie.constraints.Assertions.assertEquivalent;
+import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Exclusive;
+import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Inclusive;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
+
+public class LinearProfileTimeDomainTest {
+
+  @Test
+  public void testChangePoints() {
+    final var profile = new LinearProfile(
+        new LinearProfilePiece(Window.between( 0, Inclusive,  5, Exclusive, SECONDS), 2, 0),
+        new LinearProfilePiece(Window.between( 5, Inclusive,  8, Exclusive, SECONDS), 2, 0),
+        new LinearProfilePiece(Window.between( 8, Inclusive, 10, Inclusive, SECONDS), 3, 0),
+        new LinearProfilePiece(Window.between(10, Exclusive, 15, Exclusive, SECONDS), 3, 1),
+        new LinearProfilePiece(Window.between(15, Inclusive, 20, Inclusive, SECONDS), -2, 0)
+    );
+
+    final var result = profile.changePoints(Window.between(9, 16, SECONDS));
+
+    final var expected = new Windows();
+    expected.add(Window.between(10, Exclusive, 15, Inclusive, SECONDS));
+
+    assertEquivalent(result, expected);
+  }
+
+  @Test
+  public void testLessThan() {
+    final var profile = new LinearProfile(
+        new LinearProfilePiece(Window.between( 0, Inclusive,  4, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between( 4, Inclusive,  8, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between( 8, Inclusive, 12, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(12, Inclusive, 16, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between(16, Inclusive, 20, Inclusive, SECONDS),  0,  0)
+    );
+
+    final var other = new LinearProfile(
+        new LinearProfilePiece(Window.between( 0, Inclusive,  2, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between( 2, Inclusive,  4, Exclusive, SECONDS),  2,  0),
+        new LinearProfilePiece(Window.between( 4, Inclusive,  6, Exclusive, SECONDS),  2,  1),
+        new LinearProfilePiece(Window.between( 6, Inclusive, 12, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between(12, Inclusive, 16, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(16, Inclusive, 20, Inclusive, SECONDS),  0,  0)
+    );
+
+    final var result = profile.lessThan(other, Window.between(9, 14, SECONDS));
+
+    final var expected = new Windows();
+    expected.add(Window.between(9, Inclusive, 14, Exclusive, SECONDS));
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testLessThanOrEqualTo() {
+    final var profile = new LinearProfile(
+        new LinearProfilePiece(Window.between( 0, Inclusive,  4, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between( 4, Inclusive,  8, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between( 8, Inclusive, 12, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(12, Inclusive, 16, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between(16, Inclusive, 20, Inclusive, SECONDS),  0,  0)
+    );
+
+    final var other = new LinearProfile(
+        new LinearProfilePiece(Window.between( 0, Inclusive,  2, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between( 2, Inclusive,  4, Exclusive, SECONDS),  2,  0),
+        new LinearProfilePiece(Window.between( 4, Inclusive,  6, Exclusive, SECONDS),  2,  1),
+        new LinearProfilePiece(Window.between( 6, Inclusive, 12, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between(12, Inclusive, 16, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(16, Inclusive, 20, Inclusive, SECONDS),  0,  0)
+    );
+
+    final var result = profile.lessThanOrEqualTo(other, Window.between(0, 8, SECONDS));
+
+    final var expected = new Windows();
+    expected.add(Window.between( 0, Inclusive,  2, Inclusive, SECONDS));
+    expected.add(Window.between( 6, Inclusive, 8, Inclusive, SECONDS));
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testGreaterThan() {
+    final var profile = new LinearProfile(
+        new LinearProfilePiece(Window.between( 0, Inclusive,  4, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between( 4, Inclusive,  8, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between( 8, Inclusive, 12, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(12, Inclusive, 16, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between(16, Inclusive, 20, Inclusive, SECONDS),  0,  0)
+    );
+
+    final var other = new LinearProfile(
+        new LinearProfilePiece(Window.between( 0, Inclusive,  2, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between( 2, Inclusive,  4, Exclusive, SECONDS),  2,  0),
+        new LinearProfilePiece(Window.between( 4, Inclusive,  6, Exclusive, SECONDS),  2,  1),
+        new LinearProfilePiece(Window.between( 6, Inclusive, 12, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between(12, Inclusive, 16, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(16, Inclusive, 20, Inclusive, SECONDS),  0,  0)
+    );
+
+    final var result = profile.greaterThan(other, Window.between(2, 15, SECONDS));
+
+    final var expected = new Windows();
+    expected.add(Window.between( 2, Exclusive,  6, Exclusive, SECONDS));
+    expected.add(Window.between(14, Exclusive, 15, Inclusive, SECONDS));
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testGreaterThanOrEqualTo() {
+    final var profile = new LinearProfile(
+        new LinearProfilePiece(Window.between( 0, Inclusive,  4, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between( 4, Inclusive,  8, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between( 8, Inclusive, 12, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(12, Inclusive, 16, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between(16, Inclusive, 20, Inclusive, SECONDS),  0,  0)
+    );
+
+    final var other = new LinearProfile(
+        new LinearProfilePiece(Window.between( 0, Inclusive,  2, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between( 2, Inclusive,  4, Exclusive, SECONDS),  2,  0),
+        new LinearProfilePiece(Window.between( 4, Inclusive,  6, Exclusive, SECONDS),  2,  1),
+        new LinearProfilePiece(Window.between( 6, Inclusive, 12, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between(12, Inclusive, 16, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(16, Inclusive, 20, Inclusive, SECONDS),  0,  0)
+    );
+
+    final var result = profile.greaterThanOrEqualTo(other, Window.between(8, 20, SECONDS));
+
+    final var expected = new Windows();
+    expected.add(Window.at(8, SECONDS));
+    expected.add(Window.between(14, Inclusive, 20, Inclusive, SECONDS));
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testEqualTo() {
+    final var profile = new LinearProfile(
+        new LinearProfilePiece(Window.between( 0, Inclusive,  4, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between( 4, Inclusive,  8, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between( 8, Inclusive, 12, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(12, Inclusive, 16, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between(16, Inclusive, 20, Inclusive, SECONDS),  0,  0)
+    );
+
+    final var other = new LinearProfile(
+        new LinearProfilePiece(Window.between( 0, Inclusive,  2, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between( 2, Inclusive,  4, Exclusive, SECONDS),  2,  0),
+        new LinearProfilePiece(Window.between( 4, Inclusive,  6, Exclusive, SECONDS),  2,  1),
+        new LinearProfilePiece(Window.between( 6, Inclusive, 12, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between(12, Inclusive, 16, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(16, Inclusive, 20, Inclusive, SECONDS),  0,  0)
+    );
+
+    final var result = profile.equalTo(other, Window.between(7, 17, SECONDS));
+
+    final var expected = new Windows();
+    expected.add(Window.between( 7, Inclusive,  8, Inclusive, SECONDS));
+    expected.add(Window.at(14, SECONDS));
+    expected.add(Window.between( 16, Inclusive,  17, Inclusive, SECONDS));
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testNotEqualTo() {
+    final var profile = new LinearProfile(
+        new LinearProfilePiece(Window.between( 0, Inclusive,  4, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between( 4, Inclusive,  8, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between( 8, Inclusive, 12, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(12, Inclusive, 16, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between(16, Inclusive, 20, Inclusive, SECONDS),  0,  0)
+    );
+
+    final var other = new LinearProfile(
+        new LinearProfilePiece(Window.between( 0, Inclusive,  2, Exclusive, SECONDS),  0,  1),
+        new LinearProfilePiece(Window.between( 2, Inclusive,  4, Exclusive, SECONDS),  2,  0),
+        new LinearProfilePiece(Window.between( 4, Inclusive,  6, Exclusive, SECONDS),  2,  1),
+        new LinearProfilePiece(Window.between( 6, Inclusive, 12, Exclusive, SECONDS),  4,  0),
+        new LinearProfilePiece(Window.between(12, Inclusive, 16, Exclusive, SECONDS),  4, -1),
+        new LinearProfilePiece(Window.between(16, Inclusive, 20, Inclusive, SECONDS),  0,  0)
+    );
+
+    final var result = profile.notEqualTo(other, Window.between(2, 11, SECONDS));
+
+    final var expected = new Windows();
+    expected.add(Window.between(2, Exclusive, 6, Exclusive, SECONDS));
+    expected.add(Window.between(8, Exclusive, 11, Inclusive, SECONDS));
+
+    assertEquivalent(expected, result);
+  }
+}

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -451,7 +451,7 @@ public class ASTTests {
 
 
     @Override
-    public T evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+    public T evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
       return this.value;
     }
 


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

@mattdailis and I have noticed that bounds were partially present in constraints but not used. Scheduling often computes resource constraints on very restricted domains but current constraints are computed over the whole simulation results. 

I have added a `bounds` parameter to the `evaluate` method of the `Expression` interface. The previous prototype is still there as a default. This allows for a few optimizations that have been added in the operations of `LinearProfile` and `DiscreteProfile`.

I added a benchmark in which we want to compute a constraint on a very reduced interval (1/1000 of the duration of the profile), the version with time bounding is approx. 100x faster than the one without.  

All of the previously (and applicable) tests were duplicated and modified to test these optimizations.  

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
WIth new tests. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Look closely to the optimizations in case I missed a corner case. Or a better optimization !

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None.