### PR TITLE
[AERIE-1966] Spans

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Spans.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Spans.java
@@ -1,0 +1,88 @@
+package gov.nasa.jpl.aerie.constraints.time;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * A collection of intervals that can overlap.
+ */
+public class Spans implements Iterable<Window> {
+  private final List<Window> windows;
+
+  public Spans() {
+    this.windows = new ArrayList<>();
+  }
+
+  public Spans(final ArrayList<Window> windows) {
+    windows.removeIf(Window::isEmpty);
+    this.windows = windows;
+  }
+
+  public Spans(final Iterable<Window> iter) {
+    this.windows = StreamSupport.stream(iter.spliterator(), false).filter($ -> !$.isEmpty()).toList();
+  }
+
+  public Spans(final Window... windows) {
+    this.windows = Arrays.stream(windows).filter($ -> !$.isEmpty()).toList();
+  }
+
+  public Windows intoWindows() {
+    return new Windows(this.windows);
+  }
+
+  public void add(final Window window) {
+    if (!window.isEmpty()) {
+      this.windows.add(window);
+    }
+  }
+
+  public void addAll(final Iterable<Window> iter) {
+    this.windows.addAll(
+        StreamSupport
+            .stream(iter.spliterator(), false)
+            .filter($ -> !$.isEmpty())
+            .toList()
+    );
+  }
+
+  public Spans map(final Function<Window, Window> mapper) {
+    return new Spans(this.windows.stream().map(mapper).filter($ -> !$.isEmpty()).toList());
+  }
+
+  public Spans flatMap(final Function<Window, ? extends Stream<Window>> mapper) {
+    return new Spans(this.windows.stream().flatMap(mapper).filter($ -> !$.isEmpty()).toList());
+  }
+
+  public Spans filter(final Predicate<Window> filter) {
+    return new Spans(this.windows.stream().filter(filter).toList());
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (!(obj instanceof final Spans spans)) return false;
+
+    return Objects.equals(this.windows, spans.windows);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.windows);
+  }
+
+  @Override
+  public String toString() {
+    return this.windows.toString();
+  }
+
+  @Override
+  public Iterator<Window> iterator() {
+    return this.windows.iterator();
+  }
+}

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
@@ -28,6 +28,9 @@ public final class Windows implements Iterable<Window> {
     for (final var window : windows) this.add(window);
   }
 
+  public Spans intoSpans() {
+    return new Spans(this);
+  }
 
   public void add(final Window window) {
     this.windows.add(window);

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansFromWindows.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansFromWindows.java
@@ -1,0 +1,34 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Spans;
+import gov.nasa.jpl.aerie.constraints.time.Window;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public record SpansFromWindows(Expression<Windows> expression) implements Expression<Spans> {
+
+  @Override
+  public Spans evaluate(SimulationResults results, final Window bounds, Map<String, ActivityInstance> environment) {
+    final var windows = this.expression.evaluate(results, bounds, environment);
+    return windows.intoSpans();
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {
+    this.expression.extractResources(names);
+  }
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return String.format(
+        "\n%s(spans-from %s)",
+        prefix,
+        this.expression.prettyPrint(prefix + "  ")
+    );
+  }
+}

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsFromSpans.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsFromSpans.java
@@ -1,0 +1,34 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Spans;
+import gov.nasa.jpl.aerie.constraints.time.Window;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public record WindowsFromSpans(Expression<Spans> expression) implements Expression<Windows> {
+
+  @Override
+  public Windows evaluate(SimulationResults results, final Window bounds, Map<String, ActivityInstance> environment) {
+    final var spans = this.expression.evaluate(results, bounds, environment);
+    return spans.intoWindows();
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {
+    this.expression.extractResources(names);
+  }
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return String.format(
+        "\n%s(windows-from %s)",
+        prefix,
+        this.expression.prettyPrint(prefix + "  ")
+    );
+  }
+}

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsersTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsersTest.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.constraints.json;
 
+import gov.nasa.jpl.aerie.constraints.time.Spans;
 import gov.nasa.jpl.aerie.constraints.tree.All;
 import gov.nasa.jpl.aerie.constraints.tree.Changes;
 import gov.nasa.jpl.aerie.constraints.tree.DiscreteParameter;
@@ -22,10 +23,12 @@ import gov.nasa.jpl.aerie.constraints.tree.Rate;
 import gov.nasa.jpl.aerie.constraints.tree.RealParameter;
 import gov.nasa.jpl.aerie.constraints.tree.RealResource;
 import gov.nasa.jpl.aerie.constraints.tree.RealValue;
+import gov.nasa.jpl.aerie.constraints.tree.SpansFromWindows;
 import gov.nasa.jpl.aerie.constraints.tree.StartOf;
 import gov.nasa.jpl.aerie.constraints.tree.Times;
 import gov.nasa.jpl.aerie.constraints.tree.Transition;
 import gov.nasa.jpl.aerie.constraints.tree.ViolationsOf;
+import gov.nasa.jpl.aerie.constraints.tree.WindowsFromSpans;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.junit.jupiter.api.Test;
 
@@ -604,6 +607,81 @@ public final class ConstraintParsersTest {
                             new DiscreteParameter("B", "b"))),
                     new Invert(new ActivityWindow("A")),
                     new Invert(new ActivityWindow("B"))))));
