### PR TITLE
[AERIE-1842] Type-checking for Constraints eDSL

### DIFF
--- a/merlin-server/constraints-dsl-compiler/.prettierrc
+++ b/merlin-server/constraints-dsl-compiler/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "trailingComma": "all",
+  "singleQuote": true,
+  "arrowParens": "avoid",
+  "semi": true,
+  "printWidth": 120,
+  "tabWidth": 2,
+  "parser": "typescript"
+}

--- a/merlin-server/constraints-dsl-compiler/package-lock.json
+++ b/merlin-server/constraints-dsl-compiler/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@nasa-jpl/aerie-ts-user-code-runner": "^0.2.6",
+        "prettier": "^2.6.2",
         "source-map": "^0.7.3",
         "typescript": "^4.5.5",
         "typescript-json-schema": "^0.53.0"
@@ -327,6 +328,20 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/require-directory": {
@@ -833,6 +848,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/merlin-server/constraints-dsl-compiler/package.json
+++ b/merlin-server/constraints-dsl-compiler/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "build": "tsc",
     "test": "npm run build && node build/main.js",
-    "generate-ast-schema": "npx typescript-json-schema src/libs/constraints-ast.ts \"*\" --aliasRefs --out ./build/constraints.schema.json"
+    "generate-ast-schema": "npx typescript-json-schema src/libs/constraints-ast.ts \"*\" --aliasRefs --out ./build/constraints.schema.json",
+    "reformat": "npx prettier --config ./.prettierrc -w ./src"
   },
   "author": "",
   "dependencies": {
     "@nasa-jpl/aerie-ts-user-code-runner": "^0.2.6",
+    "prettier": "^2.6.2",
     "source-map": "^0.7.3",
     "typescript": "^4.5.5",
     "typescript-json-schema": "^0.53.0"

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -27,28 +27,24 @@ export enum NodeKind {
   ViolationsOf = 'ViolationsOf',
 }
 
-export type Constraint =
-  | ViolationsOf
-  | ForbiddenActivityOverlap
-  | ForEachActivity
-  | WindowsExpression;
+export type Constraint = ViolationsOf | ForbiddenActivityOverlap | ForEachActivity | WindowsExpression;
 
 export interface ViolationsOf {
-  kind: NodeKind.ViolationsOf,
-  expression: WindowsExpression
+  kind: NodeKind.ViolationsOf;
+  expression: WindowsExpression;
 }
 
 export interface ForbiddenActivityOverlap {
-  kind: NodeKind.ForbiddenActivityOverlap,
-  activityType1: string,
-  activityType2: string
+  kind: NodeKind.ForbiddenActivityOverlap;
+  activityType1: string;
+  activityType2: string;
 }
 
 export interface ForEachActivity {
-  kind: NodeKind.ForEachActivity,
-  activityType: string,
-  alias: string,
-  expression: Constraint
+  kind: NodeKind.ForEachActivity;
+  activityType: string;
+  alias: string;
+  expression: Constraint;
 }
 
 export type WindowsExpression =
@@ -67,89 +63,87 @@ export type WindowsExpression =
   | ExpressionNotEqual<DiscreteProfileExpression>
   | WindowsExpressionAll
   | WindowsExpressionAny
-  | WindowsExpressionNot
+  | WindowsExpressionNot;
 
 export interface ProfileChanged {
-  kind: NodeKind.ProfileChanged,
-  expression: ProfileExpression
+  kind: NodeKind.ProfileChanged;
+  expression: ProfileExpression;
 }
 
 export interface WindowsExpressionNot {
-  kind: NodeKind.WindowsExpressionNot,
-  expression: WindowsExpression
+  kind: NodeKind.WindowsExpressionNot;
+  expression: WindowsExpression;
 }
 
 export interface WindowsExpressionAny {
-  kind: NodeKind.WindowsExpressionAny,
-  expressions: WindowsExpression[]
+  kind: NodeKind.WindowsExpressionAny;
+  expressions: WindowsExpression[];
 }
 
 export interface WindowsExpressionAll {
-  kind: NodeKind.WindowsExpressionAll,
-  expressions: WindowsExpression[]
+  kind: NodeKind.WindowsExpressionAll;
+  expressions: WindowsExpression[];
 }
 
 export interface RealProfileGreaterThanOrEqual {
-  kind: NodeKind.RealProfileGreaterThanOrEqual,
-  left: RealProfileExpression,
-  right: RealProfileExpression
+  kind: NodeKind.RealProfileGreaterThanOrEqual;
+  left: RealProfileExpression;
+  right: RealProfileExpression;
 }
 
 export interface RealProfileGreaterThan {
-  kind: NodeKind.RealProfileGreaterThan,
-  left: RealProfileExpression,
-  right: RealProfileExpression
+  kind: NodeKind.RealProfileGreaterThan;
+  left: RealProfileExpression;
+  right: RealProfileExpression;
 }
 
 export interface RealProfileLessThanOrEqual {
-  kind: NodeKind.RealProfileLessThanOrEqual,
-  left: RealProfileExpression,
-  right: RealProfileExpression
+  kind: NodeKind.RealProfileLessThanOrEqual;
+  left: RealProfileExpression;
+  right: RealProfileExpression;
 }
 
 export interface RealProfileLessThan {
-  kind: NodeKind.RealProfileLessThan,
-  left: RealProfileExpression,
-  right: RealProfileExpression
+  kind: NodeKind.RealProfileLessThan;
+  left: RealProfileExpression;
+  right: RealProfileExpression;
 }
 
 export interface ExpressionNotEqual<T = ProfileExpression> {
-  kind: NodeKind.ExpressionNotEqual,
-  left: T,
-  right: T
+  kind: NodeKind.ExpressionNotEqual;
+  left: T;
+  right: T;
 }
 
 export interface ExpressionEqual<T = ProfileExpression> {
-  kind: NodeKind.ExpressionEqual,
-  left: T,
-  right: T
+  kind: NodeKind.ExpressionEqual;
+  left: T;
+  right: T;
 }
 
 export interface WindowsExpressionEndOf {
-  kind: NodeKind.WindowsExpressionEndOf,
-  alias: string
+  kind: NodeKind.WindowsExpressionEndOf;
+  alias: string;
 }
 
 export interface WindowsExpressionStartOf {
-  kind: NodeKind.WindowsExpressionStartOf,
-  alias: string
+  kind: NodeKind.WindowsExpressionStartOf;
+  alias: string;
 }
 
 export interface WindowsExpressionDuring {
-  kind: NodeKind.WindowsExpressionDuring,
-  alias: string
+  kind: NodeKind.WindowsExpressionDuring;
+  alias: string;
 }
 
 export interface DiscreteProfileTransition {
-  kind: NodeKind.DiscreteProfileTransition,
-  profile: DiscreteProfileExpression,
-  from: any,
-  to: any
+  kind: NodeKind.DiscreteProfileTransition;
+  profile: DiscreteProfileExpression;
+  from: any;
+  to: any;
 }
 
-export type ProfileExpression =
-  | RealProfileExpression
-  | DiscreteProfileExpression;
+export type ProfileExpression = RealProfileExpression | DiscreteProfileExpression;
 
 export type RealProfileExpression =
   | RealProfileRate
@@ -160,55 +154,52 @@ export type RealProfileExpression =
   | RealProfileParameter;
 
 export interface RealProfileRate {
-  kind: NodeKind.RealProfileRate,
-  profile: RealProfileExpression
+  kind: NodeKind.RealProfileRate;
+  profile: RealProfileExpression;
 }
 
 export interface RealProfileTimes {
-  kind: NodeKind.RealProfileTimes,
-  profile: RealProfileExpression,
-  multiplier: number
+  kind: NodeKind.RealProfileTimes;
+  profile: RealProfileExpression;
+  multiplier: number;
 }
 
 export interface RealProfilePlus {
-  kind: NodeKind.RealProfilePlus,
-  left: RealProfileExpression,
-  right: RealProfileExpression
+  kind: NodeKind.RealProfilePlus;
+  left: RealProfileExpression;
+  right: RealProfileExpression;
 }
 
 export interface RealProfileResource {
-  kind: NodeKind.RealProfileResource,
-  name: string
+  kind: NodeKind.RealProfileResource;
+  name: string;
 }
 
 export interface RealProfileValue {
-  kind: NodeKind.RealProfileValue,
-  value: number
+  kind: NodeKind.RealProfileValue;
+  value: number;
 }
 
 export interface RealProfileParameter {
-  kind: NodeKind.RealProfileParameter,
-  alias: string,
-  name: string
+  kind: NodeKind.RealProfileParameter;
+  alias: string;
+  name: string;
 }
 
-export type DiscreteProfileExpression =
-  | DiscreteProfileResource
-  | DiscreteProfileValue
-  | DiscreteProfileParameter;
+export type DiscreteProfileExpression = DiscreteProfileResource | DiscreteProfileValue | DiscreteProfileParameter;
 
 export interface DiscreteProfileResource {
-  kind: NodeKind.DiscreteProfileResource,
-  name: string
+  kind: NodeKind.DiscreteProfileResource;
+  name: string;
 }
 
 export interface DiscreteProfileValue {
-  kind: NodeKind.DiscreteProfileValue,
-  value: any
+  kind: NodeKind.DiscreteProfileValue;
+  value: any;
 }
 
 export interface DiscreteProfileParameter {
-  kind: NodeKind.DiscreteProfileParameter,
-  alias: string,
-  name: string
+  kind: NodeKind.DiscreteProfileParameter;
+  alias: string;
+  name: string;
 }

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -1,4 +1,5 @@
 import * as AST from './constraints-ast.js';
+import './mission-model-generated-code.js';
 
 export class Constraint {
   /** Internal AST node */

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -9,7 +9,7 @@ export class Constraint {
     this.__astNode = astNode;
   }
 
-  public static ForbiddenActivityOverlap(activityType1: string, activityType2: string): Constraint {
+  public static ForbiddenActivityOverlap(activityType1: ActivityTypeName, activityType2: ActivityTypeName): Constraint {
     return new Constraint({
       kind: AST.NodeKind.ForbiddenActivityOverlap,
       activityType1,
@@ -17,7 +17,7 @@ export class Constraint {
     })
   }
 
-  public static ForEachActivity(activityType: string, alias: string, constraint: Constraint): Constraint {
+  public static ForEachActivity(activityType: ActivityTypeName, alias: string, constraint: Constraint): Constraint {
     return new Constraint({
       kind: AST.NodeKind.ForEachActivity,
       activityType,
@@ -296,7 +296,7 @@ declare global {
      * @param activityType2
      * @constructor
      */
-    public static ForbiddenActivityOverlap(activityType1: string, activityType2: string): Constraint
+    public static ForbiddenActivityOverlap(activityType1: ActivityTypeName, activityType2: ActivityTypeName): Constraint
 
     /**
      * Check a constraint for each instance of an activity type.
@@ -306,7 +306,7 @@ declare global {
      * @param constraint constraint to apply
      * @constructor
      */
-    public static ForEachActivity(activityType: string, alias: string, constraint: Constraint): Constraint
+    public static ForEachActivity(activityType: ActivityTypeName, alias: string, constraint: Constraint): Constraint
   }
 
   export class Windows {

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -273,7 +273,7 @@ declare global {
      * Check a constraint for each instance of an activity type.
      *
      * @param activityType activity type to check
-     * @param expression
+     * @param expression function of an activity instance that returns a Constraint
      * @constructor
      */
     public static ForEachActivity<A extends Gen.ActivityTypeName>(activityType: A, expression: (instance: Gen.ActivityInstance<A>) => Constraint): Constraint

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -15,19 +15,22 @@ export class Constraint {
     return new Constraint({
       kind: AST.NodeKind.ForbiddenActivityOverlap,
       activityType1,
-      activityType2
-    })
+      activityType2,
+    });
   }
 
-  public static ForEachActivity<A extends Gen.ActivityType>(activityType: A, expression: (instance: Gen.ActivityInstance<A>) => Constraint): Constraint {
-    let alias = "activity alias " + Constraint.__numGeneratedAliases;
+  public static ForEachActivity<A extends Gen.ActivityType>(
+    activityType: A,
+    expression: (instance: Gen.ActivityInstance<A>) => Constraint,
+  ): Constraint {
+    let alias = 'activity alias ' + Constraint.__numGeneratedAliases;
     Constraint.__numGeneratedAliases += 1;
     return new Constraint({
       kind: AST.NodeKind.ForEachActivity,
       activityType,
       alias,
-      expression: expression(new Gen.ActivityInstance(activityType, alias)).__astNode
-    })
+      expression: expression(new Gen.ActivityInstance(activityType, alias)).__astNode,
+    });
   }
 }
 
@@ -42,17 +45,13 @@ export class Windows {
   public static All(...windows: Windows[]): Windows {
     return new Windows({
       kind: AST.NodeKind.WindowsExpressionAll,
-      expressions: [
-        ...windows.map(other => other.__astNode),
-      ],
+      expressions: [...windows.map(other => other.__astNode)],
     });
   }
   public static Any(...windows: Windows[]): Windows {
     return new Windows({
       kind: AST.NodeKind.WindowsExpressionAny,
-      expressions: [
-        ...windows.map(other => other.__astNode),
-      ],
+      expressions: [...windows.map(other => other.__astNode)],
     });
   }
 
@@ -62,25 +61,25 @@ export class Windows {
       expressions: [
         {
           kind: AST.NodeKind.WindowsExpressionNot,
-          expression: condition.__astNode
+          expression: condition.__astNode,
         },
-        this.__astNode
-      ]
-    })
+        this.__astNode,
+      ],
+    });
   }
 
   public not(): Windows {
     return new Windows({
       kind: AST.NodeKind.WindowsExpressionNot,
-      expression: this.__astNode
-    })
+      expression: this.__astNode,
+    });
   }
 
   public violations(): Constraint {
     return new Constraint({
       kind: AST.NodeKind.ViolationsOf,
-      expression: this.__astNode
-    })
+      expression: this.__astNode,
+    });
   }
 }
 
