### PR TITLE
[AERIE-1911] - Range check recurrence interval

### DIFF
--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -95,6 +95,29 @@ public class SchedulingIntegrationTests {
   }
 
   @Test
+  void testRecurrenceGoalNegative() {
+    try {
+      final var results = runScheduler(
+          BANANANATION,
+          List.of(),
+          List.of(new SchedulingGoal(new GoalId(0L), """
+              export default () => Goal.ActivityRecurrenceGoal({
+                activityTemplate: ActivityTemplates.PeelBanana({
+                  peelDirection: "fromStem",
+                }),
+                interval: -25 // one day in microseconds
+              })
+              """, true)));
+    }
+    catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("Duration passed to RecurrenceGoal as the goal's minimum recurrence interval cannot be negative!"));
+    }
+    catch (Exception e) {
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
   void testEmptyPlanDurationCardinalityGoal() {
     final var results = runScheduler(BANANANATION,
         List.of(),

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestRecurrenceGoal {
 
@@ -46,6 +47,40 @@ public class TestRecurrenceGoal {
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
+  }
+
+  @Test
+  public void testRecurrenceNegative() {
+    final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    Problem problem = new Problem(fooMissionModel,
+                                  planningHorizon,
+                                  new SimulationFacade(planningHorizon,
+                                                       fooMissionModel),
+                                  SimulationUtility.getFooSchedulerModel());
+
+    try {
+      final var activityType = problem.getActivityType("ControllableDurationActivity");
+      final var goal = new RecurrenceGoal.Builder()
+          .named("Test recurrence goal")
+          .forAllTimeIn(Window.betweenClosedOpen(Duration.of(1, Duration.SECONDS),
+                                                 Duration.of(20, Duration.SECONDS)))
+          .thereExistsOne(new ActivityCreationTemplate.Builder()
+                              .duration(Duration.of(2, Duration.SECONDS))
+                              .ofType(activityType)
+                              .build())
+          .repeatingEvery(Duration.of(-1, Duration.SECONDS))
+          .build();
+    }
+    catch (IllegalArgumentException e) {
+      //minimum is checked first so that's the output, even though the value for repeatingEvery is set as both the min
+      //    and max possible duration
+      assertTrue(e.getMessage()
+                  .contains("Duration passed to RecurrenceGoal as the goal's minimum recurrence interval cannot be negative!"));
+    }
+    catch (Exception e) {
+      fail(e.getMessage());
+    }
   }
 
 }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1911
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The focus of the PR is to range check recurrence intervals, that is, not allow negative recurrence intervals. To do this, we catch the error within the builder of the `RecurrenceGoal` (specifically in `fill()`). Also, since the RecurrenceGoal stores its interval as a window (with the start representing a minimum recurrence interval, the end representing a maximum, a feature not yet supported), that was replaced with a record `MinMaxAllowableRecurrenceInterval` just to make it more explicit.

## Verification
A new test was added to the existing recurrence goal tests - TestRecurrenceGoal.
Similarly, another test was added to the integration tests, to verify the entire process worked.

## Documentation
Just an update to the recurrence goal section.

## Future work
This might play weird with the AnalyzeWhen ([AERIE-1880]) PR, just because of the `MinMaxAllowableRecurrenceInterval` fix.
