### PR TITLE
[AERIE-1816] New constraints pipeline

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintsDSL.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintsDSL.java
@@ -1,4 +1,4 @@
-package gov.nasa.jpl.aerie.merlin.server.models;
+package gov.nasa.jpl.aerie.constraints.json;
 
 import gov.nasa.jpl.aerie.constraints.model.Violation;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
@@ -14,7 +14,6 @@ import gov.nasa.jpl.aerie.json.Unit;
 import java.util.List;
 
 import static gov.nasa.jpl.aerie.json.BasicParsers.chooseP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.intP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.listP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.literalP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
@@ -42,7 +41,7 @@ public class ConstraintsDSL {
                     $ -> tuple(Unit.UNIT, $.expressions)));
   }
 
-  private static JsonParser<True> trueP =
+  private static final JsonParser<True> trueP =
       productP
           .field("kind", literalP("WindowsExpressionTrue"))
           .map(

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/True.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/True.java
@@ -1,0 +1,37 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Simple expression that produces a window at all times.
+ */
+public final class True implements Expression<Windows> {
+
+  public True() {}
+
+  @Override
+  public Windows evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment) {
+    return new Windows(results.bounds);
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {
+  }
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return "True";
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof True;
+  }
+}

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/json/ConstraintDSLTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/json/ConstraintDSLTest.java
@@ -1,0 +1,94 @@
+package gov.nasa.jpl.aerie.constraints.json;
+
+import gov.nasa.jpl.aerie.constraints.tree.*;
+import org.junit.jupiter.api.Test;
+
+import javax.json.Json;
+
+import static gov.nasa.jpl.aerie.constraints.Assertions.assertEquivalent;
+import static gov.nasa.jpl.aerie.constraints.json.ConstraintsDSL.*;
+
+public final class ConstraintDSLTest {
+
+  @Test
+  public void testParseTrue() {
+    final var json = Json
+        .createObjectBuilder()
+        .add("kind", "WindowsExpressionTrue")
+        .build();
+
+    final var result = windowsExpressionP.parse(json).getSuccessOrThrow();
+
+    final var expected = new True();
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testParseAnd() {
+    final var json = Json
+        .createObjectBuilder()
+        .add("kind", "WindowsExpressionAnd")
+        .add("expressions", Json
+            .createArrayBuilder()
+            .add(Json
+                     .createObjectBuilder()
+                     .add("kind", "WindowsExpressionTrue"))
+            .add(Json
+                     .createObjectBuilder()
+                     .add("kind", "WindowsExpressionTrue")))
+        .build();
+
+    final var result = windowsExpressionP.parse(json).getSuccessOrThrow();
+
+    final var expected =
+        new And(
+            new True(),
+            new True());
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testParseOr() {
+    final var json = Json
+        .createObjectBuilder()
+        .add("kind", "WindowsExpressionOr")
+        .add("expressions", Json
+            .createArrayBuilder()
+            .add(Json
+                     .createObjectBuilder()
+                     .add("kind", "WindowsExpressionTrue"))
+            .add(Json
+                     .createObjectBuilder()
+                     .add("kind", "WindowsExpressionTrue")))
+        .build();
+
+    final var result = windowsExpressionP.parse(json).getSuccessOrThrow();
+
+    final var expected =
+        new Or(
+            new True(),
+            new True());
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testParseViolationsOf() {
+    final var json = Json
+        .createObjectBuilder()
+        .add("kind", "ViolationsOf")
+        .add("expression", Json
+            .createObjectBuilder()
+                .add("kind", "WindowsExpressionTrue"))
+        .build();
+
+    final var result = constraintP.parse(json).getSuccessOrThrow();
+
+    final var expected = new ViolationsOf(new True());
+
+    assertEquivalent(expected, result);
+  }
+
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       MERLIN_DB_USER: "aerie"
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
       MERLIN_PORT: 27183
+      MERLIN_USE_NEW_CONSTRAINT_PIPELINE: "false"
       JAVA_OPTS: >
         -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -1,38 +1,33 @@
 export enum NodeKind {
-  DummyConstraint = 'DummyConstraint',
-  ConstraintAnd = 'ConstraintAnd',
-  ConstraintOr = 'ConstraintOr'
+  ViolationsOf = 'ViolationsOf',
+  WindowsExpressionAnd = 'WindowsExpressionAnd',
+  WindowsExpressionOr = 'WindowsExpressionOr',
+  WindowsExpressionTrue = 'WindowsExpressionTrue'
 }
 
-export type Constraint = | DummyConstraint;
+export type Constraint = | ViolationsOf;
 
-export interface DummyConstraint {
-  kind: NodeKind.DummyConstraint,
-  someNumber: number,
+export interface ViolationsOf {
+  kind: NodeKind.ViolationsOf,
+  expression: WindowsExpression,
 }
 
-export type ConstraintSpecifier =
-    | Constraint
-    | ConstraintComposition
-    ;
+export type WindowsExpression =
+  | And
+  | Or
+  | True;
 
-/**
- * Constraint Composition
- *
- * Compose constraints together
- */
-export type ConstraintComposition =
-    | ConstraintAnd
-    | ConstraintOr
-    ;
-
-export interface ConstraintAnd {
-  kind: NodeKind.ConstraintAnd,
-  constraints: ConstraintSpecifier[],
+export interface And {
+  kind: NodeKind.WindowsExpressionAnd,
+  expressions: WindowsExpression[],
 }
 
-export interface ConstraintOr {
-  kind: NodeKind.ConstraintOr,
-  constraints: ConstraintSpecifier[],
+export interface Or {
+  kind: NodeKind.WindowsExpressionOr,
+  expressions: WindowsExpression[],
+}
+
+export interface True {
+  kind: NodeKind.WindowsExpressionTrue
 }
 

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -5,28 +5,52 @@ export enum NodeKind {
   WindowsExpressionTrue = 'WindowsExpressionTrue'
 }
 
+/**
+ * Top-level constraints that directly produce violations
+ * when evaluated.
+ */
 export type Constraint = | ViolationsOf;
 
+/**
+ * Generates violations whenever its expression generates a window.
+ */
 export interface ViolationsOf {
   kind: NodeKind.ViolationsOf,
   expression: WindowsExpression,
 }
 
+/**
+ * Operations that produce Windows when evaluated.
+ *
+ * These are not valid top-level constraints, and
+ * typically need to be wrapped in `Constraint.ViolationsOf`.
+ */
 export type WindowsExpression =
   | And
   | Or
   | True;
 
+/**
+ * Generates a violation when all of its sub-expressions generate windows.
+ */
 export interface And {
   kind: NodeKind.WindowsExpressionAnd,
   expressions: WindowsExpression[],
 }
 
+/**
+ * Generates a violation when any of its sub-expressions generate windows.
+ */
 export interface Or {
   kind: NodeKind.WindowsExpressionOr,
   expressions: WindowsExpression[],
 }
 
+/**
+ * Always generates a window.
+ *
+ * Currently this only exists for testing, it isn't intended to be useful.
+ */
 export interface True {
   kind: NodeKind.WindowsExpressionTrue
 }

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -1,61 +1,84 @@
 import * as AST from './constraints-ast.js';
 
-interface DummyConstraint extends Constraint {}
+interface ViolationsOf extends Constraint {}
 export class Constraint {
-  private readonly constraintSpecifier: AST.ConstraintSpecifier;
+  private readonly constraint: AST.Constraint;
 
-  private constructor(constraintSpecifier: AST.ConstraintSpecifier) {
-    this.constraintSpecifier = constraintSpecifier;
+  private constructor(constraint: AST.Constraint) {
+    this.constraint = constraint;
   }
 
-  private static new(constraintSpecifier: AST.ConstraintSpecifier): Constraint {
-    return new Constraint(constraintSpecifier);
+  private static new(constraint: AST.Constraint): Constraint {
+    return new Constraint(constraint);
   }
 
-  private __serialize(): AST.ConstraintSpecifier {
-    return this.constraintSpecifier;
+  private __serialize(): AST.Constraint {
+    return this.constraint;
   }
 
-  public and(...others: Constraint[]): Constraint {
+  public static ViolationsOf(expression: WindowsExpression): ViolationsOf {
     return Constraint.new({
-      kind: AST.NodeKind.ConstraintAnd,
-      constraints: [
-        this.constraintSpecifier,
-        ...others.map(other => other.constraintSpecifier),
+      kind: AST.NodeKind.ViolationsOf,
+      expression: expression['__serialize']()
+    });
+  }
+}
+
+interface True extends WindowsExpression {}
+export class WindowsExpression {
+  private readonly expression: AST.WindowsExpression;
+
+  private constructor(expression: AST.WindowsExpression) {
+    this.expression = expression;
+  }
+
+  private static new(expression: AST.WindowsExpression): WindowsExpression {
+    return new WindowsExpression(expression);
+  }
+
+  public static True(): True {
+    return WindowsExpression.new({
+      kind: AST.NodeKind.WindowsExpressionTrue
+    });
+  }
+
+  public and(...others: WindowsExpression[]): WindowsExpression {
+    return WindowsExpression.new({
+      kind: AST.NodeKind.WindowsExpressionAnd,
+      expressions: [
+        this.expression,
+        ...others.map(other => other.expression),
       ],
     });
   }
 
-  public or(...others: Constraint[]): Constraint {
-    return Constraint.new({
-      kind: AST.NodeKind.ConstraintOr,
-      constraints: [
-        this.constraintSpecifier,
-        ...others.map(other => other.constraintSpecifier),
+  public or(...others: WindowsExpression[]): WindowsExpression {
+    return WindowsExpression.new({
+      kind: AST.NodeKind.WindowsExpressionOr,
+      expressions: [
+        this.expression,
+        ...others.map(other => other.expression),
       ],
     });
   }
 
-  // Dummy function just for testing.
-  // Delete as soon as an actual constraint is implemented.
-  public static DummyConstraint(num: number): DummyConstraint {
-    return Constraint.new({
-      kind: AST.NodeKind.DummyConstraint,
-      someNumber: num
+  public static True(): True {
+    return WindowsExpression.new({
+      kind: AST.NodeKind.True
     });
   }
 }
 
 declare global {
   export class Constraint {
-    public and(...others: Constraint[]): Constraint
-    public or(...others: Constraint[]): Constraint
-    public static DummyConstraint(num: number): DummyConstraint
+    public static ViolationsOf(expression: WindowsExpression): ViolationsOf
   }
-  type Duration = number;
-  type Double = number;
-  type Integer = number;
+  export class WindowsExpression {
+    public and(...others: WindowsExpression[]): WindowsExpression
+    public or(...others: WindowsExpression[]): WindowsExpression
+    public static True(): True
+  }
 }
 
 // Make Constraint available on the global object
-Object.assign(globalThis, { Constraint });
+Object.assign(globalThis, { Constraint, WindowsExpression });

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -1,35 +1,35 @@
 import * as AST from './constraints-ast.js';
 
 interface ViolationsOf extends Constraint {}
+
 export class Constraint {
-  private readonly constraint: AST.Constraint;
+  /** Internal AST node */
+  public readonly __astNode: AST.Constraint;
 
-  private constructor(constraint: AST.Constraint) {
-    this.constraint = constraint;
+  private constructor(astNode: AST.Constraint) {
+    this.__astNode = astNode;
   }
 
-  private static new(constraint: AST.Constraint): Constraint {
-    return new Constraint(constraint);
-  }
-
-  private __serialize(): AST.Constraint {
-    return this.constraint;
+  private static new(astNode: AST.Constraint): Constraint {
+    return new Constraint(astNode);
   }
 
   public static ViolationsOf(expression: WindowsExpression): ViolationsOf {
     return Constraint.new({
       kind: AST.NodeKind.ViolationsOf,
-      expression: expression['__serialize']()
+      expression: expression.__astNode,
     });
   }
 }
 
 interface True extends WindowsExpression {}
+
 export class WindowsExpression {
-  private readonly expression: AST.WindowsExpression;
+  /** Internal AST node */
+  public readonly __astNode: AST.WindowsExpression;
 
   private constructor(expression: AST.WindowsExpression) {
-    this.expression = expression;
+    this.__astNode = expression;
   }
 
   private static new(expression: AST.WindowsExpression): WindowsExpression {
@@ -46,8 +46,8 @@ export class WindowsExpression {
     return WindowsExpression.new({
       kind: AST.NodeKind.WindowsExpressionAnd,
       expressions: [
-        this.expression,
-        ...others.map(other => other.expression),
+        this.__astNode,
+        ...others.map(other => other.__astNode),
       ],
     });
   }
@@ -56,29 +56,32 @@ export class WindowsExpression {
     return WindowsExpression.new({
       kind: AST.NodeKind.WindowsExpressionOr,
       expressions: [
-        this.expression,
-        ...others.map(other => other.expression),
+        this.__astNode,
+        ...others.map(other => other.__astNode),
       ],
-    });
-  }
-
-  public static True(): True {
-    return WindowsExpression.new({
-      kind: AST.NodeKind.True
     });
   }
 }
 
 declare global {
   export class Constraint {
+    /** Internal AST Node */
+    public readonly __astNode: AST.Constraint;
+
     public static ViolationsOf(expression: WindowsExpression): ViolationsOf
   }
+
   export class WindowsExpression {
-    public and(...others: WindowsExpression[]): WindowsExpression
-    public or(...others: WindowsExpression[]): WindowsExpression
+    /** Internal AST Node */
+    public readonly __astNode: AST.WindowsExpression;
+
     public static True(): True
+
+    public and(...others: WindowsExpression[]): WindowsExpression
+
+    public or(...others: WindowsExpression[]): WindowsExpression
   }
 }
 
 // Make Constraint available on the global object
-Object.assign(globalThis, { Constraint, WindowsExpression });
+Object.assign(globalThis, {Constraint, WindowsExpression});

--- a/merlin-server/constraints-dsl-compiler/src/main.ts
+++ b/merlin-server/constraints-dsl-compiler/src/main.ts
@@ -41,7 +41,7 @@ async function handleRequest(data: Buffer) {
     // The previous strategy of exporting a symbol and using it to get at a public method
     // didn't work because the symbol in the vm is different than the symbol we were using
     // here to deserialize the Constraint due to different evaluation contexts
-    const stringified = JSON.stringify(result.unwrap()['__serialize']());
+    const stringified = JSON.stringify(result.unwrap().__astNode);
     if (stringified === undefined) {
       throw Error(JSON.stringify(result.unwrap()) + ' was not JSON serializable');
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/config/AppConfiguration.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/config/AppConfiguration.java
@@ -7,7 +7,8 @@ public record AppConfiguration (
     int httpPort,
     boolean enableJavalinDevLogging,
     Path merlinFileStore,
-    Store store
+    Store store,
+    boolean useNewConstraintPipeline
 ) {
   public AppConfiguration {
     Objects.requireNonNull(merlinFileStore);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
@@ -1,5 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.jpl.aerie.constraints.model.Violation;
+import gov.nasa.jpl.aerie.constraints.tree.Expression;
 import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.merlin.server.http.InvalidEntityException;
 import gov.nasa.jpl.aerie.merlin.server.http.InvalidJsonException;
@@ -80,7 +82,7 @@ public class ConstraintsDSLCompilationService {
         case "success" -> {
           final var output = outputReader.readLine();
           try {
-            yield new ConstraintsDSLCompilationResult.Success(parseJson(output, ConstraintsDSL.constraintsJsonP));
+            yield new ConstraintsDSLCompilationResult.Success(parseJson(output, ConstraintsDSL.constraintP));
           } catch (InvalidJsonException | InvalidEntityException e) {
             throw new Error("Could not parse JSON returned from typescript: " + output, e);
           }
@@ -105,7 +107,7 @@ public class ConstraintsDSLCompilationService {
   }
 
   public sealed interface ConstraintsDSLCompilationResult {
-    record Success(ConstraintsDSL.ConstraintSpecifier constraintSpecifier) implements ConstraintsDSLCompilationResult {}
+    record Success(Expression<List<Violation>> constraintExpression) implements ConstraintsDSLCompilationResult {}
     record Error(List<ConstraintsCompilationError.UserCodeError> errors) implements ConstraintsDSLCompilationResult {}
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
@@ -7,7 +7,7 @@ import gov.nasa.jpl.aerie.merlin.server.http.InvalidEntityException;
 import gov.nasa.jpl.aerie.merlin.server.http.InvalidJsonException;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ConstraintsCompilationError;
-import gov.nasa.jpl.aerie.merlin.server.models.ConstraintsDSL;
+import gov.nasa.jpl.aerie.constraints.json.ConstraintsDSL;
 import org.json.JSONObject;
 
 import javax.json.Json;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
@@ -48,7 +48,7 @@ public class ConstraintsDSLCompilationService {
   /**
    * NOTE: This method is not re-entrant (assumes only one call to this method is running at any given time)
    */
-  public ConstraintsDSLCompilationResult compileConstraintsDSL(final PlanId planId, final String constraintTypescript, final String constraintName)
+  public ConstraintsDSLCompilationResult compileConstraintsDSL(final PlanId planId, final String constraintTypescript)
   {
     final var missionModelGeneratedCode = JSONObject.quote(this.typescriptCodeGenerationService.generateTypescriptTypesForPlan(planId));
 

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -41,7 +41,7 @@ class ConstraintsDSLCompilationServiceTests {
                 export default function myConstraint() {
                   return Constraint.DummyConstraint(4)
                 }
-            """, "constraintfile");
+            """);
     final var expectedConstraintDefinition = new ConstraintsDSL.ConstraintSpecifier.DummyConstraintDefinition(4);
     if (result instanceof ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Success r) {
       assertEquals(expectedConstraintDefinition, r.constraintSpecifier());
@@ -62,7 +62,7 @@ class ConstraintsDSLCompilationServiceTests {
                 function myHelper(n: number) {
                   return Constraint.DummyConstraint(n*2)
                 }
-            """, "constraintfile");
+            """);
     final var expectedConstraintDefinition = new ConstraintsDSL.ConstraintSpecifier.DummyConstraintDefinition(4);
     if (result instanceof ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Success r) {
       assertEquals(expectedConstraintDefinition, r.constraintSpecifier());
@@ -84,7 +84,7 @@ class ConstraintsDSLCompilationServiceTests {
                   return Constraint.DummyConstraint(x * n);
                   )
                 }
-              """, "constraintfile_with_type_error");
+              """);
     assertTrue(
         actualErrors.errors()
                     .stream()
@@ -100,7 +100,7 @@ class ConstraintsDSLCompilationServiceTests {
                 export default function myConstraint() {
                   return 5
                 }
-              """, "constraintfile_with_wrong_return_type");
+              """);
     assertTrue(
         actualErrors.errors()
                     .stream()

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -101,15 +101,14 @@ class ConstraintsDSLCompilationServiceTests {
     final ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Error actualErrors;
     actualErrors = (ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Error) constraintsDSLCompilationService.compileConstraintsDSL(
           PLAN_ID, """
-                export default function myConstraint(): Constraint {
-                  // return WindowsExpression.True()
-                  return 5
+                export default function myConstraint() {
+                   return WindowsExpression.True()
                 }
               """);
     assertTrue(
         actualErrors.errors()
                     .stream()
-                    .anyMatch(e -> e.message().contains("TypeError: TS2322 Incorrect return type. Expected: 'Constraint', Actual: 'number'."))
+                    .anyMatch(e -> e.message().contains("TypeError: TS2322 Incorrect return type. Expected: 'Constraint', Actual: 'True'."))
     );
   }
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -2,9 +2,6 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.constraints.tree.True;
 import gov.nasa.jpl.aerie.constraints.tree.ViolationsOf;
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
-import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
-import gov.nasa.jpl.aerie.merlin.server.models.ConstraintsDSL;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -12,8 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
@@ -93,8 +93,8 @@ public final class PostgresSpecificationRepository implements SpecificationRepos
   {
     final var goalCompilationResult = schedulingDSLCompilationService.compileSchedulingGoalDSL(
         planId,
-        pgGoal.definition(),
-        pgGoal.name());
+        pgGoal.definition()
+    );
 
     if (goalCompilationResult instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error g) {
       return new GoalCompilationResult.Failure(g.errors());

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationService.java
@@ -48,7 +48,7 @@ public class SchedulingDSLCompilationService {
   /**
    * NOTE: This method is not re-entrant (assumes only one call to this method is running at any given time)
    */
-  public SchedulingDSLCompilationResult compileSchedulingGoalDSL(final PlanId planId, final String goalTypescript, final String goalName)
+  public SchedulingDSLCompilationResult compileSchedulingGoalDSL(final PlanId planId, final String goalTypescript)
   {
     final var missionModelGeneratedCode = JSONObject.quote(this.typescriptCodeGenerationService.generateTypescriptTypesForPlan(planId));
 

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
@@ -135,7 +135,7 @@ class SchedulingDSLCompilationServiceTests {
                     interval: 60 * 60 * 1000 * 1000 // 1 hour in microseconds
                   })
                 }
-            """, "goalfile");
+            """);
     final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
         new SchedulingDSL.ActivityTemplate(
             "SampleActivity1",
@@ -176,7 +176,7 @@ class SchedulingDSLCompilationServiceTests {
                     interval: 60 * 60 * 1000 * 1000 // 1 hour in microseconds
                   })
                 }
-            """, "goalfile");
+            """);
     final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
         new SchedulingDSL.ActivityTemplate(
             "SampleActivity1",
@@ -216,7 +216,7 @@ class SchedulingDSLCompilationServiceTests {
                     interval: x // 1 hour in microseconds
                   })
                 }
-              """, "goalfile_with_type_error");
+              """);
     assertTrue(
         actualErrors.errors()
                     .stream()
@@ -232,7 +232,7 @@ class SchedulingDSLCompilationServiceTests {
                 export default function myGoal() {
                   return 5
                 }
-              """, "goalfile_with_wrong_return_type");
+              """);
     assertTrue(
         actualErrors.errors()
                     .stream()
@@ -256,7 +256,7 @@ class SchedulingDSLCompilationServiceTests {
                     interval: 60 * 60 * 1000 * 1000 // 1 hour in microseconds
                   })
                 }
-            """ + " ".repeat(9001), "goalfile");
+            """ + " ".repeat(9001));
     final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
         new SchedulingDSL.ActivityTemplate(
             "SampleActivity1",
@@ -291,7 +291,7 @@ class SchedulingDSLCompilationServiceTests {
               forEach: ActivityTypes.SampleActivity1,
             })
           }
-        """, "");
+        """);
 
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
       assertEquals(
@@ -333,7 +333,7 @@ class SchedulingDSLCompilationServiceTests {
             };
             return myFakeGoal;
           }
-        """, "");
+        """);
 
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
       assertEquals(r.errors().size(), 1);

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -222,7 +222,7 @@ public class SchedulingIntegrationTests {
     final var goalsByPriority = new ArrayList<GoalRecord>();
     var goalId = 0L;
     for (final var goal : goals) {
-      final var goalResult = schedulingDSLCompiler.compileSchedulingGoalDSL(planId, goal, "");
+      final var goalResult = schedulingDSLCompiler.compileSchedulingGoalDSL(planId, goal);
       if (goalResult instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success s) {
         goalsByPriority.add(new GoalRecord(new GoalId(goalId++), s.goalSpecifier()));
       } else if (goalResult instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error e) {


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1816
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

Splits the constraints pipeline into two pipelines so we can keep the old one enabled while we develop the new one.

Commits:

1. Remove unused goalName/constraintName arguments
2. Rework Constraints eDSL to match Expression tree
    - Until the old pipeline is in the trash, I think its better to use the same constraints Expressions for evaluation. Once the old pipeline is gone we can worry about changing the expression tree to something better suited to the eDSL if we want.
    - This commit deserializes the JSON coming back from the constraints compilation service directly into constraints Expressions.
    - Adds a `True` WindowsExpression just for the sake of having a simple terminal node in the AST to test with. I don't think it has any practical use and we'll probably delete it later.
3. Split the constraint evaluation pipeline
    - adds a `MERLIN_USE_NEW_CONSTRAINT_PIPELINE` environment variable (defaults to `false`) to decide which pipeline to use.
4. Fix constraints eDSL typechecking
    - This is actually @dyst5422 's contribution. Fixes the eDSL's ability to typecheck, which I broke by splitting the AST into two types of nodes. Thanks!
5. Move ConstraintsDSL class next to ConstraintParsers
    - Just for consistency.
6. Document constraints AST
7. Create constraints DSL parser tests

squashed:

8. Add constraints compilation shutdown hook
    - A piece of missed code that I forgot to copy from `scheduler-server`. Thanks Matt!
9. Prefix windows expression tags with "WindowsExpression"
    - (see discussion with Dylan](https://github.com/NASA-AMMOS/aerie/pull/159#discussion_r862257399)

## Verification

- the `ConstraintsDSLCompilationService` tests have been updated to match the new AST.
- Commit 7 adds tests for the JSON parsers.

## Documentation
I've added a bit of in-code docs in the constraints AST.

## Future work
- bring the eDSL up to feature parity with the old constraints pipeline
- remove the pipeline switch
- (probably) remove the `True` Expression node.
