### PR TITLE
[AERIE-1943]  mission specific activity directive metadata

### DIFF
--- a/command-expansion-server/sql/commanding/tables/sequence_to_simulated_activity.sql
+++ b/command-expansion-server/sql/commanding/tables/sequence_to_simulated_activity.sql
@@ -25,7 +25,7 @@ comment on constraint sequence_to_simulated_activity_primary_key on sequence_to_
 comment on constraint sequence_to_simulated_activity_activity_instance_id_fkey on sequence_to_simulated_activity is e''
   'Foreign key constrains that this join table relates to a sequence id that exists for the simulation dataset.';
 
-create trigger increment_revision_on_delete_activity_trigger
+create trigger sequence_set_updated_at_external_trigger
   after insert or update or delete on sequence_to_simulated_activity
   for each row
 execute function sequence_set_updated_at_external();

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_metadata_schema.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_metadata_schema.yaml
@@ -1,0 +1,3 @@
+table:
+  name: activity_directive_metadata_schema
+  schema: public

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
@@ -1,5 +1,6 @@
 - "!include public_activity.yaml"
 - "!include public_activity_type.yaml"
+- "!include public_activity_directive_metadata_schema.yaml"
 - "!include public_condition.yaml"
 - "!include public_dataset.yaml"
 - "!include public_mission_model.yaml"

--- a/merlin-server/sql/merlin/domain-types/merlin-activity-directive-metadata.sql
+++ b/merlin-server/sql/merlin/domain-types/merlin-activity-directive-metadata.sql
@@ -1,0 +1,7 @@
+create domain merlin_activity_directive_metadata_set as jsonb
+  constraint merlin_activity_directive_metadata_set_is_object
+    check(jsonb_typeof(value) = 'object');
+
+comment on domain merlin_activity_directive_metadata_set is e''
+  'The set of mission defined metadata associated with an activity directive.';
+

--- a/merlin-server/sql/merlin/init.sql
+++ b/merlin-server/sql/merlin/init.sql
@@ -3,6 +3,10 @@
 begin;
   -- Domain types.
   \ir domain-types/merlin-arguments.sql
+  \ir domain-types/merlin-activity-directive-metadata.sql
+
+  -- Activity Directive Metadata schema
+  \ir tables/activity_directive_metadata_schema.sql
 
   -- Tables.
   -- Uploaded files (JARs or simulation input files).

