### PR TITLE
[AERIE-1849] Test composite goals

### DIFF
--- a/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-ast.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-ast.ts
@@ -48,8 +48,7 @@ export interface ActivityRecurrenceGoal {
 export interface ActivityCardinalityGoal {
   kind: NodeKind.ActivityCardinalityGoal,
   activityTemplate: ActivityTemplate,
-  specification: CardinalityGoalArguments,
-  inPeriod: ClosedOpenInterval,
+  specification: CardinalityGoalArguments
 }
 
 export interface ActivityCoexistenceGoal {

--- a/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
@@ -67,12 +67,11 @@ export class Goal {
       endConstraint: (("endsAt" in opts) ? opts.endsAt.__astNode : ("endsWithin" in opts) ? opts.endsWithin.__astNode : undefined),
     });
   }
-  public static CardinalityGoal(opts: { activityTemplate: ActivityTemplate, specification: AST.CardinalityGoalArguments, inPeriod: ClosedOpenInterval }): ActivityCardinalityGoal {
+  public static CardinalityGoal(opts: { activityTemplate: ActivityTemplate, specification: AST.CardinalityGoalArguments }): ActivityCardinalityGoal {
     return Goal.new({
       kind: AST.NodeKind.ActivityCardinalityGoal,
       activityTemplate: opts.activityTemplate,
-      specification: opts.specification,
-      inPeriod : opts.inPeriod
+      specification: opts.specification
     });
   }
 }
@@ -183,7 +182,7 @@ declare global {
       forEach: WindowsEDSL.Windows | ActivityExpression,
     } & CoexistenceGoalTimingConstraints): ActivityCoexistenceGoal
 
-    public static CardinalityGoal(opts: { activityTemplate: ActivityTemplate, specification: AST.CardinalityGoalArguments, inPeriod: ClosedOpenInterval }): ActivityCardinalityGoal
+    public static CardinalityGoal(opts: { activityTemplate: ActivityTemplate, specification: AST.CardinalityGoalArguments }): ActivityCardinalityGoal
   }
   class ActivityExpression {
     public static ofType(activityType: ActivityType): ActivityExpression

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/SchedulingDSL.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/SchedulingDSL.java
@@ -117,13 +117,11 @@ public class SchedulingDSL {
       productP
           .field("activityTemplate", activityTemplateP)
           .field("specification", cardinalitySpecificationJsonParser)
-          .field("inPeriod", intervalP)
           .map(Iso.of(
               untuple(GoalSpecifier.CardinalityGoalDefinition::new),
               goalDefinition -> tuple(
                   goalDefinition.activityTemplate(),
-                  goalDefinition.specification(),
-                  goalDefinition.inPeriod())));
+                  goalDefinition.specification())));
 
   private static ProductParsers.JsonObjectParser<GoalSpecifier.GoalAnd> goalAndF(final JsonParser<GoalSpecifier> goalSpecifierP) {
     return productP
@@ -175,8 +173,7 @@ public class SchedulingDSL {
     ) implements GoalSpecifier {}
     record CardinalityGoalDefinition(
         ActivityTemplate activityTemplate,
-        CardinalitySpecification specification,
-        ClosedOpenInterval inPeriod
+        CardinalitySpecification specification
     ) implements GoalSpecifier {}
     record GoalAnd(List<GoalSpecifier> goals) implements GoalSpecifier {}
     record GoalOr(List<GoalSpecifier> goals) implements GoalSpecifier {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
@@ -85,6 +85,7 @@ public class GoalBuilder {
                                                  horizonEndTimestamp,
                                                  lookupActivityType));
       }
+      builder.forAllTimeIn(hor);
       return builder.build();
     }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
@@ -76,6 +76,7 @@ public class GoalBuilder {
                                                   horizonEndTimestamp,
                                                   lookupActivityType));
       }
+      builder.forAllTimeIn(new WindowsWrapperExpression(new Windows(hor)));
       return builder.build();
     } else if (goalSpecifier instanceof SchedulingDSL.GoalSpecifier.GoalOr g) {
       var builder = new OptionGoal.Builder();
@@ -85,7 +86,7 @@ public class GoalBuilder {
                                                  horizonEndTimestamp,
                                                  lookupActivityType));
       }
