### PR TITLE
[HOTFIX]: Create Partition for External Profiles

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -274,8 +274,11 @@ public final class PostgresPlanRepository implements PlanRepository {
       final Timestamp planStart,
       final Timestamp datasetStart
   ) throws SQLException {
-    try (final var createPlanDatasetAction = new CreatePlanDatasetAction(connection)) {
-      return createPlanDatasetAction.apply(planId.id(), planStart, datasetStart);
+    try (final var createPlanDatasetAction = new CreatePlanDatasetAction(connection);
+         final var createProfileSegmentPartitionAction = new CreateProfileSegmentPartitionAction(connection)) {
+      final var pdr = createPlanDatasetAction.apply(planId.id(), planStart, datasetStart);
+      createProfileSegmentPartitionAction.apply(pdr.datasetId());
+      return pdr;
     }
   }
 


### PR DESCRIPTION
* **Tickets addressed:** (none)
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Previously, parititons weren't being created automatically for external profiles. As a result, addition of external profiles would fail with the message 'no partition of relation "profile_segment"'.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
This was tested by deploying AERIE and adding external datasets, and verifying no failure messages were sent and that the external profile was correctly added to the database (verified by running `SELECT` queries).

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None.
