### PR TITLE
[AERIE-1836] Remove openjdk-17 install in dockerfiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,6 @@ services:
     build:
       context: ./merlin-server
       dockerfile: Dockerfile
-      args:
-        IMAGE_INCLUDE_JDK: "true"
     container_name: aerie_merlin
     depends_on: ["postgres"]
     environment:
@@ -77,8 +75,6 @@ services:
     build:
       context: ./scheduler-server
       dockerfile: Dockerfile
-      args:
-        IMAGE_INCLUDE_JDK: "true"
     container_name: aerie_scheduler
     depends_on: ["aerie_merlin", "postgres"]
     environment:
@@ -122,8 +118,6 @@ services:
     build:
       context: ./merlin-worker
       dockerfile: Dockerfile
-      args:
-        IMAGE_INCLUDE_JDK: "true"
     container_name: aerie_merlin_worker_1
     depends_on: ["postgres"]
     environment:
@@ -146,8 +140,6 @@ services:
     build:
       context: ./merlin-worker
       dockerfile: Dockerfile
-      args:
-        IMAGE_INCLUDE_JDK: "true"
     container_name: aerie_merlin_worker_2
     depends_on: ["postgres"]
     environment:

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -52,8 +52,6 @@ services:
     build:
       context: ./../merlin-server
       dockerfile: Dockerfile
-      args:
-        IMAGE_INCLUDE_JDK: 'true'
     container_name: aerie_merlin
     depends_on: ['postgres']
     environment:
@@ -77,8 +75,6 @@ services:
     build:
       context: ./../scheduler-server
       dockerfile: Dockerfile
-      args:
-        IMAGE_INCLUDE_JDK: 'true'
     container_name: aerie_scheduler
     depends_on: ['aerie_merlin', 'postgres']
     environment:
@@ -121,8 +117,6 @@ services:
     build:
       context: ./../merlin-worker
       dockerfile: Dockerfile
-      args:
-        IMAGE_INCLUDE_JDK: 'true'
     container_name: aerie_merlin_worker_1
     depends_on: ['postgres']
     environment:
@@ -144,8 +138,6 @@ services:
     build:
       context: ./../merlin-worker
       dockerfile: Dockerfile
-      args:
-        IMAGE_INCLUDE_JDK: 'true'
     container_name: aerie_merlin_worker_2
     depends_on: ['postgres']
     environment:

--- a/merlin-server/Dockerfile
+++ b/merlin-server/Dockerfile
@@ -6,11 +6,6 @@ RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 
 FROM eclipse-temurin:18-focal
 
-ARG IMAGE_INCLUDE_JDK=false
-RUN if [ $IMAGE_INCLUDE_JDK = "true" ] ; then \
-        apt update && apt install --no-install-recommends openjdk-17-jdk-headless -y; \
-    fi ;
-
 ENV NODE_VERSION=16.14.0
 ENV NVM_DIR=/root/.nvm
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"

--- a/merlin-worker/Dockerfile
+++ b/merlin-worker/Dockerfile
@@ -6,11 +6,6 @@ RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 
 FROM eclipse-temurin:18-focal
 
-ARG IMAGE_INCLUDE_JDK=false
-RUN if [ $IMAGE_INCLUDE_JDK = "true" ] ; then \
-        apt update && apt install openjdk-17-jdk-headless -y; \
-    fi ;
-
 COPY --from=extractor /usr/src/app/extracted /usr/src/app
 
 WORKDIR /usr/src/app

--- a/scheduler-server/Dockerfile
+++ b/scheduler-server/Dockerfile
@@ -6,11 +6,6 @@ RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 
 FROM eclipse-temurin:18-focal
 
-ARG IMAGE_INCLUDE_JDK=false
-RUN if [ $IMAGE_INCLUDE_JDK = "true" ] ; then \
-        apt update && apt install --no-install-recommends openjdk-17-jdk-headless -y; \
-    fi ;
-
 ENV NODE_VERSION=16.14.0
 ENV NVM_DIR=/root/.nvm
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1836
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The `openjdk-18-jdk-headless` package is not available in `apt` on `eclipse-temurin:18-focal`, so it cannot be upgraded from 17 to 18. However, since #129 changed the base layer to `18-focal` instead of `18-jre-focal`, the JDK is now included by default.

- dev image build times are significantly reduced by not installing the jdk separately
- the storage savings of #133 for prod images is gone (they are ~200 MB bigger again) because they now include the JDK
- the storage bloat for dev images is also gone (~200 MB smaller) because they now only include the JRE once (lol)
- there is no longer a difference between dev and prod images.

## Verification
Everything builds and runs as normal. Opening a shell in `aerie_merlin` shows that JDK-specific commands like `jstat` are included still.

## Documentation
I don't think I ever documented this in the first place 😬, so undoing it is not an issue for docs.

## Future work
If an `openjdk-18` package becomes available in the future, consider un-un-doing this change.
