### PR TITLE
[AERIE-1796] Carve out sim. results: resource samples

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -199,9 +199,6 @@ public final class ResponseSerializers {
     return Json
         .createObjectBuilder()
         .add("start", serializeTimestamp(results.startTime))
-        .add("resources", serializeMap(
-            elements -> serializeIterable(ResponseSerializers::serializeSample, elements),
-            results.resourceSamples))
         .add("constraints", serializeMap(v -> serializeIterable(ResponseSerializers::serializeConstraintViolation, v), violations))
         .add("activities", serializeSimulatedActivities(results.simulatedActivities))
         .add("unfinishedActivities", serializeUnfinishedActivities(results.unfinishedActivities))


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1796
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
[AERIE-1796](https://jira.jpl.nasa.gov/browse/AERIE-1796) will be accomplished in a piecemeal fashion (after each component of the result can be queried for independently). This PR removes resources from the `simulate` response. Users should now use the `resourceSamples` endpoint.

## Verification
#189 replaces the functionality removed in this PR. See #189's verification section.

## Documentation
Updated:
- https://github.com/NASA-AMMOS/aerie/wiki/Aerie-GraphQL-API-Software-Interface-Specification#query-for-all-resource-samples-in-simulated-plan
- https://github.com/NASA-AMMOS/aerie/wiki/Simulation-Results#resource-samples

## Future work
Carve out the rest of simulation results (for example, constraint violations).