### PR TITLE
[AERIE-1838] Adds a simulated_activity view

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulated_activity_view.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulated_activity_view.yaml
@@ -1,0 +1,50 @@
+table:
+  name: simulated_activity
+  schema: public
+object_relationships:
+- name: dataset
+  using:
+    manual_configuration:
+      remote_table:
+        name: dataset
+        schema: public
+      insertion_order: null
+      column_mapping:
+        dataset_id: id
+- name: parent_simulated_activity
+  using:
+    manual_configuration:
+      remote_table:
+        name: simulated_activity
+        schema: public
+      insertion_order: null
+      column_mapping:
+        parent_simulated_activity_id: simulated_activity_id
+- name: plan
+  using:
+    manual_configuration:
+      remote_table:
+        name: plan
+        schema: public
+      insertion_order: null
+      column_mapping:
+        plan_id: id
+- name: activity
+  using:
+    manual_configuration:
+      remote_table:
+        name: activity
+        schema: public
+      insertion_order: null
+      column_mapping:
+        activity_id: id
+- name: mission_model
+  using:
+    manual_configuration:
+      remote_table:
+        name: mission_model
+        schema: public
+      insertion_order: null
+      column_mapping:
+        model_id: id
+

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulated_activity_view.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulated_activity_view.yaml
@@ -2,49 +2,19 @@ table:
   name: simulated_activity
   schema: public
 object_relationships:
-- name: dataset
+- name: simulation_dataset
   using:
     manual_configuration:
       remote_table:
-        name: dataset
+        name: simulation_dataset
         schema: public
-      insertion_order: null
       column_mapping:
-        dataset_id: id
+        simulation_dataset_id: id
 - name: parent_simulated_activity
   using:
     manual_configuration:
       remote_table:
         name: simulated_activity
         schema: public
-      insertion_order: null
       column_mapping:
-        parent_simulated_activity_id: simulated_activity_id
-- name: plan
-  using:
-    manual_configuration:
-      remote_table:
-        name: plan
-        schema: public
-      insertion_order: null
-      column_mapping:
-        plan_id: id
-- name: activity
-  using:
-    manual_configuration:
-      remote_table:
-        name: activity
-        schema: public
-      insertion_order: null
-      column_mapping:
-        activity_id: id
-- name: mission_model
-  using:
-    manual_configuration:
-      remote_table:
-        name: mission_model
-        schema: public
-      insertion_order: null
-      column_mapping:
-        model_id: id
-
+        parent_id: id

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
@@ -16,3 +16,4 @@
 - "!include public_uploaded_file.yaml"
 - "!include public_topic.yaml"
 - "!include public_event.yaml"
+- "!include public_simulated_activity_view.yaml"

--- a/merlin-server/sql/merlin/init.sql
+++ b/merlin-server/sql/merlin/init.sql
@@ -31,4 +31,7 @@ begin;
   \ir tables/mission_model_parameters.sql
   \ir tables/simulation_dataset.sql
   \ir tables/plan_dataset.sql
+
+  -- Views
+  \ir views/simulated_activity.sql
 end;

--- a/merlin-server/sql/merlin/views/simulated_activity.sql
+++ b/merlin-server/sql/merlin/views/simulated_activity.sql
@@ -1,20 +1,14 @@
 create view simulated_activity as
 (
-  select span.id as simulated_activity_id,
-         span.dataset_id as dataset_id,
-         span.parent_id as parent_simulated_activity_id,
+  select span.id as id,
+         simulation_dataset.id as simulation_dataset_id,
+         span.parent_id as parent_id,
          span.start_offset as start_offset,
          span.duration as duration,
          span.attributes as attributes,
-         plan.id as plan_id,
-         activity.id as activity_id,
-         activity_type.model_id as model_id
+         span.type as activity_type_name
 
    from span
      join dataset on span.dataset_id = dataset.id
      join simulation_dataset on dataset.id = simulation_dataset.dataset_id
-     join simulation on simulation_dataset.simulation_id = simulation.id
-     join plan on simulation.plan_id = plan.id
-     left join activity on (span.attributes #> '{directiveId}')::int = activity.id
-     join activity_type on activity_type.name = span.type and activity_type.model_id = plan.model_id
 );

--- a/merlin-server/sql/merlin/views/simulated_activity.sql
+++ b/merlin-server/sql/merlin/views/simulated_activity.sql
@@ -1,0 +1,20 @@
+create view simulated_activity as
+(
+  select span.id as simulated_activity_id,
+         span.dataset_id as dataset_id,
+         span.parent_id as parent_simulated_activity_id,
+         span.start_offset as start_offset,
+         span.duration as duration,
+         span.attributes as attributes,
+         plan.id as plan_id,
+         activity.id as activity_id,
+         activity_type.model_id as model_id
+
+   from span
+     join dataset on span.dataset_id = dataset.id
+     join simulation_dataset on dataset.id = simulation_dataset.dataset_id
+     join simulation on simulation_dataset.simulation_id = simulation.id
+     join plan on simulation.plan_id = plan.id
+     left join activity on (span.attributes #> '{directiveId}')::int = activity.id
+     join activity_type on activity_type.name = span.type and activity_type.model_id = plan.model_id
+);


### PR DESCRIPTION
This implements a view that abstracts out the details of the simulation domain language into the domain language of activity planning so that users (and we) can interact within the domain language of the domain with which we are working.

* **Tickets addressed:** AERIE-1838
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

I decided that reinventing the wheel of our other hasura types was #bad, so I went the route of just grouping together the necessary ids and allowing hasura to do the rest of the necessary joins to pull the actual data.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I evaluated both by inspection of the SQL and by deploying it locally and ensuring the view was correctly deployed. Additionally, I tested it out with some local data.

Definitely interested in what other people think is a good test method for a change like this.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Would an updated table diagram showing the relationships between the view and the tables be useful here?

## Future work
<!-- What next steps can we anticipate from here, if any? -->