### PR TITLE
[AERIE-1878] Add Hasura `constraintViolation` action

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -99,6 +99,12 @@ type Query {
 }
 
 type Query {
+  constraintViolations(
+    planId: Int!
+  ): ConstraintViolationsResponse
+}
+
+type Query {
   validateActivityArguments(
     activityTypeName: String!
     missionModelId: ID!
@@ -255,11 +261,17 @@ type ResourceSamplesResponse {
   resourceSamples: ResourceSamples!
 }
 
+type ConstraintViolationsResponse {
+  constraintViolations: ConstraintViolations!
+}
+
 scalar ResourceSchema
 
 scalar MerlinSimulationResults
 
 scalar ResourceSamples
+
+scalar ConstraintViolations
 
 scalar MerlinSimulationFailureReason
 

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -63,6 +63,10 @@ actions:
     definition:
       kind: ""
       handler: http://aerie_merlin:27183/resourceSamples
+  - name: constraintViolations
+    definition:
+      kind: ""
+      handler: http://aerie_merlin:27183/constraintViolations
   - name: validateActivityArguments
     definition:
       kind: ""
@@ -137,10 +141,12 @@ custom_types:
     - name: UserCodeError
     - name: CodeLocation
     - name: ResourceSamplesResponse
+    - name: ConstraintViolationsResponse
   scalars:
     - name: ResourceSchema
     - name: MerlinSimulationResults
     - name: ResourceSamples
+    - name: ConstraintViolations
     - name: MerlinSimulationFailureReason
     - name: ModelArguments
     - name: ActivityArguments

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -75,6 +75,9 @@ public final class MerlinBindings implements Plugin {
       path("resourceSamples", () -> {
         post(this::getResourceSamples);
       });
+      path("constraintViolations", () -> {
+        post(this::getConstraintViolations);
+      });
       path("refreshModelParameters", () -> {
         post(this::postRefreshModelParameters);
       });
@@ -189,6 +192,23 @@ public final class MerlinBindings implements Plugin {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchPlanException(ex).toString());
     }
 }
+  private void getConstraintViolations(final Context ctx) {
+    try {
+      final var planId = parseJson(ctx.body(), hasuraPlanActionP).input().planId();
+
+      final var constraintViolations = this.simulationAction.getViolations(planId);
+
+      ctx.result(ResponseSerializers.serializeConstraintViolations(constraintViolations).toString());
+    } catch (final InvalidJsonException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
+    } catch (final InvalidEntityException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
+    } catch (final NoSuchPlanException ex) {
+      ctx.status(404).result(ResponseSerializers.serializeNoSuchPlanException(ex).toString());
+    } catch (final MissionModelService.NoSuchMissionModelException ex) {
+      ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
+    }
+  }
 
   private void validateActivityArguments(final Context ctx) {
     try {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -240,6 +240,15 @@ public final class ResponseSerializers {
         .build();
   }
 
+  public static JsonValue serializeConstraintViolations(final Map<String, List<Violation>> violations) {
+    return Json
+        .createObjectBuilder()
+        .add("constraintViolations", serializeMap(
+            v -> serializeIterable(ResponseSerializers::serializeConstraintViolation, v),
+            violations))
+        .build();
+  }
+
   private static Map<Integer, Pair<String, ValueSchema>> topicsById(List<Triple<Integer, String, ValueSchema>> topics) {
     final Map<Integer, Pair<String, ValueSchema>> topicsById = new HashMap<>();
     for (final var topic : topics) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
@@ -1,17 +1,11 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
-import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.remotes.ResultsCellRepository;
-import org.apache.commons.lang3.tuple.Pair;
 
 public record CachedSimulationService (
     SimulationAgent agent,
@@ -33,11 +27,11 @@ public record CachedSimulationService (
   }
 
   @Override
-  public <T> Optional<T> get(final PlanId planId, final RevisionData revisionData, final Function<SimulationResults, T> getter) {
+  public Optional<SimulationResults> get(final PlanId planId, final RevisionData revisionData) {
     return this.store.lookup(planId) // Only return results that have already been cached
         .map(ResultsProtocol.ReaderRole::get)
         .map(state -> state instanceof final ResultsProtocol.State.Success s ?
-            getter.apply(s.results()) :
+            s.results() :
             null);
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
@@ -1,7 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
 import java.util.Optional;
-import java.util.function.Function;
 
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
@@ -9,5 +8,5 @@ import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
 public interface SimulationService {
   ResultsProtocol.State getSimulationResults(PlanId planId, RevisionData revisionData);
-  <T> Optional<T> get(PlanId planId, RevisionData revisionData, Function<SimulationResults, T> getter);
+  Optional<SimulationResults> get(PlanId planId, RevisionData revisionData);
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/UncachedSimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/UncachedSimulationService.java
@@ -1,18 +1,12 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
-import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.mocks.InMemoryRevisionData;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.remotes.InMemoryResultsCellRepository.InMemoryCell;
-import org.apache.commons.lang3.tuple.Pair;
 
 public record UncachedSimulationService (
     SimulationAgent agent
@@ -43,10 +37,10 @@ public record UncachedSimulationService (
   }
 
   @Override
-  public <T> Optional<T> get(final PlanId planId, final RevisionData revisionData, final Function<SimulationResults, T> getter) {
+  public Optional<SimulationResults> get(final PlanId planId, final RevisionData revisionData) {
     return Optional.ofNullable(
         getSimulationResults(planId, revisionData) instanceof ResultsProtocol.State.Success s ?
-            getter.apply(s.results()) :
+            s.results() :
             null);
   }
 }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1878
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
### No longer a breaking change, backwards compatibility maintained

Instead of constraint violations being included with the `results` of the `simulate` query, they are now accessed through a separate API call `constraintViolations`. Implemented so that querying `constraintViolations` before a simulation has been run will not start the simulation and instead return an empty JSON object. This was done in anticipation of future work that will *only* run the simulation on the `simulate` query.

This was implemented by adding a getter method to the `SimulationService` interface that allow the `getViolations` method in `GetSimulationResultsAction` to be called without passing simulation results, thus allowing us to query for constraint violations irrespective of simulation status. This getter logic was necessary so that while `UncachedSimulationService` will just run the simulation regardless, `CachedSimulationService` will return an empty `Map` if uncached.

## Verification

Tested with the banananation model with one PeelBanana activity, and the following constraint:
```TypeScript
export default (): Constraint =>
    Real.Resource("/fruit").equal(4)
```
which is violated when `peelDirection` is "fromStem"

### Old Behavior
Query of:
```GraphQL
query OldLameQuery {
  simulate(planId: 1) {
    status
    results
    reason
  }
}
```
returns:
```JSON
{
  "data": {
    "simulate": {
      "status": "complete",
      "results": {
        "unfinishedActivities": {},
        "start": "2022-020T12:12:12.000000",
        "activities": {
          "1": {
            "parent": null,
            "arguments": {
              "peelDirection": "fromStem"
            },
            "children": [],
            "computedAttributes": "UNIT",
            "type": "PeelBanana",
            "duration": 0,
            "startTimestamp": "2022-020T15:02:31.354000"
          }
        },
        "constraints": {
          "model/no_mashed": [
            {
              "windows": [
                {
                  "start": 10219354000,
                  "end": 86400000000
                }
              ],
              "associations": {
                "resourceIds": [
                  "/fruit"
                ],
                "activityInstanceIds": []
              }
            }
          ]
        },
        "events": [
          {
            "graph": {
              "suffix": {
  ...
```
i.e. constraint violations are included in the simulation results.

### New Behavior
Query of
```GraphQL
query NewCoolQuery {
  constraintViolations(planId: 1) {
    constraintViolations
  }
}
```
before running the simulation returns:
```JSON
{
  "data": {
    "constraintViolations": {
      "constraintViolations": {}
    }
  }
}
```

and after running the simulation returns:
```JSON
{
  "data": {
    "constraintViolations": {
      "constraintViolations": {
        "model/no_mashed": [
          {
            "windows": [
              {
                "start": 10412050000,
                "end": 86400000000
              }
            ],
            "associations": {
              "resourceIds": [
                "/fruit"
              ],
              "activityInstanceIds": []
            }
          }
        ]
      }
    }
  }
}
```

## Documentation
While not explicitly violated, should update [API docs](https://github.com/NASA-AMMOS/aerie/wiki/Aerie-GraphQL-API-Software-Interface-Specification) and [Sim Results](https://github.com/NASA-AMMOS/aerie/wiki/Simulation-Results) to mention new GraphQL query.

## Future work
Work on separating simulation result API calls contributes to possibly streaming sim results.