### PR TITLE
[AERIE-1910] - Scheduling EDSL Parameterless Activity Fix

### DIFF
--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BananaNapActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BananaNapActivity.java
@@ -1,0 +1,20 @@
+package gov.nasa.jpl.aerie.banananation.activities;
+
+import gov.nasa.jpl.aerie.banananation.Mission;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
+
+/**
+ * Nap time [banana style]!!!!
+ * This activity has no effect :)
+ *
+ * @subsystem fruit
+ * @contact Jane Doe
+ */
+@ActivityType("BananaNap")
+public final class BananaNapActivity {
+  @EffectModel
+  public void run(final Mission mission) {
+
+  }
+}

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
@@ -16,10 +16,12 @@
 @WithActivityType(DecomposingActivity.ChildActivity.class)
 @WithActivityType(DecomposingActivity.GrandchildActivity.class)
 @WithActivityType(BakeBananaBreadActivity.class)
+@WithActivityType(BananaNapActivity.class)
 
 package gov.nasa.jpl.aerie.banananation;
 
 import gov.nasa.jpl.aerie.banananation.activities.BakeBananaBreadActivity;
+import gov.nasa.jpl.aerie.banananation.activities.BananaNapActivity;
 import gov.nasa.jpl.aerie.banananation.activities.BiteBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ChangeProducerActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DecomposingActivity;
@@ -28,6 +30,7 @@ import gov.nasa.jpl.aerie.banananation.activities.LineCountBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ParameterTestActivity;
 import gov.nasa.jpl.aerie.banananation.activities.PeelBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.PickBananaActivity;
+import gov.nasa.jpl.aerie.banananation.activities.BananaNapActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ThrowBananaActivity;
 import gov.nasa.jpl.aerie.contrib.serialization.rulesets.BasicValueMappers;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.MissionModel;

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
@@ -86,11 +86,23 @@ public class TypescriptCodeGenerationService {
     final var result = new ArrayList<String>();
     result.add("const ActivityTemplateConstructors = {");
     for (final var activityTypeCode : activityTypeCodes) {
-      result.add(indent("%s: function %sConstructor(args: {".formatted(activityTypeCode.activityTypeName(), activityTypeCode.activityTypeName())));
-      result.add(indent(indent(generateActivityArgumentTypes(activityTypeCode.parameterTypes()))));
-      result.add(indent("}): %s {".formatted(activityTypeCode.activityTypeName())));
-      result.add(indent(indent("return { activityType: ActivityType.%s, args };".formatted(activityTypeCode.activityTypeName()))));
-      result.add(indent("},"));
+      if(activityTypeCode.parameterTypes().isEmpty()) {
+        result.add(indent("%s: function %sConstructor(): %s {".formatted(
+            activityTypeCode.activityTypeName(),
+            activityTypeCode.activityTypeName(),
+            activityTypeCode.activityTypeName())));
+        result.add(indent(indent("return { activityType: ActivityType.%s, args: {} };".formatted(activityTypeCode.activityTypeName()))));
+        result.add(indent("},"));
+      }
+      else {
+        result.add(indent("%s: function %sConstructor(args: {".formatted(
+            activityTypeCode.activityTypeName(),
+            activityTypeCode.activityTypeName())));
+        result.add(indent(indent(generateActivityArgumentTypes(activityTypeCode.parameterTypes()))));
+        result.add(indent("}): %s {".formatted(activityTypeCode.activityTypeName())));
+        result.add(indent(indent("return { activityType: ActivityType.%s, args };".formatted(activityTypeCode.activityTypeName()))));
+        result.add(indent("},"));
+      }
     }
     result.add("};");
     return joinLines(result);

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
@@ -38,7 +38,12 @@ class TypescriptCodeGenerationServiceTest {
                           "quantity",
                           ValueSchema.REAL
                       )
-                  )),
+                  ),
+                  new MissionModelService.ActivityType(
+                      "SampleActivityEmpty",
+                      Map.of()
+                  )
+          ),
           List.of(new MissionModelService.ResourceType("/sample/resource/1", ValueSchema.REAL),
                   new MissionModelService.ResourceType("/sample/resource/2", ValueSchema.ofStruct(
                       Map.of("field1", ValueSchema.BOOLEAN,
@@ -57,9 +62,11 @@ class TypescriptCodeGenerationServiceTest {
             export enum ActivityType {
               SampleActivity1 = 'SampleActivity1',
               SampleActivity2 = 'SampleActivity2',
+              SampleActivityEmpty = 'SampleActivityEmpty',
             }
             interface SampleActivity1 extends ActivityTemplate {}
             interface SampleActivity2 extends ActivityTemplate {}
+            interface SampleActivityEmpty extends ActivityTemplate {}
             const ActivityTemplateConstructors = {
               SampleActivity1: function SampleActivity1Constructor(args: {
                 duration: Duration,
@@ -72,6 +79,9 @@ class TypescriptCodeGenerationServiceTest {
                 quantity: Double,
               }): SampleActivity2 {
                 return { activityType: ActivityType.SampleActivity2, args };
+              },
+              SampleActivityEmpty: function SampleActivityEmptyConstructor(): SampleActivityEmpty {
+                return { activityType: ActivityType.SampleActivityEmpty, args: {} };
               },
             };
             export enum Resource {


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1910
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This is a simple PR to address the concern in AERIE-1910 about parameterless activities allowing bogus parameters. So, if there was an activity, say `EmptyActivity`, admitting no parameters (meaning the correct instantiation would be `EmptyActivity({})`), the EDSL could allow `EmptyActivity({bogus: "param"})` to be passed. To avoid that, the fix this PR takes per @mattdailis's recommendation, is just to not accept any parameters. That is, instead of instantiating with an empty dictionary (`EmptyActivity({})`), now, no dictionary is taken (`EmptyActivity()`).

## Verification
Tests were created! A new test was created in the compilation tester, and the integration tester, and it was tested with a deployment of AERIE to confirm that the code editor could suggest this change as well.

## Documentation
A quick update to the **ActivityTemplate** section was done.

## Future work
None, maybe updating the constraints eDSL to also handle this?
