### PR TITLE
[AERIE-1953] Interval split operation for Windows and Spans

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/UnsplittableIntervalException.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/UnsplittableIntervalException.java
@@ -1,0 +1,7 @@
+package gov.nasa.jpl.aerie.constraints;
+
+public final class UnsplittableIntervalException extends RuntimeException {
+  public UnsplittableIntervalException(final String message) {
+    super(message);
+  }
+}

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/UnsplittableIntervalException.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/UnsplittableIntervalException.java
@@ -1,7 +1,0 @@
-package gov.nasa.jpl.aerie.constraints;
-
-public final class UnsplittableIntervalException extends RuntimeException {
-  public UnsplittableIntervalException(final String message) {
-    super(message);
-  }
-}

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Interval.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Interval.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.constraints.time;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Objects;
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/IntervalContainer.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/IntervalContainer.java
@@ -1,0 +1,5 @@
+package gov.nasa.jpl.aerie.constraints.time;
+
+public interface IntervalContainer<T extends IntervalContainer<T>> {
+  T split(final int numberOfSubIntervals);
+}

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/IntervalContainer.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/IntervalContainer.java
@@ -1,5 +1,7 @@
 package gov.nasa.jpl.aerie.constraints.time;
 
+import gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity;
+
 public interface IntervalContainer<T extends IntervalContainer<T>> {
-  T split(final int numberOfSubIntervals);
+  Spans split(final int numberOfSubIntervals, final Inclusivity internalStartInclusivity, final Inclusivity internalEndInclusivity);
 }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/IntervalMap.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/IntervalMap.java
