### PR TITLE
[AERIE-1922] Add absolute time to activities and resource profiles

### DIFF
--- a/command-expansion-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
+++ b/command-expansion-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
@@ -32,6 +32,8 @@ export const simulatedActivitiesBatchLoader: BatchLoader<
             }
             attributes
             start_offset
+            start_time
+            end_time
             duration
             activity_type_name
           }
@@ -95,6 +97,8 @@ export const simulatedActivityInstanceBySimulatedActivityIdBatchLoader: BatchLoa
             }
             attributes
             start_offset
+            start_time
+            end_time
             duration
             activity_type_name
           }
@@ -149,6 +153,8 @@ export interface SimulatedActivity<
   attributes: SimulatedActivityAttributes<ActivityArguments, ActivityComputedAttributes>;
   duration: Temporal.Duration;
   startOffset: Temporal.Duration;
+  startTime: Temporal.Instant;
+  endTime: Temporal.Instant;
   activityTypeName: string;
 }
 
@@ -168,6 +174,8 @@ export interface GraphQLSimulatedActivityInstance<
   attributes: SimulatedActivityAttributes<ActivityArguments, ActivityComputedAttributes>;
   duration: string;
   start_offset: string;
+  start_time: string;
+  end_time: string;
   activity_type_name: string;
 }
 
