### PR TITLE
[AERIE-1862] Change nvm install location to /usr/src

### DIFF
--- a/merlin-server/Dockerfile
+++ b/merlin-server/Dockerfile
@@ -7,9 +7,10 @@ RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 FROM eclipse-temurin:18-focal
 
 ENV NODE_VERSION=16.14.0
-ENV NVM_DIR=/root/.nvm
-ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+ENV NVM_DIR=/usr/src/.nvm
+ENV PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin:${PATH}"
 RUN apt install --no-install-recommends -y curl \
+    && mkdir -p $NVM_DIR \
     && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash \
     &&. "$NVM_DIR/nvm.sh" \
     && nvm install -b ${NODE_VERSION} \
@@ -23,7 +24,7 @@ COPY --from=extractor /usr/src/app/extracted /usr/src/app
 COPY constraints-dsl-compiler /usr/src/app/constraints-dsl-compiler
 ENV CONSTRAINTS_DSL_COMPILER_ROOT="/usr/src/app/constraints-dsl-compiler/"
 ENV CONSTRAINTS_DSL_COMPILER_COMMAND="./build/main.js"
-ENV NODE_PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/node"
+ENV NODE_PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/node"
 
 WORKDIR /usr/src/app
 ENTRYPOINT ["/usr/src/app/bin/merlin-server"]

--- a/scheduler-server/Dockerfile
+++ b/scheduler-server/Dockerfile
@@ -7,9 +7,10 @@ RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 FROM eclipse-temurin:18-focal
 
 ENV NODE_VERSION=16.14.0
-ENV NVM_DIR=/root/.nvm
-ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+ENV NVM_DIR=/usr/src/.nvm
+ENV PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin:${PATH}"
 RUN apt install --no-install-recommends -y curl \
+    && mkdir -p $NVM_DIR \
     && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash \
     &&. "$NVM_DIR/nvm.sh" \
     && nvm install -b ${NODE_VERSION} \
@@ -23,7 +24,7 @@ COPY --from=extractor /usr/src/app/extracted /usr/src/app
 COPY scheduling-dsl-compiler /usr/src/app/scheduling-dsl-compiler
 ENV SCHEDULING_DSL_COMPILER_ROOT="/usr/src/app/scheduling-dsl-compiler/"
 ENV SCHEDULING_DSL_COMPILER_COMMAND="./build/main.js"
-ENV NODE_PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/node"
+ENV NODE_PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/node"
 
 WORKDIR /usr/src/app
 ENTRYPOINT ["/usr/src/app/bin/scheduler-server"]


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1862
* **Review:** By file  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

In the `scheduler-server` and `merlin-server` Dockerfiles, the `NVM_DIR` variable was set to `/root/.nvm`, which mean that `nvm` and `node` would be installed in subfolders of the `/root` folder. The `/root` folder is locked down so that non-root users can't access its contents. This prevents our containers from running with non-root users.

This PR changes the `NVM_DIR` to `/usr/src/.nvm` in both the `scheduler-server` and the `merlin-server`.

The original choice of `/root/.nvm` came from this stack overflow answer: https://stackoverflow.com/a/57546198

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

I'm hoping that the tests run by Github actions on this PR are sufficient to verify this hasn't broken anything. I've also verified that the `SchedulingDslCompiler` doesn't crash after setting a non-root user via the docker-compose file like so:

```
user: "12345:10100"
```


## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

If we decide to support non-root users as a use case, we could mention it in our deployment docs.

## Future work
<!-- What next steps can we anticipate from here, if any? -->

I'm not sure if we intend to support "non-root users" as a feature - if we do, it may be worth thinking about how we avoid regressions. We could set up our docker compose file to run all of our services as non-root users 🤷 
