### PR TITLE
Generate `return` for activities with return values

### DIFF
--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BakeBananaBreadActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BakeBananaBreadActivity.java
@@ -15,8 +15,9 @@ public record BakeBananaBreadActivity(double temperature, int tbSugar, boolean g
   }
 
   @EffectModel
-  public void run(final Mission mission) {
+  public int run(final Mission mission) {
     mission.plant.add(-2);
+    return mission.plant.get();
   }
 
   public static @WithDefaults final class Defaults {


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
It looks like output attributes are not supported at the code generation level -- when I change `BakeBananaBreatActivity` to return an `int`, the code generator produces code that fails to compile. (We need to return a `Task<Integer>`, but the generated code does not actually return the value produced by the activity effect model.)

This PR adds an extra case to code generation, checking whether the effect model returns non-`void`, and if so, generating the necessary `return` statement.

The first commit is just a whitespace change.

## Verification
I changed `BakeBananaBreadActivity` to return an `int`, and observed a compile-time failure before the change and a successful compilation afterwards.

## Documentation
Existing documentation should be unchanged. (If anything, the documentation would have been inaccurate *before* this PR.)