@@ -94,28 +93,28 @@ export class Real {
   public static Resource(name: Gen.RealResourceName): Real {
     return new Real({
       kind: AST.NodeKind.RealProfileResource,
-      name
-    })
+      name,
+    });
   }
   public static Value(value: number): Real {
     return new Real({
       kind: AST.NodeKind.RealProfileValue,
-      value
-    })
+      value,
+    });
   }
 
   public rate(): Real {
     return new Real({
       kind: AST.NodeKind.RealProfileRate,
-      profile: this.__astNode
-    })
+      profile: this.__astNode,
+    });
   }
   public times(multiplier: number): Real {
     return new Real({
       kind: AST.NodeKind.RealProfileTimes,
       multiplier,
-      profile: this.__astNode
-    })
+      profile: this.__astNode,
+    });
   }
   public plus(other: Real | number): Real {
     if (!(other instanceof Real)) {
@@ -124,8 +123,8 @@ export class Real {
     return new Real({
       kind: AST.NodeKind.RealProfilePlus,
       left: this.__astNode,
-      right: other.__astNode
-    })
+      right: other.__astNode,
+    });
   }
 
   public lessThan(other: Real | number): Windows {
@@ -135,8 +134,8 @@ export class Real {
     return new Windows({
       kind: AST.NodeKind.RealProfileLessThan,
       left: this.__astNode,
-      right: other.__astNode
-    })
+      right: other.__astNode,
+    });
   }
   public lessThanOrEqual(other: Real | number): Windows {
     if (!(other instanceof Real)) {
@@ -145,8 +144,8 @@ export class Real {
     return new Windows({
       kind: AST.NodeKind.RealProfileLessThanOrEqual,
       left: this.__astNode,
-      right: other.__astNode
-    })
+      right: other.__astNode,
+    });
   }
   public greaterThan(other: Real | number): Windows {
     if (!(other instanceof Real)) {
@@ -155,8 +154,8 @@ export class Real {
     return new Windows({
       kind: AST.NodeKind.RealProfileGreaterThan,
       left: this.__astNode,
-      right: other.__astNode
-    })
+      right: other.__astNode,
+    });
   }
   public greaterThanOrEqual(other: Real | number): Windows {
     if (!(other instanceof Real)) {
@@ -165,8 +164,8 @@ export class Real {
     return new Windows({
       kind: AST.NodeKind.RealProfileGreaterThanOrEqual,
       left: this.__astNode,
-      right: other.__astNode
-    })
+      right: other.__astNode,
+    });
   }
 
   public equal(other: Real | number): Windows {
@@ -176,8 +175,8 @@ export class Real {
     return new Windows({
       kind: AST.NodeKind.ExpressionEqual,
       left: this.__astNode,
-      right: other.__astNode
-    })
+      right: other.__astNode,
+    });
   }
   public notEqual(other: Real | number): Windows {
     if (!(other instanceof Real)) {
@@ -186,20 +185,20 @@ export class Real {
     return new Windows({
       kind: AST.NodeKind.ExpressionNotEqual,
       left: this.__astNode,
-      right: other.__astNode
-    })
+      right: other.__astNode,
+    });
   }
 
   public changed(): Windows {
     return new Windows({
       kind: AST.NodeKind.ProfileChanged,
-      expression: this.__astNode
-    })
+      expression: this.__astNode,
+    });
   }
 }
 
 export class Discrete<Schema> {
-  public readonly __astNode: AST.DiscreteProfileExpression
+  public readonly __astNode: AST.DiscreteProfileExpression;
 
   public constructor(profile: AST.DiscreteProfileExpression) {
     this.__astNode = profile;
@@ -208,14 +207,14 @@ export class Discrete<Schema> {
   public static Resource<R extends Gen.ResourceName>(name: R): Discrete<Gen.DiscreteResourceSchema<R>> {
     return new Discrete({
       kind: AST.NodeKind.DiscreteProfileResource,
-      name
-    })
+      name,
+    });
   }
   public static Value<Schema>(value: Schema): Discrete<Schema> {
     return new Discrete({
       kind: AST.NodeKind.DiscreteProfileValue,
-      value
-    })
+      value,
+    });
   }
 
   public transition(from: Schema, to: Schema): Windows {
@@ -223,8 +222,8 @@ export class Discrete<Schema> {
       kind: AST.NodeKind.DiscreteProfileTransition,
       profile: this.__astNode,
       from,
-      to
-    })
+      to,
+    });
   }
 
   public equal(other: Schema | Discrete<Schema>): Windows {
@@ -234,8 +233,8 @@ export class Discrete<Schema> {
     return new Windows({
       kind: AST.NodeKind.ExpressionEqual,
       left: this.__astNode,
-      right: other.__astNode
-    })
+      right: other.__astNode,
+    });
   }
   public notEqual(other: Schema | Discrete<Schema>): Windows {
     if (!(other instanceof Discrete)) {
@@ -244,15 +243,15 @@ export class Discrete<Schema> {
     return new Windows({
       kind: AST.NodeKind.ExpressionNotEqual,
       left: this.__astNode,
-      right: other.__astNode
-    })
+      right: other.__astNode,
+    });
   }
 
   public changed(): Windows {
     return new Windows({
       kind: AST.NodeKind.ProfileChanged,
-      expression: this.__astNode
-    })
+      expression: this.__astNode,
+    });
   }
 }
 
