### PR TITLE
[HOTFIX] banananation cmd dict model congruency

### DIFF
--- a/command-expansion-server/cdict/command_banananation.xml
+++ b/command-expansion-server/cdict/command_banananation.xml
@@ -18,12 +18,28 @@
         <enum_table name="string">
             <values>
                 <enum symbol="fromStem" numeric="0" />
-                <enum symbol="fromBase" numeric="1" />
-                <enum symbol="fromCenter" numeric="2" />
+                <enum symbol="fromTip" numeric="1" />
             </values>
         </enum_table>
     </enum_definitions>
     <command_definitions>
+        <fsw_command opcode="0xFFFF" stem="ECHO" class="FSW">
+          <arguments>
+            <var_string_arg name="echo_string" prefix_bit_length="8" max_bit_length="1024" cts_item_type="dynamic_arg">
+              <description>String to echo back</description>
+            </var_string_arg>
+          </arguments>
+          <categories>
+            <module>shell_ctl</module>
+            <ops_category>FSW</ops_category>
+          </categories>
+          <description>This command will echo back a string</description>
+          <completion>String is echoed back</completion>
+          <fsw_specification custom_validation_required="No" command_priority="Nominal" />
+          <restricted_modes>
+            <prime_string_restriction prime_string_only="No" />
+          </restricted_modes>
+        </fsw_command>
         <fsw_command opcode="0xFFFF" stem="PREHEAT_OVEN" class="FSW">
             <arguments>
                 <unsigned_arg name="temperature" bit_length="8" units="none">

--- a/command-expansion-server/cdict/command_banananation.xml
+++ b/command-expansion-server/cdict/command_banananation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <command_dictionary>
-    <header mission_name="AERIE" version="1.0.0.0" schema_version="1.0">
+    <header mission_name="Banana Nation" version="1.0.0.0" schema_version="1.0">
         <spacecraft_ids>
             <spacecraft_id value="62" />
         </spacecraft_ids>
@@ -86,9 +86,9 @@
                     <range_of_values>
                         <include min="0" max="100" />
                     </range_of_values>
-                    <description>Number of bananans to grow</description>
+                    <description>Number of bananas to grow</description>
                 </unsigned_arg>
-                <unsigned_arg name="duration" bit_length="8" units="none">
+                <unsigned_arg name="durationSecs" bit_length="8" units="none">
                     <range_of_values>
                         <include min="0" max="100" />
                     </range_of_values>
@@ -99,8 +99,8 @@
                 <module>shell_ctl</module>
                 <ops_category>FSW</ops_category>
             </categories>
-            <description>This command will turn on the oven</description>
-            <completion>Oven is preheated</completion>
+            <description>This command will grow bananas</description>
+            <completion>Bananas are grown</completion>
             <fsw_specification custom_validation_required="No" command_priority="Nominal" />
             <restricted_modes>
                 <prime_string_restriction prime_string_only="No" />
@@ -139,8 +139,8 @@
                 <module>shell_ctl</module>
                 <ops_category>FSW</ops_category>
             </categories>
-            <description>This command make the banana bread dough</description>
-            <completion>The dough mixture is created</completion>
+            <description>This command peels a single banana</description>
+            <completion>The banana is peeled</completion>
             <fsw_specification custom_validation_required="No" command_priority="Nominal" />
             <restricted_modes>
                 <prime_string_restriction prime_string_only="No" />
@@ -151,7 +151,7 @@
                 <module>shell_ctl</module>
                 <ops_category>FSW</ops_category>
             </categories>
-            <description>This command bakes a bananan bread</description>
+            <description>This command bakes a banana bread</description>
             <completion>Banana bread is done baking</completion>
             <fsw_specification custom_validation_required="No" command_priority="Nominal" />
             <restricted_modes>
@@ -170,7 +170,7 @@
                 <prime_string_restriction prime_string_only="No" />
             </restricted_modes>
         </fsw_command>
-      <fsw_command opcode="0xFFFE" stem="PACKAGE_BANANA" class="FSW">
+        <fsw_command opcode="0xFFFE" stem="PACKAGE_BANANA" class="FSW">
         <arguments>
           <unsigned_arg name="lot_number" bit_length="16" units="Opcode">
             <description>Identification number assigned to a particular quantity</description>
@@ -193,7 +193,7 @@
           </repeat_arg>
         </arguments>
         <description>Dynamically bundle bananas into lots</description>
-        <completion>When the banana are packaged up</completion>
+        <completion>The bananas are packaged up</completion>
         <fsw_specification custom_validation_required="No" command_priority="Nominal" />
         <restricted_modes>
           <prime_string_restriction prime_string_only="No"/>
@@ -205,7 +205,7 @@
                 <ops_category>FSW</ops_category>
             </categories>
             <description>Pick a banana</description>
-            <completion>You have a single bananana</completion>
+            <completion>You have a single banana</completion>
             <fsw_specification custom_validation_required="No" command_priority="Nominal" />
             <restricted_modes>
                 <prime_string_restriction prime_string_only="No" />

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/PeelBananaActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/PeelBananaActivity.java
@@ -4,9 +4,6 @@ import gov.nasa.jpl.aerie.banananation.Mission;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Parameter;
-import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Validation;
-
-import java.util.List;
 
 /**
  * Peel a banana, in preparation for consumption.
@@ -22,17 +19,17 @@ import java.util.List;
 public final class PeelBananaActivity {
   private static final double MASHED_BANANA_AMOUNT = 1.0;
 
-  @Parameter
-  public String peelDirection = "fromStem";
-
-  @Validation("peel direction must be fromStem or fromTip")
-  public boolean validatePeelDirection() {
-    return List.of("fromStem", "fromTip").contains(this.peelDirection);
+  public enum PeelDirectionEnum {
+    fromStem,
+    fromTip,
   }
+
+  @Parameter
+  public PeelDirectionEnum peelDirection = PeelDirectionEnum.fromStem;
 
   @EffectModel
   public void run(final Mission mission) {
-    if (peelDirection.equals("fromStem")) {
+    if (peelDirection.equals(PeelDirectionEnum.fromStem)) {
       mission.fruit.subtract(MASHED_BANANA_AMOUNT);
     }
     mission.peel.subtract(1.0);


### PR DESCRIPTION
* **Tickets addressed:** HOTFIX
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The Peel Banana command expected an enum of 'fromStem' | 'fromBase' |
'fromCenter' while the model produced a string with a custom validator.

This changes the model to an enum of 'fromStem' | 'fromTip' and makes
the command match that.

Additional copy changes to the banananation command dictionary (spelling, copy/paste errors, name)

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Inspection & used the new command dictionary and model in an expansion

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None