### PR TITLE
[HotFix] Remove epoch name when generating Sequence JSON

### DIFF
--- a/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -164,7 +164,7 @@ export class Command<
         : json.time.type === TimingTypes.COMMAND_RELATIVE
         ? { relativeTime: Command.hmsToDuration(json.time.tag) }
         : json.time.type === TimingTypes.EPOCH_RELATIVE
-        ? { epochTime: { epochName: json.metadata.epochName, time: Command.hmsToDuration(json.time.tag) } }
+        ? { epochTime: Command.hmsToDuration(json.time.tag) }
         : {};
 
     return Command.new<A>({


### PR DESCRIPTION

## Description
This is what I get for doing a hotfix at the end of the day on Thursday. I forgot to remove the epoch name in the code that generates a Sequence JSON.

## Verification
This time I ran through all the command expansions and generated a sequence JSON file. 


