### PR TITLE
[AERIE-1865] User can trigger an analyze only scheduling analysis

### DIFF
--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
@@ -45,8 +45,8 @@ class SchedulerDatabaseTests {
     try(final var statement = connection.createStatement()) {
       final var res = statement.executeQuery("""
         insert into scheduling_specification(
-          revision, plan_id, plan_revision, horizon_start, horizon_end, simulation_arguments
-        ) values (0, 0, 0, now(), now(), '{}') returning id;
+          revision, plan_id, plan_revision, horizon_start, horizon_end, simulation_arguments, analysis_only
+        ) values (0, 0, 0, now(), now(), '{}', false) returning id;
       """);
       res.next();
       return res.getInt("id");

--- a/e2e-tests/src/tests/scheduler.test.ts
+++ b/e2e-tests/src/tests/scheduler.test.ts
@@ -93,7 +93,8 @@ test.describe('Scheduling', () => {
       horizon_start: plan_start_timestamp,
       plan_id : plan_id,
       plan_revision : plan_revision,
-      simulation_arguments : {}
+      simulation_arguments : {},
+      analysis_only: false
     }
     specification_id = await req.insertSchedulingSpecification(request, schedulingSpecification);
     expect(specification_id).not.toBeNull();

--- a/e2e-tests/src/types/scheduling-goal.d.ts
+++ b/e2e-tests/src/types/scheduling-goal.d.ts
@@ -44,6 +44,7 @@ type SchedulingSpec = {
   plan_revision: number;
   revision: number;
   simulation_arguments: ArgumentsMap;
+  analysis_only: boolean;
 };
 
 type SchedulingSpecInsertInput = Omit<SchedulingSpec, 'id' | 'revision'>;

--- a/e2e-tests/src/types/scheduling-specification.d.ts
+++ b/e2e-tests/src/types/scheduling-specification.d.ts
@@ -3,5 +3,6 @@ type SchedulingSpecificationInput = {
     plan_revision: number,
     horizon_start: string,
     horizon_end: string,
-    simulation_arguments: object
+    simulation_arguments: object,
+    analysis_only: boolean
 };

--- a/scheduler-server/sql/scheduler/tables/scheduling_specification.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_specification.sql
@@ -7,7 +7,7 @@ create table scheduling_specification (
   horizon_start timestamptz not null,
   horizon_end timestamptz not null,
   simulation_arguments jsonb not null,
-
+  analysis_only boolean not null,
   constraint scheduling_specification_synthetic_key
     primary key(id)
 );
@@ -26,6 +26,8 @@ comment on column scheduling_specification.horizon_end is e''
   'The end of the scheduling horizon within which the scheduler may place activities.';
 comment on column scheduling_specification.simulation_arguments is e''
   'The arguments to use for simulation during scheduling.';
+comment on column scheduling_specification.analysis_only is e''
+  'The boolean stating whether this is an analysis run only';
 
 create function increment_revision_on_update()
   returns trigger

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/Specification.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/Specification.java
@@ -11,5 +11,6 @@ public record Specification(
     List<GoalRecord> goalsByPriority,
     Timestamp horizonStartTimestamp,
     Timestamp horizonEndTimestamp,
-    Map<String, SerializedValue> simulationArguments
+    Map<String, SerializedValue> simulationArguments,
+    boolean analysisOnly
 ) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetSpecificationAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetSpecificationAction.java
@@ -20,7 +20,8 @@ import java.util.Optional;
       spec.plan_revision,
       to_char(spec.horizon_start, 'YYYY-DDD"T"HH24:MI:SS.FF6') as horizon_start,
       to_char(spec.horizon_end, 'YYYY-DDD"T"HH24:MI:SS.FF6') as horizon_end,
-      spec.simulation_arguments
+      spec.simulation_arguments,
+      spec.analysis_only
     from scheduling_specification as spec
       where spec.id = ?
     """;
@@ -45,6 +46,7 @@ import java.util.Optional;
     final var horizonStart = Timestamp.fromString(resultSet.getString("horizon_start"));
     final var horizonEnd = Timestamp.fromString(resultSet.getString("horizon_end"));
     final var arguments = parseSimulationArguments(resultSet.getCharacterStream("simulation_arguments"));
+    final var analysisOnly = resultSet.getBoolean("analysis_only");
 
     return Optional.of(new SpecificationRecord(
         specificationId,
@@ -53,7 +55,8 @@ import java.util.Optional;
         planRevision,
         horizonStart,
         horizonEnd,
-        arguments
+        arguments,
+        analysisOnly
     ));
   }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
@@ -87,7 +87,8 @@ public final class PostgresSpecificationRepository implements SpecificationRepos
         successfulGoals,
         specificationRecord.horizonStartTimestamp(),
         specificationRecord.horizonEndTimestamp(),
-        specificationRecord.simulationArguments()
+        specificationRecord.simulationArguments(),
+        specificationRecord.analysisOnly()
     );
   }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/SpecificationRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/SpecificationRecord.java
@@ -12,5 +12,6 @@ public final record SpecificationRecord(
     long planRevision,
     Timestamp horizonStartTimestamp,
     Timestamp horizonEndTimestamp,
-    Map<String, SerializedValue> simulationArguments
+    Map<String, SerializedValue> simulationArguments,
+    boolean analysisOnly
 ) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -131,7 +131,7 @@ public record SynchronousSchedulerAgent(
       }
       problem.setGoals(orderedGoals);
 
-      final var scheduler = createScheduler(planMetadata, problem);
+      final var scheduler = createScheduler(planMetadata, problem, specification.analysisOnly());
       //run the scheduler to find a solution to the posed problem, if any
       final var solutionPlan = scheduler.getNextSolution().orElseThrow(
           () -> new ResultsProtocolFailure("scheduler returned no solution"));
@@ -219,10 +219,10 @@ public record SynchronousSchedulerAgent(
    * @param problem specification of the scheduling problem that needs to be solved
    * @return a new scheduler that is set up to begin providing solutions to the problem
    */
-  private Solver createScheduler(final PlanMetadata planMetadata, final Problem problem) {
+  private Solver createScheduler(final PlanMetadata planMetadata, final Problem problem, final boolean analysisOnly) {
     //TODO: allow for separate control of windows for constraint analysis vs ability to schedule activities
     //      (eg constraint may need view into immutable past to know how to schedule things in the future)
-    final var solver = new PrioritySolver(problem);
+    final var solver = new PrioritySolver(problem, analysisOnly);
     return solver;
   }
 

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -808,7 +808,8 @@ public class SchedulingIntegrationTests {
         goalsByPriority,
         Timestamp.fromString("2021-001T00:00:00"),
         Timestamp.fromString("2021-005T00:00:00"),
-        Map.of())));
+        Map.of(),
+        false)));
     final var agent = new SynchronousSchedulerAgent(
         specificationService,
         mockMerlinService,

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -47,6 +47,11 @@ public class PrioritySolver implements Solver {
   boolean checkSimBeforeInsertingActivities;
 
   /**
+   * boolean stating whether only conflict analysis should be performed or not
+   */
+  final boolean analysisOnly;
+
+  /**
    * description of the planning problem to solve
    *
    * remains constant throughout solver lifetime
@@ -78,11 +83,16 @@ public class PrioritySolver implements Solver {
    * @param problem IN, STORED description of the planning problem to be
    *     solved, which must not change
    */
-  public PrioritySolver(Problem problem) {
+  public PrioritySolver(final Problem problem, final boolean analysisOnly) {
     checkNotNull(problem, "creating solver with null input problem descriptor");
     this.checkSimBeforeInsertingActivities = true;
     this.problem = problem;
     this.simulationFacade = problem.getSimulationFacade();
+    this.analysisOnly = analysisOnly;
+  }
+
+  public PrioritySolver(final Problem problem) {
+    this(problem, false);
   }
 
   //TODO: should probably be part of sched configuration; maybe even per rule
@@ -435,7 +445,7 @@ private void satisfyOptionGoal(OptionGoal goal) {
         assert missing != null;
 
         //determine the best activities to satisfy the conflict
-        if (missing instanceof MissingActivityInstanceConflict || missing instanceof MissingActivityTemplateConflict) {
+        if (!analysisOnly && (missing instanceof MissingActivityInstanceConflict || missing instanceof MissingActivityTemplateConflict)) {
           final var acts = getBestNewActivities((MissingActivityConflict) missing);
           assert acts != null;
           //add the activities to the output plan


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1865
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
An `analysis_only` field was added to the `scheduling_specification` table in the scheduler server. If the boolean is set to true, the scheduler should only run an analysis, otherwise it would proceed to do a normal scheduling run (insert activities to resolve conflicts).

In the solver, an `analysis_only` boolean is used to bypass branches where activities are inserted in the plan to resolve missing activity conflicts. However, association conflicts are still processed.

There is no change in what scheduling returns. Note however that compared with a regular scheduling run, `inserted_activities` will always be empty.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
One test has been added to check that the solver was indeed processing only association conflicts.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None. 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Update the UI