### PR TITLE
[AERIE-1938] Upgrade Hasura to version 2.8.4

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: warn
       HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_hasura
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: "hasura/graphql-engine:v2.2.0.cli-migrations-v3"
+    image: "hasura/graphql-engine:v2.8.4.cli-migrations-v3"
     ports: ["8080:8080"]
     restart: always
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,7 +171,7 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: info
       HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_hasura
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: "hasura/graphql-engine:v2.2.0.cli-migrations-v3"
+    image: "hasura/graphql-engine:v2.8.4.cli-migrations-v3"
     ports: ["8080:8080"]
     restart: always
     volumes:

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -168,7 +168,7 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: info
       HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_hasura
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: 'hasura/graphql-engine:v2.2.0.cli-migrations-v3'
+    image: "hasura/graphql-engine:v2.8.4.cli-migrations-v3"
     ports: ['8080:8080']
     restart: always
     volumes:


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1938
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Upgrade Hasura to [v2.8.4](https://github.com/hasura/graphql-engine/releases/tag/v2.8.4), mainly motivated by the fact that 2.7.0 introduces streaming subscriptions, which will be leveraged in the [simulation segment streaming prototype](https://jira.jpl.nasa.gov/browse/AERIE-1921).

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
All tests continue to pass, Aerie functions the same as no pertinent breaking changes were introduced from v2.2.0 -> v2.8.4 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Research new Hasura features to see if they enable new Aerie features