### PR TITLE
[AERIE-1794] Accumulate & persist unfinished activities

### DIFF
--- a/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/SimulatedActivityTest.java
+++ b/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/SimulatedActivityTest.java
@@ -1,6 +1,8 @@
 package gov.nasa.jpl.aerie.banananation;
 
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +20,13 @@ public final class SimulatedActivityTest {
     final var schedule = SimulationUtility.buildSchedule(
         Pair.of(
             duration(0, SECONDS),
-            new SerializedActivity("PeelBanana", Map.of())));
+            new SerializedActivity("PeelBanana", Map.of())),
+        Pair.of(
+            duration(0, SECONDS),
+            new SerializedActivity("GrowBanana", Map.of(
+                "quantity", SerializedValue.of(1),
+                "growingDuration", SerializedValue.of(Duration.SECOND.times(2).in(Duration.MICROSECONDS))
+            ))));
 
     final var simDuration = duration(1, SECOND);
 
@@ -26,8 +34,15 @@ public final class SimulatedActivityTest {
 
     assertEquals(1, simulationResults.simulatedActivities.size());
     simulationResults.simulatedActivities.forEach( (id, act) -> {
-        assertEquals(1, act.arguments.size());
-        assertTrue(act.arguments.containsKey("peelDirection"));
+        assertEquals(1, act.arguments().size());
+        assertTrue(act.arguments().containsKey("peelDirection"));
+    });
+
+    assertEquals(1, simulationResults.unfinishedActivities.size());
+    simulationResults.unfinishedActivities.forEach( (id, act) -> {
+      assertEquals(2, act.arguments().size());
+      assertTrue(act.arguments().containsKey("quantity"));
+      assertTrue(act.arguments().containsKey("growingDuration"));
     });
   }
 }

