### PR TITLE
[AERIE-1913]  Add simulation dataset id to `simulate` query response

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -151,6 +151,7 @@ type ResourceType {
 
 type MerlinSimulationResponse {
   status: MerlinSimulationStatus!
+  simulationDatasetId: Int!
   reason: MerlinSimulationFailureReason
 }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/ResultsProtocol.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/ResultsProtocol.java
@@ -7,16 +7,16 @@ public final class ResultsProtocol {
 
   public sealed interface State {
     /** Simulation in enqueued. */
-    record Pending() implements State {}
+    record Pending(long simulationDatasetId) implements State {}
 
     /** Simulation in progress, but no results to share yet. */
-    record Incomplete() implements State {}
+    record Incomplete(long simulationDatasetId) implements State {}
 
     /** Simulation complete -- results now available. */
-    record Success(SimulationResults results) implements State {}
+    record Success(long simulationDatasetId, SimulationResults results) implements State {}
 
     /** Simulation failed -- don't try to re-run without changing some of the inputs. */
-    record Failed(String reason) implements State {}
+    record Failed(long simulationDatasetId, String reason) implements State {}
   }
 
   public interface ReaderRole {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -239,26 +239,30 @@ public final class ResponseSerializers {
   }
 
   public static JsonValue serializeSimulationResultsResponse(final GetSimulationResultsAction.Response response) {
-    if (response instanceof GetSimulationResultsAction.Response.Pending) {
+    if (response instanceof GetSimulationResultsAction.Response.Pending r) {
       return Json
           .createObjectBuilder()
           .add("status", "pending")
+          .add("simulationDatasetId", r.simulationDatasetId())
           .build();
-    } else if (response instanceof GetSimulationResultsAction.Response.Incomplete) {
+    } else if (response instanceof GetSimulationResultsAction.Response.Incomplete r) {
       return Json
           .createObjectBuilder()
           .add("status", "incomplete")
+          .add("simulationDatasetId", r.simulationDatasetId())
           .build();
     } else if (response instanceof GetSimulationResultsAction.Response.Failed r) {
       return Json
           .createObjectBuilder()
           .add("status", "failed")
+          .add("simulationDatasetId", r.simulationDatasetId())
           .add("reason", r.reason())
           .build();
     } else if (response instanceof GetSimulationResultsAction.Response.Complete r) {
       return Json
           .createObjectBuilder()
           .add("status", "complete")
+          .add("simulationDatasetId", r.simulationDatasetId())
           .build();
      } else {
       throw new UnexpectedSubtypeError(GetSimulationResultsAction.Response.class, response);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
@@ -79,7 +79,7 @@ public final class InMemoryResultsCellRepository implements ResultsCellRepositor
 
   public static final class InMemoryCell implements ResultsProtocol.OwnerRole {
     private volatile boolean canceled = false;
-    private volatile ResultsProtocol.State state = new ResultsProtocol.State.Incomplete();
+    private volatile ResultsProtocol.State state = new ResultsProtocol.State.Incomplete(0);
     public final PlanId planId;
     public final long planRevision;
 
@@ -110,7 +110,7 @@ public final class InMemoryResultsCellRepository implements ResultsCellRepositor
             this.state.getClass().getCanonicalName()));
       }
 
-      this.state = new ResultsProtocol.State.Success(results);
+      this.state = new ResultsProtocol.State.Success(0, results);
     }
 
     @Override
@@ -120,7 +120,7 @@ public final class InMemoryResultsCellRepository implements ResultsCellRepositor
             this.state.getClass().getCanonicalName()));
       }
 
-      this.state = new ResultsProtocol.State.Failed(reason);
+      this.state = new ResultsProtocol.State.Failed(0, reason);
     }
 
     public boolean isEqualTo(final InMemoryCell other) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateSimulationDatasetAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateSimulationDatasetAction.java
@@ -23,7 +23,8 @@ import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
       dataset_id,
       status,
       reason,