-      builder.forAllTimeIn(hor);
+      builder.forAllTimeIn(new WindowsWrapperExpression(new Windows(hor)));
       return builder.build();
     }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -246,7 +246,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements PlanService.
     final var planName = getNextPlanName();
     final var planId = createEmptyPlan(
         planName, planMetadata.modelId(),
-        planMetadata.horizon().getStartHuginn(), planMetadata.horizon().getEndAerie());
+        planMetadata.horizon().getStartInstant(), planMetadata.horizon().getEndAerie());
     //create sim storage space since doesn't happen automatically (else breaks further queries)
     createSimulationForPlan(planId);
     Map<ActivityInstance, ActivityInstanceId> activityToId = createAllPlanActivities(planId, plan);

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -421,10 +421,24 @@ public record SynchronousSchedulerAgent(
     Map<GoalId, ScheduleResults.GoalResult> goalResults = new HashMap<>();
       for (var goalEval : plan.getEvaluation().getGoalEvaluations().entrySet()) {
         var goalId = goalsToIds.get(goalEval.getKey());
-        var goalResult = new ScheduleResults.GoalResult(goalEval.getValue().getInsertedActivities().stream().map(instancesToIds::get).collect(Collectors.toList()),
-                                                        goalEval.getValue().getAssociatedActivities().stream().map(instancesToIds::get).collect(Collectors.toList()),
-                                                        goalEval.getValue().getScore() >=0);
-        goalResults.put(goalId, goalResult);
+        //goal could be anonymous, a subgoal of a composite goal for example, and thus have no meaning for results sent back
+        if(goalId != null) {
+          final var goalResult = new ScheduleResults.GoalResult(
+              goalEval
+                  .getValue()
+                  .getInsertedActivities()
+                  .stream()
+                  .map(instancesToIds::get)
+                  .collect(Collectors.toList()),
+              goalEval
+                  .getValue()
+                  .getAssociatedActivities()
+                  .stream()
+                  .map(instancesToIds::get)
+                  .collect(Collectors.toList()),
+              goalEval.getValue().getScore() >= 0);
+          goalResults.put(goalId, goalResult);
+        }
       }
     return new ScheduleResults(goalResults);
   }

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockMerlinService.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockMerlinService.java
@@ -126,8 +126,8 @@ class MockMerlinService implements MissionModelService, PlanService.OwnerRole {
   {
     this.updatedPlan = extractPlannedActivityInstances(plan);
     final var res = new HashMap<ActivityInstance, ActivityInstanceId>();
+    var id = 0L;
     for (final var activity : plan.getActivities()) {
-      var id = 0L;
       res.put(activity, new ActivityInstanceId(id++));
     }
     return res;

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
@@ -472,4 +472,89 @@ class SchedulingDSLCompilationServiceTests {
       fail(r.toString());
     }
   }
+
+  @Test
+  void testAndGoal(){
+    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult result;
+    result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+        missionModelService,
+        PLAN_ID, """
+                export default function myGoal() {
+                  return Goal.ActivityRecurrenceGoal({
+                    activityTemplate: ActivityTemplates.SampleActivityEmpty(),
+                    interval: 60 * 60 * 1000 * 1000 // 1 hour in microseconds
+                  }).and(
+                    Goal.ActivityRecurrenceGoal({
+                      activityTemplate: ActivityTemplates.SampleActivityEmpty(),
+                      interval: 2 * 60 * 60 * 1000 * 1000 // 2 hour in microseconds
+                    })
+                  )
+                }
+            """);
+    final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.GoalAnd(List.of(
+        new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
+          new SchedulingDSL.ActivityTemplate(
+              "SampleActivityEmpty",
+              Map.of()
+          ),
+          Duration.HOUR
+    ), new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
+            new SchedulingDSL.ActivityTemplate(
+                "SampleActivityEmpty",
+                Map.of()
+            ),
+            Duration.HOUR.times(2)
+        )));
+    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
+      assertEquals(
+          expectedGoalDefinition,
+          r.goalSpecifier()
+      );
+    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+      fail(r.toString());
+    }
+  }
+
+  @Test
+  void testOrGoal(){
+    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult result;
+    result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+        missionModelService,
+        PLAN_ID, """
+                export default function myGoal() {
+                  return Goal.ActivityRecurrenceGoal({
+                    activityTemplate: ActivityTemplates.SampleActivityEmpty(),
+                    interval: 60 * 60 * 1000 * 1000 // 1 hour in microseconds
+                  }).or(
+                    Goal.ActivityRecurrenceGoal({
+                      activityTemplate: ActivityTemplates.SampleActivityEmpty(),
+                      interval: 2 * 60 * 60 * 1000 * 1000 // 2 hour in microseconds
+                    })
+                  )
+                }
+            """);
+    final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.GoalOr(List.of(
+        new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
+            new SchedulingDSL.ActivityTemplate(
+                "SampleActivityEmpty",
+                Map.of()
+            ),
+            Duration.HOUR
+        ), new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
+            new SchedulingDSL.ActivityTemplate(
+                "SampleActivityEmpty",
+                Map.of()
+            ),
+            Duration.HOUR.times(2)
+        )));
+    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
+      assertEquals(
+          expectedGoalDefinition,
+          r.goalSpecifier()
+      );
+    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+      fail(r.toString());
+    }
+  }
+
 }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/OptionGoal.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/OptionGoal.java
