### PR TITLE
[AERIE-1859] Remove base64 encoding

### DIFF
--- a/command-expansion-server/src/lib/batchLoaders/expansionBatchLoader.ts
+++ b/command-expansion-server/src/lib/batchLoaders/expansionBatchLoader.ts
@@ -39,7 +39,7 @@ export const expansionBatchLoader: BatchLoader<
     return {
       id: expansion.id,
       activityType: expansion.activity_type,
-      expansionLogic: Buffer.from(expansion.expansion_logic, 'base64').toString('utf8'),
+      expansionLogic: expansion.expansion_logic,
     };
   }));
 }

--- a/command-expansion-server/src/lib/batchLoaders/expansionSetBatchLoader.ts
+++ b/command-expansion-server/src/lib/batchLoaders/expansionSetBatchLoader.ts
@@ -79,7 +79,7 @@ export const expansionSetBatchLoader: BatchLoader<
         expansionRules: expansionSet.expansion_rules.map(expansionRule => ({
           id: expansionRule.id,
           activityType: expansionRule.activity_type,
-          expansionLogic: Buffer.from(expansionRule.expansion_logic, 'base64').toString('utf8'),
+          expansionLogic: expansionRule.expansion_logic,
         })),
       };
     }),

--- a/command-expansion-server/test/batchLoaders/expansionBatchLoader.spec.ts
+++ b/command-expansion-server/test/batchLoaders/expansionBatchLoader.spec.ts
@@ -22,5 +22,11 @@ it('should load expansion data', async () => {
     throw expansions[0];
   }
   expect(expansions[0].activityType).toBe('PeelBanana');
-  expect(expansions[0].expansionLogic).toBeString();
+  expect(expansions[0].expansionLogic).toBe(`export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
+  return [
+    PREHEAT_OVEN({temperature: 70}),
+    PREPARE_LOAF(50, false),
+    BAKE_BREAD,
+  ];
+}`);
 });

--- a/command-expansion-server/test/utils/Expansion.ts
+++ b/command-expansion-server/test/utils/Expansion.ts
@@ -13,8 +13,14 @@ export async function insertExpansion(graphqlClient: GraphQLClient): Promise<num
     `,
     {
       activityTypeName: 'PeelBanana',
-      expansionLogic:
-        'ZXhwb3J0IGRlZmF1bHQgZnVuY3Rpb24gU2luZ2xlQ29tbWFuZEV4cGFuc2lvbihwcm9wczogeyBhY3Rpdml0eUluc3RhbmNlOiBBY3Rpdml0eVR5cGUgfSk6IEV4cGFuc2lvblJldHVybiB7CiAgcmV0dXJuIFsKICAgIFBSRUhFQVRfT1ZFTih7dGVtcGVyYXR1cmU6IDcwfSksCiAgICBQUkVQQVJFX0xPQUYoNTAsIGZhbHNlKSwKICAgIEJBS0VfQlJFQUQsCiAgXTsKfQ==',
+      expansionLogic: `
+        export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
+          return [
+            PREHEAT_OVEN({temperature: 70}),
+            PREPARE_LOAF(50, false),
+            BAKE_BREAD,
+          ];
+        }`,
     },
   );
   return res.addCommandExpansionTypeScript.id;
@@ -33,8 +39,10 @@ export async function insertErrorExpansion(graphqlClient: GraphQLClient): Promis
     `,
     {
       activityTypeName: 'BiteBanana',
-      expansionLogic:
-        'ZXhwb3J0IGRlZmF1bHQgZnVuY3Rpb24gRXJyb3JFeHBhbnNpb24ocHJvcHM6IHsgYWN0aXZpdHlJbnN0YW5jZTogQWN0aXZpdHlUeXBlIH0pOiBFeHBhbnNpb25SZXR1cm4gewogIHRocm93IG5ldyBFcnJvcignTm90IGltcGxlbWVudGVkJyk7Cn0=',
+      expansionLogic:`
+        export default function ErrorExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
+          throw new Error('Not implemented');
+        }`,
     },
   );
   return res.addCommandExpansionTypeScript.id;

--- a/command-expansion-server/test/utils/Expansion.ts
+++ b/command-expansion-server/test/utils/Expansion.ts
@@ -13,14 +13,14 @@ export async function insertExpansion(graphqlClient: GraphQLClient): Promise<num
     `,
     {
       activityTypeName: 'PeelBanana',
-      expansionLogic: `
-        export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
-          return [
-            PREHEAT_OVEN({temperature: 70}),
-            PREPARE_LOAF(50, false),
-            BAKE_BREAD,
-          ];
-        }`,
+      expansionLogic:
+`export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
+  return [
+    PREHEAT_OVEN({temperature: 70}),
+    PREPARE_LOAF(50, false),
+    BAKE_BREAD,
+  ];
+}`,
     },
   );
   return res.addCommandExpansionTypeScript.id;


### PR DESCRIPTION
The base64 encoding isn't necessary when in a json payload, so we are
removing the additional overhead

see https://github.com/NASA-AMMOS/aerie/pull/176#issuecomment-1136412668

* **Tickets addressed:** AERIE-1859
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Did a global find in the command expansion package and removed sites where we were messing with base64 encoding.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Ran existing test cases and updated test cases to be more specific about the expansion logic content.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Need to update the documentation for command expansion to remove base64 encoding.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
@camargo Need to ensure the UI gets updated appropriately.