--- a/merlin-server/sql/merlin/tables/activity.sql
+++ b/merlin-server/sql/merlin/tables/activity.sql
@@ -10,6 +10,7 @@ create table activity (
   start_offset interval not null,
   type text not null,
   arguments merlin_argument_set not null,
+  metadata merlin_activity_directive_metadata_set default '{}'::jsonb,
 
   constraint activity_synthetic_key
     primary key (id),
@@ -48,6 +49,8 @@ comment on column activity.type is e''
   'The type of the activity, as defined in the mission model associated with the plan.';
 comment on column activity.arguments is e''
   'The set of arguments to this activity, corresponding to the parameters of the associated activity type.';
+comment on column activity.metadata is e''
+  'The metadata associated with this activity.';
 
 
 create function increment_revision_on_insert_activity()

--- a/merlin-server/sql/merlin/tables/activity_directive_metadata_schema.sql
+++ b/merlin-server/sql/merlin/tables/activity_directive_metadata_schema.sql
@@ -16,6 +16,47 @@ comment on column activity_directive_metadata_schema.created_at is 'e'
 comment on column activity_directive_metadata_schema.updated_at is 'e'
   'Timestamp when the metadata field was last updated.';
 
+create or replace function validate_activity_directive_metadata_schema()
+  returns trigger
+  security definer
+  language plpgsql as $$
+  declare
+    _type text;
+    _enumerates jsonb;
+  begin
+    _type := new.schema->>'type';
+    if _type is null then
+      raise exception 'Invalid metadata schema for key %. It must be an object with a a "type" field.', new.key;
+    end if;
+    if _type = 'enum' then
+      _enumerates := new.schema->'enumerates';
+      if _enumerates is null then
+        raise exception 'Invalid metadata schema for key %. An enum type must specify an "enumerates" field with enumerated values.', new.key;
+      end if;
+    elsif _type = 'enum_multiselect' then
+      _enumerates := new.schema->'enumerates';
+      if _enumerates is null then
+        raise exception 'Invalid metadata schema for key %. An enum_multiselect type must specify an "enumerates" field with enumerated values.', new.key;
+      end if;
+    elsif _type = 'boolean' then
+    elsif _type = 'number' then
+    elsif _type = 'string' then
+    elsif _type = 'long_string' then
+    else
+      raise exception 'Invalid metadata schema type for key %. It must be one of ["enum", "enum_multiselect", "boolean", "number", "string", "long_string"]. Found: %', new.key, _type;
+    end if;
+    return new;
+  end
+$$;
+
+create trigger validate_activity_directive_metadata_schema_trigger
+before insert or update on activity_directive_metadata_schema
+for each row
+execute function validate_activity_directive_metadata_schema();
+
+comment on trigger validate_activity_directive_metadata_schema_trigger on activity_directive_metadata_schema is 'e'
+  'Trigger to validate the metadata schema entries for the activity directive metadata.';
+
 create or replace function activity_directive_metadata_schema_updated_at()
 returns trigger
 security definer

--- a/merlin-server/sql/merlin/tables/activity_directive_metadata_schema.sql
+++ b/merlin-server/sql/merlin/tables/activity_directive_metadata_schema.sql
@@ -1,0 +1,31 @@
+create table activity_directive_metadata_schema (
+  key text not null primary key,
+  schema jsonb not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table activity_directive_metadata_schema is 'e'
+  'Schema for the activity directive metadata.';
+comment on column activity_directive_metadata_schema.key is 'e'
+  'Key of the metadata.';
+comment on column activity_directive_metadata_schema.schema is 'e'
+  'Schema of the metadata field.';
+comment on column activity_directive_metadata_schema.created_at is 'e'
+  'Timestamp when the metadata field was created.';
+comment on column activity_directive_metadata_schema.updated_at is 'e'
+  'Timestamp when the metadata field was last updated.';
+
+create or replace function activity_directive_metadata_schema_updated_at()
+returns trigger
+security definer
+language plpgsql as $$begin
+  new.updated_at = now();
+  return new;
+end$$;
+
+create trigger activity_directive_metadata_schema_updated_at_trigger
+before update
+on activity_directive_metadata_schema
+for each row
+execute procedure activity_directive_metadata_schema_updated_at();


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1943
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Add mission specific metadata management.

This adds a table and domain type to manage the contents of the metadata. A column is added to the activity table to hold the activity metadata. We specifically DO NOT prevent extra keys, but we DO validate keys for which a schema exists in the metadata schema table. The schema is there specifically to allow our front-end tools to appropriately display the values and allow appropriate editing.

There are 6 different types defined for metadata:
- string: displays as a single line text field
- long_string: displays as a textarea
- boolean: displays as a checkbox
- number: displays as a numeric input
- enum: displays as a single select dropdown
- enum_multiselect: displays as a multi-select dropdown

If the schema is defined with a type not in that list, no validation occurs and the UI should just display a raw json editor. The intent is for the UI to display all fields for which there is a schema regardless of whether that value is stored in the metadata for the activity. Edits to those fields will write the fields back to the activity table. Fields that are NOT listed in the schema table should NOT be displayed.

The schema for each looks like:
-string: `{ type: 'string' }`
-long_string: `{ type: 'long_string' }`
-boolean: `{ type: 'boolean' }`
-number: `{ type: 'number' }`
-enum: `{ type: 'enum', enumerates: [<a series of values, could be numeric or string>] }`
-enum_multiselect: `{ type: 'enum_multiselect', enumerates: [<a series of values, could be numeric or string>] }`

The value format for each looks like:
-string: <string>
-long_string: <string>
-boolean: <boolean>
-number: <number>
-enum: <string|number>
-enum_multiselect: [\<array of strings or numbers\>]

Example metadata entry for an activity:
```
{
  "Science Intent": "Perform a reading of Saturn's magnetic field",
  "Requires Waiver": true,
  "ACTID": 24543
}
```
and the associated entries in the schema table

```
key               |    schema
-----------------------------------------------
"Science Intent"  | '{ "type": "long_string" }'
"Requires Waiver" | '{ "type": "boolean" }'
"ACTID"           | '{ "type": "number" }'
```
## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

I did local tests with this and everything seemed to be working great.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
We need to document the above formats so that API users know the formats to use.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Automated tests for this feature.