### PR TITLE
[AERIE-1827] eDSL output the correct time format in seqJSON

### DIFF
--- a/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -39,17 +39,41 @@ export class Command<A extends ArgType[] | { [argName: string]: any } = [] | {}>
     }
   }
 
+  // return  yyyy-doyThh:mm:ss.sss
+  private instantToDoy(time: Temporal.Instant): string {
+    const utcZonedDate = time.toZonedDateTimeISO('UTC');
+    return `${utcZonedDate.year}-${this.format(utcZonedDate.dayOfYear, 3)}T${this.format(
+      utcZonedDate.hour,
+      2,
+    )}:${this.format(utcZonedDate.minute, 2)}:${this.format(utcZonedDate.second, 2)}.${this.format(
+      utcZonedDate.millisecond,
+      3,
+    )}`;
+  }
+
+  // return hh:mm:ss.sss
+  private durationToHms(time: Temporal.Duration): string {
+    return `${this.format(time.hours, 2)}:${this.format(time.minutes, 2)}:${this.format(time.seconds, 2)}.${this.format(
+      time.milliseconds,
+      3,
+    )}`;
+  }
+
+  private format(number: number, size: number): string {
+    return number.toString().padStart(size, '0');
+  }
+
   public toSeqJson() {
     return {
       args: typeof this.arguments == 'object' ? Object.values(this.arguments) : this.arguments,
       stem: this.stem,
       time: {
         tag: this.absoluteTime
-          ? this.absoluteTime.toString()
+          ? this.instantToDoy(this.absoluteTime) // yyyy-doyThh:mm:ss.sss
           : this.relativeTime
-          ? this.relativeTime.toString()
+          ? this.durationToHms(this.relativeTime) // hh:mm:ss.sss
           : this.epochTime
-          ? this.epochTime.time.toString()
+          ? this.durationToHms(this.epochTime.time) // hh:mm:ss.sss
           : '',
         type: this.absoluteTime
           ? 'ABSOLUTE'


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1827
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Talking with Michael L Schaffer and the seqJson team. NASA has a document discussing the time and duration used by every mission:

https://pds.nasa.gov/datastandards/pds3/standards/sr/Chapter07.pdf

Currently, we are storing time and duration as ISO 8601. We need to convert these times to the following formats used by Mike's team

@dyst5422 and @camargo had a chat with Mike and these were the agreed time formats below. 
```
yyyy-doyThh:mm:ss.sss
hh:mm:ss.sss
```

I am using this spec file here as a reference: [spec](https://github.jpl.nasa.gov/Aerie/aerie-seq-schema/blob/develop/schema.json)

Here is an example of expansion logic:

```
    BAKE_BREAD.relativeTiming(Temporal.Duration.from({ minutes: 5 })),
    BAKE_BREAD.absoluteTiming(Temporal.Instant.from("2022-04-20T20:17:13Z")),
    BAKE_BREAD.epochTiming(Temporal.Duration.from({ minutes: 15 })),
```

Here is the output from the expansion run:

```
    {
        "id": "command",
        "steps": [
            {
                "args": [],
                "stem": "BAKE_BREAD",
                "time": {
                    "tag": "00:05:00.000",
                    "type": "COMMAND_RELATIVE"
                },
                "type": "command",
                "metadata": {}
            }
        ],
        "metadata": {}
    },
    {
        "id": "command",
        "steps": [
            {
                "args": [],
                "stem": "BAKE_BREAD",
                "time": {
                    "tag": "2022-110T20:17:13.000",
                    "type": "ABSOLUTE"
                },
                "type": "command",
                "metadata": {}
            }
        ],
        "metadata": {}
    },
    {
        "id": "command",
        "steps": [
            {
                "args": [],
                "stem": "BAKE_BREAD",
                "time": {
                    "tag": "00:15:00.000",
                    "type": "EPOCH_RELATIVE"
                },
                "type": "command",
                "metadata": {}
            }
        ],
        "metadata": {}
    }
```


## Verification
I ran through the whole expansion process to generate the above seqJson.

## Documentation
None that I can think of. 

## Future work
Continue to add missing fields in the seqJson generated by sequence expansions.