-      canceled
+      canceled,
+      id
     """;
 
   private final PreparedStatement statement;
@@ -60,12 +61,15 @@ import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
         reason);
     final var canceled = results.getBoolean(4);
 
+    final var simulationDatasetId = results.getLong(5);
+
     return new SimulationDatasetRecord(
         simulationId,
         datasetId,
         state,
         canceled,
-        offsetFromPlanStart
+        offsetFromPlanStart,
+        simulationDatasetId
     );
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationDatasetAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationDatasetAction.java
@@ -16,7 +16,8 @@ import java.util.Optional;
           d.status,
           d.reason,
           d.canceled,
-          d.offset_from_plan_start
+          d.offset_from_plan_start,
+          d.id
       from simulation_dataset as d
       where
         d.dataset_id = ?
@@ -48,6 +49,7 @@ import java.util.Optional;
     final var reason = results.getString(3);
     final var canceled = results.getBoolean(4);
     final var offsetFromPlanStart = PostgresParsers.parseOffset(results, 5, planStart);
+    final var simulationDatasetId = results.getLong(6);
     final var state = new SimulationStateRecord(
         status,
         reason);
@@ -58,7 +60,8 @@ import java.util.Optional;
             datasetId,
             state,
             canceled,
-            offsetFromPlanStart));
+            offsetFromPlanStart,
+            simulationDatasetId));
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/LookupSimulationDatasetAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/LookupSimulationDatasetAction.java
@@ -31,7 +31,8 @@ import java.util.Optional;
           d.status,
           d.reason,
           d.canceled,
-          d.offset_from_plan_start
+          d.offset_from_plan_start,
+          d.id
       from simulation_dataset as d
       left join revisions as r
         on d.simulation_id = r.sim_id
@@ -75,6 +76,7 @@ import java.util.Optional;
     final var reason = results.getString(3);
     final var canceled = results.getBoolean(4);
     final var offsetFromPlanStart = PostgresParsers.parseOffset(results, 5, planStart);
+    final var simulationDatasetId = results.getLong(6);
     final var state = new SimulationStateRecord(
         status,
         reason);
@@ -85,7 +87,8 @@ import java.util.Optional;
             datasetId,
             state,
             canceled,
-            offsetFromPlanStart));
+            offsetFromPlanStart,
+            simulationDatasetId));
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -290,10 +290,10 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
 
     return Optional.of(
         switch (record.state().status()) {
-          case PENDING -> new ResultsProtocol.State.Pending();
-          case INCOMPLETE -> new ResultsProtocol.State.Incomplete();
-          case FAILED -> new ResultsProtocol.State.Failed(record.state().reason());
-          case SUCCESS -> new ResultsProtocol.State.Success(getSimulationResults(connection, record, planId));
+          case PENDING -> new ResultsProtocol.State.Pending(record.simulationDatasetId());
+          case INCOMPLETE -> new ResultsProtocol.State.Incomplete(record.simulationDatasetId());
+          case FAILED -> new ResultsProtocol.State.Failed(record.simulationDatasetId(), record.state().reason());
+          case SUCCESS -> new ResultsProtocol.State.Success(record.simulationDatasetId(), getSimulationResults(connection, record, planId));
         });
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulationDatasetRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulationDatasetRecord.java
@@ -7,4 +7,5 @@ public final record SimulationDatasetRecord(
     long datasetId,
     SimulationStateRecord state,
     boolean canceled,
-    Duration offsetFromPlanStart) {}
+    Duration offsetFromPlanStart,
+    long simulationDatasetId) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -29,10 +29,10 @@ import java.util.Objects;
 
 public final class GetSimulationResultsAction {
   public sealed interface Response {
-    record Pending() implements Response {}
-    record Incomplete() implements Response {}
-    record Failed(String reason) implements Response {}
-    record Complete() implements Response {}
+    record Pending(long simulationDatasetId) implements Response {}
+    record Incomplete(long simulationDatasetId) implements Response {}
+    record Failed(long simulationDatasetId, String reason) implements Response {}
+    record Complete(long simulationDatasetId) implements Response {}
   }
 
   private final PlanService planService;
@@ -57,14 +57,14 @@ public final class GetSimulationResultsAction {
 
     final var response = this.simulationService.getSimulationResults(planId, revisionData);
 
-    if (response instanceof ResultsProtocol.State.Pending) {
-      return new Response.Pending();
-    } else if (response instanceof ResultsProtocol.State.Incomplete) {
-      return new Response.Incomplete();
+    if (response instanceof ResultsProtocol.State.Pending r) {
+      return new Response.Pending(r.simulationDatasetId());
+    } else if (response instanceof ResultsProtocol.State.Incomplete r) {
+      return new Response.Incomplete(r.simulationDatasetId());
     } else if (response instanceof ResultsProtocol.State.Failed r) {
-      return new Response.Failed(r.reason());
+      return new Response.Failed(r.simulationDatasetId(), r.reason());
     } else if (response instanceof ResultsProtocol.State.Success r) {
-      return new Response.Complete();
+      return new Response.Complete(r.simulationDatasetId());
     } else {
       throw new UnexpectedSubtypeError(ResultsProtocol.State.class, response);
     }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1913
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This feature was added so that clients of the API could hit the `simulate` Hasura action, and instantly receive back the simulationDatasetId to subscribe with. This removes the need to poll the `simulate` action until it returns `status: complete`.

This was implemented by adding a new `long simulationDatasetId` field to the `ResultsProtocol` interface, and having both `PostgresResultsCellRepository` and `InMemoryResultsCellRepository` populate it. One possible issue with this implementation is that `InMemoryResultsCellRepository` doesn't really have a concept of `datasetId` so it is just getting hardcoded to 0. The justification for this is that `InMemory` is somewhat of a second class citizen only used in testing, so priority was given to the ergonomic use of `PostgresResults` instead.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Manually tested changes in UI and GraphQL API to make sure nothing changed except returning simulationDatasetId.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Need to update `simulate` response documentation

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Further steps towards simulation result streaming
Make use of this change in the UI