+
+    assertEquivalent(expected, result);
+  }
+
+  // I know its excessive, I just wanted to be sure :)
+  @Test
+  public void testDeepMutualRecursion() {
+    final var json = Json
+        .createObjectBuilder()
+        .add("kind", "WindowsExpressionFromSpans")
+        .add("spansExpression", Json
+            .createObjectBuilder()
+            .add("kind", "SpansExpressionFromWindows")
+            .add("windowsExpression", Json
+                .createObjectBuilder()
+                .add("kind", "WindowsExpressionFromSpans")
+                .add("spansExpression", Json
+                    .createObjectBuilder()
+                    .add("kind", "SpansExpressionFromWindows")
+                    .add("windowsExpression", Json
+                        .createObjectBuilder()
+                        .add("kind", "WindowsExpressionFromSpans")
+                        .add("spansExpression", Json
+                            .createObjectBuilder()
+                            .add("kind", "SpansExpressionFromWindows")
+                            .add("windowsExpression", Json
+                                .createObjectBuilder()
+                                .add("kind", "WindowsExpressionFromSpans")
+                                .add("spansExpression", Json
+                                    .createObjectBuilder()
+                                    .add("kind", "SpansExpressionFromWindows")
+                                    .add("windowsExpression", Json
+                                        .createObjectBuilder()
+                                        .add("kind", "WindowsExpressionFromSpans")
+                                        .add("spansExpression", Json
+                                            .createObjectBuilder()
+                                            .add("kind", "SpansExpressionFromWindows")
+                                            .add("windowsExpression", Json
+                                                .createObjectBuilder()
+                                                .add("kind", "WindowsExpressionFromSpans")
+                                                .add("spansExpression", Json
+                                                    .createObjectBuilder()
+                                                    .add("kind", "SpansExpressionFromWindows")
+                                                    .add("windowsExpression", Json
+                                                        .createObjectBuilder()
+                                                        .add("kind", "WindowsExpressionActivityWindow")
+                                                        .add("alias", "TEST")))))))))))))
+        .build();
+    final var result = windowsExpressionP.parse(json).getSuccessOrThrow();
+
+    final var expected = new WindowsFromSpans(
+        new SpansFromWindows(
+            new WindowsFromSpans(
+                new SpansFromWindows(
+                    new WindowsFromSpans(
+                        new SpansFromWindows(
+                            new WindowsFromSpans(
+                                new SpansFromWindows(
+                                    new WindowsFromSpans(
+                                        new SpansFromWindows(
+                                            new WindowsFromSpans(
+                                                new SpansFromWindows(
+                                                    new ActivityWindow("TEST")
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    );
 
     assertEquivalent(expected, result);
   }

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/time/SpansTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/time/SpansTest.java
@@ -1,0 +1,167 @@
+package gov.nasa.jpl.aerie.constraints.time;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static gov.nasa.jpl.aerie.constraints.Assertions.assertEquivalent;
+import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Exclusive;
+import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Inclusive;
+import static gov.nasa.jpl.aerie.constraints.time.Window.window;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MILLISECONDS;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECOND;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SpansTest {
+  @Test
+  public void addEmpty() {
+    final var spans = new Spans();
+    spans.add(Window.EMPTY);
+
+    final var expected = new Spans();
+
+    assertEquivalent(spans, expected);
+  }
+
+  @Test
+  public void addOpenPoint() {
+    final var spans = new Spans();
+    spans.add(window(1, Exclusive, 1, Exclusive, MICROSECONDS));
+
+    final var expected = new Spans();
+
+    assertEquivalent(spans, expected);
+  }
+
+  @Test
+  public void doNotCoalesceAdjacent() {
+    final var spans = new Spans();
+    spans.add(window(0, Inclusive, 1, Exclusive, MICROSECONDS));
+    spans.add(window(1, Inclusive, 2, Inclusive, MICROSECONDS));
+
+    final var expected = List.of(
+        window(0, Inclusive, 1, Exclusive, MICROSECONDS),
+        window(1, Inclusive, 2, Inclusive, MICROSECONDS)
+    );
+
+    assertIterableEquals(expected, spans);
+  }
+
+  @Test
+  public void doNotCoalesceOverlap() {
+    final var spans = new Spans(
+        window(0, Inclusive, 1, Inclusive, SECONDS),
+        window(500, Inclusive, 2000, Inclusive, MILLISECONDS)
+    );
+
+    final var expected = List.of(
+        window(0, Inclusive, 1, Inclusive, SECONDS),
+        window(500, Inclusive, 2000, Inclusive, MILLISECONDS)
+    );
+
+    assertIterableEquals(expected, spans);
+  }
+
+  @Test
+  public void filter() {
+    final var spans = new Spans(
+        window(0, 1, SECONDS),
+        window(0, 2, SECONDS),
+        window(0, 3, SECONDS)
+    ).filter($ -> $.duration().shorterThan(Duration.of(2, SECONDS)) || $.duration().longerThan(Duration.of(2, SECONDS)));
+
+    final var expected = List.of(
+        window(0, 1, SECONDS),
+        window(0, 3, SECONDS)
+    );
+
+    assertIterableEquals(expected, spans);
+  }
+
+  @Test
+  public void map() {
+    final var spans = new Spans(
+        window(0, 2, SECONDS),
+        window(0, 3, SECONDS)
+    ).map($ -> window($.start, $.start.plus(SECOND)));
+
+    final var expected = List.of(
+        window(0, 1, SECOND),
+        window(0, 1, SECOND)
+    );
+
+    assertIterableEquals(expected, spans);
+  }
+
+  @Test
+  public void mapFiltersEmpty() {
+    final var spans = new Spans(
+        window(0, Inclusive, 1, Exclusive, SECONDS),
+        window(0, 3, SECONDS)
+    ).map($ -> window($.start, $.startInclusivity, $.end.minus(SECOND), $.endInclusivity));
+
+    final var expected = List.of(
+        window(0, 2, SECOND)
+    );
+
+    assertIterableEquals(expected, spans);
+  }
+
+  @Test
+  public void flatMap() {
+    final var spans = new Spans(
+        window(0, 1, SECONDS),
+        window(0, 3, SECONDS)
+    ).flatMap($ -> {
+      if ($.duration().noLongerThan(SECOND)) {
+        return Stream.of();
+      } else {
+        return Stream.of(
+            window($.end, $.end),
+            window($.end, $.end.plus(SECOND))
+        );
+      }
+    });
+
+    final var expected = List.of(
+        window(3, 3, SECONDS),
+        window(3, 4, SECONDS)
+    );
+
+    assertIterableEquals(expected, spans);
+  }
+
+  @Test
+  public void flatMapFiltersEmpty() {
+    final var spans = new Spans(
+        window(0, Inclusive, 1, Exclusive, SECONDS),
+        window(0, 3, SECONDS)
+    ).flatMap($ -> Stream.of(window($.start, $.startInclusivity, $.end.minus(SECOND), $.endInclusivity)));
+
+    final var expected = List.of(
+        window(0, 2, SECOND)
+    );
+
+    assertIterableEquals(expected, spans);
+  }
+
+  @Test
+  public void intoWindows() {
+    final var windows = new Spans(
+        window(0, 2, SECONDS),
+        window(1, 3, SECONDS),
+        window(5, 5, SECONDS)
+    ).intoWindows();
+
+    final var expected = List.of(
+        window(0, 3, SECONDS),
+        window(5, 5, SECONDS)
+    );
+
+    assertIterableEquals(expected, windows);
+  }
+}

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/time/WindowsTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/time/WindowsTest.java
@@ -11,8 +11,10 @@ import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Exclusive;
 import static gov.nasa.jpl.aerie.constraints.time.Window.Inclusivity.Inclusive;
 import static gov.nasa.jpl.aerie.constraints.time.Window.window;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WindowsTest {
@@ -539,5 +541,21 @@ public class WindowsTest {
     final var expected = List.of(window(0, 5, MICROSECONDS));
 
     assertEquals(expected, windowList);
+  }
+
+  @Test
+  public void intoSpans() {
+    final var spans = new Windows(List.of(
+        window(0, 2, SECONDS),
+        window(1, 3, SECONDS),
+        window(5, 5, SECONDS)
+    )).intoSpans();
+
+    final var expected = new Spans(
+        window(0, 3, SECONDS),
+        window(5, 5, SECONDS)
+    );
+
+    assertIterableEquals(expected, spans);
   }
 }

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -15,6 +15,8 @@ export enum NodeKind {
   WindowsExpressionLongerThan = 'WindowsExpressionLongerThan',
   WindowsExpressionShorterhan = 'WindowsExpressionShorterThan',
   WindowsExpressionShiftBy = 'WindowsExpressionShiftBy',
+  WindowsExpressionFromSpans = 'WindowsExpressionFromSpans',
+  SpansExpressionFromWindows = 'SpansExpressionFromWindows',
   ExpressionEqual = 'ExpressionEqual',
   ExpressionNotEqual = 'ExpressionNotEqual',
   RealProfileLessThan = 'RealProfileLessThan',
@@ -62,7 +64,11 @@ export type WindowsExpression =
   | WindowsExpressionLongerThan
   | WindowsExpressionShorterThan
   | WindowsExpressionInvert
-  | WindowsExpressionShiftBy;
+  | WindowsExpressionShiftBy
+  | WindowsExpressionFromSpans;
+
+export type SpansExpression =
+  | SpansExpressionFromWindows;
 
 export interface ProfileChanges {
   kind: NodeKind.ProfileChanges;
@@ -154,6 +160,16 @@ export interface WindowsExpressionLongerThan {
   kind: NodeKind.WindowsExpressionLongerThan,
   windowExpression: WindowsExpression,
   duration: number
+}
+
+export interface WindowsExpressionFromSpans {
+  kind: NodeKind.WindowsExpressionFromSpans,
+  spansExpression: SpansExpression
+}
+
+export interface SpansExpressionFromWindows {
+  kind: NodeKind.SpansExpressionFromWindows,
+  windowsExpression: WindowsExpression
 }
 
 export interface DiscreteProfileTransition {

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -375,6 +375,9 @@ declare global {
     ): Constraint;
   }
 
+  /**
+   * A set of intervals that coalesces overlapping intervals.
+   */
   export class Windows {
     /** Internal AST Node */
     public readonly __astNode: AST.WindowsExpression;
@@ -442,6 +445,9 @@ declare global {
     public spans(): Spans;
   }
 
+  /**
+   * A set of intervals that can overlap without being coaleseced together.
+   */
   export class Spans {
     public readonly __astNode: AST.SpansExpression;
 

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -109,6 +109,28 @@ export class Windows {
       fromEnd: fromEnd
     })
   }
+
+  public spans(): Spans {
+    return new Spans({
+      kind: AST.NodeKind.SpansExpressionFromWindows,
+      windowsExpression: this.__astNode
+    })
+  }
+}
+
+export class Spans {
+  public readonly __astNode: AST.SpansExpression;
+
+  public constructor(expression: AST.SpansExpression) {
+    this.__astNode = expression;
+  }
+
+  public windows(): Windows {
+    return new Windows({
+      kind: AST.NodeKind.WindowsExpressionFromSpans,
+      spansExpression: this.__astNode
+    })
+  }
 }
 
 export class Real {
@@ -414,6 +436,22 @@ declare global {
      */
     public shorterThan(duration: Duration): Windows;
 
+    /**
+     * Convert this into a set of Spans.
+     */
+    public spans(): Spans;
+  }
+
+  export class Spans {
+    public readonly __astNode: AST.SpansExpression;
+
+    /**
+     * Convert this into a set of Windows.
+     *
+     * This is a lossy operation.
+     * If any spans overlap or touch, they will be coalesced into a single window.
+     */
+    public windows(): Windows;
   }
 
   export class Real {
@@ -554,4 +592,4 @@ declare global {
 }
 
 // Make Constraint available on the global object
-Object.assign(globalThis, { Constraint, Windows, Real, Discrete });
+Object.assign(globalThis, { Constraint, Windows, Spans, Real, Discrete });

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -571,6 +571,20 @@ class ConstraintsDSLCompilationServiceTests {
     );
   }
 
+  //// TESTS FOR `Spans` API CLASS
+
+  @Test
+  void testSpansFromWindows() {
+    checkSuccessfulCompilation(
+        """
+            export default () => {
+                return Real.Resource("state of charge").equal(0.3).spans().windows();
+            }
+        """,
+        new ViolationsOf(new WindowsFromSpans(new SpansFromWindows(new Equal<>(new RealResource("state of charge"), new RealValue(0.3)))))
+    );
+  }
+
   //// TESTS FOR `Constraint` API CLASS
 
   @Test


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1966
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR implements a basic Spans container, which isn't much more than a wrapper around a list of intervals. It also adds the `Spans` class to the constraints eDSL, as well as the conversion methods `windows.spans()` and `spans.windows()`.

The Spans container also includes `map`, `flatMap`, and `filter` shortcuts, that more complicated operations will make use of.

## Verification
I added tests to make sure that the coalescing behavior happens correctly and at the appropriate times. Added tests for `map`, `flatMap`, and `filter`. Also the usual tests for the two conversion functions.

## Documentation
Lots of wiki documentation will be in order when Spans near completion, but we're not there yet. The eDSL documentation is up to date though.

## Future work
moar operations