### PR TITLE
feat: datasets array_relationship on simulation

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation.yaml
@@ -15,3 +15,11 @@ object_relationships:
 - name: plan
   using:
     foreign_key_constraint_on: plan_id
+array_relationships:
+- name: datasets
+  using:
+    foreign_key_constraint_on:
+      column: simulation_id
+      table:
+        name: simulation_dataset
+        schema: public


### PR DESCRIPTION
## Description

- Add datasets array_relationship on simulation table Hasura metadata to allow querying for all datasets for a given simulation
