### PR TITLE
[FIX] Fix javadoc EventGraph#atom warning

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/timeline/EventGraph.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/timeline/EventGraph.java
@@ -47,7 +47,7 @@ public sealed interface EventGraph<Event> extends EffectExpression<Event> {
     }
   }
 
-  /** Use {@link EventGraph#atom(Event)} instead of instantiating this class directly. */
+  /** Use {@link EventGraph#atom} instead of instantiating this class directly. */
   record Atom<Event>(Event atom) implements EventGraph<Event> {
     @Override
     public String toString() {


### PR DESCRIPTION
* **Tickets addressed:** making a ticket would take longer than this took to fix :)
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Fixes that annoying javadoc warning about `EventGraph#atom(Event)`. I didn't figure out why it happens, but removing the arg list (changing it to `EventGraph#atom`) gets rid of the warning, and the docs are unchanged.