### PR TITLE
[FIX][AERIE-1829] Satisfying activities missing 

### DIFF
--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/TimeRangeExpression.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/TimeRangeExpression.java
@@ -58,7 +58,11 @@ public class TimeRangeExpression {
                 Window.Inclusivity.Exclusive)).build();
         final var anchorActs = plan.find(anchorActSearch);
         for (var anchorAct : anchorActs) {
-          actTw.add(Window.between(anchorAct.getStartTime(), Window.Inclusivity.Inclusive, anchorAct.getEndTime(), Window.Inclusivity.Exclusive));
+          var endInclusivity = Window.Inclusivity.Exclusive;
+          if(anchorAct.getDuration().isZero()){
+            endInclusivity = Window.Inclusivity.Inclusive;
+          }
+          actTw.add(Window.between(anchorAct.getStartTime(), Window.Inclusivity.Inclusive, anchorAct.getEndTime(), endInclusivity));
         }
         inter = actTw;
       }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/Evaluation.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/Evaluation.java
@@ -163,7 +163,8 @@ public class Evaluation {
 
   public boolean canAssociateMoreToCreatorOf(final ActivityInstance instance){
     final var creator$ = getGoalCreator(instance);
-    if (creator$.isEmpty()) return false;
+    // for now: all existing activities in the plan are allowed to be associated with any goal
+    if (creator$.isEmpty()) return true;
     final var creator = creator$.get();
 
     if(!(creator instanceof ActivityExistentialGoal activityExistentialCreator)) return true;

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -209,6 +209,8 @@ public class PrioritySolver implements Solver {
     //if backed by real models, initialize the simulation states/resources/profiles for the plan so state queries work
     if (problem.getMissionModel() != null) {
       simulationFacade.simulateActivities(plan.getActivities());
+      plan.getActivities().forEach(activity -> simulationFacade.getActivityDuration(activity)
+                                                       .ifPresent(activity::setDuration));
     }
   }
 


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1829
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Activities that cannot be associated to their creator goal (which happens if you run the scheduler several times in the same plan as there is no tracking what activity were created by which goal in previous runs) were considered to have Solely custody. 

If you ran the scheduler twice without activity created, you would not see the satisfying activities associated to the goal. 

We now allow goal-activity association even if the activity does not have an explicit creator goal defined.   

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
With a test specifically designed to reproduce the issue in `SimulationFacadeTest`.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
If goal/activity custody is going to be a feature, there will be a need to track from run to run what goals created which activity. And think about use cases where for example a user creates a goal, schedules activities and then deletes the goal. What happens to these activities and their custody?