@@ -325,7 +325,7 @@ public final class IntervalMap<V> implements Iterable<Segment<V>> {
 
   /** Gets the segment at a given index */
   public Segment<V> get(final int index) {
-    final var i = (index >= 0) ? index : this.segments.size() - index;
+    final var i = (index >= 0) ? index : this.segments.size() + index;
     return this.segments.get(i);
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/InvalidGapsException.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/InvalidGapsException.java
@@ -1,0 +1,7 @@
+package gov.nasa.jpl.aerie.constraints.time;
+
+public final class InvalidGapsException extends RuntimeException {
+  public InvalidGapsException(final String message) {
+    super(message);
+  }
+}

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Spans.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Spans.java
@@ -1,6 +1,5 @@
 package gov.nasa.jpl.aerie.constraints.time;
 
-import gov.nasa.jpl.aerie.constraints.UnsplittableIntervalException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
 import java.util.ArrayList;
@@ -13,7 +12,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Exclusive;
+import gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity;
 
 /**
  * A collection of intervals that can overlap.
@@ -69,8 +68,18 @@ public class Spans implements IntervalContainer<Spans>, Iterable<Interval> {
     return new Spans(this.intervals.stream().filter(filter).toList());
   }
 
+  /**
+   * Splits each span into sub-spans.
+   *
+   * @param numberOfSubSpans number of sub-spans for each span.
+   * @param internalStartInclusivity Inclusivity for any newly generated span start points (default Inclusive in eDSL).
+   * @param internalEndInclusivity Inclusivity for any newly generated span end points (default Exclusive in eDSL).
+   * @return a new Spans
+   * @throws UnsplittableSpanException if any span contains only one point or contains fewer microseconds than `numberOfSubSpans`.
+   * @throws UnsplittableSpanException if any span contains {@link Duration#MIN_VALUE} or {@link Duration#MAX_VALUE} (representing unbounded intervals)
+   */
   @Override
-  public Spans split(final int numberOfSubSpans) {
+  public Spans split(final int numberOfSubSpans, final Inclusivity internalStartInclusivity, final Inclusivity internalEndInclusivity) {
     if (numberOfSubSpans == 1) {
       return new Spans(this);
     }
@@ -82,20 +91,32 @@ public class Spans implements IntervalContainer<Spans>, Iterable<Interval> {
 
       // We throw an exception if the interval contains fewer microseconds than the requested number of sub-spans.
       if (x.isSingleton()) {
-        throw new UnsplittableIntervalException("Cannot split an instantaneous interval into " + numberOfSubSpans + " pieces.");
+        throw new UnsplittableSpanException("Cannot split an instantaneous span into " + numberOfSubSpans + " pieces.");
       } else if (numberOfMicroSeconds < numberOfSubSpans) {
-        throw new UnsplittableIntervalException("Cannot split an interval only " + numberOfMicroSeconds + " microseconds long into " + numberOfSubSpans + " pieces.");
+        throw new UnsplittableSpanException("Cannot split a span only " + numberOfMicroSeconds + " microseconds long into " + numberOfSubSpans + " pieces.");
+      }
+
+      // Throw an exception if trying to split an "unbounded" interval.
+      // It is unlikely that a user will ever need to split a Windows or Spans that includes +/- infinity.
+      //
+      // If they do, and it is a legitimate use case that we should support, this block should be replaced
+      // with a check that returns the unbounded interval unchanged, because the split points on an unbounded
+      // interval will be outside the finite range of `Duration`.
+      if (x.contains(Duration.MIN_VALUE)) {
+        throw new UnsplittableSpanException("Cannot split an unbounded span. (interval contains MIN_VALUE, which is a stand-in for -infinity.");
+      } else if (x.contains(Duration.MAX_VALUE)) {
+        throw new UnsplittableSpanException("Cannot split an unbounded span. (interval contains MAX_VALUE, which is a stand-in for +infinity.");
       }
 
       var cursor = Duration.add(x.start, width);
-      final List<Window> ret = new ArrayList<>();
-      ret.add(Window.between(x.start, x.startInclusivity, cursor, Exclusive));
+      final List<Interval> ret = new ArrayList<>();
+      ret.add(Interval.between(x.start, x.startInclusivity, cursor, internalEndInclusivity));
       for (int i = 1; i < numberOfSubSpans - 1; i++) {
         final var nextCursor = Duration.add(cursor, width);
-        ret.add(Window.between(cursor, Exclusive, nextCursor, Exclusive));
+        ret.add(Interval.between(cursor, internalStartInclusivity, nextCursor, internalEndInclusivity));
         cursor = nextCursor;
       }
-      ret.add(Window.between(cursor, Exclusive, x.end, x.endInclusivity));
+      ret.add(Interval.between(cursor, internalStartInclusivity, x.end, x.endInclusivity));
       return ret.stream();
     });
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Spans.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Spans.java
@@ -1,5 +1,8 @@
 package gov.nasa.jpl.aerie.constraints.time;
 
+import gov.nasa.jpl.aerie.constraints.UnsplittableIntervalException;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -10,10 +13,12 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Exclusive;
+
 /**
  * A collection of intervals that can overlap.
  */
-public class Spans implements Iterable<Interval> {
+public class Spans implements IntervalContainer<Spans>, Iterable<Interval> {
   private final List<Interval> intervals;
 
   public Spans() {
@@ -62,6 +67,37 @@ public class Spans implements Iterable<Interval> {
 
   public Spans filter(final Predicate<Interval> filter) {
     return new Spans(this.intervals.stream().filter(filter).toList());
+  }
+
+  @Override
+  public Spans split(final int numberOfSubSpans) {
+    if (numberOfSubSpans == 1) {
+      return new Spans(this);
+    }
+    return this.flatMap(x -> {
+      // Width of each sub-window, rounded down to the microsecond
+      final var width = Duration.divide(Duration.subtract(x.end, x.start), numberOfSubSpans);
+
+      final var numberOfMicroSeconds = Duration.subtract(x.end, x.start).in(Duration.MICROSECOND);
+
+      // We throw an exception if the interval contains fewer microseconds than the requested number of sub-spans.
+      if (x.isSingleton()) {
+        throw new UnsplittableIntervalException("Cannot split an instantaneous interval into " + numberOfSubSpans + " pieces.");
+      } else if (numberOfMicroSeconds < numberOfSubSpans) {
+        throw new UnsplittableIntervalException("Cannot split an interval only " + numberOfMicroSeconds + " microseconds long into " + numberOfSubSpans + " pieces.");
+      }
+
+      var cursor = Duration.add(x.start, width);
+      final List<Window> ret = new ArrayList<>();
+      ret.add(Window.between(x.start, x.startInclusivity, cursor, Exclusive));
+      for (int i = 1; i < numberOfSubSpans - 1; i++) {
+        final var nextCursor = Duration.add(cursor, width);
+        ret.add(Window.between(cursor, Exclusive, nextCursor, Exclusive));
+        cursor = nextCursor;
+      }
+      ret.add(Window.between(cursor, Exclusive, x.end, x.endInclusivity));
+      return ret.stream();
+    });
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/UnsplittableSpanException.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/UnsplittableSpanException.java
@@ -1,0 +1,7 @@
+package gov.nasa.jpl.aerie.constraints.time;
+
+public final class UnsplittableSpanException extends RuntimeException {
+  public UnsplittableSpanException(final String message) {
+    super(message);
+  }
+}

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
@@ -355,9 +355,17 @@ public final class Windows implements Iterable<Segment<Boolean>> {
 
       builder.set(Segment.of(shiftedInterval, segment.value()));
     }
-
     return new Windows(builder.build());
   }
+  
+  /**
+   *
+   */
+  @Override
+  public Windows split(final int numberOfSubWindows) {
+    return this.intoSpans().split(numberOfSubWindows).intoWindows();
+  }
+
 
   /**
    * Converts this into a Spans object, where each true segment is a Span.

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Split.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Split.java
@@ -3,25 +3,34 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.IntervalContainer;
-import gov.nasa.jpl.aerie.constraints.time.Window;
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity;
+import gov.nasa.jpl.aerie.constraints.time.Spans;
 
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-public final class Split<I extends IntervalContainer<I>> implements Expression<I> {
+public final class Split<I extends IntervalContainer<?>> implements Expression<Spans> {
   public final Expression<I> intervals;
   public final int numberOfSubIntervals;
+  public final Inclusivity internalStartInclusivity;
+  public final Inclusivity internalEndInclusivity;
 
-  public Split(final Expression<I> intervals, final int numberOfSubIntervals) {
+  public Split(final Expression<I> intervals,
+               final int numberOfSubIntervals,
+               final Inclusivity internalStartInclusivity,
+               final Inclusivity internalEndInclusivity) {
     this.intervals = intervals;
     this.numberOfSubIntervals = numberOfSubIntervals;
+    this.internalStartInclusivity = internalStartInclusivity;
+    this.internalEndInclusivity = internalEndInclusivity;
   }
 
   @Override
-  public I evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+  public Spans evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
     final var intervals = this.intervals.evaluate(results, bounds, environment);
-    return intervals.split(this.numberOfSubIntervals);
+    return intervals.split(this.numberOfSubIntervals, this.internalStartInclusivity, this.internalEndInclusivity);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Split.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Split.java
@@ -1,0 +1,54 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.IntervalContainer;
+import gov.nasa.jpl.aerie.constraints.time.Window;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public final class Split<I extends IntervalContainer<I>> implements Expression<I> {
+  public final Expression<I> intervals;
+  public final int numberOfSubIntervals;
+
+  public Split(final Expression<I> intervals, final int numberOfSubIntervals) {
+    this.intervals = intervals;
+    this.numberOfSubIntervals = numberOfSubIntervals;
+  }
+
+  @Override
+  public I evaluate(final SimulationResults results, final Window bounds, final Map<String, ActivityInstance> environment) {
+    final var intervals = this.intervals.evaluate(results, bounds, environment);
+    return intervals.split(this.numberOfSubIntervals);
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {
+    this.intervals.extractResources(names);
+  }
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return String.format(
+        "\n%s(split %s into %s)",
+        prefix,
+        this.intervals.prettyPrint(prefix + "  "),
+        this.numberOfSubIntervals
+    );
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Split<?> split = (Split<?>) o;
+    return numberOfSubIntervals == split.numberOfSubIntervals && Objects.equals(intervals, split.intervals);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(intervals, numberOfSubIntervals);
+  }
+}

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsersTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsersTest.java
@@ -1,6 +1,5 @@
 package gov.nasa.jpl.aerie.constraints.json;
 
-import gov.nasa.jpl.aerie.constraints.time.Spans;
 import gov.nasa.jpl.aerie.constraints.tree.All;
 import gov.nasa.jpl.aerie.constraints.tree.Changes;
 import gov.nasa.jpl.aerie.constraints.tree.DiscreteParameter;
@@ -23,6 +22,7 @@ import gov.nasa.jpl.aerie.constraints.tree.Rate;
 import gov.nasa.jpl.aerie.constraints.tree.RealParameter;
 import gov.nasa.jpl.aerie.constraints.tree.RealResource;
 import gov.nasa.jpl.aerie.constraints.tree.RealValue;
+import gov.nasa.jpl.aerie.constraints.tree.Split;
 import gov.nasa.jpl.aerie.constraints.tree.SpansFromWindows;
 import gov.nasa.jpl.aerie.constraints.tree.StartOf;
 import gov.nasa.jpl.aerie.constraints.tree.Times;
@@ -489,6 +489,57 @@ public final class ConstraintParsersTest {
     final var expected =
         new Invert(
             new ActivityWindow("A"));
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testParseSplitWindows() {
+    final var json = Json
+        .createObjectBuilder()
+        .add("kind", "IntervalsExpressionSplit")
+        .add("intervals", Json
+            .createObjectBuilder()
+            .add("kind", "WindowsExpressionActivityWindow")
+            .add("alias", "A"))
+        .add("numberOfSubIntervals", 3)
+        .build();
+
+    final var result = windowsExpressionP.parse(json).getSuccessOrThrow();
+
+    final var expected =
+        new Split<>(
+            new ActivityWindow("A"),
+            3
+        );
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testParseSplitSpans() {
+    final var json = Json
+        .createObjectBuilder()
+        .add("kind", "IntervalsExpressionSplit")
+        .add("intervals", Json.createObjectBuilder()
+            .add("kind", "SpansExpressionFromWindows")
+            .add("windowsExpression", Json
+              .createObjectBuilder()
+              .add("kind", "WindowsExpressionActivityWindow")
+              .add("alias", "A"))
+        )
+        .add("numberOfSubIntervals", 3)
+        .build();
+
+    final var result = spansExpressionP.parse(json).getSuccessOrThrow();
+
+    final var expected =
+        new Split<>(
+            new SpansFromWindows(
+                new ActivityWindow("A")
+            ),
+            3
+        );
 
     assertEquivalent(expected, result);
   }

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsersTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsersTest.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.constraints.json;
 
+import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.tree.All;
 import gov.nasa.jpl.aerie.constraints.tree.Changes;
 import gov.nasa.jpl.aerie.constraints.tree.DiscreteParameter;
@@ -497,20 +498,24 @@ public final class ConstraintParsersTest {
   public void testParseSplitWindows() {
     final var json = Json
         .createObjectBuilder()
-        .add("kind", "IntervalsExpressionSplit")
+        .add("kind", "SpansExpressionSplit")
         .add("intervals", Json
             .createObjectBuilder()
             .add("kind", "WindowsExpressionActivityWindow")
             .add("alias", "A"))
         .add("numberOfSubIntervals", 3)
+        .add("internalStartInclusivity", "Exclusive")
+        .add("internalEndInclusivity", "Exclusive")
         .build();
 
-    final var result = windowsExpressionP.parse(json).getSuccessOrThrow();
+    final var result = spansExpressionP.parse(json).getSuccessOrThrow();
 
     final var expected =
         new Split<>(
             new ActivityWindow("A"),
-            3
+            3,
+            Interval.Inclusivity.Exclusive,
+            Interval.Inclusivity.Exclusive
         );
 
     assertEquivalent(expected, result);
@@ -520,7 +525,7 @@ public final class ConstraintParsersTest {
   public void testParseSplitSpans() {
     final var json = Json
         .createObjectBuilder()
-        .add("kind", "IntervalsExpressionSplit")
+        .add("kind", "SpansExpressionSplit")
         .add("intervals", Json.createObjectBuilder()
             .add("kind", "SpansExpressionFromWindows")
             .add("windowsExpression", Json
@@ -529,6 +534,8 @@ public final class ConstraintParsersTest {
               .add("alias", "A"))
         )
         .add("numberOfSubIntervals", 3)
+        .add("internalStartInclusivity", "Inclusive")
+        .add("internalEndInclusivity", "Exclusive")
         .build();
 
     final var result = spansExpressionP.parse(json).getSuccessOrThrow();
@@ -538,7 +545,9 @@ public final class ConstraintParsersTest {
             new SpansFromWindows(
                 new ActivityWindow("A")
             ),
-            3
+            3,
+            Interval.Inclusivity.Inclusive,
+            Interval.Inclusivity.Exclusive
         );
 
     assertEquivalent(expected, result);

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/time/WindowsTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/time/WindowsTest.java
@@ -486,18 +486,28 @@ public class WindowsTest {
 
   @Test
   public void intoSpans() {
-    final var spans = new Windows(
+    final var windowsWithGaps = new Windows(
         Segment.of(interval(0, 2, SECONDS), true),
         Segment.of(interval(1, 3, SECONDS), true),
         Segment.of(interval(5, 5, SECONDS), true),
         Segment.of(interval(6, 8, SECONDS), false)
-    ).intoSpans();
+    );
+
+    assertThrows(
+        InvalidGapsException.class,
+        windowsWithGaps::intoSpans,
+        "cannot convert Windows with gaps into Spans (unbounded gap to -infinity)"
+    );
+
+    final var windowsWithoutGaps = new Windows(false).set(windowsWithGaps);
 
     final var expected = new Spans(
         interval(0, 3, SECONDS),
         interval(5, 5, SECONDS)
     );
 
-    assertIterableEquals(expected, spans);
+    assertIterableEquals(expected, windowsWithoutGaps.intoSpans());
+
+
   }
 }

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -1,7 +1,7 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
 import gov.nasa.jpl.aerie.constraints.InputMismatchException;
-import gov.nasa.jpl.aerie.constraints.UnsplittableIntervalException;
+import gov.nasa.jpl.aerie.constraints.time.UnsplittableSpanException;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfilePiece;
@@ -15,7 +15,6 @@ import gov.nasa.jpl.aerie.constraints.time.Spans;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -28,8 +27,10 @@ import static gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity.Exclusive
 import static gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity.Inclusive;
 import static gov.nasa.jpl.aerie.constraints.time.Interval.at;
 import static gov.nasa.jpl.aerie.constraints.time.Interval.interval;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ASTTests {
@@ -61,26 +62,26 @@ public class ASTTests {
   @Test
   public void testSplitWindows() {
     final var simResults = new SimulationResults(
-        Window.between(0, 20, SECONDS),
+        Interval.between(0, 20, SECONDS),
         List.of(),
         Map.of(),
         Map.of()
     );
 
-    final var windows = new Windows();
-    windows.add(Window.between(0, Inclusive, 5, Exclusive, SECONDS));
-    windows.add(Window.between(10000000, Exclusive, 15000001, Exclusive, MICROSECONDS));
+    final var windows = new Windows(false)
+        .set(Interval.between(0, Inclusive, 5, Exclusive, SECONDS), true)
+        .set(Interval.between(10000000, Exclusive, 15000001, Exclusive, MICROSECONDS), true);
 
-    final var result = new Split<Windows>(Supplier.of(windows), 3).evaluate(simResults, Map.of());
+    final var result = new WindowsFromSpans(new Split<>(Supplier.of(windows), 3, Exclusive, Exclusive)).evaluate(simResults, Map.of());
 
-    final var expected = new Windows();
-    expected.add(Window.between(0, Inclusive, 1666666, Exclusive, MICROSECONDS));
-    expected.add(Window.between(1666666, Exclusive, 3333332, Exclusive, MICROSECONDS));
-    expected.add(Window.between(3333332, Exclusive, 5000000, Exclusive, MICROSECONDS));
+    final var expected = new Windows(false)
+    		.set(Interval.between(0, Inclusive, 1666666, Exclusive, MICROSECONDS), true)
+    		.set(Interval.between(1666666, Exclusive, 3333332, Exclusive, MICROSECONDS), true)
+    		.set(Interval.between(3333332, Exclusive, 5000000, Exclusive, MICROSECONDS), true)
 
-    expected.add(Window.between(10000000, Exclusive, 11666667, Exclusive, MICROSECONDS));
-    expected.add(Window.between(11666667, Exclusive, 13333334, Exclusive, MICROSECONDS));
-    expected.add(Window.between(13333334, Exclusive, 15000001, Exclusive, MICROSECONDS));
+    		.set(Interval.between(10000000, Exclusive, 11666667, Exclusive, MICROSECONDS), true)
+    		.set(Interval.between(11666667, Exclusive, 13333334, Exclusive, MICROSECONDS), true)
+    		.set(Interval.between(13333334, Exclusive, 15000001, Exclusive, MICROSECONDS), true);
 
     assertEquivalent(expected, result);
   }
@@ -88,44 +89,44 @@ public class ASTTests {
   @Test
   public void testSplitSpans() {
     final var simResults = new SimulationResults(
-        Window.between(0, 20, SECONDS),
+        Interval.between(0, 20, SECONDS),
         List.of(),
         Map.of(),
         Map.of()
     );
 
     final var spans = new Spans();
-    spans.add(Window.between(0, Inclusive, 5, Exclusive, SECONDS));
-    spans.add(Window.between(0, Exclusive, 5000001, Exclusive, MICROSECONDS));
+    spans.add(Interval.between(0, Inclusive, 5, Exclusive, SECONDS));
+    spans.add(Interval.between(0, Exclusive, 5000001, Inclusive, MICROSECONDS));
 
-    final var result = new Split<Spans>(Supplier.of(spans), 3).evaluate(simResults, Map.of());
+    final var result = new Split<>(Supplier.of(spans), 3, Inclusive, Exclusive).evaluate(simResults, Map.of());
 
     final var expected = new Spans();
-    expected.add(Window.between(0, Inclusive, 1666666, Exclusive, MICROSECONDS));
-    expected.add(Window.between(1666666, Exclusive, 3333332, Exclusive, MICROSECONDS));
-    expected.add(Window.between(3333332, Exclusive, 5000000, Exclusive, MICROSECONDS));
+    expected.add(Interval.between(0, Inclusive, 1666666, Exclusive, MICROSECONDS));
+    expected.add(Interval.between(1666666, Inclusive, 3333332, Exclusive, MICROSECONDS));
+    expected.add(Interval.between(3333332, Inclusive, 5000000, Exclusive, MICROSECONDS));
 
-    expected.add(Window.between(0, Exclusive, 1666667, Exclusive, MICROSECONDS));
-    expected.add(Window.between(1666667, Exclusive, 3333334, Exclusive, MICROSECONDS));
-    expected.add(Window.between(3333334, Exclusive, 5000001, Exclusive, MICROSECONDS));
+    expected.add(Interval.between(0, Exclusive, 1666667, Exclusive, MICROSECONDS));
+    expected.add(Interval.between(1666667, Inclusive, 3333334, Exclusive, MICROSECONDS));
+    expected.add(Interval.between(3333334, Inclusive, 5000001, Inclusive, MICROSECONDS));
 
-    assertEquivalent(expected, result);
+    assertIterableEquals(expected, result);
   }
 
   @Test
   public void testUnsplittableInterval() {
     final var simResults = new SimulationResults(
-        Window.between(0, 20, SECONDS),
+        Interval.between(0, 20, SECONDS),
         List.of(),
         Map.of(),
         Map.of()
     );
 
     final var spans = new Spans(
-        Window.at(5, SECONDS)
+        Interval.at(5, SECONDS)
     );
 
-    assertThrows(UnsplittableIntervalException.class, () -> new Split<Spans>(Supplier.of(spans), 3).evaluate(simResults, Map.of()));
+    assertThrows(UnsplittableSpanException.class, () -> new Split<Spans>(Supplier.of(spans), 3, Inclusive, Exclusive).evaluate(simResults, Map.of()));
   }
 
   @Test

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -26,6 +26,7 @@ export enum NodeKind {
   WindowsExpressionAll = 'WindowsExpressionAll',
   WindowsExpressionAny = 'WindowsExpressionAny',
   WindowsExpressionInvert = 'WindowsExpressionInvert',
+  IntervalsExpressionSplit = 'IntervalsExpressionSplit',
   ForEachActivity = 'ForEachActivity',
   ProfileChanges = 'ProfileChanges',
   ViolationsOf = 'ViolationsOf',
@@ -65,10 +66,16 @@ export type WindowsExpression =
   | WindowsExpressionShorterThan
   | WindowsExpressionInvert
   | WindowsExpressionShiftBy
-  | WindowsExpressionFromSpans;
+  | WindowsExpressionFromSpans
+  | IntervalsExpressionSplit;
 
 export type SpansExpression =
+  | IntervalsExpressionSplit
   | SpansExpressionFromWindows;
+
+export type IntervalsExpression =
+  | WindowsExpression
+  | SpansExpression;
 
 export interface ProfileChanges {
   kind: NodeKind.ProfileChanges;
@@ -160,6 +167,12 @@ export interface WindowsExpressionLongerThan {
   kind: NodeKind.WindowsExpressionLongerThan,
   windowExpression: WindowsExpression,
   duration: number
+}
+
+export interface IntervalsExpressionSplit {
+  kind: NodeKind.IntervalsExpressionSplit,
+  intervals: IntervalsExpression,
+  numberOfSubIntervals: number
 }
 
 export interface WindowsExpressionFromSpans {

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -1,3 +1,5 @@
+import type * as API from "./constraints-edsl-fluent-api";
+
 export enum NodeKind {
   DiscreteProfileResource = 'DiscreteProfileResource',
   DiscreteProfileValue = 'DiscreteProfileValue',
@@ -17,6 +19,7 @@ export enum NodeKind {
   WindowsExpressionShiftBy = 'WindowsExpressionShiftBy',
   WindowsExpressionFromSpans = 'WindowsExpressionFromSpans',
   SpansExpressionFromWindows = 'SpansExpressionFromWindows',
+  SpansExpressionSplit = 'SpansExpressionSplit',
   ExpressionEqual = 'ExpressionEqual',
   ExpressionNotEqual = 'ExpressionNotEqual',
   RealProfileLessThan = 'RealProfileLessThan',
@@ -26,7 +29,6 @@ export enum NodeKind {
   WindowsExpressionAll = 'WindowsExpressionAll',
   WindowsExpressionAny = 'WindowsExpressionAny',
   WindowsExpressionInvert = 'WindowsExpressionInvert',
-  IntervalsExpressionSplit = 'IntervalsExpressionSplit',
   ForEachActivity = 'ForEachActivity',
   ProfileChanges = 'ProfileChanges',
   ViolationsOf = 'ViolationsOf',
@@ -67,10 +69,9 @@ export type WindowsExpression =
   | WindowsExpressionInvert
   | WindowsExpressionShiftBy
   | WindowsExpressionFromSpans
-  | IntervalsExpressionSplit;
 
 export type SpansExpression =
-  | IntervalsExpressionSplit
+  | SpansExpressionSplit
   | SpansExpressionFromWindows;
 
 export type IntervalsExpression =
@@ -169,10 +170,12 @@ export interface WindowsExpressionLongerThan {
   duration: number
 }
 
-export interface IntervalsExpressionSplit {
-  kind: NodeKind.IntervalsExpressionSplit,
+export interface SpansExpressionSplit {
+  kind: NodeKind.SpansExpressionSplit,
   intervals: IntervalsExpression,
-  numberOfSubIntervals: number
+  numberOfSubIntervals: number,
+  internalStartInclusivity: API.Inclusivity,
+  internalEndInclusivity: API.Inclusivity
 }
 
 export interface WindowsExpressionFromSpans {

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -180,6 +180,17 @@ export class Windows {
     })
   }
 
+  public split(numberOfSubWindows: number): Windows {
+    if (numberOfSubWindows < 1) {
+      throw RangeError(".split numberOfSubWindows cannot be less than 1, but was: " + numberOfSubWindows);
+    }
+    return new Windows({
+      kind: AST.NodeKind.IntervalsExpressionSplit,
+      intervals: this.__astNode,
+      numberOfSubIntervals: numberOfSubWindows
+    })
+  }
+
   public spans(): Spans {
     return new Spans({
       kind: AST.NodeKind.SpansExpressionFromWindows,
@@ -196,6 +207,18 @@ export class Spans {
   public constructor(expression: AST.SpansExpression) {
     this.__astNode = expression;
   }
+
+  public split(numberOfSubSpans: number): Spans {
+    if (numberOfSubSpans < 1) {
+      throw RangeError(".split numberOfSubSpans cannot be less than 1, but was: " + numberOfSubSpans);
+    }
+    return new Spans({
+      kind: AST.NodeKind.IntervalsExpressionSplit,
+      intervals: this.__astNode,
+      numberOfSubIntervals: numberOfSubSpans
+    })
+  }
+
 
   public windows(): Windows {
     return new Windows({
@@ -588,7 +611,7 @@ declare global {
     public shiftBy(fromStart: number, fromEnd: number): Windows;
 
     /**
-     *  Return all windows with a duration longer than the argument
+     * Return all windows with a duration longer than the argument
      * @param duration the duration
      */
     public longerThan(duration: Duration): Windows;
@@ -598,6 +621,16 @@ declare global {
      * @param duration the duration
      */
     public shorterThan(duration: Duration): Windows;
+
+    /**
+     * Splits each window into equal sized sub-windows.
+     *
+     * For `.split(N)`, N sub-windows will be created by removing N-1 points in the middle.
+     *
+     * @throws UnsplittableIntervalException during backend evaluation if the duration of a window is fewer microseconds than N.
+     * @param numberOfSubWindows how many sub-windows to split each window into
+     */
+    public split(numberOfSubWindows: number): Windows;
 
     /**
      * Convert this into a set of Spans.
@@ -610,6 +643,16 @@ declare global {
    */
   export class Spans {
     public readonly __astNode: AST.SpansExpression;
+
+    /**
+     * Splits each span into equal sized sub-spans.
+     *
+     * For `.split(N)`, N sub-spans will be created by removing N-1 points in the middle.
+     *
+     * @throws UnsplittableIntervalException during backend evaluation if the duration of a span is fewer microseconds than N.
+     * @param numberOfSubSpans how many sub-spans to split each span into
+     */
+    public split(numberOfSubSpans: number): Spans;
 
     /**
      * Convert this into a set of Windows.

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
@@ -78,7 +78,7 @@ public class ConstraintsDSLCompilationService {
           try {
             yield new ConstraintsDSLCompilationResult.Error(parseJson(output, ConstraintsCompilationError.constraintsErrorJsonP));
           } catch (InvalidJsonException | InvalidEntityException e) {
-            throw new Error("Could not parse JSON returned from typescript: " + output, e);
+            throw new Error("Could not parse error JSON returned from typescript: " + output, e);
           }
         }
         case "success" -> {
@@ -86,7 +86,7 @@ public class ConstraintsDSLCompilationService {
           try {
             yield new ConstraintsDSLCompilationResult.Success(parseJson(output, ConstraintParsers.constraintP));
           } catch (InvalidJsonException | InvalidEntityException e) {
-            throw new Error("Could not parse JSON returned from typescript: " + output, e);
+            throw new Error("Could not parse success JSON returned from typescript: " + output, e);
           }
         }
         default -> throw new Error("constraints dsl compiler returned unexpected status: " + status);

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -560,6 +560,114 @@ class ConstraintsDSLCompilationServiceTests {
   }
 
   @Test
+  void testSplit() {
+    checkSuccessfulCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(0.3).split(4)
+          }
+        """,
+        new ViolationsOf(
+            new Split<>(
+                new LessThan(new RealResource("state of charge"), new RealValue(0.3)),
+                4
+            )
+        )
+    );
+
+    checkSuccessfulCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(0.3).spans().split(4).windows()
+          }
+        """,
+        new ViolationsOf(
+            new WindowsFromSpans(
+              new Split<>(
+                  new SpansFromWindows(new LessThan(new RealResource("state of charge"), new RealValue(0.3))),
+                  4
+              )
+            )
+        )
+    );
+
+    checkSuccessfulCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(0.3).split(4, Inclusivity.Exclusive, Inclusivity.Inclusive).windows()
+          }
+        """,
+        new ViolationsOf(
+            new WindowsFromSpans(
+                new Split<>(
+                    new LessThan(new RealResource("state of charge"), new RealValue(0.3)),
+                    4,
+                    Interval.Inclusivity.Exclusive,
+                    Interval.Inclusivity.Inclusive
+                )
+            )
+        )
+    );
+
+    checkSuccessfulCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(0.3).spans().split(4, Inclusivity.Exclusive, Inclusivity.Exclusive).windows()
+          }
+        """,
+        new ViolationsOf(
+            new WindowsFromSpans(
+                new Split<>(
+                    new SpansFromWindows(new LessThan(new RealResource("state of charge"), new RealValue(0.3))),
+                    4,
+                    Interval.Inclusivity.Exclusive,
+                    Interval.Inclusivity.Exclusive
+                )
+            )
+        )
+    );
+  }
+
+  @Test
+  void testSplitArgumentError() {
+    checkFailedCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(0.3).split(0)
+          }
+        """,
+        ".split numberOfSubWindows cannot be less than 1, but was: 0"
+    );
+
+    checkFailedCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(0.3).split(-2)
+          }
+        """,
+        ".split numberOfSubWindows cannot be less than 1, but was: -2"
+    );
+
+    checkFailedCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(0.3).spans().split(0).windows()
+          }
+        """,
+        ".split numberOfSubSpans cannot be less than 1, but was: 0"
+    );
+
+    checkFailedCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(0.3).spans().split(-2).windows()
+          }
+        """,
+        ".split numberOfSubSpans cannot be less than 1, but was: -2"
+    );
+  }
+
+  @Test
   void testViolations() {
     checkSuccessfulCompilation(
         """

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -1,5 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.constraints.tree.*;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
@@ -564,13 +566,17 @@ class ConstraintsDSLCompilationServiceTests {
     checkSuccessfulCompilation(
         """
           export default () => {
-            return Real.Resource("state of charge").lessThan(0.3).split(4)
+            return Real.Resource("state of charge").lessThan(0.3).split(4).windows()
           }
         """,
         new ViolationsOf(
-            new Split<>(
-                new LessThan(new RealResource("state of charge"), new RealValue(0.3)),
-                4
+            new WindowsFromSpans(
+              new Split<>(
+                  new LessThan(new RealResource("state of charge"), new RealValue(0.3)),
+                  4,
+                  Interval.Inclusivity.Inclusive,
+                  Interval.Inclusivity.Exclusive
+              )
             )
         )
     );
@@ -585,7 +591,9 @@ class ConstraintsDSLCompilationServiceTests {
             new WindowsFromSpans(
               new Split<>(
                   new SpansFromWindows(new LessThan(new RealResource("state of charge"), new RealValue(0.3))),
-                  4
+                  4,
+                  Interval.Inclusivity.Inclusive,
+                  Interval.Inclusivity.Exclusive
               )
             )
         )
@@ -633,19 +641,19 @@ class ConstraintsDSLCompilationServiceTests {
     checkFailedCompilation(
         """
           export default () => {
-            return Real.Resource("state of charge").lessThan(0.3).split(0)
+            return Real.Resource("state of charge").lessThan(0.3).split(0).windows()
           }
         """,
-        ".split numberOfSubWindows cannot be less than 1, but was: 0"
+        ".split numberOfSubSpans cannot be less than 1, but was: 0"
     );
 
     checkFailedCompilation(
         """
           export default () => {
-            return Real.Resource("state of charge").lessThan(0.3).split(-2)
+            return Real.Resource("state of charge").lessThan(0.3).split(-2).windows()
           }
         """,
-        ".split numberOfSubWindows cannot be less than 1, but was: -2"
+        ".split numberOfSubSpans cannot be less than 1, but was: -2"
     );
 
     checkFailedCompilation(

--- a/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/json/BasicParsers.java
+++ b/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/json/BasicParsers.java
@@ -190,6 +190,19 @@ public abstract class BasicParsers {
     }
   };
 
+  public static <T> JsonParser<Optional<T>> nullableP(JsonParser<T> parser) {
+    return chooseP(
+        parser.map(Iso.of(
+            Optional::of,
+            Optional::get
+        )),
+        nullP.map(Iso.of(
+            $ -> Optional.empty(),
+            $ -> Unit.UNIT
+        ))
+    );
+  }
+
   public static final JsonParser<Unit> nullP = new JsonParser<>() {
     @Override
     public JsonObject getSchema(final SchemaCache anchors) {

--- a/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/json/BasicParsers.java
+++ b/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/json/BasicParsers.java
@@ -192,14 +192,14 @@ public abstract class BasicParsers {
 
   public static <T> JsonParser<Optional<T>> nullableP(JsonParser<T> parser) {
     return chooseP(
-        parser.map(Iso.of(
+        parser.map(
             Optional::of,
             Optional::get
-        )),
-        nullP.map(Iso.of(
+        ),
+        nullP.map(
             $ -> Optional.empty(),
             $ -> Unit.UNIT
-        ))
+        )
     );
   }
 


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1953
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Implements the `split(N)` operation, which splits each window into N equally sized sub-windows by removing N-1 points in the middle. Instantaneous point windows are left unchanged.

In practice since windows are defined in microseconds, the sub-windows might not be *exactly* equal, because the last sub-window might be up to N-1 microns longer than the others if the original duration is not a multiple of N. Also, if the original window is M microns long where M < N (however unlikely that might be), only M sub-windows will be produced.

Commits:
1. I added a basic parser for a nullable value. It is essentially `chooseP(your parser, nullP)` with some extra processing that turns it into `Optional<your parser's output>`.
2. Converts the `CodeLocation` record in ConstraintsCompilationError to have nullable fields, because runtime errors don't report code location
    - The TS API throws a runtime error if N < 1
4. Implements split
5. Tests split

## Verification
Plenty of tests, see last commit.

## Documentation
The API method is doc-commented. I'll update wiki after approval but before merge.
