### PR TITLE
[AERIE-1893 ] Remove deprecated sim results response code

### DIFF
--- a/command-expansion-server/test/utils/Simulation.ts
+++ b/command-expansion-server/test/utils/Simulation.ts
@@ -15,7 +15,6 @@ export async function executeSimulation(
         query SimulatePlan($planId: Int!) {
           simulate(planId: $planId) {
             status
-            results
             reason
           }
         }
@@ -25,6 +24,9 @@ export async function executeSimulation(
       },
     );
     const status = simulationRes.simulate.status;
+    if (status === 'failed') {
+      throw new Error(simulationRes.simulate.reason);
+    }
     if (status !== 'pending' && status !== 'incomplete') {
       const getSimulationRes = await graphqlClient.request(
         gql`

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -151,7 +151,6 @@ type ResourceType {
 
 type MerlinSimulationResponse {
   status: MerlinSimulationStatus!
-  results: MerlinSimulationResults
   reason: MerlinSimulationFailureReason
 }
 
@@ -266,8 +265,6 @@ type ConstraintViolationsResponse {
 }
 
 scalar ResourceSchema
-
-scalar MerlinSimulationResults
 
 scalar ResourceSamples
 

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -144,7 +144,6 @@ custom_types:
     - name: ConstraintViolationsResponse
   scalars:
     - name: ResourceSchema
-    - name: MerlinSimulationResults
     - name: ResourceSamples
     - name: ConstraintViolations
     - name: MerlinSimulationFailureReason

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -220,11 +220,10 @@ public final class ResponseSerializers {
         .build();
   }
 
-  public static JsonValue serializeSimulationResults(final SimulationResults results, final Map<String, List<Violation>> violations) {
+  public static JsonValue serializeSimulationResults(final SimulationResults results) {
     return Json
         .createObjectBuilder()
         .add("start", serializeTimestamp(results.startTime))
-        .add("constraints", serializeMap(v -> serializeIterable(ResponseSerializers::serializeConstraintViolation, v), violations))
         .add("activities", serializeSimulatedActivities(results.simulatedActivities))
         .add("unfinishedActivities", serializeUnfinishedActivities(results.unfinishedActivities))
         .add("events", serializeSimulationEvents(results.events, topicsById(results.topics), results.startTime))
@@ -320,7 +319,7 @@ public final class ResponseSerializers {
       return Json
           .createObjectBuilder()
           .add("status", "complete")
-          .add("results", serializeSimulationResults(r.results(), r.violations()))
+          .add("results", serializeSimulationResults(r.results()))
           .build();
      } else {
       throw new UnexpectedSubtypeError(GetSimulationResultsAction.Response.class, response);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -220,16 +220,6 @@ public final class ResponseSerializers {
         .build();
   }
 
-  public static JsonValue serializeSimulationResults(final SimulationResults results) {
-    return Json
-        .createObjectBuilder()
-        .add("start", serializeTimestamp(results.startTime))
-        .add("activities", serializeSimulatedActivities(results.simulatedActivities))
-        .add("unfinishedActivities", serializeUnfinishedActivities(results.unfinishedActivities))
-        .add("events", serializeSimulationEvents(results.events, topicsById(results.topics), results.startTime))
-        .build();
-  }
-
   public static JsonValue serializeResourceSamples(final Map<String, List<Pair<Duration, SerializedValue>>> resourceSamples) {
     return Json
         .createObjectBuilder()
@@ -246,56 +236,6 @@ public final class ResponseSerializers {
             v -> serializeIterable(ResponseSerializers::serializeConstraintViolation, v),
             violations))
         .build();
-  }
-
-  private static Map<Integer, Pair<String, ValueSchema>> topicsById(List<Triple<Integer, String, ValueSchema>> topics) {
-    final Map<Integer, Pair<String, ValueSchema>> topicsById = new HashMap<>();
-    for (final var topic : topics) {
-      topicsById.put(topic.getLeft(), Pair.of(topic.getMiddle(), topic.getRight()));
-    }
-    return topicsById;
-  }
-
-  private static JsonValue serializeSimulationEvents(
-      Map<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>> events,
-      final Map<Integer, Pair<String, ValueSchema>> topics,
-      final Instant startTime) {
-    var arrayBuilder = Json.createArrayBuilder();
-    for (final var eventPoint : events.entrySet()) {
-      final var transactionPoints = eventPoint.getValue();
-      for (final var eventGraph : transactionPoints) {
-        arrayBuilder = arrayBuilder.add(
-            Json.createObjectBuilder()
-                .add("time", serializeTimestamp(startTime.plus(eventPoint.getKey().in(Duration.MICROSECONDS), ChronoUnit.MICROS)))
-                .add("graph", serializeEventGraph(eventGraph, topics)).build());
-      }
-    }
-    return arrayBuilder.build();
-  }
-
-  private static JsonValue serializeEventGraph(
-      EventGraph<Pair<Integer, SerializedValue>> eventGraph,
-      final Map<Integer, Pair<String, ValueSchema>> topics) {
-    var objectBuilder = Json.createObjectBuilder();
-    if (eventGraph instanceof EventGraph.Atom<Pair<Integer, SerializedValue>> atom) {
-      final var event = atom.atom();
-      objectBuilder = objectBuilder
-          .add("type", "atom")
-          .add("value", serializedValueP.unparse(event.getRight()))
-          .add("schema", valueSchemaP.unparse(topics.get(event.getLeft()).getRight()))
-          .add("topic", stringP.unparse(topics.get(event.getLeft()).getLeft()));
-    } else if (eventGraph instanceof EventGraph.Sequentially<Pair<Integer, SerializedValue>> sequentially) {
-      objectBuilder = objectBuilder
-          .add("type", "sequentially")
-          .add("prefix", serializeEventGraph(sequentially.prefix(), topics))
-          .add("suffix", serializeEventGraph(sequentially.suffix(), topics));
-    } else if (eventGraph instanceof EventGraph.Concurrently<Pair<Integer, SerializedValue>> concurrently) {
-      objectBuilder = objectBuilder
-          .add("type", "concurrently")
-          .add("left", serializeEventGraph(concurrently.left(), topics))
-          .add("right", serializeEventGraph(concurrently.right(), topics));
-    }
-    return objectBuilder.build();
   }
 
   public static JsonValue serializeSimulationResultsResponse(final GetSimulationResultsAction.Response response) {
@@ -319,7 +259,6 @@ public final class ResponseSerializers {
       return Json
           .createObjectBuilder()
           .add("status", "complete")
-          .add("results", serializeSimulationResults(r.results()))
           .build();
      } else {
       throw new UnexpectedSubtypeError(GetSimulationResultsAction.Response.class, response);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -32,7 +32,7 @@ public final class GetSimulationResultsAction {
     record Pending() implements Response {}
     record Incomplete() implements Response {}
     record Failed(String reason) implements Response {}
-    record Complete(SimulationResults results, Map<String, List<Violation>> violations) implements Response {}
+    record Complete(SimulationResults results) implements Response {}
   }
 
   private final PlanService planService;
@@ -64,10 +64,8 @@ public final class GetSimulationResultsAction {
     } else if (response instanceof ResultsProtocol.State.Failed r) {
       return new Response.Failed(r.reason());
     } else if (response instanceof ResultsProtocol.State.Success r) {
-      final var results = r.results();
-      final var violations = getViolations(planId);
 
-      return new Response.Complete(results, violations);
+      return new Response.Complete(r.results());
     } else {
       throw new UnexpectedSubtypeError(ResultsProtocol.State.class, response);
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -32,7 +32,7 @@ public final class GetSimulationResultsAction {
     record Pending() implements Response {}
     record Incomplete() implements Response {}
     record Failed(String reason) implements Response {}
-    record Complete(SimulationResults results) implements Response {}
+    record Complete() implements Response {}
   }
 
   private final PlanService planService;
@@ -64,8 +64,7 @@ public final class GetSimulationResultsAction {
     } else if (response instanceof ResultsProtocol.State.Failed r) {
       return new Response.Failed(r.reason());
     } else if (response instanceof ResultsProtocol.State.Success r) {
-
-      return new Response.Complete(r.results());
+      return new Response.Complete();
     } else {
       throw new UnexpectedSubtypeError(ResultsProtocol.State.class, response);
     }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1893
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Thanks to work on previous PRs (#209, #211, #189), simulation results are now entirely separated from the `simulate` Hasura action. Constraint violations are now queried with `constraintViolations`, resource samples with `resourceSamples`, and simulated activities directly from the database. UI has been [updated](https://github.com/NASA-AMMOS/aerie-ui/pull/38) to use new queries.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Manually tested UI to ensure functionality is maintained.

```graphql
query {
  simulate(planId: 1) {
    status
    reason
    results
  }
}
```
used to get a response of
```json
{
  "data": {
    "simulate": {
      "status": "complete",
      "results": {
        "unfinishedActivities": {},
        "start": "2022-023T12:12:12.000000",
        "activities": {
           ...
        "constraints": {
          "model/no waste": [
            ...
        "events": [
          {
            "graph": {
              "suffix": {
                ...
```

now
```graphql
query {
  simulate(planId: 1) {
    reason
    status
  }
}
```

receives
```json
{
  "data": {
    "simulate": {
      "status": "complete"
    }
  }
}
```

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Need to rework existing documentation on `simulate` responses, and point towards new API calls.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Opens the door for simulation streaming to database, as clients are no longer dependent on monolithic `simulate` call
