### PR TITLE
[AERIE-1909] Explicitly set prepared statement parameter

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSpansAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostSpansAction.java
@@ -9,6 +9,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,7 +49,11 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
       setTimestamp(statement, 2, startTimestamp);
       setTimestamp(statement, 3, simulationStart);
 
-      if (endTimestamp.isPresent()) setTimestamp(statement, 4, endTimestamp.get());
+      if (endTimestamp.isPresent()) {
+        setTimestamp(statement, 4, endTimestamp.get());
+      } else {
+        statement.setNull(4, Types.TIMESTAMP_WITH_TIMEZONE);
+      }
 
       setTimestamp(statement, 5, startTimestamp);
       statement.setString(6, act.type());


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1909
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
An activity which doesn't finish within the plan time was returning a duration. It should be null. It was found that when looping to create a batch of SQL queries, each parameter of an SQL `PreparedStatement` must be set, otherwise the value from the previous iteration will be used.

## Verification
We generated a plan with two activities. One with a duration which was longer than the plan bounds, and one with zero duration. We were able to observe that when preparing the batch SQL statement in `PostSpansAction.java`, in the case that the activity with zero duration was evaluated first, the second activity with null duration would be given the previous activity's duration set. This led to the unfinished activity having a non-zero duration. After the change, with the same plan, we were able to observe (break points and in the database) that the unfinished activity was correctly being set to null duration.

Adding a test would typically be a good response here. However, a test may not be the right answer. Firstly, this bug came from incorrect API usage. Secondly, the bug is non deterministic given that a Map's iteration order is indeterminate. As such, we've judged that our manual testing is appropriate.

## Documentation
None

## Future work
None
