### PR TITLE
[AERIE-1875]  Return Dictionary fields when uploading

### DIFF
--- a/command-expansion-server/sql/commanding/tables/command_dictionary.sql
+++ b/command-expansion-server/sql/commanding/tables/command_dictionary.sql
@@ -6,6 +6,7 @@ create table command_dictionary (
   version text not null,
 
   created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
 
   constraint command_dictionary_synthetic_key
       primary key (id),
@@ -25,3 +26,17 @@ comment on column command_dictionary.version is e''
   'A human-meaningful version qualifier.';
 comment on constraint command_dictionary_natural_key on command_dictionary is e''
   'There an only be one command dictionary of a given version for a given mission.';
+
+create function command_dictionary_set_updated_at()
+returns trigger
+security definer
+language plpgsql as $$begin
+  new.updated_at = now();
+  return new;
+end$$;
+
+create trigger trigger_command_dictionary_set_updated_at
+  before
+    update on command_dictionary
+  for each row
+  execute function command_dictionary_set_updated_at();

--- a/command-expansion-server/src/app.ts
+++ b/command-expansion-server/src/app.ts
@@ -122,7 +122,7 @@ app.post('/put-dictionary', async (req, res, next) => {
     values ($1, $2, $3)
     on conflict (mission, version) do update
       set command_types_typescript_path = $1
-    returning id;
+    returning id, command_types_typescript_path, mission, version, created_at, updated_at;
   `;
 
   const { rows } = await db.query(sqlExpression, [
@@ -134,8 +134,8 @@ app.post('/put-dictionary', async (req, res, next) => {
   if (rows.length < 1) {
     throw new Error(`POST /dictionary: No command dictionary was updated in the database`);
   }
-  const id = rows[0].id;
-  res.status(200).json({ id });
+  const [row] = rows;
+  res.status(200).json(row);
   return next();
 });
 
@@ -282,10 +282,12 @@ app.post('/get-command-typescript', async (req, res, next) => {
 
     res.status(200).json({
       status: Status.SUCCESS,
-      typescriptFiles: [{
-        filePath: 'command-types.ts',
-        content: commandTypescript,
-      }],
+      typescriptFiles: [
+        {
+          filePath: 'command-types.ts',
+          content: commandTypescript,
+        },
+      ],
       reason: null,
     });
   } catch (e) {
@@ -309,10 +311,12 @@ app.post('/get-activity-typescript', async (req, res, next) => {
 
   res.status(200).json({
     status: Status.SUCCESS,
-    typescriptFiles: [{
-      filePath: 'activity-types.ts',
-      content: activityTypescript,
-    }],
+    typescriptFiles: [
+      {
+        filePath: 'activity-types.ts',
+        content: activityTypescript,
+      },
+    ],
     reason: null,
   });
   return next();

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -193,6 +193,11 @@ type TypescriptFile {
 
 type CommandDictionaryResponse {
   id: Int!
+  command_types_typescript_path: String!
+  mission: String!
+  version: String!
+  created_at: String!
+  updated_at: String!
 }
 
 type ExpansionSetResponse {


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1875
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
When you upload a command dictionary, it will save the version number, mission name, path , etc. in the database. Instead of making a second fetch call to obtain these fields in the UI, I change the `Upload Command Dictionary` action to return these fields as part of the upload process.

I also added a new field in the table with a trigger for `updated_at`. A mission can upload a dictionary with a minor change that doesn't require a version bump.  I figured we should capture this updated time as well. 


## Verification
Running this QGL mutation to upload a command dictionary you will now receive `command_types_typescript_path` `mission` `version` `created_at``updated_at`

```
mutation Upload(
  $commandDictionaryString: String!
) {
  uploadDictionary(dictionary: $commandDictionaryString) {
    id
    command_types_typescript_path
    mission
    version
    created_at
    updated_at
  }
}
```

## Documentation
I will update the Command Expansion wiki with this change. 

## Future work
None