@@ -179,6 +187,8 @@ export function mapGraphQLActivityInstance(
     id: activityInstance.id,
     duration: Temporal.Duration.from(parse(activityInstance.duration).toISOString()),
     startOffset: Temporal.Duration.from(parse(activityInstance.start_offset).toISOString()),
+    startTime: Temporal.Instant.from(activityInstance.start_time),
+    endTime: Temporal.Instant.from(activityInstance.end_time),
     simulationDatasetId: activityInstance.simulation_dataset.id,
     activityTypeName: activityInstance.activity_type_name,
     attributes: {

--- a/command-expansion-server/src/lib/codegen/ActivityTypescriptCodegen.ts
+++ b/command-expansion-server/src/lib/codegen/ActivityTypescriptCodegen.ts
@@ -2,7 +2,9 @@ import { globalDeclaration, indent, interfaceDeclaration } from './CodegenHelper
 import { GraphQLActivitySchema, Schema, SchemaTypes } from '../batchLoaders/activitySchemaBatchLoader.js';
 
 const commonProperties = `readonly duration: Temporal.Duration;
-readonly startOffset: Temporal.Duration;`;
+readonly startOffset: Temporal.Duration;
+readonly startTime: Temporal.Instant;
+readonly endTime: Temporal.Instant;`
 
 export function generateTypescriptForGraphQLActivitySchema(activitySchema: GraphQLActivitySchema): string {
   const activityTypeAlias = `type ActivityType = ${activitySchema.name};`;

--- a/command-expansion-server/test/sequence-generation.spec.ts
+++ b/command-expansion-server/test/sequence-generation.spec.ts
@@ -189,21 +189,21 @@ describe('sequence generation', () => {
         // expansion 1
         type: 'command',
         stem: 'PREHEAT_OVEN',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [70],
         metadata: { simulatedActivityId: simulatedActivityId1 },
       },
       {
         type: 'command',
         stem: 'PREPARE_LOAF',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [50, false],
         metadata: { simulatedActivityId: simulatedActivityId1 },
       },
       {
         type: 'command',
         stem: 'BAKE_BREAD',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [],
         metadata: { simulatedActivityId: simulatedActivityId1 },
       },
@@ -211,21 +211,21 @@ describe('sequence generation', () => {
         // expansion 2
         type: 'command',
         stem: 'PREHEAT_OVEN',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [70],
         metadata: { simulatedActivityId: simulatedActivityId2 },
       },
       {
         type: 'command',
         stem: 'BAKE_BREAD',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [],
         metadata: { simulatedActivityId: simulatedActivityId2 },
       },
       {
         type: 'command',
         stem: 'PREPARE_LOAF',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [50, false],
         metadata: { simulatedActivityId: simulatedActivityId2 },
       },
@@ -283,21 +283,21 @@ describe('sequence generation', () => {
       {
         type: 'command',
         stem: 'PACKAGE_BANANA',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: ['Chiquita', 43, 'Dole', 12, 1093],
         metadata: { simulatedActivityId: simulatedActivityId4 },
       },
       {
         type: 'command',
         stem: 'PACKAGE_BANANA',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: ['Chiquita', 43, 'Dole', 12, 1093],
         metadata: { simulatedActivityId: simulatedActivityId4 },
       },
       {
         type: 'command',
         stem: 'PACKAGE_BANANA',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: ['Chiquita', 43, 'Dole', 12, 'Blue', 1, 1093],
         metadata: { simulatedActivityId: simulatedActivityId4 },
       },
@@ -387,49 +387,49 @@ describe('sequence generation', () => {
       {
         type: 'command',
         stem: 'PREHEAT_OVEN',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [70],
         metadata: { simulatedActivityId: simulatedActivityId1 },
       },
       {
         type: 'command',
         stem: 'PREPARE_LOAF',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [50, false],
         metadata: { simulatedActivityId: simulatedActivityId1 },
       },
       {
         type: 'command',
         stem: 'BAKE_BREAD',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [],
         metadata: { simulatedActivityId: simulatedActivityId1 },
       },
       {
         type: 'command',
         stem: 'PREHEAT_OVEN',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [70],
         metadata: { simulatedActivityId: simulatedActivityId2 },
       },
       {
         type: 'command',
         stem: 'BAKE_BREAD',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [],
         metadata: { simulatedActivityId: simulatedActivityId2 },
       },
       {
         type: 'command',
         stem: 'PREPARE_LOAF',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [50, false],
         metadata: { simulatedActivityId: simulatedActivityId2 },
       },
       {
         type: 'command',
         stem: '$$ERROR$$',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: ['Error: Unimplemented'],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
@@ -502,42 +502,42 @@ describe('sequence generation', () => {
       {
         type: 'command',
         stem: 'PREHEAT_OVEN',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [70],
         metadata: { simulatedActivityId: simulatedActivityId1 },
       },
       {
         type: 'command',
         stem: 'PREPARE_LOAF',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [50, false],
         metadata: { simulatedActivityId: simulatedActivityId1 },
       },
       {
         type: 'command',
         stem: 'BAKE_BREAD',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [],
         metadata: { simulatedActivityId: simulatedActivityId1 },
       },
       {
         type: 'command',
         stem: 'PREHEAT_OVEN',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [70],
         metadata: { simulatedActivityId: simulatedActivityId2 },
       },
       {
         type: 'command',
         stem: 'BAKE_BREAD',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [],
         metadata: { simulatedActivityId: simulatedActivityId2 },
       },
       {
         type: 'command',
         stem: 'PREPARE_LOAF',
-        time: { type: 'COMMAND_COMPLETE' },
+        time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [50, false],
         metadata: { simulatedActivityId: simulatedActivityId2 },
       },
@@ -608,3 +608,89 @@ describe('expansion regressions', () => {
   }, 10000);
 });
 
+
+it('should provide start and end times on activities', async () => {
+  // Setup
+
+  const activityId = await insertActivity(graphqlClient, planId, 'BiteBanana', '1 hours');
+  const simulationArtifactPk = await executeSimulation(graphqlClient, planId);
+  const expansionId = await insertExpansion(
+    graphqlClient,
+    'BiteBanana',
+    `
+    export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
+      return [
+        BAKE_BREAD.absoluteTiming(props.activityInstance.startTime),
+        BAKE_BREAD.absoluteTiming(props.activityInstance.endTime),
+      ];
+    }
+    `,
+  );
+
+
+  const expansionSet0Id = await insertExpansionSet(graphqlClient, commandDictionaryId, missionModelId, [
+    expansionId,
+  ]);
+  await expand(graphqlClient, expansionSet0Id, simulationArtifactPk.simulationDatasetId);
+  const sequencePk = await insertSequence(graphqlClient, {
+    seqId: 'test00000',
+    simulationDatasetId: simulationArtifactPk.simulationDatasetId,
+  });
+  await linkActivityInstance(graphqlClient, sequencePk, activityId);
+
+
+  const simulatedActivityId3 = await convertActivityIdToSimulatedActivityId(
+      graphqlClient,
+      simulationArtifactPk.simulationDatasetId,
+      activityId,
+  );
+
+  const { getSequenceSeqJson } = await graphqlClient.request<{ getSequenceSeqJson: SequenceSeqJson }>(
+      gql`
+        query GetSeqJsonForSequence($seqId: String!, $simulationDatasetId: Int!) {
+          getSequenceSeqJson(seqId: $seqId, simulationDatasetId: $simulationDatasetId) {
+            id
+            metadata
+            steps {
+              type
+              stem
+              time {
+                type
+                tag
+              }
+              args
+              metadata
+            }
+          }
+        }
+      `,
+      {
+        seqId: 'test00000',
+        simulationDatasetId: simulationArtifactPk.simulationDatasetId,
+      },
+  );
+
+  expect(getSequenceSeqJson.id).toBe('test00000');
+  expect(getSequenceSeqJson.metadata).toEqual({});
+  expect(getSequenceSeqJson.steps).toEqual([
+    {
+      type: 'command',
+      stem: 'BAKE_BREAD',
+      time: { type: TimingTypes.ABSOLUTE, tag: '2020-001T01:00:00.000' },
+      args: [],
+      metadata: { simulatedActivityId: simulatedActivityId3 },
+    },
+    {
+      type: 'command',
+      stem: 'BAKE_BREAD',
+      time: { type: TimingTypes.ABSOLUTE, tag: '2020-001T01:00:00.000' },
+      args: [],
+      metadata: { simulatedActivityId: simulatedActivityId3 },
+    },
+  ]);
+
+  // Cleanup
+  {
+    await removeSequence(graphqlClient, sequencePk);
+  }
+}, 30000);

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_resource_profile_view.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_resource_profile_view.yaml
@@ -1,0 +1,20 @@
+table:
+  name: resource_profile
+  schema: public
+object_relationships:
+- name: dataset
+  using:
+    manual_configuration:
+      remote_table:
+        name: dataset
+        schema: public
+      column_mapping:
+        dataset_id: id
+- name: profile
+  using:
+    manual_configuration:
+      remote_table:
+        name: profile
+        schema: public
+      column_mapping:
+        profile_id: id

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
@@ -17,3 +17,4 @@
 - "!include public_topic.yaml"
 - "!include public_event.yaml"
 - "!include public_simulated_activity_view.yaml"
+- "!include public_resource_profile_view.yaml"

--- a/merlin-server/sql/merlin/init.sql
+++ b/merlin-server/sql/merlin/init.sql
@@ -34,4 +34,5 @@ begin;
 
   -- Views
   \ir views/simulated_activity.sql
+  \ir views/resource_profile.sql
 end;

--- a/merlin-server/sql/merlin/views/resource_profile.sql
+++ b/merlin-server/sql/merlin/views/resource_profile.sql
@@ -1,0 +1,54 @@
+create view resource_profile as
+(
+select profile_segment.dataset_id as dataset_id,
+       profile_segment.profile_id as profile_id,
+       profile_segment.start_offset as start_offset,
+       profile_segment.dynamics as dynamics,
+       plan.start_time + profile_segment.start_offset as start_time,
+       coalesce(
+             plan.start_time + (
+             select p.start_offset
+             from profile_segment p
+             where p.start_offset > profile_segment.start_offset
+               and p.profile_id = profile_segment.profile_id
+               and p.dataset_id = profile_segment.dataset_id
+             order by p.start_offset
+             limit 1
+           ),
+             plan.start_time + plan.duration
+         ) as end_time
+
+from profile_segment
+       join dataset on profile_segment.dataset_id = dataset.id
+       left join plan_dataset pd on dataset.id = pd.dataset_id
+       left join simulation_dataset sd on dataset.id = sd.dataset_id
+       left join simulation s on sd.simulation_id = s.id
+       join plan on plan.id = s.plan_id or plan.id = pd.plan_id
+);
+
+comment on view resource_profile is e''
+  'A piece of a profile associated with a dataset, starting at a particular offset from the dataset basis. '
+  'The profile is governed at any time T by the latest profile whose start_offset is no later than T.'
+  'This view adds in absolute start and end times to the profile segment.';
+
+comment on column resource_profile.dataset_id is e''
+  'The dataset this segment''s profile is a part of.'
+  '\n'
+  'Denormalized for partitioning. Should always match ''profile.dataset_id''.';
+
+comment on column resource_profile.profile_id is e''
+  'The profile this segment is a part of.';
+
+comment on column resource_profile.start_offset is e''
+  'The offset from the start of the plan at which this profile segment takes over the profile''s behavior.';
+
+comment on column resource_profile.dynamics is e''
+  'A formal description of the behavior of the resource between this segment and the next.'
+  '\n'
+  'May be NULL if no behavior is known, thereby canceling any prior behavior.';
+
+comment on column resource_profile.start_time is e''
+  'The absolute time this profile segment takes over the profile''s behavior.';
+
+comment on column resource_profile.end_time is e''
+  'The absolute time this profile segment ends influencing the profile''s behavior.';

--- a/merlin-server/sql/merlin/views/simulated_activity.sql
+++ b/merlin-server/sql/merlin/views/simulated_activity.sql
@@ -7,9 +7,47 @@ create view simulated_activity as
          span.duration as duration,
          span.attributes as attributes,
          span.type as activity_type_name,
-         (span.attributes#>>'{directiveId}')::integer as directive_id
+         (span.attributes#>>'{directiveId}')::integer as directive_id,
+         plan.start_time + span.start_offset as start_time,
+         plan.start_time + span.start_offset + span.duration as end_time
+
 
    from span
      join dataset on span.dataset_id = dataset.id
      join simulation_dataset on dataset.id = simulation_dataset.dataset_id
+     join simulation on simulation.id = simulation_dataset.simulation_id
+     join plan on plan.id = simulation.plan_id
 );
+
+comment on view simulated_activity is e''
+  'Concrete activity instance created via simulation.';
+
+comment on column simulated_activity.id is e''
+  'Unique identifier for the activity instance span.';
+
+comment on column simulated_activity.simulation_dataset_id is e''
+  'The simulation dataset this activity is part of.';
+
+comment on column simulated_activity.parent_id is e''
+  'The parent activity of this activity.';
+
+comment on column simulated_activity.start_offset is e''
+  'The offset from the dataset start at which this activity begins.';
+
+comment on column simulated_activity.duration is e''
+  'The amount of time this activity extends for.';
+
+comment on column simulated_activity.attributes is e''
+  'A set of named values annotating this activity.';
+
+comment on column simulated_activity.activity_type_name is e''
+  'The activity type of this activity.';
+
+comment on column simulated_activity.directive_id is e''
+  'The id of the activity directive that created this activity.';
+
+comment on column simulated_activity.start_time is e''
+  'The absolute start time of this activity.';
+
+comment on column simulated_activity.end_time is e''
+  'The absolute end time of this activity.';


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1922
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Because Postgres doesn't allow cross table selects for generated columns, we have to use a view instead that can do the appropriate query through to plan to get the start time. The view adds the plan start time to the start offset of the item to get the start time and adds duration to that to get the end time. In the case of the resource profiles, we have to find the time the next profile takes over to determine the end time of the profile.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Did some basic local inspection of DB contents with the new views and added some tests to the command expansion server to use the new absolute times.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None - all changes should be auto-documented in the graphql API and the command expansion types

## Future work
<!-- What next steps can we anticipate from here, if any? -->
