### PR TITLE
[AERIE-1861] Hasura `resourceSamples` action

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -92,6 +92,12 @@ type Query {
 }
 
 type Query {
+  resourceSamples(
+    planId: Int!
+  ): ResourceSamplesResponse
+}
+
+type Query {
   validateActivityArguments(
     activityTypeName: String!
     missionModelId: ID!
@@ -242,9 +248,15 @@ type CodeLocation {
   column: Int!
 }
 
+type ResourceSamplesResponse {
+  resourceSamples: ResourceSamples!
+}
+
 scalar ResourceSchema
 
 scalar MerlinSimulationResults
+
+scalar ResourceSamples
 
 scalar MerlinSimulationFailureReason
 

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -59,6 +59,10 @@ actions:
     definition:
       kind: ""
       handler: http://aerie_merlin:27183/getSimulationResults
+  - name: resourceSamples
+    definition:
+      kind: ""
+      handler: http://aerie_merlin:27183/resourceSamples
   - name: validateActivityArguments
     definition:
       kind: ""
@@ -129,9 +133,11 @@ custom_types:
     - name: CommandSeqJsonTime
     - name: UserCodeError
     - name: CodeLocation
+    - name: ResourceSamplesResponse
   scalars:
     - name: ResourceSchema
     - name: MerlinSimulationResults
+    - name: ResourceSamples
     - name: MerlinSimulationFailureReason
     - name: ModelArguments
     - name: ActivityArguments

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
@@ -61,7 +61,7 @@ public final class AerieAppDriver {
     final var simulationAgent = ThreadedSimulationAgent.spawn(
         "simulation-agent",
         new SynchronousSimulationAgent(planController, missionModelController));
-    final var simulationController = new CachedSimulationService(stores.results(), simulationAgent);
+    final var simulationController = new CachedSimulationService(simulationAgent, stores.results());
     final var simulationAction = new GetSimulationResultsAction(
         planController,
         missionModelController,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/NoSuchPlanException.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/NoSuchPlanException.java
@@ -2,15 +2,11 @@ package gov.nasa.jpl.aerie.merlin.server.exceptions;
 
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
-public class NoSuchPlanException extends Exception {
-  private final PlanId id;
+public final class NoSuchPlanException extends Exception {
+  public final PlanId id;
 
   public NoSuchPlanException(final PlanId id) {
     super("No plan exists with id `" + id + "`");
     this.id = id;
-  }
-
-  public PlanId getInvalidPlanId() {
-    return this.id;
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -70,6 +70,9 @@ public final class MerlinBindings implements Plugin {
       path("getSimulationResults", () -> {
         post(this::getSimulationResults);
       });
+      path("resourceSamples", () -> {
+        post(this::getResourceSamples);
+      });
       path("refreshModelParameters", () -> {
         post(this::postRefreshModelParameters);
       });
@@ -165,6 +168,22 @@ public final class MerlinBindings implements Plugin {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
     }
   }
+
+  private void getResourceSamples(final Context ctx) {
+    try {
+      final var planId = parseJson(ctx.body(), hasuraPlanActionP).input().planId();
+
+      final var resourceSamples = this.simulationAction.getResourceSamples(planId);
+
+      ctx.result(ResponseSerializers.serializeResourceSamples(resourceSamples).toString());
+    } catch (final InvalidJsonException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
+    } catch (final InvalidEntityException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
+    } catch (final NoSuchPlanException ex) {
+      ctx.status(404).result(ResponseSerializers.serializeNoSuchPlanException(ex).toString());
+    }
+}
 
   private void validateActivityArguments(final Context ctx) {
     try {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -209,6 +209,15 @@ public final class ResponseSerializers {
         .build();
   }
 
+  public static JsonValue serializeResourceSamples(final Map<String, List<Pair<Duration, SerializedValue>>> resourceSamples) {
+    return Json
+        .createObjectBuilder()
+        .add("resourceSamples", serializeMap(
+            elements -> serializeIterable(ResponseSerializers::serializeSample, elements),
+            resourceSamples))
+        .build();
+  }
+
   private static Map<Integer, Pair<String, ValueSchema>> topicsById(List<Triple<Integer, String, ValueSchema>> topics) {
     final Map<Integer, Pair<String, ValueSchema>> topicsById = new HashMap<>();
     for (final var topic : topics) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
@@ -8,7 +8,7 @@ public record HasuraAction<I extends HasuraAction.Input>(String name, I input, S
 {
   public record Session(String hasuraRole, String hasuraUserId) { }
 
-  public interface Input { }
+  public sealed interface Input { }
 
   public record MissionModelInput(String missionModelId) implements Input { }
   public record PlanInput(PlanId planId) implements Input { }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
@@ -1,13 +1,20 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import java.util.List;
+import java.util.Map;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.remotes.ResultsCellRepository;
+import org.apache.commons.lang3.tuple.Pair;
 
 public record CachedSimulationService (
-    ResultsCellRepository store,
-    SimulationAgent agent
+    SimulationAgent agent,
+    ResultsCellRepository store
 ) implements SimulationService {
+
   @Override
   public ResultsProtocol.State getSimulationResults(final PlanId planId, final RevisionData revisionData) {
     final var cell$ = this.store.lookup(planId);
@@ -20,5 +27,16 @@ public record CachedSimulationService (
       // Return the current value of the reader; if it's incomplete, the caller can check it again later.
       return cell.get();
     }
+  }
+
+  @Override
+  public Map<String, List<Pair<Duration, SerializedValue>>> getResourceSamples(final PlanId planId, final RevisionData revisionData) {
+    return this.store.lookup(planId) // Only return results that have already been cached
+        .map(ResultsProtocol.ReaderRole::get)
+        .map(state -> {
+            if (!(state instanceof final ResultsProtocol.State.Success s)) return null;
+            return s.results().resourceSamples;
+        })
+        .orElseGet(Map::of);
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -12,10 +12,12 @@ import gov.nasa.jpl.aerie.constraints.time.Window;
 import gov.nasa.jpl.aerie.constraints.tree.Expression;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import org.apache.commons.lang3.tuple.Pair;
 
 import javax.json.Json;
 import java.io.StringReader;
@@ -28,7 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public final class GetSimulationResultsAction {
-  public /*sealed*/ interface Response {
+  public sealed interface Response {
     record Pending() implements Response {}
     record Incomplete() implements Response {}
     record Failed(String reason) implements Response {}
@@ -74,6 +76,13 @@ public final class GetSimulationResultsAction {
     } else {
       throw new UnexpectedSubtypeError(ResultsProtocol.State.class, response);
     }
+  }
+
+  public Map<String, List<Pair<Duration, SerializedValue>>> getResourceSamples(final PlanId planId)
+  throws NoSuchPlanException
+  {
+    final var revisionData = this.planService.getPlanRevisionData(planId);
+    return simulationService.getResourceSamples(planId, revisionData);
   }
 
   public Map<String, List<Violation>> getViolations(final PlanId planId, final SimulationResults results)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
@@ -1,8 +1,15 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import java.util.List;
+import java.util.Map;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import org.apache.commons.lang3.tuple.Pair;
 
 public interface SimulationService {
   ResultsProtocol.State getSimulationResults(PlanId planId, RevisionData revisionData);
+  Map<String, List<Pair<Duration, SerializedValue>>> getResourceSamples(PlanId planId, RevisionData revisionData);
 }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1861
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds `resourceSamples` Hasura action.

An action to return resource samples is needed as an intermediate step for decoupling sim. results and resource samples/profiles. Clients (UI and GQL users) can incrementally switch over to ditching sim. results in favor of this action and sim. results stored in the DB.

## Verification

Running the following query returns resource samples for a given dataset:
```gql
query {
  resourceSamples(planId: 1) {
    resourceSamples
  }
}
```

Prior to running a simulation (prior to the existence of dataset ID `1`) this returns:
```
{
  "data": {
    "resourceSamples": {
      "resourceSamples": { }
    }
  }
}
```

After running a simulation (after dataset ID `1` exists) this returns:
```
{
  "data": {
    "resourceSamples": {
      "resourceSamples": {
        "/data/line_count": [
          {
            "x": 0,
            "y": 12
          },
...
```

## Documentation
This section will be updated after 1-2 reviews, this way any changes to the response structure can be reflected properly in our Wiki documentation.

## Future work
Carving out sim. results (https://jira.jpl.nasa.gov/browse/AERIE-1796).