### PR TITLE
[AERIE-1974] Remove nested ternary type checks in constraints eDSL

### DIFF
--- a/merlin-server/constraints-dsl-compiler/src/libs/mission-model-generated-code.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/mission-model-generated-code.ts
@@ -1,17 +1,31 @@
 // The following are only to satisfy the type checker before any code is generated.
 // All of this will be overwritten before any constraints are evaluated.
 
-import { Windows } from "./constraints-edsl-fluent-api.js";
+import { Windows, Discrete } from "./constraints-edsl-fluent-api.js";
 import * as AST from "./constraints-ast.js";
 
-export type ResourceName = string;
-export type DiscreteResourceSchema<R extends ResourceName> = any;
-export type RealResourceName = string;
+export type Resource = {
+  "my discrete resource": string,
+  "my real resource": number
+};
+export type ResourceName = "my discrete resource" | "my real resource";
+export type RealResourceName = "my real resource";
 
 export enum ActivityType {
   // This indicates to the compiler that we are using a string enum so we can assign it to string for our AST
-  _ = '_',
+  activity = 'activity',
 }
+
+export const ActivityTypeParameterMap = {
+  [ActivityType.activity]: (alias: string) => ({
+    parameter: new Discrete<string>({
+      kind: AST.NodeKind.DiscreteProfileParameter,
+      alias,
+      name: 'parameter'
+    })
+  }),
+}
+
 export type ActivityParameters<A extends ActivityType> = any;
 export class ActivityInstance<A extends ActivityType> {
   private readonly __activityType: A;

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -609,7 +609,7 @@ class ConstraintsDSLCompilationServiceTests {
 
     checkSuccessfulCompilation(
         """
-        import * as Gen from './mission-model-generated-code.js';
+        import { ActivityInstance } from './constraints-edsl-fluent-api.js';
         export default () => {
           return Constraint.ForEachActivity(
             ActivityType.activity,
@@ -617,7 +617,7 @@ class ConstraintsDSLCompilationServiceTests {
           )
         }
 
-        function myHelperFunction(instance: Gen.ActivityInstance<ActivityType.activity>): Constraint {
+        function myHelperFunction(instance: ActivityInstance<ActivityType.activity>): Constraint {
           return instance.window();
         }
         """,

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
@@ -19,61 +19,27 @@ class TypescriptCodeGenerationServiceTest {
            export enum ActivityType {
              activity = "activity",
            }
+           export type Resource = {
+             "mode": ( | "Option1" | "Option2"),
+             "state of charge": {initial: number, rate: number, },
+             "an integer": number,
+           };
            export type ResourceName = "mode" | "state of charge" | "an integer";
-           export type DiscreteResourceSchema<R extends ResourceName> =
-             R extends "mode" ? ( | "Option1" | "Option2") :
-             R extends "state of charge" ? {initial: number, rate: number, } :
-             R extends "an integer" ? number :
-             never;
            export type RealResourceName = "state of charge" | "an integer";
-           export type ActivityParameters<A extends ActivityType> =
-             A extends ActivityType.activity ? {Param: Discrete<string>, AnotherParam: Real, } :
-             never;
-           export class ActivityInstance<A extends ActivityType> {
-             private readonly __activityType: A;
-             private readonly __alias: string;
-             constructor(activityType: A, alias: string) {
-               this.__activityType = activityType;
-               this.__alias = alias;
-             }
-             public get parameters(): ActivityParameters<A> {
-               let result = (
-                 this.__activityType === ActivityType.activity ? {Param: new Discrete<string>({ kind: AST.NodeKind.DiscreteProfileParameter, alias: this.__alias, name: "Param"}), AnotherParam: new Real({ kind: AST.NodeKind.RealProfileParameter, alias: this.__alias, name: "AnotherParam"}), } :
-                 undefined) as ActivityParameters<A>;
-               if (result === undefined) {
-                 throw new TypeError("Unreachable state. Activity type was unexpected string in ActivityInstance.parameters(): " + this.__activityType);
-               } else {
-                 return result;
-               }
-             }
-             /**
-              * Produces a window for the duration of the activity.
-              */
-             public window(): Windows {
-               return new Windows({
-                 kind: AST.NodeKind.WindowsExpressionActivityWindow,
-                 alias: this.__alias
-               });
-             }
-             /**
-              * Produces an instantaneous window at the start of the activity.
-              */
-             public start(): Windows {
-               return new Windows({
-                 kind: AST.NodeKind.WindowsExpressionStartOf,
-                 alias: this.__alias
-               });
-             }
-             /**
-              * Produces an instantaneous window at the end of the activity.
-              */
-             public end(): Windows {
-               return new Windows({
-                 kind: AST.NodeKind.WindowsExpressionEndOf,
-                 alias: this.__alias
-               });
-             }
-           }
+           export const ActivityTypeParameterMap = {
+             [ActivityType.activity]: (alias: string) => ({
+               "Param": new Discrete<string>({
+                 kind: AST.NodeKind.DiscreteProfileParameter,
+                 alias,
+                 name: "Param"
+               }),
+               "AnotherParam": new Real({
+                 kind: AST.NodeKind.RealProfileParameter,
+                 alias,
+                 name: "AnotherParam"
+               }),
+             }),
+           };
            declare global {
              enum ActivityType {
                activity = "activity",


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1974
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Credit where its due, this is actually mostly @dyst5422 's wizardry, I just messed with the code generation.

Large mission models like Clipper would encounter a stack-overflow-like error when typechecking constraints because of the massive nested ternary expressions involved. This PR refactors that to avoid those types. As an added benefit, the `ActivityInstance` class now doesn't need to be generated.

## Verification
The code gen test was the only one that need to be updated.

## Documentation
None needed

## Future work
None
