### PR TITLE
[AERIE-1948] Starts and Ends windows (and spans!) operations

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
@@ -288,6 +288,24 @@ public final class ConstraintParsers {
             $ -> tuple(Unit.UNIT, $.expression));
   }
 
+  static <I extends IntervalContainer<I>> JsonParser<Starts<I>> startsF(final JsonParser<Expression<I>> intervalExpressionP) {
+    return productP
+        .field("kind", literalP("IntervalsExpressionStarts"))
+        .field("expression", intervalExpressionP)
+        .map(
+            untuple((kind, expr) -> new Starts<I>(expr)),
+            $ -> tuple(Unit.UNIT, $.expression));
+  }
+
+  static <I extends IntervalContainer<I>> JsonParser<Ends<I>> endsF(final JsonParser<Expression<I>> intervalsExpressionP) {
+    return productP
+        .field("kind", literalP("IntervalsExpressionEnds"))
+        .field("expression", intervalsExpressionP)
+        .map(
+            untuple((kind, expr) -> new Ends<I>(expr)),
+            $ -> tuple(Unit.UNIT, $.expression));
+  }
+
   static <I extends IntervalContainer<I>> JsonParser<Split<I>> splitF(final JsonParser<Expression<I>> intervalExpressionP) {
     return productP
         .field("kind", literalP("SpansExpressionSplit"))
@@ -351,6 +369,8 @@ public final class ConstraintParsers {
         anyF(selfP),
         invertF(selfP),
         shiftByF(selfP),
+        startsF(selfP),
+        endsF(selfP),
         windowsFromSpansF(spansP)));
   }
 
@@ -365,6 +385,8 @@ public final class ConstraintParsers {
 
   private static JsonParser<Expression<Spans>> spansExpressionF(JsonParser<Expression<Windows>> windowsP) {
       return recursiveP(selfP -> chooseP(
+          startsF(selfP),
+          endsF(selfP),
           splitF(selfP),
           splitF(windowsP),
           spansFromWindowsF(windowsP)

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/IntervalContainer.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/IntervalContainer.java
@@ -4,4 +4,6 @@ import gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity;
 
 public interface IntervalContainer<T extends IntervalContainer<T>> {
   Spans split(final int numberOfSubIntervals, final Inclusivity internalStartInclusivity, final Inclusivity internalEndInclusivity);
+  T starts();
+  T ends();
 }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Spans.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Spans.java
@@ -122,6 +122,16 @@ public class Spans implements IntervalContainer<Spans>, Iterable<Interval> {
   }
 
   @Override
+  public Spans starts() {
+    return this.map($ -> Interval.at($.start));
+  }
+
+  @Override
+  public Spans ends() {
+    return this.map($ -> Interval.at($.end));
+  }
+
+  @Override
   public boolean equals(final Object obj) {
     if (!(obj instanceof final Spans spans)) return false;
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Ends.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Ends.java
@@ -1,0 +1,50 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.IntervalContainer;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public final class Ends<I extends IntervalContainer<I>> implements Expression<I> {
+  public final Expression<I> expression;
+
+  public Ends(final Expression<I> expression) {
+    this.expression = expression;
+  }
+
+  @Override
+  public I evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+    final var expression = this.expression.evaluate(results, bounds, environment);
+    return expression.ends();
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {
+    this.expression.extractResources(names);
+  }
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return String.format(
+        "\n%s(ends-of %s)",
+        prefix,
+        this.expression.prettyPrint(prefix + "  ")
+    );
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof final Ends o)) return false;
+
+    return Objects.equals(this.expression, o.expression);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.expression);
+  }
+}

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Starts.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Starts.java
@@ -1,0 +1,50 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.IntervalContainer;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public final class Starts<I extends IntervalContainer<I>> implements Expression<I> {
+  public final Expression<I> expression;
+
+  public Starts(final Expression<I> expression) {
+    this.expression = expression;
+  }
+
+  @Override
+  public I evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+    final var expression = this.expression.evaluate(results, bounds, environment);
+    return expression.starts();
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {
+    this.expression.extractResources(names);
+  }
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return String.format(
+        "\n%s(starts-of %s)",
+        prefix,
+        this.expression.prettyPrint(prefix + "  ")
+    );
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof final Starts o)) return false;
+
+    return Objects.equals(this.expression, o.expression);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.expression);
+  }
+}

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsersTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsersTest.java
@@ -8,6 +8,7 @@ import gov.nasa.jpl.aerie.constraints.tree.DiscreteResource;
 import gov.nasa.jpl.aerie.constraints.tree.DiscreteValue;
 import gov.nasa.jpl.aerie.constraints.tree.ActivityWindow;
 import gov.nasa.jpl.aerie.constraints.tree.EndOf;
