### PR TITLE
[AERIE-1843] Add constraintsDslTypescript hasura action

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -76,7 +76,13 @@ type Query {
 type Query {
   schedulingDslTypescript(
     missionModelId: Int!
-  ): SchedulingDslTypescriptResponse
+  ): DslTypescriptResponse
+}
+
+type Query {
+  constraintsDslTypescript(
+    missionModelId: ID!
+  ): DslTypescriptResponse
 }
 
 type Query {
@@ -112,11 +118,6 @@ enum SchedulingStatus {
   incomplete
 }
 
-enum SchedulingDslTypescriptResponseStatus {
-  success
-  failure
-}
-
 type ResourceType {
   name: String!
   schema: ResourceSchema!
@@ -148,11 +149,16 @@ type SchedulingResponse {
   reason: SchedulingFailureReason
 }
 
-type SchedulingDslTypescriptResponse {
-  status: SchedulingDslTypescriptResponseStatus!
+type DslTypescriptResponse {
+  status: DslTypescriptResponseStatus!
   typescript: String
   typescriptFiles: [TypescriptFile]
   reason: String
+}
+
+enum DslTypescriptResponseStatus {
+  success
+  failure
 }
 
 type TypescriptFile {

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -151,7 +151,6 @@ type SchedulingResponse {
 
 type DslTypescriptResponse {
   status: DslTypescriptResponseStatus!
-  typescript: String
   typescriptFiles: [TypescriptFile]
   reason: String
 }
@@ -162,8 +161,8 @@ enum DslTypescriptResponseStatus {
 }
 
 type TypescriptFile {
-  filename: String,
-  contents: String
+  filePath: String,
+  content: String
 }
 
 type CommandDictionaryResponse {

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -47,6 +47,10 @@ actions:
     definition:
       kind: ""
       handler: http://aerie_scheduler:27185/schedulingDslTypescript
+  - name: constraintsDslTypescript
+    definition:
+      kind: ""
+      handler: http://aerie_merlin:27183/constraintsDslTypescript
   - name: simulate
     definition:
       kind: ""
@@ -101,7 +105,7 @@ custom_types:
     - name: EffectiveArgumentsResponse
     - name: AddExternalDatasetResponse
     - name: SchedulingResponse
-    - name: SchedulingDslTypescriptResponse
+    - name: DslTypescriptResponse
     - name: CommandDictionaryResponse
     - name: AddCommandExpansionResponse
     - name: TypeScriptResponse

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
@@ -22,6 +22,7 @@ import gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresPlanRepository;
 import gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresResultsCellRepository;
 import gov.nasa.jpl.aerie.merlin.server.services.CachedSimulationService;
 import gov.nasa.jpl.aerie.merlin.server.services.ConstraintsDSLCompilationService;
+import gov.nasa.jpl.aerie.merlin.server.services.GenerateConstraintsLibAction;
 import gov.nasa.jpl.aerie.merlin.server.services.GetSimulationResultsAction;
 import gov.nasa.jpl.aerie.merlin.server.services.LocalMissionModelService;
 import gov.nasa.jpl.aerie.merlin.server.services.LocalPlanService;
@@ -67,7 +68,13 @@ public final class AerieAppDriver {
         constraintsDSLCompilationService,
         configuration.useNewConstraintPipeline()
     );
-    final var merlinBindings = new MerlinBindings(missionModelController, planController, simulationAction);
+    final var generateSchedulingLibAction = new GenerateConstraintsLibAction(typescriptCodeGenerationService);
+    final var merlinBindings = new MerlinBindings(
+        missionModelController,
+        planController,
+        simulationAction,
+        generateSchedulingLibAction
+    );
 
     // Configure an HTTP server.
     final var javalin = Javalin.create(config -> {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -298,14 +298,13 @@ public final class MerlinBindings implements Plugin {
         for (final var entry : r.files().entrySet()) {
           files = files.add(
               Json.createObjectBuilder()
-                  .add("filename", entry.getKey())
-                  .add("contents", entry.getValue())
+                  .add("filePath", entry.getKey())
+                  .add("content", entry.getValue())
                   .build());
         }
         resultString = Json
             .createObjectBuilder()
             .add("status", "success")
-            .add("typescript", r.typescript()) // TODO deprecate when the UI uses typescriptFiles
             .add("typescriptFiles", files)
             .build().toString();
       } else if (response instanceof GenerateConstraintsLibAction.Response.Failure r) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -5,6 +5,7 @@ import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.services.GenerateConstraintsLibAction;
 import gov.nasa.jpl.aerie.merlin.server.services.GetSimulationResultsAction;
 import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService;
 import gov.nasa.jpl.aerie.merlin.server.services.PlanService;
@@ -44,15 +45,18 @@ public final class MerlinBindings implements Plugin {
   private final MissionModelService missionModelService;
   private final PlanService planService;
   private final GetSimulationResultsAction simulationAction;
+  private final GenerateConstraintsLibAction generateConstraintsLibAction;
 
   public MerlinBindings(
       final MissionModelService missionModelService,
       final PlanService planService,
-      final GetSimulationResultsAction simulationAction)
-  {
+      final GetSimulationResultsAction simulationAction,
+      final GenerateConstraintsLibAction generateConstraintsLibAction
+  ) {
     this.missionModelService = missionModelService;
     this.planService = planService;
     this.simulationAction = simulationAction;
+    this.generateConstraintsLibAction = generateConstraintsLibAction;
   }
 
   @Override
@@ -86,6 +90,9 @@ public final class MerlinBindings implements Plugin {
       });
       path("addExternalDataset", () -> {
         post(this::addExternalDataset);
+      });
+      path("constraintsDslTypescript", () -> {
+        post(this::getConstraintsDslTypescript);
       });
     });
 
@@ -271,6 +278,50 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     } catch (final InvalidEntityException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
+    }
+  }
+
+  /**
+   * action bound to the /constraintsDslTypescript endpoint: generates the typescript code for a given mission model
+   *
+   * @param ctx the http context of the request from which to read input or post results
+   */
+  private void getConstraintsDslTypescript(final Context ctx) {
+    try {
+      final var body = parseJson(ctx.body(), hasuraMissionModelActionP);
+      final var missionModelId = body.input().missionModelId();
+
+      final var response = this.generateConstraintsLibAction.run(missionModelId);
+      final String resultString;
+      if (response instanceof GenerateConstraintsLibAction.Response.Success r) {
+        var files = Json.createArrayBuilder();
+        for (final var entry : r.files().entrySet()) {
+          files = files.add(
+              Json.createObjectBuilder()
+                  .add("filename", entry.getKey())
+                  .add("contents", entry.getValue())
+                  .build());
+        }
+        resultString = Json
+            .createObjectBuilder()
+            .add("status", "success")
+            .add("typescript", r.typescript()) // TODO deprecate when the UI uses typescriptFiles
+            .add("typescriptFiles", files)
+            .build().toString();
+      } else if (response instanceof GenerateConstraintsLibAction.Response.Failure r) {
+        resultString = Json
+            .createObjectBuilder()
+            .add("status", "failure")
+            .add("reason", r.reason())
+            .build().toString();
+      } else {
+        throw new Error("Unhandled variant of Response: " + response);
+      }
+      ctx.result(resultString);
+    } catch (final InvalidEntityException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
+    } catch (final InvalidJsonException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     }
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GenerateConstraintsLibAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GenerateConstraintsLibAction.java
@@ -16,7 +16,7 @@ public record GenerateConstraintsLibAction(TypescriptCodeGenerationService types
    */
   public sealed interface Response {
     record Failure(String reason) implements Response {}
-    record Success(String typescript, Map<String, String> files) implements Response {}
+    record Success(Map<String, String> files) implements Response {}
   }
 
   /**
@@ -33,7 +33,6 @@ public record GenerateConstraintsLibAction(TypescriptCodeGenerationService types
       final var constraintsAst = Files.readString(Paths.get(constraintsDslCompilerRoot, "src", "libs", "constraints-ast.ts"));
       final var generated = TypescriptCodeGenerationService.generateTypescriptTypesFromMissionModel();
       return new Response.Success(
-          constraintsApi + "\n" + generated, // TODO deprecate this when the UI is updated.
           Map.of("constraints-edsl-fluent-api.ts", constraintsApi,
                  "mission-model-generated-code.ts", generated,
                  "constraints-ast.ts", constraintsAst));

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GenerateConstraintsLibAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GenerateConstraintsLibAction.java
@@ -1,0 +1,44 @@
+package gov.nasa.jpl.aerie.merlin.server.services;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Objects;
+
+public record GenerateConstraintsLibAction(TypescriptCodeGenerationService typescriptCodeGenerationService) {
+  public GenerateConstraintsLibAction {
+    Objects.requireNonNull(typescriptCodeGenerationService);
+  }
+
+  /**
+   * common interface for different possible results of the query
+   */
+  public sealed interface Response {
+    record Failure(String reason) implements Response {}
+    record Success(String typescript, Map<String, String> files) implements Response {}
+  }
+
+  /**
+   * Generate the source files used for running constraint definitions.
+   *
+   * @param missionModelId
+   * @return a response object wrapping the results of generating the code (either successful or not)
+   */
+  public Response run(final String missionModelId) {
+
+    try {
+      final var constraintsDslCompilerRoot = System.getenv("CONSTRAINTS_DSL_COMPILER_ROOT");
+      final var constraintsApi = Files.readString(Paths.get(constraintsDslCompilerRoot, "src", "libs", "constraints-edsl-fluent-api.ts"));
+      final var constraintsAst = Files.readString(Paths.get(constraintsDslCompilerRoot, "src", "libs", "constraints-ast.ts"));
+      final var generated = TypescriptCodeGenerationService.generateTypescriptTypesFromMissionModel();
+      return new Response.Success(
+          constraintsApi + "\n" + generated, // TODO deprecate this when the UI is updated.
+          Map.of("constraints-edsl-fluent-api.ts", constraintsApi,
+                 "mission-model-generated-code.ts", generated,
+                 "constraints-ast.ts", constraintsAst));
+    } catch (IOException e) {
+      return new Response.Failure(e.getMessage());
+    }
+  }
+}

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/DevAppDriver.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/DevAppDriver.java
@@ -7,6 +7,7 @@ import gov.nasa.jpl.aerie.merlin.server.http.MissionModelRepositoryExceptionBind
 import gov.nasa.jpl.aerie.merlin.server.mocks.Fixtures;
 import gov.nasa.jpl.aerie.merlin.server.mocks.InMemoryMissionModelRepository;
 import gov.nasa.jpl.aerie.merlin.server.services.ConstraintsDSLCompilationService;
+import gov.nasa.jpl.aerie.merlin.server.services.GenerateConstraintsLibAction;
 import gov.nasa.jpl.aerie.merlin.server.services.GetSimulationResultsAction;
 import gov.nasa.jpl.aerie.merlin.server.services.LocalMissionModelService;
 import gov.nasa.jpl.aerie.merlin.server.services.LocalPlanService;
@@ -46,11 +47,13 @@ public final class DevAppDriver {
         false
     );
 
+    final var generateConstraintsLibAction = new GenerateConstraintsLibAction(typescriptCodeGenerationService);
+
     // Configure an HTTP server.
     final Javalin javalin = Javalin.create(config -> {
         config.enableDevLogging();
         config.enableCorsForAllOrigins();
-        config.registerPlugin(new MerlinBindings(missionModelController, planController, simulationAction));
+        config.registerPlugin(new MerlinBindings(missionModelController, planController, simulationAction, generateConstraintsLibAction));
         config.registerPlugin(new LocalAppExceptionBindings());
         config.registerPlugin(new MissionModelRepositoryExceptionBindings());
         config.registerPlugin(new MissionModelExceptionBindings());

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindingsTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindingsTest.java
@@ -5,6 +5,7 @@ import gov.nasa.jpl.aerie.merlin.server.mocks.FakeFile;
 import gov.nasa.jpl.aerie.merlin.server.mocks.StubMissionModelService;
 import gov.nasa.jpl.aerie.merlin.server.mocks.StubPlanService;
 import gov.nasa.jpl.aerie.merlin.server.services.ConstraintsDSLCompilationService;
+import gov.nasa.jpl.aerie.merlin.server.services.GenerateConstraintsLibAction;
 import gov.nasa.jpl.aerie.merlin.server.services.GetSimulationResultsAction;
 import gov.nasa.jpl.aerie.merlin.server.services.SynchronousSimulationAgent;
 import gov.nasa.jpl.aerie.merlin.server.services.TypescriptCodeGenerationService;
@@ -59,10 +60,12 @@ public final class MerlinBindingsTest {
         false
     );
 
+    final var generateConstraintsLibAction = new GenerateConstraintsLibAction(typescriptCodeGenerationService);
+
     SERVER = Javalin.create(config -> {
       config.showJavalinBanner = false;
       config.enableCorsForAllOrigins();
-      config.registerPlugin(new MerlinBindings(missionModelApp, planApp, simulationAction));
+      config.registerPlugin(new MerlinBindings(missionModelApp, planApp, simulationAction, generateConstraintsLibAction));
     });
 
     SERVER.start(54321); // Use likely unused port to avoid clash with any currently hosted port 80 services

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
@@ -103,14 +103,13 @@ public record SchedulerBindings(
         for (final var entry : r.files().entrySet()) {
           files = files.add(
               Json.createObjectBuilder()
-                  .add("filename", entry.getKey())
-                  .add("contents", entry.getValue())
+                  .add("filePath", entry.getKey())
+                  .add("content", entry.getValue())
                   .build());
         }
         resultString = Json
             .createObjectBuilder()
             .add("status", "success")
-            .add("typescript", r.typescript()) // TODO deprecate when the UI uses typescriptFiles
             .add("typescriptFiles", files)
             .build().toString();
       } else if (response instanceof GenerateSchedulingLibAction.Response.Failure r) {

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GenerateSchedulingLibAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GenerateSchedulingLibAction.java
@@ -19,7 +19,7 @@ public record GenerateSchedulingLibAction(TypescriptCodeGenerationService typesc
    */
   public sealed interface Response {
     record Failure(String reason) implements Response {}
-    record Success(String typescript, Map<String, String> files) implements Response {}
+    record Success(Map<String, String> files) implements Response {}
   }
 
   /**
@@ -38,7 +38,6 @@ public record GenerateSchedulingLibAction(TypescriptCodeGenerationService typesc
       final var windowsAst = Files.readString(Paths.get(schedulingDslCompilerRoot, "src", "libs", "windows-expressions-ast.ts"));
       final var generated = this.typescriptCodeGenerationService.generateTypescriptTypesForMissionModel(missionModelId);
       return new Response.Success(
-          schedulingDsl + "\n" + generated, // TODO deprecate this when the UI is updated.
           Map.of("scheduling-edsl-fluent-api.ts", schedulingDsl,
                  "mission-model-generated-code.ts", generated,
                  "scheduler-ast.ts", schedulerAst,


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1843
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds a hasura action to get generated typescript files for the constraints dsl.

Action name is `constraintsDslTypescript`, and takes a mission model id int (or string, see discussion with Chris below) as input. Example query:

```graphql
query MyQuery {
  constraintsDslTypescript(missionModelId: 1) {
    reason
    status
    typescriptFiles {
      content
      filePath
    }
  }
}
```

Currently it doesn't use the missionModelId argument, but it will be used so I included it here.

## Verification
Try it out in the hasura console!

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
