### PR TITLE
[HOTFIX] GrowBanana positive duration

### DIFF
--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/GrowBananaActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/GrowBananaActivity.java
@@ -22,12 +22,17 @@ import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.*;
 public record GrowBananaActivity(int quantity, Duration growingDuration) {
 
   public static @Template GrowBananaActivity defaults() {
-    return new GrowBananaActivity(0, Duration.ZERO);
+    return new GrowBananaActivity(1, Duration.of(1, Duration.HOUR));
   }
 
   @Validation("Quantity must be positive")
-  public boolean validateBiteSize() {
+  public boolean validateQuantity() {
     return this.quantity() > 0;
+  }
+
+  @Validation("Growing Duration must be positive")
+  public boolean validateGrowingDuration() {
+    return this.growingDuration().longerThan(Duration.ZERO);
   }
 
   @EffectModel


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The default arguments for GrowBanana result in a division by zero when computing the rate. Instead of throwing a division by zero error, we get a `NaN` rate, which blows up when we're trying to serialize the real resource into JSON. (The JSON number type does not admit NaN or infinite).

The fix for now is to make sure that GrowBanana gives a valid result. We may want a broader fix for Real Resources, however, since the error message is far from intuitive:

> java.lang.NumberFormatException: Character N is neither a decimal digit number, decimal point, nor "e" notation exponential mark.


## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I re-ran the sequence-generation tests, and did not observe any failed simulations.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
This is a banananation-only change

## Future work
<!-- What next steps can we anticipate from here, if any? -->
We might want to think about Real Resources and NaN values.