### PR TITLE
[AERIE-1852] Command expansion authoring columns

### DIFF
--- a/command-expansion-server/sql/commanding/tables/expansion_rule.sql
+++ b/command-expansion-server/sql/commanding/tables/expansion_rule.sql
@@ -4,11 +4,18 @@ create table expansion_rule (
   activity_type text not null,
   expansion_logic text not null,
 
+  authoring_command_dict_id integer,
+  authoring_mission_model_id integer,
+
   constraint expansion_rule_primary_key
   primary key (id),
 
   constraint expansion_rule_activity_type_foreign_key
-    unique (id, activity_type)
+    unique (id, activity_type),
+
+  foreign key (authoring_command_dict_id)
+    references command_dictionary (id)
+    on delete cascade
 );
 comment on table expansion_rule is e''
   'The user defined logic to expand an activity type.';
@@ -18,5 +25,9 @@ comment on column expansion_rule.activity_type is e''
   'The user selected activity type.';
 comment on column expansion_rule.expansion_logic is e''
   'The expansion logic used to generate commands.';
+comment on column expansion_rule.authoring_command_dict_id is e''
+  'The id of the command dictionary to be used for authoring of this expansion.';
+comment on column expansion_rule.authoring_mission_model_id is e''
+  'The id of the mission model to be used for authoring of this expansion.';
 comment on constraint expansion_rule_activity_type_foreign_key on expansion_rule is e''
   'This enables us to have a foreign key on expansion_set_to_rule which is necessary for building the unique constraint `max_one_expansion_of_each_activity_type_per_expansion_set`.';

--- a/command-expansion-server/src/app.ts
+++ b/command-expansion-server/src/app.ts
@@ -109,6 +109,8 @@ app.post('/put-dictionary', async (req, res, next) => {
 });
 
 app.post('/put-expansion', async (req, res, next) => {
+  const context: Context = res.locals.context;
+
   const activityTypeName = req.body.input.activityTypeName as string;
   const expansionLogicBase64 = req.body.input.expansionLogic as string;
   const authoringCommandDictionaryId = req.body.input.authoringCommandDictionaryId as number | null;
@@ -129,7 +131,23 @@ app.post('/put-expansion', async (req, res, next) => {
 
   const id = rows[0].id;
   logger.info(`POST /put-expansion: Updated expansion in the database: id=${id}`);
-  res.status(200).json({ id });
+
+  if (authoringMissionModelId == null || authoringCommandDictionaryId == null) {
+    res.status(200).json({ id })
+    return next();
+  }
+
+  const commandTypes = await context.commandTypescriptDataLoader.load({ dictionaryId: authoringCommandDictionaryId });
+  const activitySchema = await context.activitySchemaDataLoader.load({missionModelId: authoringMissionModelId, activityTypeName });
+  const activityTypescript = generateTypescriptForGraphQLActivitySchema(activitySchema);
+
+  const result = await (piscina.run({
+    expansionLogic: Buffer.from(expansionLogicBase64, 'base64').toString('utf8'),
+    commandTypes: commandTypes,
+    activityTypes: activityTypescript,
+  }, { name: 'typecheckExpansion' }) as ReturnType<typeof typecheckExpansion>);
+
+  res.status(200).json({ id, errors: result.errors });
   return next();
 });
 

--- a/command-expansion-server/src/app.ts
+++ b/command-expansion-server/src/app.ts
@@ -111,14 +111,16 @@ app.post('/put-dictionary', async (req, res, next) => {
 app.post('/put-expansion', async (req, res, next) => {
   const activityTypeName = req.body.input.activityTypeName as string;
   const expansionLogicBase64 = req.body.input.expansionLogic as string;
+  const authoringCommandDictionaryId = req.body.input.authoringCommandDictionaryId as number | null;
+  const authoringMissionModelId = req.body.input.authoringMissionModelId as number | null;
 
   const { rows } = await db.query(
     `
-    INSERT INTO expansion_rule (activity_type, expansion_logic)
-    VALUES ($1, $2)
+    INSERT INTO expansion_rule (activity_type, expansion_logic, authoring_command_dict_id, authoring_mission_model_id)
+    VALUES ($1, $2, $3, $4)
     RETURNING id;
   `,
-    [activityTypeName, expansionLogicBase64],
+    [activityTypeName, expansionLogicBase64, authoringCommandDictionaryId, authoringMissionModelId],
   );
 
   if (rows.length < 1) {

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -14,6 +14,8 @@ type Mutation {
   addCommandExpansionTypeScript(
     activityTypeName: String!
     expansionLogic: String!
+    authoringCommandDictionaryId: Int
+    authoringMissionModelId: Int
   ): AddCommandExpansionResponse
 }
 

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -164,6 +164,7 @@ type ExpansionSetResponse {
 
 type AddCommandExpansionResponse {
   id: Int!
+  errors: [UserCodeError!]
 }
 
 type TypeScriptResponse {


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1852
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Added authoring informational columns to the expansion_rule table for the UI to use to default the type checking libs.

Additionally, performs type checking if the authoring information is provided and returns type errors purely as a programmatic API usage convenience, but does not block insertion on that type checking.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Did a run through the expansion submission process locally. This is fully backwards compatible.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Might want to adjust the command authoring documentation, but this could also be considered an "advanced" feature that only the UI needs to really know about formally.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
