### PR TITLE
[AERIE-1847]  Add duration filter to constraints eDSL

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
@@ -11,6 +11,7 @@ import gov.nasa.jpl.aerie.json.Iso;
 import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.json.Unit;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
 
 import java.util.List;
 
@@ -207,6 +208,26 @@ public final class ConstraintParsers {
               untuple((kind, left, right) -> new LessThan(left, right)),
               $ -> tuple(Unit.UNIT, $.left, $.right)));
 
+  static JsonParser<LongerThan> longerThanP(JsonParser<Expression<Windows>> windowsExpressionP) {
+    return productP
+            .field("kind", literalP("WindowsExpressionLongerThan"))
+            .field("windowExpression", windowsExpressionP)
+            .field("duration", durationP)
+            .map(Iso.of(
+                untuple((kind, windowsExpression, duration) -> new LongerThan(windowsExpression, duration)),
+                $ -> tuple(Unit.UNIT, $.windows, $.duration)));
+  }
+
+  static JsonParser<ShorterThan> shorterThanP(JsonParser<Expression<Windows>> windowsExpressionP) {
+    return productP
+        .field("kind", literalP("WindowsExpressionShorterThan"))
+        .field("windowExpression", windowsExpressionP)
+        .field("duration", durationP)
+        .map(Iso.of(
+            untuple((kind, windowsExpression, duration) -> new ShorterThan(windowsExpression, duration)),
+            $ -> tuple(Unit.UNIT, $.windows, $.duration)));
+  }
+
   static final JsonParser<LessThanOrEqual> lessThanOrEqualP =
       productP
           .field("kind", literalP("RealProfileLessThanOrEqual"))
