### PR TITLE
[AERIE-1857]  command expansion timestamps

### DIFF
--- a/command-expansion-server/sql/commanding/tables/command_dictionary.sql
+++ b/command-expansion-server/sql/commanding/tables/command_dictionary.sql
@@ -5,6 +5,8 @@ create table command_dictionary (
   mission text not null,
   version text not null,
 
+  created_at timestamptz not null default now(),
+
   constraint command_dictionary_synthetic_key
       primary key (id),
   constraint command_dictionary_natural_key

--- a/command-expansion-server/sql/commanding/tables/expansion_rule.sql
+++ b/command-expansion-server/sql/commanding/tables/expansion_rule.sql
@@ -7,6 +7,9 @@ create table expansion_rule (
   authoring_command_dict_id integer,
   authoring_mission_model_id integer,
 
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
   constraint expansion_rule_primary_key
   primary key (id),
 
@@ -31,3 +34,16 @@ comment on column expansion_rule.authoring_mission_model_id is e''
   'The id of the mission model to be used for authoring of this expansion.';
 comment on constraint expansion_rule_activity_type_foreign_key on expansion_rule is e''
   'This enables us to have a foreign key on expansion_set_to_rule which is necessary for building the unique constraint `max_one_expansion_of_each_activity_type_per_expansion_set`.';
+
+create or replace function expansion_rule_set_updated_at()
+returns trigger
+security definer
+language plpgsql as $$begin
+  new.updated_at = now();
+  return new;
+end$$;
+
+create trigger set_timestamp
+before update on expansion_rule
+for each row
+execute function expansion_rule_set_updated_at();

--- a/command-expansion-server/sql/commanding/tables/expansion_run.sql
+++ b/command-expansion-server/sql/commanding/tables/expansion_run.sql
@@ -4,6 +4,8 @@ create table expansion_run (
   simulation_dataset_id integer not null,
   expansion_set_id integer not null,
 
+  created_at timestamptz not null default now(),
+
   constraint expansion_run_primary_key
     primary key (id),
 

--- a/command-expansion-server/sql/commanding/tables/expansion_set.sql
+++ b/command-expansion-server/sql/commanding/tables/expansion_set.sql
@@ -4,6 +4,8 @@ create table expansion_set (
   command_dict_id integer not null,
   mission_model_id integer not null,
 
+  created_at timestamptz not null default now(),
+
   constraint expansion_set_primary_key
     primary key (id),
 

--- a/command-expansion-server/sql/commanding/tables/sequence.sql
+++ b/command-expansion-server/sql/commanding/tables/sequence.sql
@@ -3,6 +3,9 @@ create table sequence (
   simulation_dataset_id int not null,
   metadata jsonb,
 
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
   constraint sequence_primary_key
     primary key (seq_id, simulation_dataset_id)
 );
@@ -14,3 +17,28 @@ comment on column sequence.simulation_dataset_id is e''
   'The simulation dataset id whose outputs are associated with this sequence';
 comment on column sequence.metadata is e''
   'The metadata associated with this sequence';
+
+create or replace function sequence_set_updated_at()
+returns trigger
+security definer
+language plpgsql as $$begin
+  new.updated_at = now();
+  return new;
+end$$;
+
+create or replace function sequence_set_updated_at_external()
+  returns trigger
+  security definer
+  language plpgsql as $$begin
+  update sequence
+    set updated_at = now()
+    where
+        seq_id = old.seq_id and simulation_dataset_id = old.simulation_dataset_id
+     or seq_id = new.seq_id and simulation_dataset_id = new.simulation_dataset_id;
+  return null;
+end$$;
+
+create trigger set_timestamp
+before update on sequence
+for each row
+execute procedure sequence_set_updated_at();

--- a/command-expansion-server/sql/commanding/tables/sequence_to_simulated_activity.sql
+++ b/command-expansion-server/sql/commanding/tables/sequence_to_simulated_activity.sql
@@ -24,3 +24,8 @@ comment on constraint sequence_to_simulated_activity_primary_key on sequence_to_
   'Primary key constrains one simulated activity id per simulation dataset.';
 comment on constraint sequence_to_simulated_activity_activity_instance_id_fkey on sequence_to_simulated_activity is e''
   'Foreign key constrains that this join table relates to a sequence id that exists for the simulation dataset.';
+
+create trigger increment_revision_on_delete_activity_trigger
+  after insert or update or delete on sequence_to_simulated_activity
+  for each row
+execute procedure sequence_set_updated_at_external();

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/CommandExpansionDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/CommandExpansionDatabaseTests.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -64,6 +65,78 @@ class CommandExpansionDatabaseTests {
         updateRes.next();
         final var created_at2 = updateRes.getTimestamp("created_at");
         final var updated_at2 = updateRes.getTimestamp("updated_at");
+
+        assertEquals(created_at, created_at2);
+        assertNotEquals(updated_at, updated_at2);
+        assertNotEquals(created_at2, updated_at2);
+      }
+    }
+  }
+
+  @Nested
+  class SequenceTriggers {
+    @Test
+    void shouldModifyUpdatedAtTimeOnUpdate() throws SQLException {
+      try(final var statement = connection.createStatement()) {
+        final var insertRes = statement.executeQuery("""
+          insert into sequence (seq_id, simulation_dataset_id, metadata)
+          values ('%s', 1, '{}')
+          returning seq_id, simulation_dataset_id, created_at, updated_at
+        """.formatted(UUID.randomUUID().toString()));
+        insertRes.next();
+        final var seq_id = insertRes.getString("seq_id");
+        final var simulation_dataset_id = insertRes.getInt("simulation_dataset_id");
+        final var created_at = insertRes.getTimestamp("created_at");
+        final var updated_at = insertRes.getTimestamp("updated_at");
+
+        assertEquals(created_at, updated_at);
+
+        final var updateRes = statement.executeQuery("""
+        update sequence set metadata = '{"key": "value"}'
+        where seq_id = '%s' and simulation_dataset_id = %d
+        returning created_at, updated_at
+      """.formatted(seq_id, simulation_dataset_id));
+        updateRes.next();
+        final var created_at2 = updateRes.getTimestamp("created_at");
+        final var updated_at2 = updateRes.getTimestamp("updated_at");
+
+        assertEquals(created_at, created_at2);
+        assertNotEquals(updated_at, updated_at2);
+        assertNotEquals(created_at2, updated_at2);
+      }
+    }
+
+    @Test
+    void shouldModifyUpdatedAtTimeOnInsertToSequenceToSimulatedActivityTable() throws SQLException {
+      try(final var statement = connection.createStatement()) {
+        final var insertRes = statement.executeQuery("""
+          insert into sequence (seq_id, simulation_dataset_id, metadata)
+          values ('%s', 1, '{}')
+          returning seq_id, simulation_dataset_id, created_at, updated_at
+        """.formatted(UUID.randomUUID().toString()));
+        insertRes.next();
+        final var seq_id = insertRes.getString("seq_id");
+        final var simulation_dataset_id = insertRes.getInt("simulation_dataset_id");
+        final var created_at = insertRes.getTimestamp("created_at");
+        final var updated_at = insertRes.getTimestamp("updated_at");
+
+        assertEquals(created_at, updated_at);
+
+        final var linkActivityRes = statement.executeQuery("""
+          insert into sequence_to_simulated_activity (simulated_activity_id, simulation_dataset_id, seq_id)
+          values (%d, %d, '%s')
+          returning seq_id
+        """.formatted(1, simulation_dataset_id, seq_id));
+        linkActivityRes.next();
+
+        final var queryRes = statement.executeQuery("""
+          select created_at, updated_at
+          from sequence
+          where seq_id = '%s' and simulation_dataset_id = %d
+        """.formatted(seq_id, simulation_dataset_id));
+        queryRes.next();
+        final var created_at2 = queryRes.getTimestamp("created_at");
+        final var updated_at2 = queryRes.getTimestamp("updated_at");
 
         assertEquals(created_at, created_at2);
         assertNotEquals(updated_at, updated_at2);

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/CommandExpansionDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/CommandExpansionDatabaseTests.java
@@ -46,10 +46,10 @@ class CommandExpansionDatabaseTests {
     void shouldModifyUpdatedAtTimeOnUpdate() throws SQLException {
       try(final var statement = connection.createStatement()) {
         final var insertRes = statement.executeQuery("""
-        insert into expansion_rule (activity_type, expansion_logic)
-        values ('test-activity-type', 'test-activity-logic')
-        returning id, created_at, updated_at
-      """);
+          insert into expansion_rule (activity_type, expansion_logic)
+          values ('test-activity-type', 'test-activity-logic')
+          returning id, created_at, updated_at
+        """);
         insertRes.next();
         final var id = insertRes.getInt("id");
         final var created_at = insertRes.getTimestamp("created_at");
@@ -58,10 +58,10 @@ class CommandExpansionDatabaseTests {
         assertEquals(created_at, updated_at);
 
         final var updateRes = statement.executeQuery("""
-        update expansion_rule set expansion_logic = 'updated-logic'
-        where id = %d
-        returning created_at, updated_at
-      """.formatted(id));
+          update expansion_rule set expansion_logic = 'updated-logic'
+          where id = %d
+          returning created_at, updated_at
+        """.formatted(id));
         updateRes.next();
         final var created_at2 = updateRes.getTimestamp("created_at");
         final var updated_at2 = updateRes.getTimestamp("updated_at");
@@ -92,10 +92,10 @@ class CommandExpansionDatabaseTests {
         assertEquals(created_at, updated_at);
 
         final var updateRes = statement.executeQuery("""
-        update sequence set metadata = '{"key": "value"}'
-        where seq_id = '%s' and simulation_dataset_id = %d
-        returning created_at, updated_at
-      """.formatted(seq_id, simulation_dataset_id));
+          update sequence set metadata = '{"key": "value"}'
+          where seq_id = '%s' and simulation_dataset_id = %d
+          returning created_at, updated_at
+        """.formatted(seq_id, simulation_dataset_id));
         updateRes.next();
         final var created_at2 = updateRes.getTimestamp("created_at");
         final var updated_at2 = updateRes.getTimestamp("updated_at");

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/CommandExpansionDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/CommandExpansionDatabaseTests.java
@@ -1,0 +1,74 @@
+package gov.nasa.jpl.aerie.database;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CommandExpansionDatabaseTests {
+  private static final File initSqlScriptFile = new File("../command-expansion-server/sql/commanding/init.sql");
+  private DatabaseTestHelper helper;
+
+  private Connection connection;
+
+  @BeforeAll
+  void beforeAll() throws SQLException, IOException, InterruptedException {
+    helper = new DatabaseTestHelper(
+        "command_expansion_test",
+        "Command Expansion Database Tests",
+        initSqlScriptFile
+    );
+    helper.startDatabase();
+    connection = helper.connection();
+  }
+
+  @AfterAll
+  void afterAll() throws SQLException, IOException, InterruptedException {
+    helper.stopDatabase();
+    connection = null;
+    helper = null;
+  }
+
+  @Nested
+  class ExpansionRuleTriggers {
+    @Test
+    void shouldModifyUpdatedAtTimeOnUpdate() throws SQLException {
+      try(final var statement = connection.createStatement()) {
+        final var insertRes = statement.executeQuery("""
+        insert into expansion_rule (activity_type, expansion_logic)
+        values ('test-activity-type', 'test-activity-logic')
+        returning id, created_at, updated_at
+      """);
+        insertRes.next();
+        final var id = insertRes.getInt("id");
+        final var created_at = insertRes.getTimestamp("created_at");
+        final var updated_at = insertRes.getTimestamp("updated_at");
+
+        assertEquals(created_at, updated_at);
+
+        final var updateRes = statement.executeQuery("""
+        update expansion_rule set expansion_logic = 'updated-logic'
+        where id = %d
+        returning created_at, updated_at
+      """.formatted(id));
+        updateRes.next();
+        final var created_at2 = updateRes.getTimestamp("created_at");
+        final var updated_at2 = updateRes.getTimestamp("updated_at");
+
+        assertEquals(created_at, created_at2);
+        assertNotEquals(updated_at, updated_at2);
+        assertNotEquals(created_at2, updated_at2);
+      }
+    }
+  }
+}


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1857
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Added created_at columns to all non-join tables in command expansion. Added updated_at to sequence and expansion_rule columns as those are the ones that get updated.

Note that the trigger to update the sequence updated_at when the sequence_to_simulated_activity join table updates is in the sequence_to_simulated_activity.sql file is because of execution order when deploying, the sequence_to_simulated_activity table needs to exist before creating the trigger.

This ordering of sql file execution has a high likelihood of biting us in other places.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Added tests for the updated_at columns, but the create_at columns are so simple, as long as they parse via postgres, a test would just be overhead

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

No documentation needed

## Future work
<!-- What next steps can we anticipate from here, if any? -->
