### PR TITLE
[AERIE-1957] fix: add Hasura web socket URL env var

### DIFF
--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -87,13 +87,14 @@ This document provides detailed information about environment variables for each
 
 ## Aerie UI
 
-| Name                 | Description                                                                                               | Type     | Default                          |
-| -------------------- | --------------------------------------------------------------------------------------------------------- | -------- | -------------------------------- |
-| `GATEWAY_CLIENT_URL` | Url of the Gateway as called from the client (i.e. web browser)                                           | `string` | http://localhost:9000            |
-| `GATEWAY_SERVER_URL` | Url of the Gateway as called from the server (i.e. Node.js container)                                     | `string` | http://localhost:9000            |
-| `HASURA_CLIENT_URL`  | Url of Hasura as called from the client (i.e. web browser)                                                | `string` | http://localhost:8080/v1/graphql |
-| `HASURA_SERVER_URL`  | Url of Hasura as called from the server (i.e. Node.js container)                                          | `string` | http://localhost:8080/v1/graphql |
-| `ORIGIN`             | Url of where the UI is served from. See the [Svelte Kit Adapter Node docs][svelte-kit-adapter-node-docs]. | `string` | http://localhost                 |
+| Name                    | Description                                                                                               | Type     | Default                          |
+| ----------------------- | --------------------------------------------------------------------------------------------------------- | -------- | -------------------------------- |
+| `GATEWAY_CLIENT_URL`    | Url of the Gateway as called from the client (i.e. web browser)                                           | `string` | http://localhost:9000            |
+| `GATEWAY_SERVER_URL`    | Url of the Gateway as called from the server (i.e. Node.js container)                                     | `string` | http://localhost:9000            |
+| `HASURA_CLIENT_URL`     | Url of Hasura as called from the client (i.e. web browser)                                                | `string` | http://localhost:8080/v1/graphql |
+| `HASURA_SERVER_URL`     | Url of Hasura as called from the server (i.e. Node.js container)                                          | `string` | http://localhost:8080/v1/graphql |
+| `HASURA_WEB_SOCKET_URL` | Url of Hasura called to establish a web-socket connection from the client                                 | `string` | ws://localhost:8080/v1/graphql   |
+| `ORIGIN`                | Url of where the UI is served from. See the [Svelte Kit Adapter Node docs][svelte-kit-adapter-node-docs]. | `string` | http://localhost                 |
 
 ## Hasura
 

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -108,6 +108,7 @@ services:
       GATEWAY_SERVER_URL: http://aerie_gateway:9000
       HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
       HASURA_SERVER_URL: http://hasura:8080/v1/graphql
+      HASURA_WEB_SOCKET_URL: ws://localhost:8080/v1/graphql
       ORIGIN: http://localhost
     image: "${REPOSITORY_DOCKER_URL}/aerie-ui:${DOCKER_TAG}"
     ports: ["80:80"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       GATEWAY_SERVER_URL: http://aerie_gateway:9000
       HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
       HASURA_SERVER_URL: http://hasura:8080/v1/graphql
+      HASURA_WEB_SOCKET_URL: ws://localhost:8080/v1/graphql
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
       ORIGIN: http://localhost
     image: "ghcr.io/nasa-ammos/aerie-ui:develop"

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -108,6 +108,7 @@ services:
       GATEWAY_SERVER_URL: http://aerie_gateway:9000
       HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
       HASURA_SERVER_URL: http://hasura:8080/v1/graphql
+      HASURA_WEB_SOCKET_URL: ws://localhost:8080/v1/graphql
       NODE_TLS_REJECT_UNAUTHORIZED: '0'
       ORIGIN: http://localhost
     image: 'ghcr.io/nasa-ammos/aerie-ui:develop'


### PR DESCRIPTION
* **Tickets addressed:** [AERIE-1957](https://jira.jpl.nasa.gov/browse/AERIE-1957)
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

- Allow for more explicit configuration of the web socket URL

## Documentation

Updated in this commit.

## Future work

Aerie UI PR: https://github.com/NASA-AMMOS/aerie-ui/pull/66