### PR TITLE
[AERIE-1884] Serialize Boolean Arguments when Expanding

### DIFF
--- a/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -142,7 +142,10 @@ export class Command<
 
   public toSeqJson(): CommandSeqJson {
     return {
-      args: typeof this.arguments == 'object' ? Object.values(this.arguments) : this.arguments,
+      args:
+        typeof this.arguments == 'object'
+          ? this.serializeArguments(Object.values(this.arguments))
+          : this.serializeArguments(this.arguments),
       stem: this.stem,
       time:
         this.absoluteTime !== null
@@ -155,6 +158,16 @@ export class Command<
       type: 'command',
       metadata: {},
     };
+  }
+
+  private serializeArguments(args: ArgType[]): ArgType[] {
+    return args.map(arg => {
+      if (typeof arg == 'boolean') {
+        // Europa Clipper boolean values are 0 or 1
+        return arg ? 1 : 0;
+      }
+      return arg;
+    });
   }
 
   public static fromSeqJson<A extends ArgType[]>(json: CommandSeqJson<A>): Command<A> {

--- a/command-expansion-server/test/sequence-generation.spec.ts
+++ b/command-expansion-server/test/sequence-generation.spec.ts
@@ -48,7 +48,7 @@ beforeEach(async () => {
     return [
       PREHEAT_OVEN({temperature: 70}),
       BAKE_BREAD,
-      PREPARE_LOAF(50, false),
+      PREPARE_LOAF(50, true),
     ];
   }
   `,
@@ -111,11 +111,11 @@ it('should return sequence seqjson', async () => {
   expect(getSequenceSeqJson.metadata).toEqual({});
   expect(getSequenceSeqJson.steps).toEqual([
     { type: 'command', stem: 'PREHEAT_OVEN', time: { type: 'COMMAND_COMPLETE' }, args: [70], metadata: {} },
-    { type: 'command', stem: 'PREPARE_LOAF', time: { type: 'COMMAND_COMPLETE' }, args: [50, false], metadata: {} },
+    { type: 'command', stem: 'PREPARE_LOAF', time: { type: 'COMMAND_COMPLETE' }, args: [50, 0], metadata: {} },
     { type: 'command', stem: 'BAKE_BREAD', time: { type: 'COMMAND_COMPLETE' }, args: [], metadata: {} },
     { type: 'command', stem: 'PREHEAT_OVEN', time: { type: 'COMMAND_COMPLETE' }, args: [70], metadata: {} },
     { type: 'command', stem: 'BAKE_BREAD', time: { type: 'COMMAND_COMPLETE' }, args: [], metadata: {} },
-    { type: 'command', stem: 'PREPARE_LOAF', time: { type: 'COMMAND_COMPLETE' }, args: [50, false], metadata: {} },
+    { type: 'command', stem: 'PREPARE_LOAF', time: { type: 'COMMAND_COMPLETE' }, args: [50, 1], metadata: {} },
   ]);
 
   // Cleanup
@@ -185,11 +185,11 @@ it('should work for throwing expansions', async () => {
   expect(getSequenceSeqJson.metadata).toEqual({});
   expect(getSequenceSeqJson.steps).toEqual([
     { type: 'command', stem: 'PREHEAT_OVEN', time: { type: 'COMMAND_COMPLETE' }, args: [70], metadata: {} },
-    { type: 'command', stem: 'PREPARE_LOAF', time: { type: 'COMMAND_COMPLETE' }, args: [50, false], metadata: {} },
+    { type: 'command', stem: 'PREPARE_LOAF', time: { type: 'COMMAND_COMPLETE' }, args: [50, 0], metadata: {} },
     { type: 'command', stem: 'BAKE_BREAD', time: { type: 'COMMAND_COMPLETE' }, args: [], metadata: {} },
     { type: 'command', stem: 'PREHEAT_OVEN', time: { type: 'COMMAND_COMPLETE' }, args: [70], metadata: {} },
     { type: 'command', stem: 'BAKE_BREAD', time: { type: 'COMMAND_COMPLETE' }, args: [], metadata: {} },
-    { type: 'command', stem: 'PREPARE_LOAF', time: { type: 'COMMAND_COMPLETE' }, args: [50, false], metadata: {} },
+    { type: 'command', stem: 'PREPARE_LOAF', time: { type: 'COMMAND_COMPLETE' }, args: [50, 1], metadata: {} },
     {
       type: 'command',
       stem: '$$ERROR$$',
@@ -252,11 +252,11 @@ it('should work for non-existent expansions', async () => {
   expect(getSequenceSeqJson.metadata).toEqual({});
   expect(getSequenceSeqJson.steps).toEqual([
     { type: 'command', stem: 'PREHEAT_OVEN', time: { type: 'COMMAND_COMPLETE' }, args: [70], metadata: {} },
-    { type: 'command', stem: 'PREPARE_LOAF', time: { type: 'COMMAND_COMPLETE' }, args: [50, false], metadata: {} },
+    { type: 'command', stem: 'PREPARE_LOAF', time: { type: 'COMMAND_COMPLETE' }, args: [50, 0], metadata: {} },
     { type: 'command', stem: 'BAKE_BREAD', time: { type: 'COMMAND_COMPLETE' }, args: [], metadata: {} },
     { type: 'command', stem: 'PREHEAT_OVEN', time: { type: 'COMMAND_COMPLETE' }, args: [70], metadata: {} },
     { type: 'command', stem: 'BAKE_BREAD', time: { type: 'COMMAND_COMPLETE' }, args: [], metadata: {} },
-    { type: 'command', stem: 'PREPARE_LOAF', time: { type: 'COMMAND_COMPLETE' }, args: [50, false], metadata: {} },
+    { type: 'command', stem: 'PREPARE_LOAF', time: { type: 'COMMAND_COMPLETE' }, args: [50, 1], metadata: {} },
   ]);
 
   // Cleanup


### PR DESCRIPTION


* **Tickets addressed:** AERIE-1884
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Europa Clipper will need to have their boolean arguments serialized to '0' and '1' in the Sequence JSON.

I added a serialize method in case we need to serialize more arguments in the future

`AVS_SS_READ_CHECK_EMEM_NAND(10, 10, 10, false, 10)`

## Verification
Generated a Sequence JSON from the above command and verified it serialized the boolean value

```
      {
          "type": "command",
          "stem": "AVS_SS_READ_CHECK_EMEM_NAND",
          "args": [
            10,
            10,
            10,
            0,  <------ boolean value 'false'
            10
          ],
          "time": {
            "tag": "00:15:00.000",
            "type": "EPOCH_RELATIVE"
          },
          "metadata": {}
        }
```

