### PR TITLE
[AERIE 1885] Add enabled/disabled to goal in sceduling specification

### DIFF
--- a/scheduler-server/sql/scheduler/tables/scheduling_specification_goals.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_specification_goals.sql
@@ -6,6 +6,7 @@ create table scheduling_specification_goals (
     default null -- Nulls are detected and replaced with the next
                  -- available priority by the insert trigger
     constraint non_negative_specification_goal_priority check (priority >= 0),
+  enabled boolean default true,
 
   constraint scheduling_specification_goals_primary_key
     primary key (specification_id, goal_id),

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GoalRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GoalRecord.java
@@ -1,3 +1,3 @@
 package gov.nasa.jpl.aerie.scheduler.server.models;
 
-public final record GoalRecord(GoalId id, SchedulingDSL.GoalSpecifier definition) {}
+public record GoalRecord(GoalId id, SchedulingDSL.GoalSpecifier definition, boolean enabled) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetSpecificationGoalsAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetSpecificationGoalsAction.java
@@ -16,6 +16,7 @@ import java.util.List;
             s.specification_id,
             s.goal_id,
             s.priority,
+            s.enabled,
             g.name,
             g.definition,
             g.revision
@@ -26,7 +27,8 @@ import java.util.List;
       g.goal_id,
       g.name,
       g.definition,
-      g.revision
+      g.revision,
+      g.enabled
     from goals as g
       where g.specification_id = ?
       order by g.priority asc
@@ -48,7 +50,8 @@ import java.util.List;
       final var revision = resultSet.getLong("revision");
       final var name = resultSet.getString("name");
       final var definition = resultSet.getString("definition");
-      goals.add(new PostgresGoalRecord(id, revision, name, definition));
+      final var enabled = resultSet.getBoolean("enabled");
+      goals.add(new PostgresGoalRecord(id, revision, name, definition, enabled));
     }
 
     return goals;

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresGoalRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresGoalRecord.java
@@ -4,5 +4,6 @@ public record PostgresGoalRecord(
     long id,
     long revision,
     String name,
-    String definition
+    String definition,
+    boolean enabled
 ) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
@@ -105,7 +105,7 @@ public final class PostgresSpecificationRepository implements SpecificationRepos
     if (goalCompilationResult instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error g) {
       return new GoalCompilationResult.Failure(g.errors());
     } else if (goalCompilationResult instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success g) {
-      return new GoalCompilationResult.Success(new GoalRecord(new GoalId(pgGoal.id()), g.goalSpecifier()));
+      return new GoalCompilationResult.Success(new GoalRecord(new GoalId(pgGoal.id()), g.goalSpecifier(), pgGoal.enabled()));
     } else {
       throw new Error("Unhandled variant of SchedulingDSLCompilationResult: " + goalCompilationResult);
     }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
@@ -51,6 +51,7 @@ public final class PostgresSpecificationRepository implements SpecificationRepos
 
     final var goals = postgresGoalRecords
         .stream()
+        .filter(PostgresGoalRecord::enabled)
         .map((PostgresGoalRecord pgGoal) -> compileGoalDefinition(
             missionModelService,
             planId,


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1885
* **Review:** By commit 
* **Merge strategy:** Merge (no squash) 

## Description
This PR adds the capability to toggle a scheduling goal within a scheduling specification as either enabled or disabled. A disabled scheduling goal is ignored during scheduling execution. 

## Verification
A test is added `testSingleActivityPlanGoalDisabled()` in `SchedulingIntegrationTests.java`. Also tested through the UI by adding three goals, disabling the second goal directly via the db, observed correct behavior. 

## Documentation
Two sentence have been added to https://github.com/NASA-AMMOS/aerie/wiki/Scheduling-Guide#specifying-the-order-of-goals noting the effect of enabled/disabled goals.

## Future work
There have been discussions around how the ordering/priority of goals is implemented in the UI. These discussions are some ways off resulting in tickets, so for now there are no clear next steps resulting from this PR. 
