### PR TITLE
[AERIE-1833] SeqJson should preserve parameter order

### DIFF
--- a/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -304,3 +304,10 @@ export class Sequence {
     });
   }
 }
+
+//helper functions
+function orderCommandArguments(args: { [argName: string]: any }, order: string[]): any {
+  return order.map(key => args[key]);
+}
+
+/** END Preface */

--- a/command-expansion-server/src/lib/codegen/CommandTypeCodegen.ts
+++ b/command-expansion-server/src/lib/codegen/CommandTypeCodegen.ts
@@ -91,7 +91,7 @@ ${doc}
 export function ${fswCommandName}<T extends any[]>(args: T[]) {
   return Command.new({
     stem: '${fswCommandName}',
-    arguments: typeof args[0] === 'object' ? args[0] : args,
+    arguments: typeof args[0] === 'object' ? orderCommandArguments(args[0],${fswCommandName}_ARGS_ORDER) : args,
   }) as ${fswCommandName};
 }`;
 
@@ -132,6 +132,7 @@ ${overloadDeclarations.join('')}
   // language=TypeScript
   const value = `
 ${doc}
+const ${fswCommandName}_ARGS_ORDER = [${fswCommand.arguments.map(argument => `'${argument.name}'`).join(', ')}];
 export function ${fswCommandName}(...args: [\n${fswCommand.arguments
     .map(argument => (argument.arg_type === 'repeat' ? '' : `\t${mapArgumentType(argument, enumMap)},\n`))
     .join('')}] | [{\n${fswCommand.arguments
@@ -141,7 +142,7 @@ export function ${fswCommandName}(...args: [\n${fswCommand.arguments
     .join('')}}]): ${fswCommandName} {
   return Command.new({
     stem: '${fswCommand.stem}',
-    arguments: typeof args[0] === 'object' ? args[0] : args,
+    arguments: typeof args[0] === 'object' ? orderCommandArguments(args[0],${fswCommandName}_ARGS_ORDER) : args,
   }) as ${fswCommandName};
 }`;
 


### PR DESCRIPTION

* **Tickets addressed:** AERIE-1833
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Command parameters need to be in the correct order for downstream tools. Javascript objects do not always preserve order and the below is an example of a user who will provide a parameter object in the wrong order. When the sequence seqJSON is created then the order of the parameters is not correct.

```
PREPARE_LOAF(1, false),
PREPARE_LOAF({
      gluten_free: false,
      tb_sugar: 1,
    }),
```

```
"args": [
            1,
            false
        ],
        "stem": "PREPARE_LOAF",

and

"args": [
            false,
            1
        ],
        "stem": "PREPARE_LOAF",
```

The command library will now generate ARGS_ORDER and use a helper function to order the user define parameters in the correct order:

```
const PREPARE_LOAF_ARGS_ORDER = ["tb_sugar", "gluten_free"];
export function PREPARE_LOAF(
  ...args:
    | [U8, boolean]
    | [
        {
          tb_sugar: U8;
          gluten_free: boolean;
        }
      ]
): PREPARE_LOAF {
  return Command.new({
    stem: "PREPARE_LOAF",
    arguments:
      typeof args[0] === "object"
        ? ORDER_OBJECT_PARAMETERS(args[0], PREPARE_LOAF_ARGS_ORDER)
        : args,
  }) as PREPARE_LOAF;
}
```

## Verification
With this expansion logic I was able to generate the parameters in the correct order

```
export default function BakeBananaBreadExpansionLogic(props: {
  activityInstance: ActivityType;
}): ExpansionReturn {
  return [
    PREPARE_LOAF(1, false),
    PREPARE_LOAF({
      gluten_free: false,
      tb_sugar: 1,
    }),
  ];
}
```

seqJSON

```


"args": [
            1,
            false
        ],
        "stem": "PREPARE_LOAF",

and

"args": [
            1,
            false
        ],
        "stem": "PREPARE_LOAF",

```

## Documentation
None

## Future work
None