@@ -288,6 +309,8 @@ public final class ConstraintParsers {
           changesP,
           lessThanP,
           lessThanOrEqualP,
+          longerThanP(selfP),
+          shorterThanP(selfP),
           greaterThanOrEqualP,
           greaterThanP,
           transitionP,

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
@@ -104,12 +104,11 @@ public final class Windows implements Iterable<Window> {
   }
 
   public Windows filterByDuration(Duration minDur, Duration maxDur){
-    Windows ret = new Windows();
-    for(var win : windows.ascendingOrder()){
-      if(win.duration().noShorterThan(minDur) && win.duration().noLongerThan(maxDur)){
-        ret.add(win);
-      }
-    }
+    final var ret = new Windows();
+    StreamSupport
+        .stream(windows.ascendingOrder().spliterator(), false)
+        .filter(win -> win.duration().noShorterThan(minDur) && win.duration().noLongerThan(maxDur))
+        .forEach(ret::add);
     return ret;
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LongerThan.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LongerThan.java
@@ -1,0 +1,56 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public final class LongerThan implements Expression<Windows> {
+  public final Expression<Windows> windows;
+  public final Duration duration;
+
+  public LongerThan(final Expression<Windows> left, final Duration duration) {
+    this.windows = left;
+    this.duration = duration;
+  }
+
+  @Override
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    final var windows = this.windows.evaluate(results, bounds, environment);
+    return windows.filterByDuration(this.duration, Duration.MAX_VALUE);
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {
+    this.windows.extractResources(names);
+  }
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return String.format(
+        "\n%s(duration-of %s larger than %s)",
+        prefix,
+        this.windows.prettyPrint(prefix + "  "),
+        this.duration.toString()
+    );
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof LongerThan)) return false;
+    final var o = (LongerThan)obj;
+
+    return Objects.equals(this.windows, o.windows) &&
+           Objects.equals(this.duration, o.duration);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.windows, this.duration);
+  }
+}

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShorterThan.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShorterThan.java
@@ -1,0 +1,56 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Window;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public final class ShorterThan implements Expression<Windows> {
+  public final Expression<Windows> windows;
+  public final Duration duration;
+
+  public ShorterThan(final Expression<Windows> left, final Duration right) {
+    this.windows = left;
+    this.duration = right;
+  }
+
+  @Override
+  public Windows evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    final var windows = this.windows.evaluate(results, bounds, environment);
+    return windows.filterByDuration(Duration.ZERO, duration);
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {
+    this.windows.extractResources(names);
+  }
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return String.format(
+        "\n%s(duration-of %s shorter than %s)",
+        prefix,
+        this.windows.prettyPrint(prefix + "  "),
+        this.duration.toString()
+    );
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof ShorterThan)) return false;
+    final var o = (ShorterThan)obj;
+
+    return Objects.equals(this.windows, o.windows) &&
+           Objects.equals(this.duration, o.duration);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.windows, this.duration);
+  }
+}

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import static gov.nasa.jpl.aerie.constraints.Assertions.assertEquivalent;
 import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Exclusive;
 import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Inclusive;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECOND;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -496,6 +497,59 @@ public class ASTTests {
     final var result = new EndOf("act").evaluate(simResults, environment);
 
     final var expected = new Windows(Window.at(8, SECONDS));
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testLongerThan() {
+    final var simResults = new SimulationResults(
+        Window.between(0, 20, SECONDS),
+        List.of(),
+        Map.of(),
+        Map.of()
+    );
+
+    final var left = new Windows();
+    left.add(Window.between(0, Inclusive, 5, Exclusive, SECONDS));
+    left.add(Window.between(6, Inclusive, 7, Inclusive, SECONDS));
+    left.add(Window.between(8, Exclusive, 9, Exclusive, SECONDS));
+    left.add(Window.between(10, Exclusive, 15, Exclusive, SECONDS));
+    left.add(Window.at(20, SECONDS));
+
+    final var right = Duration.of(2, SECONDS);
+    final var result = new LongerThan(Supplier.of(left), right).evaluate(simResults, Map.of());
+
+    final var expected = new Windows();
+    expected.add(Window.between(0, Inclusive, 5, Exclusive, SECONDS));
+    expected.add(Window.between(10, Exclusive, 15, Exclusive, SECONDS));
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testShorterThan() {
+    final var simResults = new SimulationResults(
+        Window.between(0, 20, SECONDS),
+        List.of(),
+        Map.of(),
+        Map.of()
+    );
+
+    final var left = new Windows();
+    left.add(Window.between(0, Inclusive, 5, Exclusive, SECONDS));
+    left.add(Window.between(6, Inclusive, 7, Inclusive, SECONDS));
+    left.add(Window.between(8, Exclusive, 9, Exclusive, SECONDS));
+    left.add(Window.between(10, Exclusive, 15, Exclusive, SECONDS));
+    left.add(Window.at(20, SECONDS));
+
+    final var right = Duration.of(2, SECONDS);
+    final var result = new ShorterThan(Supplier.of(left), right).evaluate(simResults, Map.of());
+
+    final var expected = new Windows();
+    expected.add(Window.between(6, Inclusive, 7, Inclusive, SECONDS));
+    expected.add(Window.between(8, Exclusive, 9, Exclusive, SECONDS));
+    expected.add(Window.at(20, SECONDS));
 
     assertEquivalent(expected, result);
   }

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -12,6 +12,8 @@ export enum NodeKind {
   WindowsExpressionActivityWindow = 'WindowsExpressionActivityWindow',
   WindowsExpressionStartOf = 'WindowsExpressionStartOf',
   WindowsExpressionEndOf = 'WindowsExpressionEndOf',
+  WindowsExpressionLongerThan = 'WindowsExpressionLongerThan',
+  WindowsExpressionShorterhan = 'WindowsExpressionShorterThan',
   WindowsExpressionShiftBy = 'WindowsExpressionShiftBy',
   ExpressionEqual = 'ExpressionEqual',
   ExpressionNotEqual = 'ExpressionNotEqual',
@@ -57,6 +59,8 @@ export type WindowsExpression =
   | ExpressionNotEqual<DiscreteProfileExpression>
   | WindowsExpressionAll
   | WindowsExpressionAny
+  | WindowsExpressionLongerThan
+  | WindowsExpressionShorterThan
   | WindowsExpressionInvert
   | WindowsExpressionShiftBy;
 
@@ -138,6 +142,18 @@ export interface WindowsExpressionStartOf {
 export interface WindowsExpressionActivityWindow {
   kind: NodeKind.WindowsExpressionActivityWindow;
   alias: string;
+}
+
+export interface WindowsExpressionShorterThan {
+  kind: NodeKind.WindowsExpressionShorterhan,
+  windowExpression: WindowsExpression,
+  duration: number
+}
+
+export interface WindowsExpressionLongerThan {
+  kind: NodeKind.WindowsExpressionLongerThan,
+  windowExpression: WindowsExpression,
+  duration: number
 }
 
 export interface DiscreteProfileTransition {

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -84,6 +84,22 @@ export class Windows {
     });
   }
 
+  public longerThan(duration: Duration) : Windows {
+    return new Windows({
+      kind: AST.NodeKind.WindowsExpressionLongerThan,
+      windowExpression: this.__astNode,
+      duration: duration
+    })
+  }
+
+  public shorterThan(duration: Duration) : Windows {
+    return new Windows({
+      kind: AST.NodeKind.WindowsExpressionShorterhan,
+      windowExpression: this.__astNode,
+      duration: duration
+    })
+  }
+
   public shiftBy(fromStart: Duration, fromEnd: Duration) : Windows {
     return new Windows({
       kind: AST.NodeKind.WindowsExpressionShiftBy,
@@ -343,6 +359,19 @@ declare global {
      * @param fromEnd duration to add from the end of the window
      */
     public shiftBy(fromStart: number, fromEnd: number): Windows;
+
+    /**
+     *  Return all windows with a duration longer than the argument
+     * @param duration the duration
+     */
+    public longerThan(duration: Duration): Windows;
+
+    /**
+     * Returns all windows with a duration shorter than the argument
+     * @param duration the duration
+     */
+    public shorterThan(duration: Duration): Windows;
+
   }
 
   export class Real {

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -279,6 +279,30 @@ class ConstraintsDSLCompilationServiceTests {
   }
 
   @Test
+  void testLongerThan() {
+    checkSuccessfulCompilation(
+        """
+            export default() => {
+              return Real.Resource("state of charge").rate().equal(Real.Value(4.0)).longerThan(1000)
+            }
+        """,
+        new ViolationsOf(new LongerThan(new Equal<>(new Rate(new RealResource("state of charge")), new RealValue(4.0)), Duration.of(1000, Duration.MICROSECOND)))
+    );
+  }
+
+  @Test
+  void testShorterThan() {
+    checkSuccessfulCompilation(
+        """
+            export default() => {
+              return Real.Resource("state of charge").rate().equal(Real.Value(4.0)).shorterThan(1000)
+            }
+        """,
+        new ViolationsOf(new ShorterThan(new Equal<>(new Rate(new RealResource("state of charge")), new RealValue(4.0)), Duration.of(1000, Duration.MICROSECOND)))
+    );
+  }
+
+  @Test
   void testShiftBy() {
     checkSuccessfulCompilation(
         """

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
 import gov.nasa.jpl.aerie.constraints.tree.GreaterThan;
+import gov.nasa.jpl.aerie.constraints.tree.LongerThan;
 import gov.nasa.jpl.aerie.constraints.tree.RealResource;
 import gov.nasa.jpl.aerie.constraints.tree.RealValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -332,7 +333,7 @@ class SchedulingDSLCompilationServiceTests {
                 fancy: { subfield1: 'value1', subfield2: [{subsubfield1: 2}]},
                 duration: 60 * 60 * 1000 * 1000 // 1 hour in microseconds
               }),
-              forEach: Real.Resource(Resources["/sample/resource/1"]).greaterThan(50.0),
+              forEach: Real.Resource(Resources["/sample/resource/1"]).greaterThan(50.0).longerThan(10),
               startsAt: TimingConstraint.singleton(WindowProperty.END)
             })
           }
@@ -351,7 +352,7 @@ class SchedulingDSLCompilationServiceTests {
                                                      Map.entry("duration", SerializedValue.of(60L * 60 * 1000 * 1000))
                                                  )
               ),
-              new SchedulingDSL.ConstraintExpression.WindowsExpression(new GreaterThan(new RealResource("/sample/resource/1"), new RealValue(50.0))),
+              new SchedulingDSL.ConstraintExpression.WindowsExpression(new LongerThan(new GreaterThan(new RealResource("/sample/resource/1"), new RealValue(50.0)), Duration.of(10, Duration.MICROSECOND))),
               Optional.of(new SchedulingDSL.ActivityTimingConstraint(TimeAnchor.END, TimeUtility.Operator.PLUS, Duration.ZERO, true)),
               Optional.empty()
           ),


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1847
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This is building on top of #179.

I have reimplemented the filters in the constraints library. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Several tests have been written/modified. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Documentation about these two constraints has been added to the [Constraints](https://github.com/NASA-AMMOS/aerie/wiki/Constraints) page.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
All of the other filters/transformers.
