### PR TITLE
Fix package names in merlin and scheduler dsl compilers

### DIFF
--- a/merlin-server/constraints-dsl-compiler/package-lock.json
+++ b/merlin-server/constraints-dsl-compiler/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "constraints-typescript-compiler",
+  "name": "constraints-dsl-compiler",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "constraints-typescript-compiler",
+      "name": "constraints-dsl-compiler",
       "version": "1.0.0",
       "dependencies": {
         "@nasa-jpl/aerie-ts-user-code-runner": "^0.2.6",

--- a/scheduler-server/scheduling-dsl-compiler/package-lock.json
+++ b/scheduler-server/scheduling-dsl-compiler/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "scheduler-typescript-compiler",
+  "name": "scheduling-dsl-compiler",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "scheduler-typescript-compiler",
+      "name": "scheduling-dsl-compiler",
       "version": "1.0.0",
       "dependencies": {
         "@nasa-jpl/aerie-ts-user-code-runner": "^0.2.6",


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1817
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Fixes package-lock.json package names for scheduler-server and merlin-server, which should have been included in #150 