### PR TITLE
[REFACTOR] Read activity types from database for constraints codegen

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryMissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryMissionModelRepository.java
@@ -92,4 +92,9 @@ public final class InMemoryMissionModelRepository implements MissionModelReposit
     public Map<String, MissionModelJar> getAllMissionModels() {
         return new HashMap<>(this.missionModels);
     }
+
+  @Override
+  public Map<String, ActivityType> getActivityTypes(final String missionModelId) {
+    return Map.of();
+  }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/MissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/MissionModelRepository.java
@@ -13,6 +13,7 @@ public interface MissionModelRepository {
     Map<String, MissionModelJar> getAllMissionModels();
     MissionModelJar getMissionModel(String id) throws NoSuchMissionModelException;
     Map<String, Constraint> getConstraints(String missionModelId) throws NoSuchMissionModelException;
+    Map<String, ActivityType> getActivityTypes(String missionModelId) throws NoSuchMissionModelException;
 
     // Mutations
     void updateModelParameters(String missionModelId, final List<Parameter> modelParameters) throws NoSuchMissionModelException;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityTypesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityTypesAction.java
@@ -1,0 +1,101 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
+import org.intellij.lang.annotations.Language;
+
+import javax.json.Json;
+import java.io.Reader;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static gov.nasa.jpl.aerie.json.BasicParsers.intP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.listP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.mapP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
+import static gov.nasa.jpl.aerie.merlin.server.http.ValueSchemaJsonParser.valueSchemaP;
+
+/*package-local*/ final class GetActivityTypesAction implements AutoCloseable {
+  private static final @Language("SQL") String sql = """
+    select
+      a.name,
+      a.parameters,
+      a.required_parameters,
+      a.computed_attributes_value_schema
+    from activity_type as a
+    where a.model_id = ?
+    """;
+
+  private final PreparedStatement statement;
+
+  public GetActivityTypesAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public List<ActivityType> get(final long missionModelId) throws SQLException {
+    this.statement.setLong(1, missionModelId);
+
+    final var activityTypes = new ArrayList<ActivityType>();
+    try (final var results = this.statement.executeQuery()) {
+      while (results.next()) {
+        activityTypes.add(
+            new ActivityType(
+                results.getString("name"),
+                parseParameters(results.getCharacterStream("parameters")),
+                parseRequiredParameters(results.getCharacterStream("required_parameters")),
+                parseComputedAttributesValueSchema(results.getCharacterStream("computed_attributes_value_schema"))));
+      }
+    }
+
+    return activityTypes;
+  }
+
+  private record ParameterRecord(String name, int order, ValueSchema schema) {}
+  private static List<Parameter> parseParameters(final Reader stream) {
+    final var json = Json.createReader(stream).readValue();
+    final var parametersMap =
+        mapP(productP
+                 .field("order", intP)
+                 .field("schema", valueSchemaP))
+        .parse(json)
+        .getSuccessOrThrow(
+            failureReason -> new Error("Corrupt activity type parameters cannot be parsed: " + failureReason.reason())
+        );
+    return parametersMap
+        .entrySet()
+        .stream()
+        .map(entry -> new ParameterRecord(entry.getKey(), entry.getValue().getKey(), entry.getValue().getValue()))
+        .sorted(Comparator.comparingInt(ParameterRecord::order))
+        .map(record -> new Parameter(record.name(), record.schema()))
+        .toList();
+  }
+
+  private static List<String> parseRequiredParameters(final Reader stream) {
+    final var json = Json.createReader(stream).readValue();
+    return listP(stringP)
+        .parse(json)
+        .getSuccessOrThrow(
+            failureReason -> new Error("Corrupt activity type required parameters cannot be parsed: " + failureReason.reason())
+        );
+  }
+
+  private static ValueSchema parseComputedAttributesValueSchema(final Reader stream) {
+    final var json = Json.createReader(stream).readValue();
+    return valueSchemaP
+        .parse(json)
+        .getSuccessOrThrow(
+            failureReason -> new Error("Corrupt activity type computed attribute schema cannot be parsed: " + failureReason.reason())
+        );
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresMissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresMissionModelRepository.java
@@ -10,6 +10,7 @@ import javax.sql.DataSource;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -71,6 +72,23 @@ public final class PostgresMissionModelRepository implements MissionModelReposit
     } catch (final SQLException ex) {
       throw new DatabaseException(
           "Failed to retrieve constraints for mission model with id `%s`".formatted(missionModelId), ex);
+    }
+  }
+
+  @Override
+  public Map<String, ActivityType> getActivityTypes(final String missionModelId) throws NoSuchMissionModelException {
+    try (final var connection = this.dataSource.getConnection()) {
+      try (final var getActivityTypesAction = new GetActivityTypesAction(connection)) {
+        final var id = toMissionModelId(missionModelId);
+        final var result = new HashMap<String, ActivityType>();
+        for (final var activityType: getActivityTypesAction.get(id)) {
+          result.put(activityType.name(), activityType);
+        }
+        return result;
+      }
+    } catch (final SQLException ex) {
+      throw new DatabaseException(
+          "Failed to retrieve activity types for mission model with id `%s`".formatted(missionModelId), ex);
     }
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -84,11 +84,14 @@ public final class LocalMissionModelService implements MissionModelService {
    * it contains may not abide by the expected contract at load time.
    */
   @Override
-  public Map<String, ActivityType> getActivityTypes(String missionModelId)
+  public Map<String, ActivityType> getActivityTypes(final String missionModelId)
   throws NoSuchMissionModelException, MissionModelLoadException
   {
-    return loadUnconfiguredMissionModel(missionModelId)
-        .getActivityTypes();
+    try {
+      return missionModelRepository.getActivityTypes(missionModelId);
+    } catch (MissionModelRepository.NoSuchMissionModelException e) {
+      throw new NoSuchMissionModelException(missionModelId, e);
+    }
   }
 
   /**
@@ -225,7 +228,10 @@ public final class LocalMissionModelService implements MissionModelService {
   throws NoSuchMissionModelException
   {
     try {
-      this.missionModelRepository.updateActivityTypes(missionModelId, getActivityTypes(missionModelId));
+      final var activityTypes =
+          loadUnconfiguredMissionModel(missionModelId)
+              .getActivityTypes();
+      this.missionModelRepository.updateActivityTypes(missionModelId, activityTypes);
     } catch (final MissionModelRepository.NoSuchMissionModelException ex) {
       throw new NoSuchMissionModelException(missionModelId, ex);
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -28,6 +28,11 @@ public interface MissionModelService {
 
   Map<String, ValueSchema> getStatesSchemas(String missionModelId)
   throws NoSuchMissionModelException;
+
+  /**
+   * getActivityTypes uses the cached result of refreshActivityTypes. For this reason, refreshActivityTypes
+   * should be called first.
+   */
   Map<String, ActivityType> getActivityTypes(String missionModelId)
   throws NoSuchMissionModelException;
   // TODO: Provide a finer-scoped validation return type. Mere strings make all validations equally severe.


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

The motivation behind this change is to avoid loading the mission model jar twice for constraints codegen. We currently load it once to get activity types, and once to get resource types.

The activity types are cached in the database, so this PR modifies the merlin-server's MissionModelService to pull activity types from the database.

An alternative solution would be to add a new method to the MissionModelService, "getActivityAndResourceTypes", which would query both, and only load the mission model once. However, we're evaluating options for caching resource types in the database as well, so the chosen solution feels more aligned with our longer term goals.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I uploaded a banananation jar to my local aerie deployment, and ran this query via the hasura console:

```graphql
query GetTypescript {
  constraintsDslTypescript(missionModelId: 1) {
    status
    reason
    typescriptFiles {
      filePath
      content
    }
  }
}
```

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
This change does not invalidate any existing documentation, and I don't think it warrants any new documentation.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None, aside from the longer-term considerations for what to do about resource types.