### PR TITLE
[REFACTOR] Remove redundant query in Scheduling DSL codegen

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
@@ -24,7 +24,6 @@ import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleAction;
 import gov.nasa.jpl.aerie.scheduler.server.services.SchedulingDSLCompilationService;
 import gov.nasa.jpl.aerie.scheduler.server.services.SynchronousSchedulerAgent;
 import gov.nasa.jpl.aerie.scheduler.server.services.ThreadedSchedulerAgent;
-import gov.nasa.jpl.aerie.scheduler.server.services.TypescriptCodeGenerationService;
 import gov.nasa.jpl.aerie.scheduler.server.services.UnexpectedSubtypeError;
 import io.javalin.Javalin;
 import org.slf4j.LoggerFactory;
@@ -54,11 +53,10 @@ public final class SchedulerAppDriver {
     final var config = loadConfiguration();
 
     final var merlinService = new GraphQLMerlinService(config.merlinGraphqlURI());
-    final var typescriptCodeGenerationService = new TypescriptCodeGenerationService();
 
     final SchedulingDSLCompilationService schedulingDSLCompilationService;
     try {
-      schedulingDSLCompilationService = new SchedulingDSLCompilationService(typescriptCodeGenerationService);
+      schedulingDSLCompilationService = new SchedulingDSLCompilationService();
     } catch (IOException e) {
       throw new Error("Failed to start SchedulingDSLCompilationService", e);
     }
@@ -79,7 +77,7 @@ public final class SchedulerAppDriver {
     final var schedulerService = new CachedSchedulerService(stores.results(), scheduleAgent);
     final var scheduleAction = new ScheduleAction(specificationService, schedulerService);
 
-    final var generateSchedulingLibAction = new GenerateSchedulingLibAction(typescriptCodeGenerationService, merlinService);
+    final var generateSchedulingLibAction = new GenerateSchedulingLibAction(merlinService);
 
     //establish bindings to the service layers
     final var bindings = new SchedulerBindings(schedulerService, scheduleAction, generateSchedulingLibAction);

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GenerateSchedulingLibAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GenerateSchedulingLibAction.java
@@ -10,11 +10,9 @@ import java.util.Map;
 import java.util.Objects;
 
 public record GenerateSchedulingLibAction(
-    TypescriptCodeGenerationService schedulingCodeGenService,
     MissionModelService missionModelService
 ) {
   public GenerateSchedulingLibAction {
-    Objects.requireNonNull(schedulingCodeGenService);
     Objects.requireNonNull(missionModelService);
   }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GenerateSchedulingLibAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GenerateSchedulingLibAction.java
@@ -40,7 +40,8 @@ public record GenerateSchedulingLibAction(
       final var schedulerAst = Files.readString(Paths.get(schedulingDslCompilerRoot, "src", "libs", "scheduler-ast.ts"));
       final var windowsDsl = Files.readString(Paths.get(schedulingDslCompilerRoot, "src", "libs", "constraints", "constraints-edsl-fluent-api.ts"));
       final var windowsAst = Files.readString(Paths.get(schedulingDslCompilerRoot, "src", "libs", "constraints", "constraints-ast.ts"));
-      final var generatedSchedulerCode = this.schedulingCodeGenService.generateTypescriptTypesForMissionModel(missionModelService, missionModelId);
+
+      final var generatedSchedulerCode = TypescriptCodeGenerationService.generateTypescriptTypesFromMissionModel(missionModelService.getMissionModelTypes(missionModelId));
 
       final var missionModelTypes = missionModelService.getMissionModelTypes(missionModelId);
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GenerateSchedulingLibAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GenerateSchedulingLibAction.java
@@ -41,10 +41,9 @@ public record GenerateSchedulingLibAction(
       final var windowsDsl = Files.readString(Paths.get(schedulingDslCompilerRoot, "src", "libs", "constraints", "constraints-edsl-fluent-api.ts"));
       final var windowsAst = Files.readString(Paths.get(schedulingDslCompilerRoot, "src", "libs", "constraints", "constraints-ast.ts"));
 
-      final var generatedSchedulerCode = TypescriptCodeGenerationService.generateTypescriptTypesFromMissionModel(missionModelService.getMissionModelTypes(missionModelId));
-
       final var missionModelTypes = missionModelService.getMissionModelTypes(missionModelId);
 
+      final var generatedSchedulerCode = TypescriptCodeGenerationService.generateTypescriptTypesFromMissionModel(missionModelTypes);
       final var generatedConstraintsCode = gov.nasa.jpl.aerie.constraints.TypescriptCodeGenerationService
           .generateTypescriptTypes(
               SchedulingDSLCompilationService.activityTypes(missionModelTypes),

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationService.java
@@ -22,12 +22,10 @@ import java.util.stream.Collectors;
 public class SchedulingDSLCompilationService {
 
   private final Process nodeProcess;
-  private final TypescriptCodeGenerationService schedulerCodeGenService;
 
-  public SchedulingDSLCompilationService(final TypescriptCodeGenerationService schedulerCodeGenService)
+  public SchedulingDSLCompilationService()
   throws IOException
   {
-    this.schedulerCodeGenService = schedulerCodeGenService;
     final var schedulingDslCompilerRoot = System.getenv("SCHEDULING_DSL_COMPILER_ROOT");
     final var schedulingDslCompilerCommand = System.getenv("SCHEDULING_DSL_COMPILER_COMMAND");
     final var nodePath = System.getenv("NODE_PATH");

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
@@ -3,7 +3,6 @@ package gov.nasa.jpl.aerie.scheduler.server.services;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchMissionModelException;
 import gov.nasa.jpl.aerie.scheduler.server.models.MissionModelId;
-import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.IOException;
@@ -13,14 +12,6 @@ import java.util.List;
 import java.util.Map;
 
 public class TypescriptCodeGenerationService {
-
-  public String generateTypescriptTypesForPlan(final MissionModelService missionModelService, final PlanId planId) {
-    try {
-      return generateTypescriptTypesFromMissionModel(missionModelService.getMissionModelTypes(planId));
-    } catch (MissionModelService.MissionModelServiceException | IOException e) {
-      throw new Error("Could not fetch mission model types", e);
-    }
-  }
 
   public String generateTypescriptTypesForMissionModel(final MissionModelService missionModelService, final MissionModelId missionModelId) throws NoSuchMissionModelException {
     try {

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
@@ -1,26 +1,14 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
-import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchMissionModelException;
-import gov.nasa.jpl.aerie.scheduler.server.models.MissionModelId;
 import org.apache.commons.lang3.tuple.Pair;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 public class TypescriptCodeGenerationService {
-
-  public String generateTypescriptTypesForMissionModel(final MissionModelService missionModelService, final MissionModelId missionModelId) throws NoSuchMissionModelException {
-    try {
-      return generateTypescriptTypesFromMissionModel(missionModelService.getMissionModelTypes(missionModelId));
-    } catch (MissionModelService.MissionModelServiceException | IOException e) {
-      throw new Error("Could not fetch mission model types", e);
-    }
-  }
-
   public static String generateTypescriptTypesFromMissionModel(final MissionModelService.MissionModelTypes missionModelTypes) {
     final var activityTypeCodes = new ArrayList<ActivityTypeCode>();
     for (final var activityType : missionModelTypes.activityTypes()) {

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
@@ -10,7 +10,6 @@ import gov.nasa.jpl.aerie.scheduler.TimeUtility;
 import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.TimeAnchor;
 import gov.nasa.jpl.aerie.scheduler.server.models.MissionModelId;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
-import gov.nasa.jpl.aerie.scheduler.server.models.SchedulingCompilationError;
 import gov.nasa.jpl.aerie.scheduler.server.models.SchedulingDSL;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,7 +46,7 @@ class SchedulingDSLCompilationServiceTests {
 
   @BeforeAll
   void setUp() throws IOException {
-    schedulingDSLCompilationService = new SchedulingDSLCompilationService(new TypescriptCodeGenerationService());
+    schedulingDSLCompilationService = new SchedulingDSLCompilationService();
   }
 
   @AfterAll

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -54,7 +54,7 @@ public class SchedulingIntegrationTests {
 
   @BeforeAll
   void setup() throws IOException {
-    this.schedulingDSLCompiler = new SchedulingDSLCompilationService(new TypescriptCodeGenerationService());
+    this.schedulingDSLCompiler = new SchedulingDSLCompilationService();
   }
 
   @Test


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The scheduling DSL codegen makes two queries for mission model types - one for the scheduler's codegen service, one for the constraints codegen service. This PR re-uses the results of the first query for both codegen services.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
All tests pass

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
This is an internal change, and shouldn't require changes to any documentation.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
There is more to be done to reduce the work done on plan load time (which is when the `schedulingDslTypescript` action is triggered).