### PR TITLE
[HOTFIX] Close Simulation Engine in Scheduler

### DIFF
--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationDriver.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationDriver.java
@@ -53,7 +53,7 @@ public class IncrementalSimulationDriver {
     simulateUntil(Duration.ZERO);
   }
 
-  private void initSimulation(){
+  /*package-private*/ void initSimulation(){
     plannedDirectiveToTask.clear();
     taskToPlannedDirective.clear();
     lastSimResults = null;

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationDriver.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationDriver.java
@@ -58,6 +58,7 @@ public class IncrementalSimulationDriver {
     taskToPlannedDirective.clear();
     lastSimResults = null;
     lastSimResultsEnd = Duration.ZERO;
+    if (this.engine != null) this.engine.close();
     this.engine = new SimulationEngine();
     activitiesInserted.clear();
 

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationUtility.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationUtility.java
@@ -1,9 +1,12 @@
 package gov.nasa.jpl.aerie.scheduler;
 
 import gov.nasa.jpl.aerie.banananation.Configuration;
+import gov.nasa.jpl.aerie.foomissionmodel.Mission;
+import gov.nasa.jpl.aerie.foomissionmodel.generated.ActivityTypes;
 import gov.nasa.jpl.aerie.merlin.driver.DirectiveTypeRegistry;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
+import gov.nasa.jpl.aerie.merlin.framework.RootModel;
 import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 
 import java.nio.file.Path;
@@ -17,7 +20,7 @@ public final class SimulationUtility {
     return builder.build(model, factory.getConfigurationType(), registry);
   }
 
-  public static MissionModel<?>
+  public static MissionModel<RootModel<ActivityTypes, Mission>>
   getFooMissionModel() {
     final var conf = new gov.nasa.jpl.aerie.foomissionmodel.Configuration();
     final var factory = new gov.nasa.jpl.aerie.foomissionmodel.generated.GeneratedMissionModelFactory();

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationTest.java
@@ -1,11 +1,11 @@
-package gov.nasa.jpl.aerie.scheduler;
+package gov.nasa.jpl.aerie.scheduler.simulation;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
-import gov.nasa.jpl.aerie.scheduler.simulation.IncrementalSimulationDriver;
+import gov.nasa.jpl.aerie.scheduler.SimulationUtility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,6 +52,22 @@ public class IncrementalSimulationTest {
     assertTrue(act1Dur.isPresent() && act2Dur.isPresent());
     assertTrue(act1Dur.get().isEqualTo(Duration.of(1, SECONDS)));
     assertTrue(act2Dur.get().isEqualTo(Duration.of(1, SECONDS)));
+  }
+
+  @Test
+  public void testThreadsReleased() throws TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException {
+    final var activity = new TestSimulatedActivity(
+        Duration.of(0, SECONDS),
+        new SerializedActivity("BasicActivity", Map.of()),
+        new ActivityInstanceId(1));
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    final var executor = (ThreadPoolExecutor) fooMissionModel.getModel().executor();
+    incrementalSimulationDriver = new IncrementalSimulationDriver(fooMissionModel);
+    for (var i = 0; i < 20000; i++) {
+      incrementalSimulationDriver.initSimulation();
+      incrementalSimulationDriver.simulateActivity(activity.activity, activity.start, activity.id);
+      assertTrue(executor.getActiveCount() < 100, "Threads are not being cleaned up properly - this test shouldn't need more than 2 threads, but it used at least 100");
+    }
   }
 
   private ArrayList<TestSimulatedActivity> getActivities(){


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The scheduler's IncrementalSimulationDriver creates a new SimlationEngine whenever it restarts the simulation from the beginning. This is fine, but it neglects to call the `close` method on the old SimulationEngine object. This results in a resource leak, as the number of threads in use continues to grow without bound.

The fix is simple - adding one line to close the simulation engine before starting a new one.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I added a test to the `IncrementalSimulationTest` called `testThreadsReleased`. It re-initializes a simulation twenty thousand times, each time simulating one activity. Running this test before adding the fix resulted in a `Failed to start thread` error after about eight thousand iterations (which spawned sixteen thousand threads).

![Screen Shot 2022-05-05 at 5 36 50 PM](https://user-images.githubusercontent.com/1189602/167049967-7d3ac0f0-ebc8-481e-9cc4-1840037dc0e9.png)

After making the fix, the test ran to completion. Instead of taking 50 seconds, it took less than 4.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

No documentation is relevant to this change.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None at the moment.
