### PR TITLE
[AERIE-1766] Add healthcheck endpoints

### DIFF
--- a/command-expansion-server/src/app.ts
+++ b/command-expansion-server/src/app.ts
@@ -100,6 +100,10 @@ app.get('/', (_: Request, res: Response) => {
   res.send('Aerie Command Service');
 });
 
+app.get('/health', (_: Request, res: Response) => {
+  res.status(200).send();
+});
+
 app.post('/put-dictionary', async (req, res, next) => {
   const dictionary = req.body.input.dictionary as string;
   logger.info(`Dictionary received`);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
-    ports: ["5007:5005"]
+    ports: ["5007:5005", "27187:8080"]
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store:ro
@@ -153,7 +153,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
-    ports: ["5008:5005"]
+    ports: ["5008:5005", "27188:8080"]
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store:ro

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -129,7 +129,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
-    ports: ['5007:5005']
+    ports: ['5007:5005', '27187:8080']
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store:ro
@@ -150,7 +150,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
-    ports: ['5008:5005']
+    ports: ['5008:5005', '27188:8080']
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store:ro

--- a/e2e-tests/src/tests/health.test.ts
+++ b/e2e-tests/src/tests/health.test.ts
@@ -16,4 +16,24 @@ test.describe('Health', () => {
     const healthy = await req.healthUI(request);
     expect(healthy).toBeTruthy();
   });
+
+  test('Merlin is healthy', async ({ request }) => {
+    const healthy = await req.healthMerlin(request);
+    expect(healthy).toBeTruthy();
+  });
+
+  test('Commanding is healthy', async ({ request }) => {
+    const healthy = await req.healthCommanding(request);
+    expect(healthy).toBeTruthy();
+  });
+
+  test('Scheduler is healthy', async ({ request }) => {
+    const healthy = await req.healthScheduler(request);
+    expect(healthy).toBeTruthy();
+  });
+
+  test('Worker is healthy', async ({ request }) => {
+    const healthy = await req.healthWorker(request);
+    expect(healthy).toBeTruthy();
+  });
 });

--- a/e2e-tests/src/utilities/requests.ts
+++ b/e2e-tests/src/utilities/requests.ts
@@ -2,7 +2,7 @@ import type { APIRequestContext } from '@playwright/test';
 import { sync as glob } from 'fast-glob';
 import { createReadStream } from 'fs';
 import { basename, resolve } from 'path';
-import { GATEWAY_URL, HASURA_URL, UI_URL } from '../utilities/urls';
+import * as urls from '../utilities/urls';
 import gql from './gql';
 import {request} from "@playwright/test";
 import time from "./time";
