### PR TITLE
[AERIE-1832] Hasura `validatePlan` action

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -113,6 +113,12 @@ type Query {
 }
 
 type Query {
+  validatePlan(
+    planId: Int!
+  ): ValidationResponse
+}
+
+type Query {
   getSequenceSeqJson(
     seqId: String!
     simulationDatasetId: Int!

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -71,6 +71,10 @@ actions:
     definition:
       kind: ""
       handler: http://aerie_merlin:27183/validateModelArguments
+  - name: validatePlan
+    definition:
+      kind: ""
+      handler: http://aerie_merlin:27183/validatePlan
 custom_types:
   enums:
     - name: MerlinSimulationStatus

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -195,6 +195,31 @@ public final class ResponseSerializers {
                 Collectors.toMap(e -> Long.toString(e.getKey().id()), Map.Entry::getValue)));
   }
 
+  private static JsonValue serializeUnconstructableActivityFailure(final String reason) {
+    return Json
+        .createObjectBuilder()
+        .add("reason", reason)
+        .build();
+  }
+
+  public static JsonValue serializeUnconstructableActivityFailures(final Map<ActivityInstanceId, String> failures) {
+    if (failures.isEmpty()) {
+      return Json.createObjectBuilder()
+        .add("success", JsonValue.TRUE)
+        .build();
+    }
+    return Json.createObjectBuilder()
+        .add("success", JsonValue.FALSE)
+        .add("errors", serializeMap(
+           ResponseSerializers::serializeUnconstructableActivityFailure,
+               failures
+                   .entrySet()
+                   .stream()
+                   .collect(
+                       Collectors.toMap(e -> Long.toString(e.getKey().id()), Map.Entry::getValue))))
+        .build();
+  }
+
   public static JsonValue serializeSimulationResults(final SimulationResults results, final Map<String, List<Violation>> violations) {
     return Json
         .createObjectBuilder()

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelFacade.java
@@ -131,9 +131,9 @@ public final class MissionModelFacade {
   }
 
   /** Get activity instantiation failure messages as a mapping of activity instance ID to failure. */
-  public <T> Map<T, String> validateActivityInstantiations(final Map<T, SerializedActivity> activities)
+  public Map<ActivityInstanceId, String> validateActivityInstantiations(final Map<ActivityInstanceId, SerializedActivity> activities)
   {
-    final var failures = new HashMap<T, String>();
+    final var failures = new HashMap<ActivityInstanceId, String>();
 
     activities.forEach((id, act) -> {
       try {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -76,7 +76,7 @@ public final class GetSimulationResultsAction {
   throws NoSuchPlanException
   {
     final var revisionData = this.planService.getPlanRevisionData(planId);
-    return simulationService.getResourceSamples(planId, revisionData);
+    return simulationService.get(planId, revisionData, r -> r.resourceSamples).orElseGet(Map::of);
   }
 
   public Map<String, List<Violation>> getViolations(final PlanId planId, final SimulationResults results)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelLoader;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
@@ -122,7 +123,7 @@ public final class LocalMissionModelService implements MissionModelService {
    * @return A map of validation errors mapping activity instance ID to failure message. If validation succeeds the map is empty.
    */
   @Override
-  public <T> Map<T, String> validateActivityInstantiations(final String missionModelId, final Map<T, SerializedActivity> activities)
+  public Map<ActivityInstanceId, String> validateActivityInstantiations(final String missionModelId, final Map<ActivityInstanceId, SerializedActivity> activities)
   throws NoSuchMissionModelException, MissionModelFacade.MissionModelContractException, MissionModelLoadException
   {
     return this.loadConfiguredMissionModel(missionModelId).validateActivityInstantiations(activities);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelLoader;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
@@ -33,7 +34,7 @@ public interface MissionModelService {
   List<String> validateActivityArguments(String missionModelId, SerializedActivity activity)
   throws NoSuchMissionModelException, TaskSpecType.UnconstructableTaskSpecException, MissingArgumentsException;
 
-  <T> Map<T, String> validateActivityInstantiations(String missionModelId, Map<T, SerializedActivity> activities)
+  Map<ActivityInstanceId, String> validateActivityInstantiations(String missionModelId, Map<ActivityInstanceId, SerializedActivity> activities)
   throws NoSuchMissionModelException, MissionModelFacade.MissionModelContractException,
          LocalMissionModelService.MissionModelLoadException;
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
@@ -1,15 +1,13 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
-import java.util.List;
-import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
-import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
-import org.apache.commons.lang3.tuple.Pair;
 
 public interface SimulationService {
   ResultsProtocol.State getSimulationResults(PlanId planId, RevisionData revisionData);
-  Map<String, List<Pair<Duration, SerializedValue>>> getResourceSamples(PlanId planId, RevisionData revisionData);
+  <T> Optional<T> get(PlanId planId, RevisionData revisionData, Function<SimulationResults, T> getter);
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SynchronousSimulationAgent.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SynchronousSimulationAgent.java
@@ -6,6 +6,7 @@ import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.http.ResponseSerializers;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelFacade;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
@@ -36,7 +37,7 @@ public record SynchronousSimulationAgent (
       final var currentRevisionData = this.planService.getPlanRevisionData(planId);
       final var validationResult = currentRevisionData.matches(revisionData);
       if (validationResult instanceof RevisionData.MatchResult.Failure failure) {
-        writer.failWith(String.format("Simulation request no longer relevant: %s", failure.reason()));
+        writer.failWith("Simulation request no longer relevant: %s".formatted(failure.reason()));
         return;
       }
     } catch (final NoSuchPlanException ex) {
@@ -59,9 +60,7 @@ public record SynchronousSimulationAgent (
                 e -> new SerializedActivity(e.getValue().type, e.getValue().arguments))));
 
         if (!failures.isEmpty()) {
-          writer.failWith(failures.entrySet().stream()
-              .map(e -> "%s: %s".formatted(e.getKey(), e.getValue()))
-              .collect(Collectors.joining(System.lineSeparator())));
+          writer.failWith(ResponseSerializers.serializeUnconstructableActivityFailures(failures).toString());
           return;
         }
       }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/UncachedSimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/UncachedSimulationService.java
@@ -2,7 +2,10 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
@@ -40,9 +43,10 @@ public record UncachedSimulationService (
   }
 
   @Override
-  public Map<String, List<Pair<Duration, SerializedValue>>> getResourceSamples(final PlanId planId, final RevisionData revisionData) {
-    return getSimulationResults(planId, revisionData) instanceof ResultsProtocol.State.Success s ?
-        s.results().resourceSamples :
-        Map.of();
+  public <T> Optional<T> get(final PlanId planId, final RevisionData revisionData, final Function<SimulationResults, T> getter) {
+    return Optional.ofNullable(
+        getSimulationResults(planId, revisionData) instanceof ResultsProtocol.State.Success s ?
+            getter.apply(s.results()) :
+            null);
   }
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.mocks;
 
 import gov.nasa.jpl.aerie.contrib.serialization.mappers.EnumValueMapper;
+import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException;
@@ -144,9 +145,9 @@ public final class StubMissionModelService implements MissionModelService {
   }
 
   @Override
-  public <T> Map<T, String> validateActivityInstantiations(
+  public Map<ActivityInstanceId, String> validateActivityInstantiations(
       final String missionModelId,
-      final Map<T, SerializedActivity> activities)
+      final Map<ActivityInstanceId, SerializedActivity> activities)
   throws NoSuchMissionModelException, MissionModelFacade.MissionModelContractException, LocalMissionModelService.MissionModelLoadException
   {
     return Map.of();


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1832
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Exposes plan validation endpoint for validating activity instances within a plan prior to simulation. Note that our `SynchronousSimulationAgent` will report the same validation errors (if any), this endpoint just allows clients to run their own validation prior to simulation.

## Verification

<details>
<summary>Expand</summary>

### Reporting Success

With a single `BiteBanana` activity inserted into a plan with ID `1` the following query:
```gql
query {
  validatePlan(planId:1) {
    success
    errors
  }
}
```
results in:
```json
{
  "data": {
    "validatePlan": {
      "success": true
    }
  }
}
```

### Reporting Failures

An activity that will result in an **unconstructable argument** error is inserted with:
```gql
mutation {
  insert_activity_one(object: { plan_id: $plan_id, start_offset: \"300 seconds\", type: \"BiteBanana\", arguments: { biteSize: true } }) {
    id
  }
}
```

An activity that will result in an **extraneous parameter** error is inserted with:
```gql
mutation {
  insert_activity_one(object: { plan_id: $plan_id, start_offset: \"310 seconds\", type: \"BiteBanana\", arguments: { bad: 42 } }) {
    id
  }
}
```

An activity that will result in a **missing arguments** error is inserted with:
```gql
mutation {
  insert_activity_one(object: { plan_id: $plan_id, start_offset: \"320 seconds\", type: \"BakeBananaBread\", arguments: { tbSugar: 42 } }) {
    id
  }
}
```

An activity that will result in a **nonexistent activity type** error is inserted with:
```gql
mutation {
  insert_activity_one(object: { plan_id: $plan_id, start_offset: \"330 seconds\", type: \"BadActivity\", arguments: { } }) {
    id
  }
}
```

To trigger plan validation a simple `validatePlan` call is needed:
```gql
query {
  validatePlan(planId:1) {
    success
    errors
  }
}
```

This results in:
```json
{
  "data": {
    "validatePlan": {
      "success": false,
      "errors": {
        "1": {
          "reason": "gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType$UnconstructableTaskSpecException: Unconstructable argument \"biteSize\": Expected real number, got true"
        },
        "2": {
          "reason": "gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType$UnconstructableTaskSpecException: Extraneous parameter \"bad\""
        },
        "3": {
          "reason": "gov.nasa.jpl.aerie.merlin.protocol.types.MissingArgumentsException: Missing arguments for activity \"BakeBananaBread\": \"glutenFree\""
        },
        "4": {
          "reason": "gov.nasa.jpl.aerie.merlin.server.models.MissionModelFacade$NoSuchActivityTypeException: No such activity type: \"BadActivity\""
        }
      }
    }
  }
}
```
</details>

## Documentation
This section will be updated after 1-2 reviews, this way any changes to the response structure can be reflected properly in our Wiki documentation.

## Future work

Copied from https://github.com/NASA-AMMOS/aerie/pull/140 "Future Work" section:
- Look into exception `getMessage()` null handling (see [AERIE-1784](https://jira.jpl.nasa.gov/browse/AERIE-1784)).
- Accumulate all invalid/nonexistent argument exceptions within activity/config. mappers (see [AERIE-1826](https://jira.jpl.nasa.gov/browse/AERIE-1826)).
  - This would allow the `UnconstructableTaskSpecException`/`UnconstructableConfigurationException` to not fail-fast during instantiation.
- Structure `simulation_dataset.reason` as a `jsonb` since unconstructable activities currently serve [3 distinct failure modes](https://jpl.slack.com/archives/GHK90JHH8/p1649904711420249?thread_ts=1649903505.320229&cid=GHK90JHH8)  (see [AERIE-1826](https://jira.jpl.nasa.gov/browse/AERIE-1826)).
  - Would likely require splitting `UnconstructableTaskSpecException`/`UnconstructableConfigurationException` up into 3 distinct cases to allow the UI to react appropriately.
  - All depends on if the UI needs to be aware of these different failure modes (which I believe it does).