### PR TITLE
[AERIE-1838] Add activity_id to span

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_span.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_span.yaml
@@ -12,6 +12,12 @@ object_relationships:
       remote_table:
         name: span
         schema: public
+- name: activity
+  using:
+    foreign_key_constraint_on: activity_id
+- name: dataset
+  using:
+    foreign_key_constraint_on: dataset_id
 array_relationships:
 - name: spans
   using:

--- a/merlin-server/sql/merlin/tables/span.sql
+++ b/merlin-server/sql/merlin/tables/span.sql
@@ -3,6 +3,7 @@ create table span (
 
   dataset_id integer not null,
   parent_id integer null,
+  activity_id integer null,
 
   start_offset interval not null,
   duration interval null,
@@ -20,6 +21,11 @@ create table span (
     foreign key (dataset_id, parent_id)
     references span
     on update cascade
+    on delete cascade,
+  constraint span_has_activity
+    foreign key (activity_id)
+    references activity
+    on update cascade
     on delete cascade
 )
 partition by list (dataset_id);
@@ -34,6 +40,8 @@ comment on column span.dataset_id is e''
   'The dataset this span is part of.';
 comment on column span.parent_id is e''
   'The span this span refines.';
+comment on column span.activity_id is e''
+  'The activity this span represents in the simulation.';
 comment on column span.start_offset is e''
   'The offset from the dataset start at which this span begins.';
 comment on column span.duration is e''

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSpansAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSpansAction.java
@@ -19,8 +19,8 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
 
 /*package-local*/ final class PostSpansAction implements AutoCloseable {
   private static final @Language("SQL") String sql = """
-      insert into span (dataset_id, start_offset, duration, type, attributes)
-      values (?, ?::timestamptz - ?::timestamptz, ?::timestamptz - ?::timestamptz, ?, ?)
+      insert into span (dataset_id, start_offset, duration, type, activity_id, attributes)
+      values (?, ?::timestamptz - ?::timestamptz, ?::timestamptz - ?::timestamptz, ?, ?, ?)
     """;
 
   private final PreparedStatement statement;
@@ -52,7 +52,12 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
 
       setTimestamp(statement, 5, startTimestamp);
       statement.setString(6, act.type());
-      statement.setString(7, buildAttributes(act.attributes().directiveId(), act.attributes().arguments(), act.attributes().computedAttributes()));
+      if (act.attributes().directiveId().isPresent()){
+        statement.setLong(7, act.attributes().directiveId().get());
+      } else {
+        statement.setNull(7, java.sql.Types.BIGINT);
+      }
+      statement.setString(8, buildAttributes(act.attributes().directiveId(), act.attributes().arguments(), act.attributes().computedAttributes()));
       statement.addBatch();
     }
 


### PR DESCRIPTION
This is an alternative approach to the simulated_activity_instance view
that creates foreign key relationship column on span with activity

* **Tickets addressed:** AERIE-1838
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Adds a foreign key constraint to the span column with the activity column

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Did local testing

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
