### PR TITLE
[AERIE-1812] Add cardinality goal (with implied mutex) to the scheduling eDSL

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsOf.java
@@ -1,0 +1,53 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.model.Violation;
+import gov.nasa.jpl.aerie.constraints.time.Window;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public final class WindowsOf implements Expression<Windows> {
+  public final Expression<List<Violation>> expression;
+
+  public WindowsOf(Expression<List<Violation>> expression) {
+    this.expression = expression;
+  }
+
+  @Override
+  public Windows evaluate(SimulationResults results, final Window bounds, Map<String, ActivityInstance> environment) {
+    final var ret = new Windows(bounds);
+    final var unsatisfiedWindows = this.expression.evaluate(results, bounds, environment);
+    for(var unsatisfiedWindow : unsatisfiedWindows){
+      ret.intersectWith(unsatisfiedWindow.violationWindows);
+    }
+    return ret;
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {
+    this.expression.extractResources(names);
+  }
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return this.expression.prettyPrint(prefix);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof WindowsOf)) return false;
+    final var o = (WindowsOf)obj;
+
+    return Objects.equals(this.expression, o.expression);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.expression);
+  }
+}

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -70,7 +70,7 @@ dependencies {
   implementation project(':constraints')
   implementation project(':scheduler')
 
-  runtimeOnly project(':merlin-framework')
+  implementation project(':merlin-framework')
 
   implementation 'org.apache.commons:commons-lang3:3.12.0'
   implementation 'io.javalin:javalin:4.1.1'

--- a/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-ast.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-ast.ts
@@ -5,9 +5,20 @@ export interface ActivityTemplate {
   args: {[key: string]: any},
 }
 
+export interface ClosedOpenInterval {
+  start: number
+  end: number
+}
+
+export type CardinalityGoalArguments =
+  |  { duration: number, occurrence: number }
+  |  { duration: number }
+  |  { occurrence: number }
+
 export enum NodeKind {
   ActivityRecurrenceGoal = 'ActivityRecurrenceGoal',
   ActivityCoexistenceGoal = 'ActivityCoexistenceGoal',
+  ActivityCardinalityGoal = 'ActivityCardinalityGoal',
   GoalAnd = 'GoalAnd',
   GoalOr = 'GoalOr'
 }
@@ -22,13 +33,20 @@ export enum NodeKind {
 export type Goal =
   | ActivityRecurrenceGoal
   | ActivityCoexistenceGoal
+  | ActivityCardinalityGoal
   ;
-// TODO cardinality goal
 
 export interface ActivityRecurrenceGoal {
   kind: NodeKind.ActivityRecurrenceGoal,
   activityTemplate: ActivityTemplate,
   interval: number,
+}
+
+export interface ActivityCardinalityGoal {
+  kind: NodeKind.ActivityCardinalityGoal,
+  activityTemplate: ActivityTemplate,
+  specification: CardinalityGoalArguments,
+  inPeriod: ClosedOpenInterval,
 }
 
 export interface ActivityCoexistenceGoal {

--- a/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
@@ -3,6 +3,7 @@ import * as WindowsEDSL from './windows-edsl-fluent-api'
 
 interface ActivityRecurrenceGoal extends Goal {}
 interface ActivityCoexistenceGoal extends Goal {}
+interface ActivityCardinalityGoal extends Goal {}
 
 export class Goal {
   public readonly __astNode: AST.GoalSpecifier;
@@ -49,6 +50,14 @@ export class Goal {
       forEach: opts.forEach.__astnode,
     });
   }
+  public static CardinalityGoal(opts: { activityTemplate: ActivityTemplate, specification: AST.CardinalityGoalArguments, inPeriod: ClosedOpenInterval }): ActivityCardinalityGoal {
+    return Goal.new({
+      kind: AST.NodeKind.ActivityCardinalityGoal,
+      activityTemplate: opts.activityTemplate,
+      specification: opts.specification,
+      inPeriod : opts.inPeriod
+    });
+  }
 }
 
 declare global {
@@ -61,12 +70,15 @@ declare global {
     public static ActivityRecurrenceGoal(opts: { activityTemplate: ActivityTemplate, interval: Duration }): ActivityRecurrenceGoal
 
     public static CoexistenceGoal(opts: { activityTemplate: ActivityTemplate, forEach: WindowsEDSL.WindowSet }): ActivityCoexistenceGoal
+
+    public static CardinalityGoal(opts: { activityTemplate: ActivityTemplate, specification: AST.CardinalityGoalArguments, inPeriod: ClosedOpenInterval }): ActivityCardinalityGoal
   }
   type Duration = number;
   type Double = number;
   type Integer = number;
 }
 
+export interface ClosedOpenInterval extends AST.ClosedOpenInterval {}
 export interface ActivityTemplate extends AST.ActivityTemplate {}
 
 // Make Goal available on the global object

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -8,6 +8,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.scheduler.constraints.scheduling.BinaryMutexConstraint;
 import gov.nasa.jpl.aerie.scheduler.constraints.scheduling.GlobalConstraint;
 import gov.nasa.jpl.aerie.scheduler.goals.Goal;
 import gov.nasa.jpl.aerie.scheduler.model.ActivityInstance;
@@ -112,6 +113,10 @@ public record SynchronousSchedulerAgent(
 
       //apply constraints/goals to the problem
       loadConstraints(planMetadata, schedulerMissionModel.missionModel()).forEach(problem::add);
+
+      //TODO: workaround to get the Cardinality goal working. To remove once we have global constraints in the eDSL
+      problem.getActivityTypes().forEach(at -> problem.add(BinaryMutexConstraint.buildMutexConstraint(at, at)));
+
       final var orderedGoals = new ArrayList<Goal>();
       final var goals = new HashMap<Goal, GoalId>();
       for (final var goalRecord : specification.goalsByPriority()) {

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockMerlinService.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockMerlinService.java
@@ -1,7 +1,9 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
+import gov.nasa.jpl.aerie.contrib.serialization.mappers.DurationValueMapper;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.scheduler.TimeUtility;
 import gov.nasa.jpl.aerie.scheduler.model.ActivityInstance;
@@ -163,9 +165,17 @@ class MockMerlinService implements MissionModelService, PlanService.OwnerRole {
   private static Collection<PlannedActivityInstance> extractPlannedActivityInstances(final Plan plan) {
     final var plannedActivityInstances = new ArrayList<PlannedActivityInstance>();
     for (final var activity : plan.getActivities()) {
+      final var type = activity.getType();
+      final var arguments = new HashMap<>(activity.getArguments());
+      if(type.getDurationType() instanceof DurationType.Controllable durationType){
+        //detect duration parameter and add it to parameters
+        if(!arguments.containsKey(durationType.parameterName())){
+          arguments.put(durationType.parameterName(), new DurationValueMapper().serializeValue(activity.getDuration()));
+        }
+      }
       plannedActivityInstances.add(new PlannedActivityInstance(
           activity.getType().getName(),
-          activity.getArguments(),
+          arguments,
           activity.getStartTime()));
     }
     return plannedActivityInstances;

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/conflicts/UnsatisfiableGoalConflict.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/conflicts/UnsatisfiableGoalConflict.java
@@ -3,16 +3,19 @@ package gov.nasa.jpl.aerie.scheduler.conflicts;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.scheduler.goals.Goal;
 
-public class UnsatisfiableMissingActivityConflict extends Conflict {
+public class UnsatisfiableGoalConflict extends Conflict {
 
+  final private String reason;
 
   /**
    * ctor creates a new conflict
    *
    * @param goal IN STORED the dissatisfied goal that issued the conflict
+   * @param  reason IN the reason why the goal issued the conflict
    */
-  public UnsatisfiableMissingActivityConflict(Goal goal) {
+  public UnsatisfiableGoalConflict(final Goal goal, final String reason) {
     super(goal);
+    this.reason = reason;
   }
 
   @Override

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/BinaryMutexConstraint.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/BinaryMutexConstraint.java
@@ -42,11 +42,11 @@ public class BinaryMutexConstraint extends GlobalConstraint {
 
 
   private Windows findWindows(Plan plan, Windows windows, ActivityType actToBeScheduled, SimulationResults simulationResults) {
-
-    if (!(actToBeScheduled.equals(actType) || actToBeScheduled.equals(otherActType))) {
-      throw new IllegalArgumentException("Activity type must be one of the mutexed types");
-    }
     Windows validWindows = new Windows(windows);
+    if (!(actToBeScheduled.equals(actType) || actToBeScheduled.equals(otherActType))) {
+      //not concerned by this constraint
+      return validWindows;
+    }
     ActivityType actToBeSearched = actToBeScheduled.equals(actType) ? otherActType : actType;
     final var actSearch = new ActivityExpression.Builder()
         .ofType(actToBeSearched).build();

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CardinalityGoal.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CardinalityGoal.java
@@ -5,7 +5,7 @@ import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.constraints.tree.Expression;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
-import gov.nasa.jpl.aerie.scheduler.conflicts.UnsatisfiableMissingActivityConflict;
+import gov.nasa.jpl.aerie.scheduler.conflicts.UnsatisfiableGoalConflict;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate;
@@ -171,7 +171,8 @@ public class CardinalityGoal extends ActivityTemplateGoal {
         durToSchedule = this.durationRange.start.minus(total);
       } else if (total.compareTo(this.durationRange.end) > 0) {
         logger.warn("Need to decrease duration of activities from the plan, impossible because scheduler cannot remove activities");
-        return List.of(new UnsatisfiableMissingActivityConflict(this));
+        return List.of(new UnsatisfiableGoalConflict(this,
+                                                     "Need to decrease duration of activities from the plan, impossible because scheduler cannot remove activities"));
       }
     }
     if (this.occurrenceRange != null && !this.occurrenceRange.contains(nbActs)) {
@@ -179,7 +180,8 @@ public class CardinalityGoal extends ActivityTemplateGoal {
         nbToSchedule = this.occurrenceRange.getMinimum() - nbActs;
       } else if (nbActs > this.occurrenceRange.getMaximum()) {
         logger.warn("Need to remove activities from the plan to satify cardinality goal, impossible");
-        return List.of(new UnsatisfiableMissingActivityConflict(this));
+        return List.of(new UnsatisfiableGoalConflict(this,
+                                                     "Need to remove activities from the plan to satify cardinality goal, impossible"));
       }
     }
 

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -193,9 +193,12 @@ public class SimulationFacade {
   {
     final var startT = Duration.of(startTime.until(driverActivity.start(), ChronoUnit.MICROS), MICROSECONDS);
     final var endT = startT.plus(driverActivity.duration());
+    final var activityWindow = startT.isEqualTo(endT)
+        ? Window.between(startT, endT)
+        : Window.betweenClosedOpen(startT, endT);
     return new gov.nasa.jpl.aerie.constraints.model.ActivityInstance(
         id, driverActivity.type(), driverActivity.arguments(),
-        Window.betweenClosedOpen(startT, endT));
+        activityWindow);
   }
 
   /**

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/Evaluation.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/Evaluation.java
@@ -91,11 +91,11 @@ public class Evaluation {
      * @param createdByThisGoal IN a boolean stating whether the instance has been created by this goal or not
      */
     public void associate(java.util.Collection<ActivityInstance> acts, boolean createdByThisGoal) {
-      acts.forEach((a)->this.acts.put(a, createdByThisGoal));
+      acts.forEach(a ->this.acts.put(a, createdByThisGoal));
     }
 
     public void removeAssociation(java.util.Collection<ActivityInstance> acts){
-      acts.forEach((a)->this.acts.remove(a));
+      this.acts.entrySet().removeIf(act -> acts.contains(act.getKey()));
     }
 
     /**

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -422,7 +422,7 @@ private void satisfyOptionGoal(OptionGoal goal) {
     assert plan != null;
 
     //continue creating activities as long as goal wants more and we can do so
-    var missingConflicts = getMissingConflicts(goal);
+    var missingConflicts = getConflicts(goal);
     //setting the number of conflicts detected at first evaluation, will be used at backtracking
     evaluation.forGoal(goal).setNbConflictsDetected(missingConflicts.size());
     assert missingConflicts != null;
@@ -474,11 +474,11 @@ private void satisfyOptionGoal(OptionGoal goal) {
       }//for(missing)
 
       if (madeProgress) {
-        missingConflicts = getMissingConflicts(goal);
+        missingConflicts = getConflicts(goal);
       }
     }//while(missingConflicts&&madeProgress)
 
-    if(missingConflicts.size() > 0 && !goal.isPartiallySatisfiable()){
+    if(!missingConflicts.isEmpty() && !goal.isPartiallySatisfiable()){
       rollback(goal);
     } else{
       evaluation.forGoal(goal).setScore(-missingConflicts.size());
@@ -495,28 +495,15 @@ private void satisfyOptionGoal(OptionGoal goal) {
    *     plan due to the specified goal
    */
   private Collection<Conflict>
-  getMissingConflicts(Goal goal)
+  getConflicts(Goal goal)
   {
     assert goal != null;
     assert plan != null;
-
-    //find all the reasons this goal is crying
     //REVIEW: maybe should have way to request only certain kinds of conflicts
     this.simulationFacade.computeSimulationResultsUntil(this.problem.getPlanningHorizon().getEndAerie());
     final var rawConflicts = goal.getConflicts(plan, this.simulationFacade.getLatestConstraintSimulationResults());
     assert rawConflicts != null;
-
-    //filter out any issues that this simple algorithm can't deal with (ie
-    //anything that doesn't just require throwing more instances in the plan)
-    final var filteredConflicts = new LinkedList<Conflict>();
-    for (final var conflict : rawConflicts) {
-      assert conflict != null;
-      //if( conflict instanceof MissingActivityConflict ) {
-      filteredConflicts.add(conflict);
-      //}
-    }
-
-    return filteredConflicts;
+    return rawConflicts;
   }
 
   /**


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1812
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

A first version of the CardinalityGoal available in the backend is implemented in the scheduling eDSL. 

Here below are the two flavors. The first is the "duration" one where the user can specify a lower bound for the sum of the durations of activities present in the plan: 
```javascript
export default function myGoal() {
    return Goal.CardinalityGoal({
        activityTemplate: ActivityTemplates.GrowBanana({
            quantity: 1,
            growingDuration: 1000000,
        }),
        inPeriod: { start: 0, end: 10000000 },
        specification: { duration: 10 * 1000000 }
    })
}
```
The second one is about the minimum number of occurrences that should be present in the plan:
```javascript
export default function myGoal() {
    return Goal.CardinalityGoal({
        activityTemplate: ActivityTemplates.GrowBanana({
            quantity: 1,
            growingDuration: 1000000,
        }),
        inPeriod: { start: 0, end: 10000000 },
        specification: { occurrence: 10 }
    })
}
```

Finally, both specifications can be put together and solved by the same goal: 
```javascript
export default function myGoal() {
    return Goal.CardinalityGoal({
        activityTemplate: ActivityTemplates.GrowBanana({
            quantity: 1,
            growingDuration: 1000000,
        }),
        inPeriod: { start: 0, end: 10000000 },
        specification: { occurrence: 10, duration: 10 * 1000000 }
    })
}
```

The cardinality goal requires to insert a certain number of occurrences/duration of an activity type. Without an explicit noOverlap/mutex constraint, the scheduler can/would insert activities of the same type concurrently. And we assume this is not the behavior the user expects. For now we assume the user implies a self-mutex on all activity types of the mission model. 

The creation of `WindowsOf` expression to translate `Violation` objs returned by `ForEachActivity` expressions into `Windows` is a byproduct of the early prototype. As it is useful, we keep it. 

During testing, a few issues have been encountered and fixed:
- `Evaluation::removeAssociation` was producing a ConcurrentModification exception.
- When converting simulation `SimulationResults`  to constraints `SimulationResults` in `SimulationFacade`, instantaneous activities disappeared from because a closed-open interval (used to represent durative activities) cannot represent a single instant in a `Windows`. 
- In the case of an activity type with controllable duration, the duration parameter was incorrectly handled in the scheduler server in both "ways" (1) when a plan/scheduling specification is fetched (2) when the scheduling results are saved.
-  When a `CardinalityGoal` of the "duration" flavor is specified and that its activity type produce instantaneous activities, it is possible that the cardinality goal is unsatisfiable. But in the case of uncontrollable activities, this behavior can be detected only after simulation. A diagnostic mechanism has been added to the `CardinalityGoal`. If the scheduler keeps adding zero-duration activities to satisfy a duration goal without progress for a certain number of iterations, an `UnsatisfiableGoalConflict` is returned. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Tests of the two types of `CardinalityGoal` have been added to `SchedulingIntegrationTests`.
I have also tested the goal within the UI. 
## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None. 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Implement global constraints and let the user add them explicitly. 
- Implement complete support of CardinalityGoal functionalities.
- Reflect seriously about what instantaneous activities mean for the scheduler