### PR TITLE
[HOTFIX] Simulation results persistence bugs

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -343,7 +343,7 @@ public final class SimulationEngine implements AutoCloseable {
     }
 
     public boolean isActivity(final TaskId id) {
-      return this.taskToPlannedDirective.containsKey(id.id());
+      return this.input.containsKey(id.id());
     }
 
     public record Trait(MissionModel<?> missionModel, Topic<ActivityInstanceId> activityTopic)

--- a/merlin-server/sql/merlin/tables/event.sql
+++ b/merlin-server/sql/merlin/tables/event.sql
@@ -9,7 +9,7 @@ create table event
   topic_index integer not null,
 
   constraint event_natural_key
-    primary key (dataset_id, real_time, causal_time),
+    primary key (dataset_id, real_time, transaction_index, causal_time),
   constraint event_owned_by_topic
     foreign key (dataset_id, topic_index)
       references topic


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
There are two bugs addressed in this PR:
1. Events from two different transactions (aka "commits") are treated as duplicates and rejected by postgres
2. There are no spans persisted for child activities

The cause of bug 1 is that the event table didn't include `transaction_index` in its primary key - so events that differ in the transaction index, but not in the real time or causal time, would erroneously trigger an error. (This is the bug that @camargo noticed when simulating a plan that included a `parent` activity from Banananation).

I noticed bug 2 when testing to make sure I had fixed bug one 😅 . I expected to see the whole decomposition tree of the `parent` activity, but instead I would only see the top level activity, and no children. I checked the database, and saw that the child activities were not being persisted in the `span` table.

I traced the bug to the `TaskInfo::isActivity` method, which defined activities as "tasks that correspond to directives". This definition includes top level activities, but not child activities. This PR changes that definition to be "tasks that have emitted an event to a registered `input` topic".

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I've run simulations through the UI to make sure that this fix did the job:

<img width="1604" alt="Screen Shot 2022-06-07 at 10 44 49 AM" src="https://user-images.githubusercontent.com/1189602/172448360-6af960b8-7cb0-42cf-95ac-a318ab86045a.png">


## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No documentation should be affected; these are internal bug fixes.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Just noticed the "undefined" start times in the table at the bottom of the screenshot - not sure what's up with those.