--- a/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/SimulateMapSchedule.java
+++ b/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/SimulateMapSchedule.java
@@ -58,7 +58,7 @@ public class SimulateMapSchedule {
       });
 
       simulationResults.simulatedActivities.forEach((name, activity) -> {
-        System.out.println(name + ": " + activity.start + " for " + activity.duration);
+        System.out.println(name + ": " + activity.start() + " for " + activity.duration());
       });
     } finally {
       missionModel.getModel().close();

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationResults.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationResults.java
@@ -21,7 +21,7 @@ public final class SimulationResults {
   public final Map<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>> discreteProfiles;
   public final Map<String, List<Pair<Duration, SerializedValue>>> resourceSamples;
   public final Map<ActivityInstanceId, SimulatedActivity> simulatedActivities;
-  public final Map<ActivityInstanceId, SerializedActivity> unfinishedActivities;
+  public final Map<ActivityInstanceId, UnfinishedActivity> unfinishedActivities;
   public final List<Triple<Integer, String, ValueSchema>> topics;
   public final Map<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>> events;
 
@@ -29,7 +29,7 @@ public final class SimulationResults {
         final Map<String, List<Pair<Duration, RealDynamics>>> realProfiles,
         final Map<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>> discreteProfiles,
         final Map<ActivityInstanceId, SimulatedActivity> simulatedActivities,
-        final Map<ActivityInstanceId, SerializedActivity> unfinishedActivities,
+        final Map<ActivityInstanceId, UnfinishedActivity> unfinishedActivities,
         final Instant startTime,
         final List<Triple<Integer, String, ValueSchema>> topics,
         final SortedMap<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>> events)

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/UnfinishedActivity.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/UnfinishedActivity.java
@@ -1,6 +1,5 @@
 package gov.nasa.jpl.aerie.merlin.driver;
 
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.time.Instant;
@@ -8,13 +7,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public record SimulatedActivity(
+public record UnfinishedActivity(
   String type,
   Map<String, SerializedValue> arguments,
   Instant start,
-  Duration duration,
   ActivityInstanceId parentId,
   List<ActivityInstanceId> childIds,
-  Optional<ActivityInstanceId> directiveId,
-  SerializedValue computedAttributes
+  Optional<ActivityInstanceId> directiveId
 ) { }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ActivityAttributesRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ActivityAttributesRecord.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public record ActivityAttributesRecord(
     Optional<Long> directiveId,
     Map<String, SerializedValue> arguments,
-    SerializedValue computedAttributes
+    Optional<SerializedValue> computedAttributes
 ) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
@@ -62,7 +62,7 @@ public final class PostgresParsers {
   public static final JsonParser<ActivityAttributesRecord> activityAttributesP = productP
       .optionalField("directiveId", longP)
       .field("arguments", activityArgumentsP)
-      .field("computedAttributes", serializedValueP)
+      .optionalField("computedAttributes", serializedValueP)
         .map(Iso.of(
             untuple(ActivityAttributesRecord::new),
             $ -> tuple($.directiveId(), $.arguments(), $.computedAttributes())

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SpanRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SpanRecord.java
@@ -8,13 +8,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-/*package-local*/ record SimulatedActivityRecord(
+/*package-local*/ record SpanRecord(
     String type,
-    Map<String, SerializedValue> arguments,
     Instant start,
-    Duration duration,
+    Optional<Duration> duration,
     Optional<Long> parentId,
     List<Long> childIds,
-    Optional<Long> directiveId,
-    SerializedValue computedAttributes
+    ActivityAttributesRecord attributes
 ) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateSimulatedActivityParentsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateSimulatedActivityParentsAction.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
   public void apply(
       final long datasetId,
-      final Map<Long, SimulatedActivityRecord> simulatedActivities,
+      final Map<Long, SpanRecord> simulatedActivities,
       final Map<Long, Long> simIdToPgId
   ) throws SQLException {
     for (final var id : simulatedActivities.keySet()) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -101,14 +101,14 @@ public final class GetSimulationResultsAction {
       final var activity = entry.getValue();
 
       final var activityOffset = Duration.of(
-          plan.startTimestamp.toInstant().until(activity.start, ChronoUnit.MICROS),
+          plan.startTimestamp.toInstant().until(activity.start(), ChronoUnit.MICROS),
           Duration.MICROSECONDS);
 
       activities.add(new ActivityInstance(
           id.id(),
-          activity.type,
-          activity.arguments,
-          Window.between(activityOffset, activityOffset.plus(activity.duration))));
+          activity.type(),
+          activity.arguments(),
+          Window.between(activityOffset, activityOffset.plus(activity.duration()))));
     }
 
     final var discreteProfiles = new HashMap<String, DiscreteProfile>(results.discreteProfiles.size());

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -258,10 +258,10 @@ public class SimulationFacade {
       long id, SimulatedActivity driverActivity)
   {
     final var planStartT = this.planningHorizon.getStartHuginn();
-    final var startT = Duration.of(planStartT.until(driverActivity.start, ChronoUnit.MICROS), MICROSECONDS);
-    final var endT = startT.plus(driverActivity.duration);
+    final var startT = Duration.of(planStartT.until(driverActivity.start(), ChronoUnit.MICROS), MICROSECONDS);
+    final var endT = startT.plus(driverActivity.duration());
     return new gov.nasa.jpl.aerie.constraints.model.ActivityInstance(
-        id, driverActivity.type, driverActivity.arguments,
+        id, driverActivity.type(), driverActivity.arguments(),
         Window.betweenClosedOpen(startT, endT));
   }
 


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1794
* **Review:** By file  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

Persists unfinished activities without our Postgres DB.

Suggesting to review by file due to the nature of the commit in this PR. Changing `SimulationResults` to contain `UnfinishedActivity` propagates to many places, so instead of having non-compilable intermediate commits I decided to keep this as one commit.

## Verification

Activities with `null` durations now denote unfinished activities:
![Screen Shot 2022-05-04 at 1 44 39 PM](https://user-images.githubusercontent.com/2623817/166822921-4e2066e8-0880-49c6-917d-1a4bdc989e03.png)

Inserting `GrowBanana` at the end of a plan with a duration that surpasses the plan end results in:
```json
{
  "data": {
    "simulate": {
      "results": {
        "unfinishedActivities": {
          "1": {
            "parent": null,
            "arguments": {
              "quantity": 0,
              "growingDuration": 10000000000
            },
            "children": [],
            "type": "GrowBanana",
            "startTimestamp": "2022-001T22:25:50.239000"
          }
        },
        "start": "2022-001T00:00:00.000000",
...
```
Note that this PR probably didn't need to even add `unfinishedActivities` to the sim. response JSON since it will be removed by https://jira.jpl.nasa.gov/browse/AERIE-1796 (see future work section). However, no harm done here – it's kind of nice to be able to see unfinished activities right in the HTTP response while testing this PR.

## Documentation

https://github.com/NASA-AMMOS/aerie/wiki/Simulation-Results#unfinished-activities currently contains up-to-date information regarding unfinished activities.

## Future work

- Carve out simulation HTTP response JSON (see https://jira.jpl.nasa.gov/browse/AERIE-1796).