+import gov.nasa.jpl.aerie.constraints.tree.Ends;
 import gov.nasa.jpl.aerie.constraints.tree.Equal;
 import gov.nasa.jpl.aerie.constraints.tree.ForEachActivity;
 import gov.nasa.jpl.aerie.constraints.tree.GreaterThan;
@@ -26,6 +27,7 @@ import gov.nasa.jpl.aerie.constraints.tree.RealValue;
 import gov.nasa.jpl.aerie.constraints.tree.Split;
 import gov.nasa.jpl.aerie.constraints.tree.SpansFromWindows;
 import gov.nasa.jpl.aerie.constraints.tree.StartOf;
+import gov.nasa.jpl.aerie.constraints.tree.Starts;
 import gov.nasa.jpl.aerie.constraints.tree.Times;
 import gov.nasa.jpl.aerie.constraints.tree.Transition;
 import gov.nasa.jpl.aerie.constraints.tree.ViolationsOf;
@@ -489,6 +491,46 @@ public final class ConstraintParsersTest {
 
     final var expected =
         new Invert(
+            new ActivityWindow("A"));
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testParseStarts() {
+    final var json = Json
+        .createObjectBuilder()
+        .add("kind", "IntervalsExpressionStarts")
+        .add("expression", Json
+            .createObjectBuilder()
+            .add("kind", "WindowsExpressionActivityWindow")
+            .add("alias", "A"))
+        .build();
+
+    final var result = windowsExpressionP.parse(json).getSuccessOrThrow();
+
+    final var expected =
+        new Starts<>(
+            new ActivityWindow("A"));
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testParseEnds() {
+    final var json = Json
+        .createObjectBuilder()
+        .add("kind", "IntervalsExpressionEnds")
+        .add("expression", Json
+            .createObjectBuilder()
+            .add("kind", "WindowsExpressionActivityWindow")
+            .add("alias", "A"))
+        .build();
+
+    final var result = windowsExpressionP.parse(json).getSuccessOrThrow();
+
+    final var expected =
+        new Ends<>(
             new ActivityWindow("A"));
 
     assertEquivalent(expected, result);

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -29,6 +29,8 @@ export enum NodeKind {
   WindowsExpressionAll = 'WindowsExpressionAll',
   WindowsExpressionAny = 'WindowsExpressionAny',
   WindowsExpressionInvert = 'WindowsExpressionInvert',
+  IntervalsExpressionStarts = 'IntervalsExpressionStarts',
+  IntervalsExpressionEnds = 'IntervalsExpressionEnds',
   ForEachActivity = 'ForEachActivity',
   ProfileChanges = 'ProfileChanges',
   ViolationsOf = 'ViolationsOf',
@@ -69,9 +71,13 @@ export type WindowsExpression =
   | WindowsExpressionInvert
   | WindowsExpressionShiftBy
   | WindowsExpressionFromSpans
+  | IntervalsExpressionStarts
+  | IntervalsExpressionEnds;
 
 export type SpansExpression =
   | SpansExpressionSplit
+  | IntervalsExpressionStarts
+  | IntervalsExpressionEnds
   | SpansExpressionFromWindows;
 
 export type IntervalsExpression =
@@ -186,6 +192,16 @@ export interface WindowsExpressionFromSpans {
 export interface SpansExpressionFromWindows {
   kind: NodeKind.SpansExpressionFromWindows,
   windowsExpression: WindowsExpression
+}
+
+export interface IntervalsExpressionStarts {
+  kind: NodeKind.IntervalsExpressionStarts,
+  expression: IntervalsExpression
+}
+
+export interface IntervalsExpressionEnds {
+  kind: NodeKind.IntervalsExpressionEnds,
+  expression: IntervalsExpression
 }
 
 export interface DiscreteProfileTransition {

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -179,6 +179,7 @@ export class Windows {
       fromEnd: fromEnd
     })
   }
+
   /**
    * Splits each window into equal sized sub-intervals. Returns a Spans object.
    *
@@ -206,6 +207,40 @@ export class Windows {
       numberOfSubIntervals: numberOfSubSpans,
       internalStartInclusivity: internalStartInclusivity,
       internalEndInclusivity: internalEndInclusivity
+    })
+  }
+
+  /**
+   * Replaces each window with its start point.
+   *
+   * Since gaps represent "unknown", true segments that come after a gap don't have a known start point.
+   * So instead their first known point is unset and the rest is set to false.
+   *
+   * True segments that explicitly come directly after false and include their start point have all except their
+   * start point set to false. If they don't include the start point, then the whole interval is set to false and the
+   * start point is set true.
+   */
+  public starts(): Windows {
+    return new Windows({
+      kind: AST.NodeKind.IntervalsExpressionStarts,
+      expression: this.__astNode
+    })
+  }
+
+  /**
+   * Replaces each window with its end point.
+   *
+   * Since gaps represent "unknown", true segments that come before a gap don't have a known end point.
+   * So instead their last known point is unset and the rest is set to false.
+   *
+   * True segments that explicitly come directly before false and include their end point have all except their
+   * end point set to false. If they don't include the end point, then the whole interval is set to false and the
+   * end point is set true.
+   */
+  public ends(): Windows {
+    return new Windows({
+      kind: AST.NodeKind.IntervalsExpressionEnds,
+      expression: this.__astNode
     })
   }
 
@@ -245,6 +280,7 @@ export class Spans {
       internalStartInclusivity: Inclusivity = Inclusivity.Inclusive,
       internalEndInclusivity: Inclusivity = Inclusivity.Exclusive
   ): Spans {
+
     if (numberOfSubSpans < 1) {
       throw RangeError(".split numberOfSubSpans cannot be less than 1, but was: " + numberOfSubSpans);
     }
@@ -254,6 +290,26 @@ export class Spans {
       numberOfSubIntervals: numberOfSubSpans,
       internalStartInclusivity: internalStartInclusivity,
       internalEndInclusivity: internalEndInclusivity
+    })
+  }
+
+  /**
+   * Replaces each Span with its start point.
+   */
+  public starts(): Spans {
+    return new Spans({
+      kind: AST.NodeKind.IntervalsExpressionStarts,
+      expression: this.__astNode
+    })
+  }
+
+  /**
+   * Replaces each Span with its end point.
+   */
+  public ends(): Spans {
+    return new Spans({
+      kind: AST.NodeKind.IntervalsExpressionEnds,
+      expression: this.__astNode
     })
   }
 
@@ -686,6 +742,30 @@ declare global {
     public split(numberOfSubSpans: number, internalStartInclusivity?: Inclusivity, internalEndInclusivity?: Inclusivity): Spans;
 
     /**
+     * Replaces each window with its start point.
+     *
+     * Since gaps represent "unknown", true segments that come after a gap don't have a known start point.
+     * So instead their first known point is unset and the rest is set to false.
+     *
+     * True segments that explicitly come directly after false and include their start point have all except their
+     * start point set to false. If they don't include the start point, then the whole interval is set to false and the
+     * start point is set true.
+     */
+    public starts(): Windows;
+
+    /**
+     * Replaces each window with its end point.
+     *
+     * Since gaps represent "unknown", true segments that come before a gap don't have a known end point.
+     * So instead their last known point is unset and the rest is set to false.
+     *
+     * True segments that explicitly come directly before false and include their end point have all except their
+     * end point set to false. If they don't include the end point, then the whole interval is set to false and the
+     * end point is set true.
+     */
+    public ends(): Windows;
+
+    /**
      * Convert this into a set of Spans.
      *
      * @throws InvalidGapsException if this contains any gaps.
@@ -698,6 +778,16 @@ declare global {
    */
   export class Spans {
     public readonly __astNode: AST.SpansExpression;
+
+    /**
+     * Returns the instantaneous start points of the these spans.
+     */
+    public starts(): Spans;
+
+    /**
+     * Returns the instantaneous end points of the these spans.
+     */
+    public ends(): Spans;
 
     /**
      * Splits each span into equal sized sub-spans.

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -562,6 +562,56 @@ class ConstraintsDSLCompilationServiceTests {
   }
 
   @Test
+  void testStarts() {
+    checkSuccessfulCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(0.3).starts()
+          }
+        """,
+        new ViolationsOf(
+            new Starts<>(new LessThan(new RealResource("state of charge"), new RealValue(0.3)))
+        )
+    );
+
+    checkSuccessfulCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(0.3).spans().starts().windows()
+          }
+        """,
+        new ViolationsOf(
+            new WindowsFromSpans(new Starts<>(new SpansFromWindows(new LessThan(new RealResource("state of charge"), new RealValue(0.3)))))
+        )
+    );
+  }
+
+  @Test
+  void testEnds() {
+    checkSuccessfulCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(0.3).ends()
+          }
+        """,
+        new ViolationsOf(
+            new Ends<>(new LessThan(new RealResource("state of charge"), new RealValue(0.3)))
+        )
+    );
+
+    checkSuccessfulCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(0.3).spans().ends().windows()
+          }
+        """,
+        new ViolationsOf(
+            new WindowsFromSpans(new Ends<>(new SpansFromWindows(new LessThan(new RealResource("state of charge"), new RealValue(0.3)))))
+        )
+    );
+  }
+
+  @Test
   void testSplit() {
     checkSuccessfulCompilation(
         """


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1948
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
These operations transform windows by replacing them with either their start point or end point. It doesn't care about the inclusivity of the original bounds.

Commits:
1. Implements the operations.
2. Adds the tests.

## Verification
I added tests for eDSL execution, JSON parsing, and evaluation behavior.

## Documentation
eDSL methods have doc comments. Wiki will be updated after this PR is approved, but before it is merged.

# Note
This PR is only the last two commits! It is rebased on top of #260, which will need to be merged first.
