### PR TITLE
[HOTFIX] Don't delete expansion rule on dictionary delete

### DIFF
--- a/command-expansion-server/sql/commanding/tables/expansion_rule.sql
+++ b/command-expansion-server/sql/commanding/tables/expansion_rule.sql
@@ -18,7 +18,7 @@ create table expansion_rule (
 
   foreign key (authoring_command_dict_id)
     references command_dictionary (id)
-    on delete cascade
+    on delete set null
 );
 comment on table expansion_rule is e''
   'The user defined logic to expand an activity type.';


### PR DESCRIPTION
When we delete a command dictionary, we shouldn't delete expansions that
 have that dictionary set as the authoring version

* **Tickets addressed:** HOTFIX
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

We had `on delete cascade` for the foreign key relationship of authoring command dictionary on expansion rules. Generally, we don't want to remove the expansion rules if the dictionary it was authored with is removed. It might still be valid for other dictionaries. Instead, I changed it to `on delete set null` to just null out the authoring command dictionary version.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
The change was so small and well known that I verified it by inspection

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None