### PR TITLE
[AERIE-1824] - Rework TimeType API

### DIFF
--- a/command-expansion-server/src/lib/codegen/CommandTypeCodegen.ts
+++ b/command-expansion-server/src/lib/codegen/CommandTypeCodegen.ts
@@ -22,7 +22,7 @@ function generateTypescriptCode(dictionary: ampcs.CommandDictionary): {
 declare global {
 ${typescriptFswCommands.map(fswCommand => fswCommand.declaration).join('\n')}
 \tconst Commands: {\n${dictionary.fswCommands
-    .map(fswCommand => `\t\t${fswCommand.stem}: ${fswCommand.stem},\n`)
+    .map(fswCommand => `\t\t${fswCommand.stem}: typeof ${fswCommand.stem},\n`)
     .join('')}\t};
 }`;
 
@@ -33,7 +33,7 @@ export const Commands = {${dictionary.fswCommands
     .map(fswCommand => `\t\t${fswCommand.stem}: ${fswCommand.stem},\n`)
     .join('')}};
 
-Object.assign(globalThis, Commands);
+Object.assign(globalThis, Commands, { A:A, R:R, E:E, C:Commands});
 `;
 
   return {
@@ -120,7 +120,7 @@ ${repeatArgsDeclaration}${otherArgs.map(arg => `\t${arg.name}: ${mapArgumentType
     const value = `
 ${doc}
 const ${fswCommandName}_ARGS_ORDERS = [${argsOrder.join(',')}];
-export function ${fswCommandName}<T extends any[]>(...args: T[]) {
+export function ${fswCommandName}<T extends any[]>(...args: T) {
   return Command.new({
     stem: '${fswCommandName}',
     arguments: typeof args[0] === 'object' ? findAndOrderCommandArguments("${fswCommandName}",args[0],${fswCommandName}_ARGS_ORDERS) : args,


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1824
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Currently, the eDSL for command authoring has the v1 structure below. The original way isn't too bad but there was some feedback from Basak to make it easier to write.


**Original way:**

```
<command>.absoluteTiming(Temporal.instance)
<command>.relativeTiming(Temporal.duration)
<command>.epochTiming(Temporal.duration)
<command>
```

**New Way:**

With this PR you have multiple ways to specify Timing Types

```
// Absolute
A`2020-060T03:45:19`.ADD_WATER
A(Temporal.Instant.from("2025-12-24T12:01:59Z")).ADD_WATER
A("2020-060T03:45:19").ADD_WATER

// Relative
R`00:15:00`.EAT_BANANA
R(Temporal.Duration.from({ minutes: 15 }).EAT_BANANA
R(00:15:00)EAT_BANANA

// Epoch
E`00:15:30`.PREPARE_LOAF(1,true)
E(Temporal.Duration.from({ minutes: 15, seconds: 30 }).PREPARE_LOAF(1,true)
E(00:15:30).PREPARE_LOAF(1,true)

C.BAKE_BREAD

```

## Verification
All JEST Test Pass on my end. 

To run the test locally:

* Nuke all docker containers
* In Docker Compose, Change `cam` to `none`
* Navigate to `Command-Expansion-Server`
* Enter `nvm use 16` to use node 16
* Run the test `npm run test`
* All the tests should pass

## Documentation
I will update the documentation once this PR is merged.

## Future work
Add more helper methods to make authoring easier. 