@@ -2,26 +2,21 @@ package gov.nasa.jpl.aerie.scheduler.goals;
 
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.scheduler.conflicts.Conflict;
-import gov.nasa.jpl.aerie.scheduler.solver.optimizers.Optimizer;
 import gov.nasa.jpl.aerie.scheduler.model.Plan;
-import gov.nasa.jpl.aerie.scheduler.Range;
+import gov.nasa.jpl.aerie.scheduler.solver.optimizers.Optimizer;
+import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class OptionGoal extends Goal {
 
-  private Range<Integer> namongp;
 
   private List<Goal> goals;
   private Optimizer optimizer;
 
   public List<Goal> getSubgoals() {
     return goals;
-  }
-
-  public Range<Integer> getNamongP(){
-    return this.namongp;
   }
 
   public boolean hasOptimizer(){
@@ -34,87 +29,37 @@ public class OptionGoal extends Goal {
 
   @Override
   public java.util.Collection<Conflict> getConflicts(Plan plan, final SimulationResults simulationResults) {
-    return null;
-
+    throw new NotImplementedException("Conflict detection is performed at solver level");
   }
 
-  public static class Builder {
+  public static class Builder extends Goal.Builder<OptionGoal.Builder> {
 
     final List<Goal> goals = new ArrayList<>();
-    private String name;
-
-    enum CHOICE {
-      ATLEAST,
-      ATMOST,
-      EXACTLY
-    }
 
     Optimizer optimizer;
 
-    int namongp = 0;
-    CHOICE choice = null;
-
-    public Builder exactlyOneOf() {
-      if (choice != null) {
-        throw new IllegalArgumentException("Choice of goal satisfaction has been done already");
-      }
-      choice = CHOICE.EXACTLY;
-      namongp = 1;
-      return this;
-    }
-
-    public Builder named(String name) {
-      this.name = name;
-      return this;
-    }
-
-    public Builder atLeast(int n) {
-
-      if (choice != null) {
-        throw new IllegalArgumentException("Choice of goal satisfaction has been done already");
-      }
-      namongp = n;
-      choice = CHOICE.ATLEAST;
-      return this;
-    }
-
-
-    public Builder atMost(int n) {
-
-      if (choice != null) {
-        throw new IllegalArgumentException("Choice of goal satisfaction has been done already");
-      }
-      namongp = n;
-      choice = CHOICE.ATMOST;
-      return this;
-    }
-
     public Builder or(Goal goal) {
       goals.add(goal);
-      return this;
+      return getThis();
     }
 
     public Builder optimizingFor(Optimizer s) {
       optimizer = s;
+      return getThis();
+    }
+
+    @Override
+    protected Builder getThis() {
       return this;
     }
 
     public OptionGoal build() {
-
       OptionGoal dg = new OptionGoal();
+      super.fill(dg);
       dg.goals = goals;
       dg.name = name;
       dg.optimizer = optimizer;
-      switch (choice) {
-        case ATLEAST -> dg.namongp = new Range<>(this.namongp, goals.size());
-        case ATMOST -> dg.namongp = new Range<>(0, this.namongp);
-        case EXACTLY -> dg.namongp = new Range<>(this.namongp, this.namongp);
-      }
-
       return dg;
-
     }
-
   }
-
 }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/model/PlanningHorizon.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/model/PlanningHorizon.java
@@ -24,8 +24,12 @@ public final class PlanningHorizon{
     return aerieHorizon;
   }
 
-  public Instant getStartHuginn(){
+  public Instant getStartInstant(){
     return start;
+  }
+
+  public Instant getEndInstant(){
+    return end;
   }
 
   public boolean contains(Duration time){

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -299,7 +299,6 @@ public class PrioritySolver implements Solver {
 
 
   private void satisfyOptionGoal(OptionGoal goal) {
-    if (goal.getNamongP().isSingleton() && goal.getNamongP().getMaximum() == 1) {
       if (goal.hasOptimizer()) {
         //try to satisfy all and see what is best
         Goal currentSatisfiedGoal = null;
@@ -340,8 +339,7 @@ public class PrioritySolver implements Solver {
             throw new IllegalStateException("Had satisfied subgoal but (1) simulation or (2) association with supergoal failed");
           }
         } else {
-          //number of subgoals needed to achieve supergoal
-          evaluation.forGoal(goal).setScore(goal.getNamongP().getMaximum() - goal.getNamongP().getMinimum());
+          evaluation.forGoal(goal).setScore(-1);
         }
       } else {
         //just satisfy any goal
@@ -357,11 +355,6 @@ public class PrioritySolver implements Solver {
           }
         }
       }
-    } else {
-        throw new IllegalArgumentException(
-            "Other options than singleton namongp of OptionGoal has not yet been implemented");
-    }
-
   }
 
   private void rollback(Goal goal){


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1849
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
OR/AND goals are available in the eDSL since an early version but they were dysfunctional/were not tested. 

While working on testing, I stumbled on the criterion required for satisfying these goals. 

How normal goal satisfaction works: the goal generates conflicts that the solver tries to solve. Whenever a goal cannot be completely satisfied because there are conflicts that cannot be addressed (ex: we want 6 activities in some time period but only 5 fit), the solver would remove all activities associated to this goal from the plan and go to the next goal. Either the goal can be satisfied or not. 

But that’s not always the desired behavior. Sometimes, we want a best-effort approach. So we introduced “partial satisfiability”. 
Partial satisfiability is a boolean property of any goal. If it is set to true, and whenever the goal cannot be totally satisfied, activities associated to the goal are NOT removed from the plan. The goal will still appear unsatisfied. 

By default, partial satisfiability is set to true. We do not have yet the possibility of updating this value in the eDSL but I hope we will get it soon.

Because of the presence of partial satisfiability, the logic of composite goal satisfaction had to be updated/made clearer. 

Commit 2, refactor disjunctive goal: it was a mess of to-be-implemented features and it did not inherit correctly from `Goal`
Commit 3: when building a conjunctive goal, the horizon was not set (`forAllTimeIn`), producing an error. This commit fixes this issue.
Commit 4: The solver has access to results of subgoals but these goals are "anonymous" for the rest of the scheduler, they do not appear by themselves to the user. When building scheduling results for a composite and/or goals, this lead to the results of these anonymous goals to be added to the returned results (with a `null` id) which is not the desired behavior. 
Commit 5: The criterion for satisfaction of composite or/and goal has been refactored to be similar with the semantics of `partialSatisfiability` for non-composite goals. 
Commit 6: An accessor is added to `PlanningHorizon`.
Commit 7: tests are added for composite or/and goals. 
Commit 8: An id bug is fixed in `MockMerlinService`
Commit 9: the `inPeriod` operator of the `CardinalityGoal` is purged from the eDSL  

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
New tests have been added. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

- [x] I have to update the documentation with a paragraph on the logic of goal satisfaction

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Implement an operator in the scheduling eDSL allowing the user to specify whether he wants partial satisfaction for a goal or not.