@@ -267,7 +266,10 @@ declare global {
      * @param activityType2
      * @constructor
      */
-    public static ForbiddenActivityOverlap(activityType1: Gen.ActivityType, activityType2: Gen.ActivityType): Constraint
+    public static ForbiddenActivityOverlap(
+      activityType1: Gen.ActivityType,
+      activityType2: Gen.ActivityType,
+    ): Constraint;
 
     /**
      * Check a constraint for each instance of an activity type.
@@ -276,7 +278,10 @@ declare global {
      * @param expression function of an activity instance that returns a Constraint
      * @constructor
      */
-    public static ForEachActivity<A extends Gen.ActivityType>(activityType: A, expression: (instance: Gen.ActivityInstance<A>) => Constraint): Constraint
+    public static ForEachActivity<A extends Gen.ActivityType>(
+      activityType: A,
+      expression: (instance: Gen.ActivityInstance<A>) => Constraint,
+    ): Constraint;
   }
 
   export class Windows {
@@ -290,7 +295,7 @@ declare global {
      *
      * @param windows any number of windows expressions
      */
-    public static All(...windows: Windows[]): Windows
+    public static All(...windows: Windows[]): Windows;
 
     /**
      * Produce a window when any argument produces a window.
@@ -299,19 +304,19 @@ declare global {
      *
      * @param windows one or more windows expressions
      */
-    public static Any(...windows: Windows[]): Windows
+    public static Any(...windows: Windows[]): Windows;
 
     /**
      * Only check this expression of the condition argument produces a window.
      *
      * @param condition
      */
-    public if(condition: Windows): Windows
+    public if(condition: Windows): Windows;
 
     /**
      * Negate all the windows produced this.
      */
-    public not(): Windows
+    public not(): Windows;
 
     /**
      * Produce a constraint violation whenever this does NOT produce a window.
@@ -319,7 +324,7 @@ declare global {
      * Essentially, express the condition you want to be satisfied, then use
      * this method to produce a violation whenever it is NOT satisfied.
      */
-    public violations(): Constraint
+    public violations(): Constraint;
   }
 
   export class Real {
@@ -331,77 +336,77 @@ declare global {
      * @param name
      * @constructor
      */
-    public static Resource(name: Gen.RealResourceName): Real
+    public static Resource(name: Gen.RealResourceName): Real;
 
     /**
      * Create a constant real profile for all time.
      * @param value
      * @constructor
      */
-    public static Value(value: number): Real
+    public static Value(value: number): Real;
 
     /**
      * Create a real profile from this profile's derivative.
      */
-    public rate(): Real
+    public rate(): Real;
 
     /**
      * Create a real profile by multiplying this profile by a constant
      * @param multiplier
      */
-    public times(multiplier: number): Real
+    public times(multiplier: number): Real;
 
     /**
      * Create a real profile by adding this and another real profile together.
      * @param other
      */
-    public plus(other: Real | number): Real
+    public plus(other: Real | number): Real;
 
     /**
      * Produce a window whenever this profile is less than another real profile.
      * @param other
      */
-    public lessThan(other: Real | number): Windows
+    public lessThan(other: Real | number): Windows;
 
     /**
      * Produce a window whenever this profile is less than or equal to another real profile.
      * @param other
      */
-    public lessThanOrEqual(other: Real | number): Windows
+    public lessThanOrEqual(other: Real | number): Windows;
 
     /**
      * Produce a window whenever this profile is greater than to another real profile.
      * @param other
      */
-    public greaterThan(other: Real | number): Windows
+    public greaterThan(other: Real | number): Windows;
 
     /**
      * Produce a window whenever this profile is greater than or equal to another real profile.
      * @param other
      */
-    public greaterThanOrEqual(other: Real | number): Windows
+    public greaterThanOrEqual(other: Real | number): Windows;
 
     /**
      * Produce a window whenever this profile is equal to another real profile.
      * @param other
      */
-    public equal(other: Real | number): Windows
+    public equal(other: Real | number): Windows;
 
     /**
      * Produce a window whenever this profile is not equal to another real profile.
      * @param other
      */
-    public notEqual(other: Real | number): Windows
+    public notEqual(other: Real | number): Windows;
 
     /**
      * Produce an instantaneous window whenever this profile changes.
      */
-    public changed(): Windows
+    public changed(): Windows;
   }
 
   export class Discrete<Schema> {
     /** Internal AST Node */
-    public readonly __astNode: AST.DiscreteProfileExpression
+    public readonly __astNode: AST.DiscreteProfileExpression;
 
     /**
      * Internal instance of the Schema type, for type checking.
@@ -421,14 +426,14 @@ declare global {
      * @param name
      * @constructor
      */
-    public static Resource<R extends Gen.ResourceName>(name: R): Discrete<Gen.DiscreteResourceSchema<R>>
+    public static Resource<R extends Gen.ResourceName>(name: R): Discrete<Gen.DiscreteResourceSchema<R>>;
 
     /**
      * Create a constant discrete profile for all time.
      * @param value
      * @constructor
      */
-    public static Value<Schema>(value: Schema): Discrete<Schema>
+    public static Value<Schema>(value: Schema): Discrete<Schema>;
 
     /**
      * Produce an instantaneous window whenever this profile makes a specific transition.
@@ -436,28 +441,28 @@ declare global {
      * @param from initial value
      * @param to final value
      */
-    public transition(from: Schema, to: Schema): Windows
+    public transition(from: Schema, to: Schema): Windows;
 
     /**
      * Produce a window whenever this profile is equal to another discrete profile.
      * @param other
      */
-    public equal(other: Schema | Discrete<Schema>): Windows
+    public equal(other: Schema | Discrete<Schema>): Windows;
 
     /**
      * Produce a window whenever this profile is not equal to another discrete profile.
      * @param other
      */
-    public notEqual(other: Schema | Discrete<Schema>): Windows
+    public notEqual(other: Schema | Discrete<Schema>): Windows;
 
     /**
      * Produce an instantaneous window whenever this profile changes.
      */
-    public changed(): Windows
+    public changed(): Windows;
   }
 
   type Duration = number;
 }
 
 // Make Constraint available on the global object
-Object.assign(globalThis, {Constraint, Windows, Real, Discrete});
+Object.assign(globalThis, { Constraint, Windows, Real, Discrete });

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -11,7 +11,7 @@ export class Constraint {
     this.__astNode = astNode;
   }
 
-  public static ForbiddenActivityOverlap(activityType1: Gen.ActivityTypeName, activityType2: Gen.ActivityTypeName): Constraint {
+  public static ForbiddenActivityOverlap(activityType1: Gen.ActivityType, activityType2: Gen.ActivityType): Constraint {
     return new Constraint({
       kind: AST.NodeKind.ForbiddenActivityOverlap,
       activityType1,
@@ -19,7 +19,7 @@ export class Constraint {
     })
   }
 
-  public static ForEachActivity<A extends Gen.ActivityTypeName>(activityType: A, expression: (instance: Gen.ActivityInstance<A>) => Constraint): Constraint {
+  public static ForEachActivity<A extends Gen.ActivityType>(activityType: A, expression: (instance: Gen.ActivityInstance<A>) => Constraint): Constraint {
     let alias = "activity alias " + Constraint.__numGeneratedAliases;
     Constraint.__numGeneratedAliases += 1;
     return new Constraint({
@@ -267,7 +267,7 @@ declare global {
      * @param activityType2
      * @constructor
      */
-    public static ForbiddenActivityOverlap(activityType1: Gen.ActivityTypeName, activityType2: Gen.ActivityTypeName): Constraint
+    public static ForbiddenActivityOverlap(activityType1: Gen.ActivityType, activityType2: Gen.ActivityType): Constraint
 
     /**
      * Check a constraint for each instance of an activity type.
@@ -276,7 +276,7 @@ declare global {
      * @param expression function of an activity instance that returns a Constraint
      * @constructor
      */
-    public static ForEachActivity<A extends Gen.ActivityTypeName>(activityType: A, expression: (instance: Gen.ActivityInstance<A>) => Constraint): Constraint
+    public static ForEachActivity<A extends Gen.ActivityType>(activityType: A, expression: (instance: Gen.ActivityInstance<A>) => Constraint): Constraint
   }
 
   export class Windows {

--- a/merlin-server/constraints-dsl-compiler/src/libs/mission-model-generated-code.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/mission-model-generated-code.ts
@@ -1,10 +1,20 @@
 // The following are only to satisfy the type checker before any code is generated.
 // All of this will be overwritten before any constraints are evaluated.
 
-export type ActivityTypeName = string;
 export type ResourceName = string;
 export type DiscreteResourceSchema<R extends ResourceName> = any;
-export function discreteResourceSchemaDummyValue<R extends ResourceName>(resource: R): DiscreteResourceSchema<R> {
-  return 5;
-}
 export type RealResourceName = string;
+
+export type ActivityTypeName = string;
+export type ActivityParameters<A extends ActivityTypeName> = any;
+export class ActivityInstance<A extends ActivityTypeName> {
+  private readonly __activityType: A;
+  private readonly __alias: string;
+
+  public readonly parameters: ActivityParameters<A>;
+  constructor(activityType: A, alias: string) {
+    this.__activityType = activityType;
+    this.__alias = alias;
+    this.parameters = 5;
+  }
+}

--- a/merlin-server/constraints-dsl-compiler/src/libs/mission-model-generated-code.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/mission-model-generated-code.ts
@@ -5,9 +5,12 @@ export type ResourceName = string;
 export type DiscreteResourceSchema<R extends ResourceName> = any;
 export type RealResourceName = string;
 
-export type ActivityTypeName = string;
-export type ActivityParameters<A extends ActivityTypeName> = any;
-export class ActivityInstance<A extends ActivityTypeName> {
+export enum ActivityType {
+  // This indicates to the compiler that we are using a string enum so we can assign it to string for our AST
+  _ = '_',
+}
+export type ActivityParameters<A extends ActivityType> = any;
+export class ActivityInstance<A extends ActivityType> {
   private readonly __activityType: A;
   private readonly __alias: string;
 

--- a/merlin-server/constraints-dsl-compiler/src/libs/mission-model-generated-code.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/mission-model-generated-code.ts
@@ -1,0 +1,1 @@
+type ActivityTypeName = string;

--- a/merlin-server/constraints-dsl-compiler/src/libs/mission-model-generated-code.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/mission-model-generated-code.ts
@@ -1,1 +1,10 @@
-type ActivityTypeName = string;
+// The following are only to satisfy the type checker before any code is generated.
+// All of this will be overwritten before any constraints are evaluated.
+
+export type ActivityTypeName = string;
+export type ResourceName = string;
+export type DiscreteResourceSchema<R extends ResourceName> = any;
+export function discreteResourceSchemaDummyValue<R extends ResourceName>(resource: R): DiscreteResourceSchema<R> {
+  return 5;
+}
+export type RealResourceName = string;

--- a/merlin-server/constraints-dsl-compiler/src/main.ts
+++ b/merlin-server/constraints-dsl-compiler/src/main.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import ts from 'typescript';
 import { UserCodeRunner } from '@nasa-jpl/aerie-ts-user-code-runner';
 import type { Constraint } from './libs/constraints-edsl-fluent-api.js'
+import * as readline from "readline";
 
 const codeRunner = new UserCodeRunner();
 const constraintsEDSL = fs.readFileSync(`${process.env.CONSTRAINTS_DSL_COMPILER_ROOT}/src/libs/constraints-edsl-fluent-api.ts`, 'utf8');
@@ -14,8 +15,19 @@ process.on('uncaughtException', (err) => {
   process.exit(1);
 });
 
+const lineReader = readline.createInterface({
+  input: process.stdin
+});
+lineReader.once('line', handleRequest);
+
 async function handleRequest(data: Buffer) {
   try {
+    // Test the health of the service by responding to "ping" with "pong".
+    if (data.toString() === "ping") {
+      process.stdout.write("pong\n");
+      lineReader.once('line', handleRequest);
+      return;
+    }
     const { constraintCode, missionModelGeneratedCode } = JSON.parse(data.toString()) as { constraintCode: string, missionModelGeneratedCode: string };
 
     const result = await codeRunner.executeUserCode<[], Constraint>(
@@ -33,7 +45,7 @@ async function handleRequest(data: Buffer) {
 
     if (result.isErr()) {
       process.stdout.write('error\n' + JSON.stringify(result.unwrapErr().map(err => err.toJSON())) + '\n');
-      process.stdin.once('data', handleRequest);
+      lineReader.once('line', handleRequest);
       return;
     }
 
@@ -43,16 +55,7 @@ async function handleRequest(data: Buffer) {
     }
     process.stdout.write('success\n' + stringified + '\n');
   } catch (error: any) {
-    process.stdout.write('panic\n' + JSON.stringify(error.stack ?? error.message) + '\n');
+    process.stdout.write('panic\n' + JSON.stringify(error.stack ?? error.message) + " attempted to handle: " + data.toString() + '\n');
   }
-  process.stdin.once('data', handleRequest);
+  lineReader.once('line', handleRequest);
 }
-
-process.stdin.once('data', data => {
-  if (data.toString().trim() === 'ping') {
-    // Enable testing the health of the service by sending 'ping' and expecting 'pong' in return.
-    process.stdout.write('pong\n');
-    process.stdin.once('data', handleRequest);
-  }
-});
-

--- a/merlin-server/constraints-dsl-compiler/src/main.ts
+++ b/merlin-server/constraints-dsl-compiler/src/main.ts
@@ -1,47 +1,49 @@
 import fs from 'fs';
 import ts from 'typescript';
 import { UserCodeRunner } from '@nasa-jpl/aerie-ts-user-code-runner';
-import type { Constraint } from './libs/constraints-edsl-fluent-api.js'
-import * as readline from "readline";
+import type { Constraint } from './libs/constraints-edsl-fluent-api.js';
+import * as readline from 'readline';
 
 const codeRunner = new UserCodeRunner();
-const constraintsEDSL = fs.readFileSync(`${process.env.CONSTRAINTS_DSL_COMPILER_ROOT}/src/libs/constraints-edsl-fluent-api.ts`, 'utf8');
-const constraintsAST = fs.readFileSync(`${process.env.CONSTRAINTS_DSL_COMPILER_ROOT}/src/libs/constraints-ast.ts`, 'utf8');
+const constraintsEDSL = fs.readFileSync(
+  `${process.env.CONSTRAINTS_DSL_COMPILER_ROOT}/src/libs/constraints-edsl-fluent-api.ts`,
+  'utf8',
+);
+const constraintsAST = fs.readFileSync(
+  `${process.env.CONSTRAINTS_DSL_COMPILER_ROOT}/src/libs/constraints-ast.ts`,
+  'utf8',
+);
 
-process.on('uncaughtException', (err) => {
+process.on('uncaughtException', err => {
   console.error('uncaughtException');
-  console.error((err && err.stack) ? err.stack : err);
+  console.error(err && err.stack ? err.stack : err);
   process.stdout.write('panic\n' + err.stack ?? err.message);
   process.exit(1);
 });
 
 const lineReader = readline.createInterface({
-  input: process.stdin
+  input: process.stdin,
 });
 lineReader.once('line', handleRequest);
 
 async function handleRequest(data: Buffer) {
   try {
     // Test the health of the service by responding to "ping" with "pong".
-    if (data.toString() === "ping") {
-      process.stdout.write("pong\n");
+    if (data.toString() === 'ping') {
+      process.stdout.write('pong\n');
       lineReader.once('line', handleRequest);
       return;
     }
-    const { constraintCode, missionModelGeneratedCode } = JSON.parse(data.toString()) as { constraintCode: string, missionModelGeneratedCode: string };
+    const { constraintCode, missionModelGeneratedCode } = JSON.parse(data.toString()) as {
+      constraintCode: string;
+      missionModelGeneratedCode: string;
+    };
 
-    const result = await codeRunner.executeUserCode<[], Constraint>(
-        constraintCode,
-        [],
-        'Constraint',
-        [],
-        10000,
-        [
-          ts.createSourceFile('constraints-ast.ts', constraintsAST, ts.ScriptTarget.ESNext),
-          ts.createSourceFile('constraints-edsl-fluent-api.ts', constraintsEDSL, ts.ScriptTarget.ESNext),
-          ts.createSourceFile('mission-model-generated-code.ts', missionModelGeneratedCode, ts.ScriptTarget.ESNext),
-        ],
-    );
+    const result = await codeRunner.executeUserCode<[], Constraint>(constraintCode, [], 'Constraint', [], 10000, [
+      ts.createSourceFile('constraints-ast.ts', constraintsAST, ts.ScriptTarget.ESNext),
+      ts.createSourceFile('constraints-edsl-fluent-api.ts', constraintsEDSL, ts.ScriptTarget.ESNext),
+      ts.createSourceFile('mission-model-generated-code.ts', missionModelGeneratedCode, ts.ScriptTarget.ESNext),
+    ]);
 
     if (result.isErr()) {
       process.stdout.write('error\n' + JSON.stringify(result.unwrapErr().map(err => err.toJSON())) + '\n');
@@ -55,7 +57,9 @@ async function handleRequest(data: Buffer) {
     }
     process.stdout.write('success\n' + stringified + '\n');
   } catch (error: any) {
-    process.stdout.write('panic\n' + JSON.stringify(error.stack ?? error.message) + " attempted to handle: " + data.toString() + '\n');
+    process.stdout.write(
+      'panic\n' + JSON.stringify(error.stack ?? error.message) + ' attempted to handle: ' + data.toString() + '\n',
+    );
   }
   lineReader.once('line', handleRequest);
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -113,7 +113,7 @@ public final class MerlinBindings implements Plugin {
     } catch (final InvalidEntityException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
-      ctx.status(404);
+      ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
     }
   }
 
@@ -127,7 +127,7 @@ public final class MerlinBindings implements Plugin {
     } catch (final InvalidEntityException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
-      ctx.status(404);
+      ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
     }
   }
 
@@ -143,7 +143,7 @@ public final class MerlinBindings implements Plugin {
     } catch (final InvalidEntityException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
-      ctx.status(404);
+      ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
     }
   }
 
@@ -183,7 +183,7 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400)
          .result(ResponseSerializers.serializeFailures(List.of(ex.getMessage())).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
-      ctx.status(404);
+      ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
     } catch (final InvalidJsonException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     } catch (final InvalidEntityException ex) {
@@ -201,7 +201,7 @@ public final class MerlinBindings implements Plugin {
 
       ctx.result(ResponseSerializers.serializeFailures(failures).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
-      ctx.status(404);
+      ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
     } catch (final MissionModelService.UnconfigurableMissionModelException | MissionModelService.UnconstructableMissionModelConfigurationException ex) {
       ctx.status(400)
          .result(ResponseSerializers.serializeFailures(List.of(ex.getMessage())).toString());
@@ -227,7 +227,7 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400)
          .result(ResponseSerializers.serializeFailures(List.of(ex.getMessage())).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
-      ctx.status(404);
+      ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
     } catch (final InvalidJsonException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     } catch (final InvalidEntityException ex) {
@@ -255,7 +255,7 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400)
          .result(ResponseSerializers.serializeFailures(List.of(ex.getMessage())).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
-      ctx.status(404);
+      ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
     } catch (final InvalidJsonException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     } catch (final InvalidEntityException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -161,6 +161,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     } catch (final NoSuchPlanException ex) {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchPlanException(ex).toString());
+    } catch (final MissionModelService.NoSuchMissionModelException ex) {
+      ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
     }
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -18,6 +18,7 @@ import gov.nasa.jpl.aerie.merlin.server.models.MissionModelFacade;
 import gov.nasa.jpl.aerie.merlin.server.remotes.MissionModelAccessException;
 import gov.nasa.jpl.aerie.merlin.server.services.GetSimulationResultsAction;
 import gov.nasa.jpl.aerie.merlin.server.services.LocalMissionModelService;
+import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService;
 import gov.nasa.jpl.aerie.merlin.server.services.UnexpectedSubtypeError;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
@@ -404,7 +405,15 @@ public final class ResponseSerializers {
         .build();
   }
 
-  private static final class ValueSchemaSerializer implements ValueSchema.Visitor<JsonValue> {
+  public static JsonValue serializeNoSuchMissionModelException(final MissionModelService.NoSuchMissionModelException ex) {
+    // TODO: Improve diagnostic information
+    return Json.createObjectBuilder()
+               .add("message", "no such mission model")
+               .build();
+  }
+
+
+    private static final class ValueSchemaSerializer implements ValueSchema.Visitor<JsonValue> {
     @Override
     public JsonValue onReal() {
       return Json

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
@@ -77,7 +77,7 @@ public class ConstraintsDSLCompilationService {
           try {
             yield new ConstraintsDSLCompilationResult.Error(parseJson(output, ConstraintsCompilationError.constraintsErrorJsonP));
           } catch (InvalidJsonException | InvalidEntityException e) {
-            throw new Error("Could not parse JSON returned from typescript: ", e);
+            throw new Error("Could not parse JSON returned from typescript: " + output, e);
           }
         }
         case "success" -> {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
@@ -50,9 +50,10 @@ public class ConstraintsDSLCompilationService {
   /**
    * NOTE: This method is not re-entrant (assumes only one call to this method is running at any given time)
    */
-  public ConstraintsDSLCompilationResult compileConstraintsDSL(final PlanId planId, final String constraintTypescript)
+  public ConstraintsDSLCompilationResult compileConstraintsDSL(final String missionModelId, final String constraintTypescript)
+  throws MissionModelService.NoSuchMissionModelException
   {
-    final var missionModelGeneratedCode = JSONObject.quote(this.typescriptCodeGenerationService.generateTypescriptTypesForPlan(planId));
+    final var missionModelGeneratedCode = JSONObject.quote(this.typescriptCodeGenerationService.generateTypescriptTypesFromMissionModel(missionModelId));
 
     /*
      * PROTOCOL:

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GenerateConstraintsLibAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GenerateConstraintsLibAction.java
@@ -31,12 +31,12 @@ public record GenerateConstraintsLibAction(TypescriptCodeGenerationService types
       final var constraintsDslCompilerRoot = System.getenv("CONSTRAINTS_DSL_COMPILER_ROOT");
       final var constraintsApi = Files.readString(Paths.get(constraintsDslCompilerRoot, "src", "libs", "constraints-edsl-fluent-api.ts"));
       final var constraintsAst = Files.readString(Paths.get(constraintsDslCompilerRoot, "src", "libs", "constraints-ast.ts"));
-      final var generated = TypescriptCodeGenerationService.generateTypescriptTypesFromMissionModel();
+      final var generated = typescriptCodeGenerationService.generateTypescriptTypesFromMissionModel(missionModelId);
       return new Response.Success(
           Map.of("constraints-edsl-fluent-api.ts", constraintsApi,
                  "mission-model-generated-code.ts", generated,
                  "constraints-ast.ts", constraintsAst));
-    } catch (IOException e) {
+    } catch (MissionModelService.NoSuchMissionModelException | IOException e) {
       return new Response.Failure(e.getMessage());
     }
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -55,7 +55,7 @@ public final class GetSimulationResultsAction {
     this.useNewConstraintPipeline = useNewConstraintPipeline;
   }
 
-  public Response run(final PlanId planId) throws NoSuchPlanException {
+  public Response run(final PlanId planId) throws NoSuchPlanException, MissionModelService.NoSuchMissionModelException {
     final var revisionData = this.planService.getPlanRevisionData(planId);
 
     final var response = this.simulationService.getSimulationResults(planId, revisionData);
@@ -77,7 +77,7 @@ public final class GetSimulationResultsAction {
   }
 
   public Map<String, List<Violation>> getViolations(final PlanId planId, final SimulationResults results)
-  throws NoSuchPlanException
+  throws NoSuchPlanException, MissionModelService.NoSuchMissionModelException
   {
     final var plan = this.planService.getPlan(planId);
 
@@ -172,7 +172,7 @@ public final class GetSimulationResultsAction {
 
         // TODO: cache these results
         final var constraintCompilationResult = constraintsDSLCompilationService.compileConstraintsDSL(
-            planId,
+            plan.missionModelId,
             constraint.definition()
         );
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
@@ -40,7 +40,7 @@ public final class TypescriptCodeGenerationService {
 
     result.add("export type RealResourceName = " + String.join(
         " | ",
-        resources.entrySet().stream().filter($ -> valueSchemaIsReal($.getValue())).map($ -> ("\"" + $.getKey() + "\"")).toList()
+        resources.entrySet().stream().filter($ -> valueSchemaIsNumeric($.getValue())).map($ -> ("\"" + $.getKey() + "\"")).toList()
     ) + ";");
 
     // ActivityParameters
@@ -247,7 +247,7 @@ public final class TypescriptCodeGenerationService {
     }
   }
 
-  private static boolean valueSchemaIsReal(final ValueSchema valueSchema) {
+  private static boolean valueSchemaIsNumeric(final ValueSchema valueSchema) {
     return valueSchema.match(new ValueSchema.DefaultVisitor<>() {
       @Override
       protected Boolean onDefault() {
@@ -256,6 +256,11 @@ public final class TypescriptCodeGenerationService {
 
       @Override
       public Boolean onReal() {
+        return true;
+      }
+
+      @Override
+      public Boolean onInt() {
         return true;
       }
     });

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
@@ -106,18 +106,27 @@ public final class TypescriptCodeGenerationService {
 
     result.add(indent("""
                           }
+                          /**
+                           * Produces a window for the duration of the activity.
+                           */
                           public during(): Windows {
                             return new Windows({
                               kind: AST.NodeKind.WindowsExpressionDuring,
                               alias: this.__alias
                             });
                           }
+                          /**
+                           * Produces an instantaneous window at the start of the activity.
+                           */
                           public start(): Windows {
                             return new Windows({
                               kind: AST.NodeKind.WindowsExpressionStartOf,
                               alias: this.__alias
                             });
                           }
+                          /**
+                           * Produces an instantaneous window at the end of the activity.
+                           */
                           public end(): Windows {
                             return new Windows({
                               kind: AST.NodeKind.WindowsExpressionEndOf,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
@@ -16,10 +16,15 @@ public final class TypescriptCodeGenerationService {
   {
     final var activityTypes = this.missionModelService.getActivityTypes(missionModelId);
 
-
-
     final var result = new ArrayList<String>();
     result.add("/** Start Codegen */");
+
+    result.add("type ActivityTypeName =");
+    for (String activityType: activityTypes.keySet()) {
+      result.add(indent("| \"" + activityType + "\""));
+    }
+    result.add(indent(";"));
+
     result.add("/** End Codegen */");
     return joinLines(result);
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
@@ -36,7 +36,7 @@ public final class TypescriptCodeGenerationService {
     for (var resource: resources.keySet()) {
       result.add(indent("R extends \"" + resource + "\" ? " + valueSchemaToTypescript(resources.get(resource)) + " :"));
     }
-    result.add(indent("void;"));
+    result.add(indent("never;"));
 
     result.add("export type RealResourceName = " + String.join(
         " | ",
@@ -58,7 +58,7 @@ public final class TypescriptCodeGenerationService {
       parameterSchema.append("}");
       result.add(indent("A extends \"" + activityType + "\" ? " + parameterSchema + " :"));
     }
-    result.add(indent("void;"));
+    result.add(indent("never;"));
 
     // ActivityInstance
 
@@ -77,7 +77,7 @@ public final class TypescriptCodeGenerationService {
                           }
                           public get parameters(): ActivityParameters<A> {"""));
 
-    result.add(indent(indent("return (")));
+    result.add(indent(indent("let result = (")));
     for (String activityType: activityTypes.keySet()) {
       final var profileObject = new StringBuilder("{");
       for (var parameter: activityTypes.get(activityType).parameters()) {
@@ -103,6 +103,12 @@ public final class TypescriptCodeGenerationService {
       result.add(indent(indent(indent("this.__activityType === \"" + activityType + "\" ? " + profileObject + " :"))));
     }
     result.add(indent(indent(indent("undefined) as ActivityParameters<A>;"))));
+    result.add(indent(indent("""
+                                 if (result === undefined) {
+                                   throw new TypeError("Unreachable state. Activity type was unexpected string in ActivityInstance.parameters(): " + this.__activityType);
+                                 } else {
+                                   return result;
+                                 }""")));
 
     result.add(indent("""
                           }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
@@ -115,7 +115,7 @@ public final class TypescriptCodeGenerationService {
                           /**
                            * Produces a window for the duration of the activity.
                            */
-                          public during(): Windows {
+                          public window(): Windows {
                             return new Windows({
                               kind: AST.NodeKind.WindowsExpressionDuring,
                               alias: this.__alias

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
@@ -1,25 +1,23 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
-import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
 
-public class TypescriptCodeGenerationService {
-  public record ActivityType(String name, Map<String, ValueSchema> parameters) {}
-  public record ResourceType(String name, String type, ValueSchema schema) {}
-  public record MissionModelTypes(Collection<ActivityType> activityTypes, Collection<ResourceType> resourceTypes) {}
+public final class TypescriptCodeGenerationService {
+  private final MissionModelService missionModelService;
 
-  public TypescriptCodeGenerationService() {}
-
-  public String generateTypescriptTypesForPlan(final PlanId planId) {
-    return generateTypescriptTypesFromMissionModel();
+  public TypescriptCodeGenerationService(final MissionModelService missionModelService) {
+    this.missionModelService = missionModelService;
   }
 
-  public static String generateTypescriptTypesFromMissionModel() {
+  public String generateTypescriptTypesFromMissionModel(final String missionModelId)
+  throws MissionModelService.NoSuchMissionModelException
+  {
+    final var activityTypes = this.missionModelService.getActivityTypes(missionModelId);
+
+
+
     final var result = new ArrayList<String>();
     result.add("/** Start Codegen */");
     result.add("/** End Codegen */");

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationService.java
@@ -3,6 +3,8 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public final class TypescriptCodeGenerationService {
   private final MissionModelService missionModelService;
@@ -15,15 +17,37 @@ public final class TypescriptCodeGenerationService {
   throws MissionModelService.NoSuchMissionModelException
   {
     final var activityTypes = this.missionModelService.getActivityTypes(missionModelId);
+    final var resources = this.missionModelService.getStatesSchemas(missionModelId);
 
     final var result = new ArrayList<String>();
     result.add("/** Start Codegen */");
 
-    result.add("type ActivityTypeName =");
+    result.add("export type ActivityTypeName =");
     for (String activityType: activityTypes.keySet()) {
       result.add(indent("| \"" + activityType + "\""));
     }
     result.add(indent(";"));
+
+    result.add("export type ResourceName = " + String.join(" | ", resources.keySet().stream().map($ -> "\"" + $ + "\"").toList()) + ";");
+    result.add("export type DiscreteResourceSchema<R extends ResourceName> =");
+    for (var resource: resources.keySet()) {
+      result.add(indent("R extends \"" + resource + "\" ? " + valueSchemaToTypescript(resources.get(resource)) + " :"));
+    }
+    result.add(indent("void;"));
+
+    result.add("export function discreteResourceSchemaDummyValue<R extends ResourceName>(resource: R): DiscreteResourceSchema<R> {");
+    result.add(indent("return ("));
+    for (var resource: resources.keySet()) {
+      result.add(indent(indent("resource === \"" + resource + "\" ? " + valueSchemaToTypescriptDefault(resources.get(resource)) + " :")));
+    }
+    result.add(indent(indent("undefined")));
+    result.add(indent(") as DiscreteResourceSchema<R>;"));
+    result.add("}");
+
+    result.add("export type RealResourceName = " + String.join(
+        " | ",
+        resources.entrySet().stream().filter($ -> valueSchemaIsReal($.getValue())).map($ -> ("\"" + $.getKey() + "\"")).toList()
+    ) + ";");
 
     result.add("/** End Codegen */");
     return joinLines(result);
@@ -35,5 +59,99 @@ public final class TypescriptCodeGenerationService {
 
   private static String indent(final String s) {
     return joinLines(s.lines().map(line -> "  " + line).toList());
+  }
+
+
+  private static String valueSchemaToTypescript(final ValueSchema valueSchema) {
+    return valueSchema.match(new ValueSchema.Visitor<>() {
+      @Override
+      public String onReal() {
+        return "number";
+      }
+
+      @Override
+      public String onInt() {
+        return "number";
+      }
+
+      @Override
+      public String onBoolean() {
+        return "boolean";
+      }
+
+      @Override
+      public String onString() {
+        return "string";
+      }
+
+      @Override
+      public String onDuration() {
+        return "Duration";
+      }
+
+      @Override
+      public String onPath() {
+        return "string";
+      }
+
+      @Override
+      public String onSeries(final ValueSchema value) {
+        return valueSchemaToTypescript(value) + "[]";
+      }
+
+      @Override
+      public String onStruct(final Map<String, ValueSchema> values) {
+        final var result = new StringBuilder("{");
+
+        for (final var member: values.keySet()) {
+          result
+              .append(member)
+              .append(": ")
+              .append(valueSchemaToTypescript(values.get(member)))
+              .append(", ");
+        }
+
+        result.append("}");
+        return result.toString();
+      }
+
+      @Override
+      public String onVariant(final List<ValueSchema.Variant> variants) {
+        final var result = new StringBuilder("(");
+
+        for (final var variant: variants) {
+          result
+              .append(" | \"")
+              .append(variant.label())
+              .append("\"");
+        }
+
+        result.append(")");
+        return result.toString();
+      }
+    });
+  }
+
+  private static String valueSchemaToTypescriptProfile(final ValueSchema valueSchema) {
+    var basicTypescript = valueSchemaToTypescript(valueSchema);
+    if (basicTypescript.equals("number")) {
+      return "Real";
+    } else {
+      return "Discrete<" + basicTypescript + ">";
+    }
+  }
+
+  private static boolean valueSchemaIsReal(final ValueSchema valueSchema) {
+    return valueSchema.match(new ValueSchema.DefaultVisitor<>() {
+      @Override
+      protected Boolean onDefault() {
+        return false;
+      }
+
+      @Override
+      public Boolean onReal() {
+        return true;
+      }
+    });
   }
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/DevAppDriver.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/DevAppDriver.java
@@ -28,7 +28,7 @@ public final class DevAppDriver {
     final var missionModelController = new LocalMissionModelService(Path.of("/dev/null"), new InMemoryMissionModelRepository());
     final var planController = new LocalPlanService(fixtures.planRepository);
 
-    final var typescriptCodeGenerationService = new TypescriptCodeGenerationService();
+    final var typescriptCodeGenerationService = new TypescriptCodeGenerationService(missionModelController);
 
     final ConstraintsDSLCompilationService constraintsDSLCompilationService;
     try {

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindingsTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindingsTest.java
@@ -41,7 +41,7 @@ public final class MerlinBindingsTest {
     final var planApp = new StubPlanService();
     final var missionModelApp = new StubMissionModelService();
 
-    final var typescriptCodeGenerationService = new TypescriptCodeGenerationService();
+    final var typescriptCodeGenerationService = new TypescriptCodeGenerationService(missionModelApp);
 
     final ConstraintsDSLCompilationService constraintsDSLCompilationService;
     try {

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -34,7 +34,7 @@ public final class StubMissionModelService implements MissionModelService {
   public static final String NONEXISTENT_ACTIVITY_TYPE = "no-activity";
   public static final ActivityType EXISTENT_ACTIVITY = new ActivityType(
       EXISTENT_ACTIVITY_TYPE,
-      List.of(new Parameter("Param", ValueSchema.STRING)),
+      List.of(new Parameter("Param", ValueSchema.STRING), new Parameter("AnotherParam", ValueSchema.REAL)),
       List.of(),
       new EnumValueMapper<>(Unit.class).getValueSchema());
 

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -81,6 +81,7 @@ public final class StubMissionModelService implements MissionModelService {
         new ValueSchema.Variant("Option2", "Option2")
     )));
     RESOURCES.put("state of charge", ValueSchema.REAL);
+    RESOURCES.put("an integer", ValueSchema.INT);
   }
 
   @Override

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -19,6 +19,7 @@ import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -50,6 +51,8 @@ public final class StubMissionModelService implements MissionModelService {
       NONEXISTENT_ACTIVITY_TYPE,
       Map.of());
 
+  public static final Map<String, ValueSchema> RESOURCES;
+
   public static final List<String> NO_SUCH_ACTIVITY_TYPE_FAILURES = List.of("no such activity type");
   public static final List<String> INVALID_ACTIVITY_INSTANCE_FAILURES = List.of("just wrong");
   public static final List<String> UNCONSTRUCTABLE_ACTIVITY_INSTANCE_FAILURES = List.of(
@@ -71,6 +74,13 @@ public final class StubMissionModelService implements MissionModelService {
     EXISTENT_MISSION_MODEL.mission = "mission";
     EXISTENT_MISSION_MODEL.owner = "Tester";
     EXISTENT_MISSION_MODEL.path = Path.of("existent-missionModel");
+
+    RESOURCES = new LinkedHashMap<>();
+    RESOURCES.put("mode", ValueSchema.ofVariant(List.of(
+        new ValueSchema.Variant("Option1", "Option1"),
+        new ValueSchema.Variant("Option2", "Option2")
+    )));
+    RESOURCES.put("state of charge", ValueSchema.REAL);
   }
 
   @Override
@@ -98,7 +108,7 @@ public final class StubMissionModelService implements MissionModelService {
       throw new NoSuchMissionModelException(missionModelId);
     }
 
-    return Map.of();
+    return RESOURCES;
   }
 
   @Override

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -366,10 +366,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
         export default () => {
-          return Real.Resource("state of charge").notEqual(Real.Value(-1));
+          return Real.Resource("an integer").notEqual(Real.Value(-1));
         }
         """,
-        new ViolationsOf(new NotEqual<>(new RealResource("state of charge"), new RealValue(-1.0)))
+        new ViolationsOf(new NotEqual<>(new RealResource("an integer"), new RealValue(-1.0)))
     );
   }
 
@@ -634,7 +634,7 @@ class ConstraintsDSLCompilationServiceTests {
           return Real.Resource("mode").changed()
         }
         """,
-        "TypeError: TS2345 Argument of type '\"mode\"' is not assignable to parameter of type '\"state of charge\"'."
+        "TypeError: TS2345 Argument of type '\"mode\"' is not assignable to parameter of type 'RealResourceName'."
     );
   }
 

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -61,14 +61,14 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
       """
         export default function myConstraint() {
-          return times2(Real.Resource("my_resource")).changed()
+          return times2(Real.Resource("state of charge")).changed()
         }
         function times2(e: Real): Real {
           return e.times(2)
         }
       """,
       new ViolationsOf(
-          new Changed<>(new ProfileExpression<>(new Times(new RealResource("my_resource"), 2.0)))
+          new Changed<>(new ProfileExpression<>(new Times(new RealResource("state of charge"), 2.0)))
       )
     );
   }
@@ -79,7 +79,7 @@ class ConstraintsDSLCompilationServiceTests {
         """
           export default function myConstraint() {
             const x = 5;
-            return times2(Real.Resource("my_resource")).changed()
+            return times2(Real.Resource("mode")).changed()
           }
           function times2(e: Real): Real {
             return e.times(x)
@@ -94,7 +94,7 @@ class ConstraintsDSLCompilationServiceTests {
     checkFailedCompilation(
         """
           export default function myConstraint() {
-             return Real.Resource("my_resource");
+             return Real.Resource("state of charge");
           }
         """,
         "TypeError: TS2322 Incorrect return type. Expected: 'Constraint', Actual: 'Real'."
@@ -108,10 +108,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
             export default () => {
-              return Discrete.Resource("my_resource").changed();
+              return Discrete.Resource("mode").changed();
             }
         """,
-        new ViolationsOf(new Changed<>(new ProfileExpression<>(new DiscreteResource("my_resource"))))
+        new ViolationsOf(new Changed<>(new ProfileExpression<>(new DiscreteResource("mode"))))
     );
   }
 
@@ -144,14 +144,14 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
             export default () => {
-              return Discrete.Resource("my_resource").transition("from one state", "to another");
+              return Discrete.Resource("mode").transition("Option1", "Option2");
             }
         """,
         new ViolationsOf(
             new Transition(
-                new DiscreteResource("my_resource"),
-                SerializedValue.of("from one state"),
-                SerializedValue.of("to another")
+                new DiscreteResource("mode"),
+                SerializedValue.of("Option1"),
+                SerializedValue.of("Option2")
             )
         )
     );
@@ -162,10 +162,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkFailedCompilation(
         """
           export default () => {
-            return Discrete.Resource("my_resource").transition("from one state", 5);
+            return Discrete.Resource("mode").transition("something else", 5);
           }
         """,
-        "TS2345 Argument of type 'number' is not assignable to parameter of type 'string'."
+        "TS2345 Argument of type '\"something else\"' is not assignable to parameter of type '\"Option1\" | \"Option2\"'."
     );
   }
 
@@ -174,10 +174,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
         export default () => {
-          return Discrete.Resource("my_resource").equal(Discrete.Value("hello there"));
+          return Discrete.Resource("mode").equal("Option2");
         }
         """,
-        new ViolationsOf(new Equal<>(new DiscreteResource("my_resource"), new DiscreteValue(SerializedValue.of("hello there"))))
+        new ViolationsOf(new Equal<>(new DiscreteResource("mode"), new DiscreteValue(SerializedValue.of("Option2"))))
     );
   }
 
@@ -186,10 +186,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
         export default () => {
-          return Discrete.Resource("my_resource").notEqual(Discrete.Value("hello there"));
+          return Discrete.Resource("state of charge").notEqual(4.0);
         }
         """,
-        new ViolationsOf(new NotEqual<>(new DiscreteResource("my_resource"), new DiscreteValue(SerializedValue.of("hello there"))))
+        new ViolationsOf(new NotEqual<>(new DiscreteResource("state of charge"), new DiscreteValue(SerializedValue.of(4.0))))
     );
   }
 
@@ -210,10 +210,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
           export default () => {
-            return Discrete.Resource("my_resource").equal("some value")
+            return Discrete.Resource("mode").equal("Option1")
           }
         """,
-        new ViolationsOf(new Equal<>(new DiscreteResource("my_resource"), new DiscreteValue(SerializedValue.of("some value"))))
+        new ViolationsOf(new Equal<>(new DiscreteResource("mode"), new DiscreteValue(SerializedValue.of("Option1"))))
     );
   }
 
@@ -224,10 +224,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
             export default () => {
-              return Real.Resource("my_resource").changed();
+              return Real.Resource("state of charge").changed();
             }
         """,
-        new ViolationsOf(new Changed<>(new ProfileExpression<>(new RealResource("my_resource"))))
+        new ViolationsOf(new Changed<>(new ProfileExpression<>(new RealResource("state of charge"))))
     );
   }
 
@@ -260,10 +260,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
             export default() => {
-              return Real.Resource("my_resource").rate().equal(Real.Value(4.0))
+              return Real.Resource("state of charge").rate().equal(Real.Value(4.0))
             }
         """,
-        new ViolationsOf(new Equal<>(new Rate(new RealResource("my_resource")), new RealValue(4.0)))
+        new ViolationsOf(new Equal<>(new Rate(new RealResource("state of charge")), new RealValue(4.0)))
     );
   }
 
@@ -272,10 +272,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
             export default() => {
-              return Real.Resource("my_resource").times(2).equal(Real.Value(4.0))
+              return Real.Resource("state of charge").times(2).equal(Real.Value(4.0))
             }
         """,
-        new ViolationsOf(new Equal<>(new Times(new RealResource("my_resource"), 2.0), new RealValue(4.0)))
+        new ViolationsOf(new Equal<>(new Times(new RealResource("state of charge"), 2.0), new RealValue(4.0)))
     );
   }
 
@@ -284,10 +284,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
             export default() => {
-              return Real.Resource("my_resource").plus(Real.Value(2.0)).equal(Real.Value(4.0))
+              return Real.Resource("state of charge").plus(Real.Value(2.0)).equal(Real.Value(4.0))
             }
         """,
-        new ViolationsOf(new Equal<>(new Plus(new RealResource("my_resource"), new RealValue(2.0)), new RealValue(4.0)))
+        new ViolationsOf(new Equal<>(new Plus(new RealResource("state of charge"), new RealValue(2.0)), new RealValue(4.0)))
     );
   }
 
@@ -296,10 +296,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
             export default() => {
-              return Real.Resource("my_resource").lessThan(Real.Value(2.0))
+              return Real.Resource("state of charge").lessThan(Real.Value(2.0))
             }
         """,
-        new ViolationsOf(new LessThan(new RealResource("my_resource"), new RealValue(2.0)))
+        new ViolationsOf(new LessThan(new RealResource("state of charge"), new RealValue(2.0)))
     );
   }
 
@@ -308,10 +308,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
             export default() => {
-              return Real.Resource("my_resource").lessThanOrEqual(Real.Value(2.0))
+              return Real.Resource("state of charge").lessThanOrEqual(Real.Value(2.0))
             }
         """,
-        new ViolationsOf(new LessThanOrEqual(new RealResource("my_resource"), new RealValue(2.0)))
+        new ViolationsOf(new LessThanOrEqual(new RealResource("state of charge"), new RealValue(2.0)))
     );
   }
 
@@ -320,10 +320,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
             export default() => {
-              return Real.Resource("my_resource").greaterThan(Real.Value(2.0))
+              return Real.Resource("state of charge").greaterThan(Real.Value(2.0))
             }
         """,
-        new ViolationsOf(new GreaterThan(new RealResource("my_resource"), new RealValue(2.0)))
+        new ViolationsOf(new GreaterThan(new RealResource("state of charge"), new RealValue(2.0)))
     );
   }
 
@@ -332,10 +332,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
             export default() => {
-              return Real.Resource("my_resource").greaterThanOrEqual(Real.Value(2.0))
+              return Real.Resource("state of charge").greaterThanOrEqual(Real.Value(2.0))
             }
         """,
-        new ViolationsOf(new GreaterThanOrEqual(new RealResource("my_resource"), new RealValue(2.0)))
+        new ViolationsOf(new GreaterThanOrEqual(new RealResource("state of charge"), new RealValue(2.0)))
     );
   }
 
@@ -344,10 +344,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
         export default () => {
-          return Real.Resource("my_resource").equal(Real.Value(-1));
+          return Real.Resource("state of charge").equal(Real.Value(-1));
         }
         """,
-        new ViolationsOf(new Equal<>(new RealResource("my_resource"), new RealValue(-1.0)))
+        new ViolationsOf(new Equal<>(new RealResource("state of charge"), new RealValue(-1.0)))
     );
   }
 
@@ -356,10 +356,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
         export default () => {
-          return Real.Resource("my_resource").notEqual(Real.Value(-1));
+          return Real.Resource("state of charge").notEqual(Real.Value(-1));
         }
         """,
-        new ViolationsOf(new NotEqual<>(new RealResource("my_resource"), new RealValue(-1.0)))
+        new ViolationsOf(new NotEqual<>(new RealResource("state of charge"), new RealValue(-1.0)))
     );
   }
 
@@ -436,16 +436,16 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
           export default () => {
-            return Real.Resource("my_real_resource").lessThan(2)
-              .if(Discrete.Resource("my_discrete_resource").changed());
+            return Real.Resource("state of charge").lessThan(2)
+              .if(Discrete.Resource("mode").changed());
           }
         """,
         new ViolationsOf(
             new Or(
                 new Not(new Changed<>(
-                    new ProfileExpression<>(new DiscreteResource("my_discrete_resource"))
+                    new ProfileExpression<>(new DiscreteResource("mode"))
                 )),
-                new LessThan(new RealResource("my_real_resource"), new RealValue(2.0))
+                new LessThan(new RealResource("state of charge"), new RealValue(2.0))
             )
         )
     );
@@ -457,7 +457,7 @@ class ConstraintsDSLCompilationServiceTests {
         """
           export default () => {
             return Windows.All(
-              Real.Resource("my_resource").lessThan(2),
+              Real.Resource("state of charge").lessThan(2),
               Discrete.Value("hello there").notEqual(Discrete.Value("hello there")),
               Real.Value(5).changed()
             );
@@ -466,7 +466,7 @@ class ConstraintsDSLCompilationServiceTests {
         new ViolationsOf(
             new And(
                 java.util.List.of(
-                    new LessThan(new RealResource("my_resource"), new RealValue(2.0)),
+                    new LessThan(new RealResource("state of charge"), new RealValue(2.0)),
                     new NotEqual<>(new DiscreteValue(SerializedValue.of("hello there")), new DiscreteValue(SerializedValue.of("hello there"))),
                     new Changed<>(new ProfileExpression<>(new RealValue(5.0)))
                 )
@@ -481,7 +481,7 @@ class ConstraintsDSLCompilationServiceTests {
         """
           export default () => {
             return Windows.Any(
-              Real.Resource("my_resource").lessThan(2),
+              Real.Resource("state of charge").lessThan(2),
               Discrete.Value("hello there").notEqual(Discrete.Value("hello there")),
               Real.Value(5).changed()
             );
@@ -490,7 +490,7 @@ class ConstraintsDSLCompilationServiceTests {
         new ViolationsOf(
             new Or(
                 java.util.List.of(
-                    new LessThan(new RealResource("my_resource"), new RealValue(2.0)),
+                    new LessThan(new RealResource("state of charge"), new RealValue(2.0)),
                     new NotEqual<>(new DiscreteValue(SerializedValue.of("hello there")), new DiscreteValue(SerializedValue.of("hello there"))),
                     new Changed<>(new ProfileExpression<>(new RealValue(5.0)))
                 )
@@ -504,12 +504,12 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
           export default () => {
-            return Discrete.Resource("my_resource").changed().not()
+            return Discrete.Resource("mode").changed().not()
           }
         """,
         new ViolationsOf(
             new Not(
-                new Changed<>(new ProfileExpression<>(new DiscreteResource("my_resource")))
+                new Changed<>(new ProfileExpression<>(new DiscreteResource("mode")))
             )
         )
     );
@@ -520,10 +520,10 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
         export default () => {
-          return Real.Resource("my_resource").equal(Real.Value(-1)).violations();
+          return Real.Resource("state of charge").equal(Real.Value(-1)).violations();
         }
         """,
-        new ViolationsOf(new Equal<>(new RealResource("my_resource"), new RealValue(-1.0)))
+        new ViolationsOf(new Equal<>(new RealResource("state of charge"), new RealValue(-1.0)))
     );
   }
 

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -132,7 +132,7 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
             export default () => Constraint.ForEachActivity(
-              "activity",
+              ActivityType.activity,
               (instance) => instance.parameters.Param.changed()
             )
         """,
@@ -253,7 +253,7 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
             export default () => Constraint.ForEachActivity(
-              "activity",
+              ActivityType.activity,
               (instance) => instance.parameters.AnotherParam.changed()
             )
         """,
@@ -404,7 +404,7 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
           export default () => {
-            return Constraint.ForEachActivity("activity", (alias) => alias.during());
+            return Constraint.ForEachActivity(ActivityType.activity, (alias) => alias.during());
           }
         """,
         new ForEachActivity("activity", "activity alias 0", new ViolationsOf(new During("activity alias 0")))
@@ -416,7 +416,7 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
           export default () => {
-            return Constraint.ForEachActivity("activity", (alias) => alias.start());
+            return Constraint.ForEachActivity(ActivityType.activity, (alias) => alias.start());
           }
         """,
         new ForEachActivity("activity", "activity alias 0", new ViolationsOf(new StartOf("activity alias 0")))
@@ -428,7 +428,7 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
           export default () => {
-            return Constraint.ForEachActivity("activity", (alias) => alias.end());
+            return Constraint.ForEachActivity(ActivityType.activity, (alias) => alias.end());
           }
         """,
         new ForEachActivity("activity", "activity alias 0", new ViolationsOf(new EndOf("activity alias 0")))
@@ -538,7 +538,7 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
         export default () => {
-          return Constraint.ForbiddenActivityOverlap("activity", "activity")
+          return Constraint.ForbiddenActivityOverlap(ActivityType.activity, ActivityType.activity)
         }
         """,
         new ForbiddenActivityOverlap("activity", "activity")
@@ -551,7 +551,7 @@ class ConstraintsDSLCompilationServiceTests {
         """
         export default () => {
           return Constraint.ForEachActivity(
-            "activity",
+            ActivityType.activity,
             (myAlias) => myAlias.during()
           )
         }
@@ -564,12 +564,12 @@ class ConstraintsDSLCompilationServiceTests {
         import * as Gen from './mission-model-generated-code.js';
         export default () => {
           return Constraint.ForEachActivity(
-            "activity",
+            ActivityType.activity,
             myHelperFunction
           )
         }
 
-        function myHelperFunction(instance: Gen.ActivityInstance<"activity">): Constraint {
+        function myHelperFunction(instance: Gen.ActivityInstance<ActivityType.activity>): Constraint {
           return instance.during();
         }
         """,
@@ -583,9 +583,9 @@ class ConstraintsDSLCompilationServiceTests {
         """
         export default () => {
           return Constraint.ForEachActivity(
-            "activity",
+            ActivityType.activity,
             (alias1) => Constraint.ForEachActivity(
-              "activity",
+              ActivityType.activity,
               (alias2) => Windows.All(alias1.during(), alias2.during())
             )
           )

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -404,7 +404,7 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
           export default () => {
-            return Constraint.ForEachActivity(ActivityType.activity, (alias) => alias.during());
+            return Constraint.ForEachActivity(ActivityType.activity, (alias) => alias.window());
           }
         """,
         new ForEachActivity("activity", "activity alias 0", new ViolationsOf(new During("activity alias 0")))
@@ -552,7 +552,7 @@ class ConstraintsDSLCompilationServiceTests {
         export default () => {
           return Constraint.ForEachActivity(
             ActivityType.activity,
-            (myAlias) => myAlias.during()
+            (myAlias) => myAlias.window()
           )
         }
         """,
@@ -570,7 +570,7 @@ class ConstraintsDSLCompilationServiceTests {
         }
 
         function myHelperFunction(instance: Gen.ActivityInstance<ActivityType.activity>): Constraint {
-          return instance.during();
+          return instance.window();
         }
         """,
         new ForEachActivity("activity", "activity alias 0", new ViolationsOf(new During("activity alias 0")))
@@ -586,7 +586,7 @@ class ConstraintsDSLCompilationServiceTests {
             ActivityType.activity,
             (alias1) => Constraint.ForEachActivity(
               ActivityType.activity,
-              (alias2) => Windows.All(alias1.during(), alias2.during())
+              (alias2) => Windows.All(alias1.window(), alias2.window())
             )
           )
         }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
@@ -19,12 +19,13 @@ class TypescriptCodeGenerationServiceTest {
            export enum ActivityType {
              activity = "activity",
            }
-           export type ResourceName = "mode" | "state of charge";
+           export type ResourceName = "mode" | "state of charge" | "an integer";
            export type DiscreteResourceSchema<R extends ResourceName> =
              R extends "mode" ? ( | "Option1" | "Option2") :
              R extends "state of charge" ? number :
+             R extends "an integer" ? number :
              never;
-           export type RealResourceName = "state of charge";
+           export type RealResourceName = "state of charge" | "an integer";
            export type ActivityParameters<A extends ActivityType> =
              A extends ActivityType.activity ? {Param: Discrete<string>, AnotherParam: Real, } :
              never;

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
@@ -14,9 +14,22 @@ class TypescriptCodeGenerationServiceTest {
     assertEquals(
         """
             /** Start Codegen */
-            type ActivityTypeName =
+            export type ActivityTypeName =
               | "activity"
               ;
+            export type ResourceName = "mode" | "state of charge";
+            export type DiscreteResourceSchema<R extends ResourceName> =
+              R extends "mode" ? ( | "Option1" | "Option2") :
+              R extends "state of charge" ? number :
+              void;
+            export function discreteResourceSchemaDummyValue<R extends ResourceName>(resource: R): DiscreteResourceSchema<R> {
+              return (
+                resource === "mode" ? "Option1" :
+                resource === "state of charge" ? 1.0 :
+                undefined
+              ) as DiscreteResourceSchema<R>;
+            }
+            export type RealResourceName = "state of charge";
             /** End Codegen */""",
         codeGenService.generateTypescriptTypesFromMissionModel("abc")
     );

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
@@ -48,7 +48,7 @@ class TypescriptCodeGenerationServiceTest {
              /**
               * Produces a window for the duration of the activity.
               */
-             public during(): Windows {
+             public window(): Windows {
                return new Windows({
                  kind: AST.NodeKind.WindowsExpressionDuring,
                  alias: this.__alias

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
@@ -74,7 +74,6 @@ class TypescriptCodeGenerationServiceTest {
              }
            }
            declare global {
-
              enum ActivityType {
                activity = "activity",
              }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
@@ -13,24 +13,76 @@ class TypescriptCodeGenerationServiceTest {
 
     assertEquals(
         """
-            /** Start Codegen */
-            export type ActivityTypeName =
-              | "activity"
-              ;
-            export type ResourceName = "mode" | "state of charge";
-            export type DiscreteResourceSchema<R extends ResourceName> =
-              R extends "mode" ? ( | "Option1" | "Option2") :
-              R extends "state of charge" ? number :
-              void;
-            export function discreteResourceSchemaDummyValue<R extends ResourceName>(resource: R): DiscreteResourceSchema<R> {
-              return (
-                resource === "mode" ? "Option1" :
-                resource === "state of charge" ? 1.0 :
-                undefined
-              ) as DiscreteResourceSchema<R>;
-            }
-            export type RealResourceName = "state of charge";
-            /** End Codegen */""",
+           /** Start Codegen */
+           import * as AST from './constraints-ast.js';
+           import { Discrete, Real, Windows } from './constraints-edsl-fluent-api.js';
+           export enum ActivityType {
+             activity = "activity",
+           }
+           export type ResourceName = "mode" | "state of charge";
+           export type DiscreteResourceSchema<R extends ResourceName> =
+             R extends "mode" ? ( | "Option1" | "Option2") :
+             R extends "state of charge" ? number :
+             never;
+           export type RealResourceName = "state of charge";
+           export type ActivityParameters<A extends ActivityType> =
+             A extends ActivityType.activity ? {Param: Discrete<string>, AnotherParam: Real, } :
+             never;
+           export class ActivityInstance<A extends ActivityType> {
+             private readonly __activityType: A;
+             private readonly __alias: string;
+             constructor(activityType: A, alias: string) {
+               this.__activityType = activityType;
+               this.__alias = alias;
+             }
+             public get parameters(): ActivityParameters<A> {
+               let result = (
+                 this.__activityType === ActivityType.activity ? {Param: new Discrete<string>({ kind: AST.NodeKind.DiscreteProfileParameter, alias: this.__alias, name: "Param"}), AnotherParam: new Real({ kind: AST.NodeKind.RealProfileParameter, alias: this.__alias, name: "AnotherParam"}), } :
+                 undefined) as ActivityParameters<A>;
+               if (result === undefined) {
+                 throw new TypeError("Unreachable state. Activity type was unexpected string in ActivityInstance.parameters(): " + this.__activityType);
+               } else {
+                 return result;
+               }
+             }
+             /**
+              * Produces a window for the duration of the activity.
+              */
+             public during(): Windows {
+               return new Windows({
+                 kind: AST.NodeKind.WindowsExpressionDuring,
+                 alias: this.__alias
+               });
+             }
+             /**
+              * Produces an instantaneous window at the start of the activity.
+              */
+             public start(): Windows {
+               return new Windows({
+                 kind: AST.NodeKind.WindowsExpressionStartOf,
+                 alias: this.__alias
+               });
+             }
+             /**
+              * Produces an instantaneous window at the end of the activity.
+              */
+             public end(): Windows {
+               return new Windows({
+                 kind: AST.NodeKind.WindowsExpressionEndOf,
+                 alias: this.__alias
+               });
+             }
+           }
+           declare global {
+
+             enum ActivityType {
+               activity = "activity",
+             }
+           }
+           Object.assign(globalThis, {
+             ActivityType
+           });
+           /** End Codegen */""",
         codeGenService.generateTypescriptTypesFromMissionModel("abc")
     );
   }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.jpl.aerie.merlin.server.mocks.StubMissionModelService;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -7,11 +8,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class TypescriptCodeGenerationServiceTest {
 
   @Test
-  void testCodeGen() {
+  void testCodeGen() throws MissionModelService.NoSuchMissionModelException {
+    final var codeGenService = new TypescriptCodeGenerationService(new StubMissionModelService());
+
     assertEquals(
         """
             /** Start Codegen */
+            type ActivityTypeName =
+              | "activity"
+              ;
             /** End Codegen */""",
-        TypescriptCodeGenerationService.generateTypescriptTypesFromMissionModel());
+        codeGenService.generateTypescriptTypesFromMissionModel("abc")
+    );
   }
 }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1842
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds type-checking for the following values in the constraints DSL:
- Activity type names
- Resource names
    - All resources, including Reals, are considered valid Discrete resources. Real resource names only accept the subset of resources that have a value schema exactly equal to `ValueSchema.REAL`.
- Activity aliases generated by `ForEachActivity` - kind of
    - Instead of enforcing that a specific string is declared and used to reference an alias, the user instead now provides a function of type `(instance: ActivityInstance<A extends ActivityTypeName>) => Constraint`. Essentially, the alias is no longer a string but a variable. (Thanks @mattdailis for the idea!)
    - Since the expression tree in the backend still expects the old string-based alias approach, `ForEachActivity` calls `.toString()` on the function handle and searches through to find the argument name. The "alias" string is set to the argument name and stored inside the `ActivityInstance` class.
    - Activity parameters are accessed through `instance.parameters().myParameter`. The `During`, `StartOf`, and `EndOf` functions are now `instance.during()`, `instance.start()` and `instance.end()`.
    - Example usage:
```typescript
// Forbids the usage of an activity type.
export default (): Constraint => Constraint.ForEachActivity(
    "activityType",
    (instance) => instance.during().not()
);
```
- Schemas for discrete profiles
    - The schemas of all discrete profiles are checked, including those from `Discrete.Resource(...)` and `instance.parameters().myDiscreteParameter`. This is done by adding a `__schemaInstance: Schema` private field to the `Discrete<Schema>` class, and populating it with an unrelated dummy default value.

## Verification
Many tests have been added and updated in `ConstraintsDSLCompilationServiceTests`.

## Documentation
The in-code docs for the constraints API have been updated.

## Future work
- In my opinion we are ready to start expanding the DSL with new features and remove the JSON version.
- Wiki tutorial
- Video demo

## Checklist

checkmark = committed

- [x] "Lets go ahead and make ActivityInstance#parameters be a getter"
- [x] "Can we make the ActivityType an enum instead of a union of strings"
- [x] "Who the heck invited this `__schemaInstance` field and how do we make it go away"
- [x] Autoformat
- [x] Bring back `once` in main.ts
- [x] squash a few commits