### PR TITLE
[AERIE-1830] Adjust the seqJSON output when expanding the plan.

### DIFF
--- a/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -41,35 +41,26 @@ export class Command<A extends ArgType[] | { [argName: string]: any } = [] | {}>
 
   public toSeqJson() {
     return {
-      id: 'command',
+      args: typeof this.arguments == 'object' ? Object.values(this.arguments) : this.arguments,
+      stem: this.stem,
+      time: {
+        tag: this.absoluteTime
+          ? this.absoluteTime.toString()
+          : this.relativeTime
+          ? this.relativeTime.toString()
+          : this.epochTime
+          ? this.epochTime.time.toString()
+          : '',
+        type: this.absoluteTime
+          ? 'ABSOLUTE'
+          : this.relativeTime
+          ? 'COMMAND_RELATIVE'
+          : this.epochTime
+          ? 'EPOCH_RELATIVE'
+          : 'COMMAND_COMPLETE',
+      },
+      type: 'command',
       metadata: {},
-
-      steps: [
-        {
-          stem: this.stem,
-          time: {
-            tag: this.absoluteTime
-              ? this.absoluteTime.toString()
-              : this.relativeTime
-              ? this.relativeTime.toString()
-              : this.epochTime
-              ? this.epochTime.time.toString()
-              : '',
-            type: this.absoluteTime
-              ? 'ABSOLUTE'
-              : this.relativeTime
-              ? 'COMMAND_RELATIVE'
-              : this.epochTime
-              ? 'EPOCH_RELATIVE'
-              : 'COMMAND_COMPLETE',
-          },
-          type: 'command',
-          metadata: {},
-          // include epoch field if we have an epoch time
-          ...(this.epochTime !== null ? { epoch: this.epochTime?.epochName } : {}),
-          args: typeof this.arguments == 'object' ? Object.values(this.arguments) : this.arguments,
-        },
-      ],
     };
   }
 


### PR DESCRIPTION

* **Tickets addressed:** AERIE-1830
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
I will need this [PR](https://github.com/NASA-AMMOS/aerie/pull/160) merged so I can rebase its changes to this PR.

From our conversation with the seqJSON team, we will need to modify the output generated when the user `expands-all`. This new output will match what is needed to build a seqJSON for a sequence. We are now storing the `step` portion of the seqJSON in the `activity_instance_command`

https://jpl.slack.com/archives/C015FPVM21Y/p1651613519197649

Valid seqJson

```
{
  "id": "seq_id",
  "metadata": {
    "onboard_path": "/eng",
    "onboard_name": "test.seq"
  },
  "steps": []
}
```

What the new format will look like in the `activity_instance_command `table. 

```
[
{
        "args": [],
        "stem": "PICK_BANANA",
        "time": {
            "tag": "",
            "type": "COMMAND_COMPLETE"
        },
        "type": "command",
        "metadata": {}
    },
    {
        "args": [
            "fromStem"
        ],
        "stem": "PEEL_BANANA",
        "time": {
            "tag": "",
            "type": "COMMAND_COMPLETE"
        },
        "type": "command",
        "metadata": {}
    },
    {
        "args": [
            425
        ],
        "stem": "PREHEAT_OVEN",
        "time": {
            "tag": "",
            "type": "COMMAND_COMPLETE"
        },
        "type": "command",
        "metadata": {}
    },
    {
        "args": [
            10,
            true
        ],
        "stem": "PREPARE_LOAF",
        "time": {
            "tag": "",
            "type": "COMMAND_COMPLETE"
        },
        "type": "command",
        "metadata": {}
    },
    {
        "args": [],
        "stem": "BAKE_BREAD",
        "time": {
            "tag": "",
            "type": "COMMAND_COMPLETE"
        },
        "type": "command",
        "metadata": {}
    }
]
```


## Verification
Ran through the expand procedure to generate the above.

## Documentation
None

## Future work
* Boolean values need to be represented as a string
* Generate the Metadata part of the seqJSON