@@ -32,7 +32,7 @@ const req = {
     variables: Record<string, unknown> = {},
   ): Promise<T> {
     const options = { data: { query, variables } };
-    const response = await request.post(`${HASURA_URL}/v1/graphql`, options);
+    const response = await request.post(`${urls.HASURA_URL}/v1/graphql`, options);
 
     if (response.ok()) {
       const json = await response.json();
@@ -53,18 +53,39 @@ const req = {
   },
 
   async healthGateway(request: APIRequestContext): Promise<boolean> {
-    const response = await request.get(`${GATEWAY_URL}/health`);
+    const response = await request.get(`${urls.GATEWAY_URL}/health`);
     return response.ok();
   },
 
   async healthHasura(request: APIRequestContext): Promise<boolean> {
-    const response = await request.get(`${HASURA_URL}/healthz`);
+    const response = await request.get(`${urls.HASURA_URL}/healthz`);
     return response.ok();
   },
 
   async healthUI(request: APIRequestContext): Promise<boolean> {
-    const response = await request.get(`${UI_URL}/health`);
+    const response = await request.get(`${urls.UI_URL}/health`);
     return response.ok();
+  },
+
+  async healthMerlin(request: APIRequestContext): Promise<boolean> {
+    const response = await request.get(`${urls.MERLIN_URL}/health`);
+    return response.ok();
+  },
+
+  async healthCommanding(request: APIRequestContext): Promise<boolean> {
+    const response = await request.get(`${urls.COMMANDING_URL}/health`);
+    return response.ok();
+  },
+
+  async healthScheduler(request: APIRequestContext): Promise<boolean> {
+    const response = await request.get(`${urls.SCHEDULER_URL}/health`);
+    return response.ok();
+  },
+
+  async healthWorker(request: APIRequestContext): Promise<boolean> {
+    const workerOneResponse = await request.get(`${urls.WORKER_1_URL}/health`);
+    const workerTwoResponse = await request.get(`${urls.WORKER_2_URL}/health`);
+    return workerOneResponse.ok() && workerTwoResponse.ok();
   },
 
   /**
@@ -81,7 +102,7 @@ const req = {
     const name = basename(jarPath);
     const mimeType = 'application/java-archive';
     const multipart = { buffer, mimeType, name };
-    const response = await request.post(`${GATEWAY_URL}/file`, { multipart });
+    const response = await request.post(`${urls.GATEWAY_URL}/file`, { multipart });
 
     if (response.ok()) {
       const json = await response.json();

--- a/e2e-tests/src/utilities/urls.ts
+++ b/e2e-tests/src/utilities/urls.ts
@@ -3,3 +3,13 @@ export const GATEWAY_URL = 'http://localhost:9000';
 export const HASURA_URL = 'http://localhost:8080';
 
 export const UI_URL = 'http://localhost';
+
+export const MERLIN_URL = 'http://localhost:27183';
+
+export const COMMANDING_URL = 'http://localhost:27184';
+
+export const SCHEDULER_URL = 'http://localhost:27185';
+
+export const WORKER_1_URL = 'http://localhost:27187';
+
+export const WORKER_2_URL = 'http://localhost:27188';

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -29,6 +29,7 @@ import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraPlanActi
 import static io.javalin.apibuilder.ApiBuilder.before;
 import static io.javalin.apibuilder.ApiBuilder.path;
 import static io.javalin.apibuilder.ApiBuilder.post;
+import static io.javalin.apibuilder.ApiBuilder.get;
 
 /**
  * Lift native Java agents into an HTTP-oriented service.
@@ -104,6 +105,9 @@ public final class MerlinBindings implements Plugin {
       });
       path("constraintsDslTypescript", () -> {
         post(this::getConstraintsDslTypescript);
+      });
+      path("health", () -> {
+        get(ctx -> ctx.status(200));
       });
     });
 

--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
@@ -16,6 +16,7 @@ import gov.nasa.jpl.aerie.merlin.server.services.LocalPlanService;
 import gov.nasa.jpl.aerie.merlin.server.services.SynchronousSimulationAgent;
 import gov.nasa.jpl.aerie.merlin.server.services.UnexpectedSubtypeError;
 import gov.nasa.jpl.aerie.merlin.worker.postgres.PostgresSimulationNotificationPayload;
+import io.javalin.Javalin;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -56,6 +57,9 @@ public final class MerlinWorkerAppDriver {
         new LinkedBlockingQueue<>();
     final var listenAction = new ListenSimulationCapability(hikariDataSource, notificationQueue);
     listenAction.registerListener();
+
+    final var app = Javalin.create().start(8080);
+    app.get("/health", ctx -> ctx.status(200));
 
     while (true) {
       final var notification = notificationQueue.take();

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
@@ -27,6 +27,7 @@ import static gov.nasa.jpl.aerie.scheduler.server.http.SchedulerParsers.hasuraSp
 import static io.javalin.apibuilder.ApiBuilder.before;
 import static io.javalin.apibuilder.ApiBuilder.path;
 import static io.javalin.apibuilder.ApiBuilder.post;
+import static io.javalin.apibuilder.ApiBuilder.get;
 
 /**
  * set up mapping between scheduler http endpoints and java method calls
@@ -57,6 +58,7 @@ public record SchedulerBindings(
       before(ctx -> ctx.contentType("application/json"));
 
       path("schedule", () -> post(this::schedule));
+      path("health", () -> get(ctx -> ctx.status(200)));
       path("schedulingDslTypescript", () -> post(this::getSchedulingDslTypescript));
     });
   }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1766
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Relatively simple extension of existing HTTP servers to include a `/health` endpoint. Note that this is only for `GET` HTTP requests, in contrast to the `POST` requests that are commonly used throughout Aerie.

For merlin-worker, an entirely new HTTP server had to be added, hence the addition of new exposed ports for workers in `docker-compose.yml`.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Added several e2e tests that hit new `/health` endpoints

`curl -i http://0.0.0.0:2718{3,4,5,7,8}/health`
now returns
```http
HTTP/1.1 200 OK
Date: Tue, 14 Jun 2022 21:54:55 GMT
Content-Type: application/json
Content-Length: 0

HTTP/1.1 200 OK
X-Powered-By: Express
Date: Tue, 14 Jun 2022 21:54:55 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Content-Length: 0

HTTP/1.1 200 OK
Date: Tue, 14 Jun 2022 21:54:55 GMT
Content-Type: application/json
Content-Length: 0

HTTP/1.1 200 OK
Date: Tue, 14 Jun 2022 21:54:55 GMT
Content-Type: text/plain
Content-Length: 0

HTTP/1.1 200 OK
Date: Tue, 14 Jun 2022 21:54:55 GMT
Content-Type: text/plain
Content-Length: 0
```

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No invalidated documentation. Can update existing API documentation to make note of new endpoint.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Automatically hit these new health checks
*Possibly* add introspective logic to health checks