### PR TITLE
[AERIE-1935] Expose plan start time to mission model

### DIFF
--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -19,10 +19,10 @@ This document provides detailed information about environment variables for each
 | `MERLIN_GRAPHQL_URL`     | URI of the Aerie GraphQL API                      | `string` | http://hasura:8080/v1/graphql      |
 | `COMMANDING_SERVER_PORT` | Port the server listens on                        | `number` | 27184                              |
 | `COMMANDING_DB`          | Name of Commanding Postgres database              | `string` | aerie_commanding                   |
-| `COMMANDING_DB_SERVER`   | Hostname of Postgres instance                     | `string` |                            |
-| `COMMANDING_DB_PASSWORD` | Password of Postgres instance                     | `string` |                               |
+| `COMMANDING_DB_SERVER`   | Hostname of Postgres instance                     | `string` |                                    |
+| `COMMANDING_DB_PASSWORD` | Password of Postgres instance                     | `string` |                                    |
 | `COMMANDING_DB_PORT`     | Port of Postgres instance                         | `number` | 5432                               |
-| `COMMANDING_DB_USER`     | User of Postgres instance                         | `string` |                               |
+| `COMMANDING_DB_USER`     | User of Postgres instance                         | `string` |                                    |
 | `COMMANDING_LOCAL_STORE` | Local storage file storage in the container       | `string` | /usr/src/app/commanding_file_store |
 
 ## Aerie Gateway
@@ -36,54 +36,56 @@ This document provides detailed information about environment variables for each
 | `POSTGRES_AERIE_MERLIN_DB`    | Name of Merlin Postgres database.                        | `string` | aerie_merlin                     |
 | `POSTGRES_AERIE_SCHEDULER_DB` | Name of scheduler Postgres database.                     | `string` | aerie_scheduler                  |
 | `POSTGRES_HOST`               | Hostname of Postgres instance.                           | `string` | localhost                        |
-| `POSTGRES_PASSWORD`           | Password of Postgres instance.                           | `string` |                             |
+| `POSTGRES_PASSWORD`           | Password of Postgres instance.                           | `string` |                                  |
 | `POSTGRES_PORT`               | Port of Postgres instance.                               | `number` | 5432                             |
-| `POSTGRES_USER`               | User of Postgres instance.                               | `string` |                             |
+| `POSTGRES_USER`               | User of Postgres instance.                               | `string` |                                  |
 | `RATE_LIMITER_FILES_MAX`      | Max requests allowed every 15 minutes to file endpoints  | `number` | 1000                             |
 | `RATE_LIMITER_LOGIN_MAX`      | Max requests allowed every 15 minutes to login endpoints | `number` | 1000                             |
 
 ## Aerie Merlin
 
-| Name                 | Description                                               | Type     | Default                         |
-| -------------------- | --------------------------------------------------------- | -------- | ------------------------------- |
-| `JAVA_OPTS`          | Configuration for Merlin's logging level and output file  | `string` | log level: warn. output: stderr |
-| `MERLIN_PORT`        | Port number for the Merlin server                         | `number` | 27183                           |
-| `MERLIN_LOCAL_STORE` | Local storage for Merlin in the container                 | `string` | /usr/src/app/merlin_file_store  |
-| `MERLIN_DB_SERVER`   | The DB instance that Merlin will connect with             | `string` |                         |
-| `MERLIN_DB_PORT`     | The DB instance port number that Merlin will connect with | `number` | 5432                            |
-| `MERLIN_DB_USER`     | Username of the DB instance                               | `string` |                            |
-| `MERLIN_DB_PASSWORD` | Password of the DB instance                               | `string` |                            |
-| `MERLIN_DB`          | The DB for Merlin.                                        | `string` | aerie_merlin                    |
+| Name                 | Description                                                                                                                 | Type     | Default                         |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------- |
+| `JAVA_OPTS`          | Configuration for Merlin's logging level and output file                                                                    | `string` | log level: warn. output: stderr |
+| `MERLIN_PORT`        | Port number for the Merlin server                                                                                           | `number` | 27183                           |
+| `MERLIN_LOCAL_STORE` | Local storage for Merlin in the container                                                                                   | `string` | /usr/src/app/merlin_file_store  |
+| `MERLIN_DB_SERVER`   | The DB instance that Merlin will connect with                                                                               | `string` |                                 |
+| `MERLIN_DB_PORT`     | The DB instance port number that Merlin will connect with                                                                   | `number` | 5432                            |
+| `MERLIN_DB_USER`     | Username of the DB instance                                                                                                 | `string` |                                 |
+| `MERLIN_DB_PASSWORD` | Password of the DB instance                                                                                                 | `string` |                                 |
+| `MERLIN_DB`          | The DB for Merlin.                                                                                                          | `string` | aerie_merlin                    |
+| `UNTRUE_PLAN_START`  | Temporary solution to provide plan start time to models, should be set to a time that models will not fail to initialize on | `string` |                                 |
 
 ## Aerie Merlin Worker
 
-| Name                        | Description                                               | Type     | Default                                      |
-| --------------------------- | --------------------------------------------------------- | -------- | -------------------------------------------- |
-| `JAVA_OPTS`                 | Configuration for Merlin's logging level and output file  | `string` | log level: warn. output: stderr              |
-| `MERLIN_WORKER_LOCAL_STORE` | The local storage as for the Merlin container             | `string` | /usr/src/app/merlin_file_store               |
-| `MERLIN_WORKER_DB_SERVER`   | The DB instance that Merlin will connect with             | `string` | (this must the same as the Merlin container) |
-| `MERLIN_WORKER_DB_PORT`     | The DB instance port number that Merlin will connect with | `number` | (this must the same as the Merlin container) |
-| `MERLIN_WORKER_DB_USER`     | Username of the DB instance                               | `string` | (this must the same as the Merlin container) |
-| `MERLIN_WORKER_DB_PASSWORD` | Password of the DB instance                               | `string` | (this must the same as the Merlin container) |
-| `MERLIN_WORKER_DB`          | The DB for Merlin.                                        | `string` | (this must the same as the Merlin container) |
+| Name                        | Description                                                                                                                 | Type     | Default                                      |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------------------- |
+| `JAVA_OPTS`                 | Configuration for Merlin's logging level and output file                                                                    | `string` | log level: warn. output: stderr              |
+| `MERLIN_WORKER_LOCAL_STORE` | The local storage as for the Merlin container                                                                               | `string` | /usr/src/app/merlin_file_store               |
+| `MERLIN_WORKER_DB_SERVER`   | The DB instance that Merlin will connect with                                                                               | `string` | (this must the same as the Merlin container) |
+| `MERLIN_WORKER_DB_PORT`     | The DB instance port number that Merlin will connect with                                                                   | `number` | (this must the same as the Merlin container) |
+| `MERLIN_WORKER_DB_USER`     | Username of the DB instance                                                                                                 | `string` | (this must the same as the Merlin container) |
+| `MERLIN_WORKER_DB_PASSWORD` | Password of the DB instance                                                                                                 | `string` | (this must the same as the Merlin container) |
+| `MERLIN_WORKER_DB`          | The DB for Merlin.                                                                                                          | `string` | (this must the same as the Merlin container) |
+| `UNTRUE_PLAN_START`         | Temporary solution to provide plan start time to models, should be set to a time that models will not fail to initialize on | `string` |                                              |
 
 ## Aerie Scheduler
 
-| Name                    | Description                                                           | Type     | Default                                           |
-| ----------------------- | --------------------------------------------------------------------- | -------- |---------------------------------------------------|
-| `JAVA_OPTS`             | Configuration for the scheduler's logging level and output file       | `string` | log level: warn. output: stderr                   |
-| `MERLIN_GRAPHQL_URL`    | URI of the Merlin graphql interface to call                           | `string` | http://hasura:8080/v1/graphql                     |
-| `MERLIN_LOCAL_STORE`    | Local storage for Merlin in the container (for backdoor jar access)   | `string` | /usr/src/app/merlin_file_store                    |
-| `SCHEDULER_DB`          | The DB for scheduler                                                  | `string` | aerie_scheduler                                   |
-| `SCHEDULER_DB_PASSWORD` | Password of the DB instance                                           | `string` |                                                   |
-| `SCHEDULER_DB_PORT`     | The DB instance port number that scheduler will connect with          | `number` | 5432                                              |
-| `SCHEDULER_DB_SERVER`   | The DB instance that scheduler will connect with                      | `string` |                                           |
-| `SCHEDULER_DB_USER`     | Username of the DB instance                                           | `string` |                                              |
-| `SCHEDULER_LOCAL_STORE` | Local storage for scheduler in the container                          | `string` | /usr/src/app/scheduler_file_store                 |
-| `SCHEDULER_LOGGING`     | Whether or not you want Javalin to log server information             | `string` | true                                              |
-| `SCHEDULER_OUTPUT_MODE` | how scheduler output is sent back to aerie                            | `string` | UpdateInputPlanWithNewActivities                  |
-| `SCHEDULER_PORT`        | Port number for the scheduler server                                  | `number` | 27185                                             |
-| `SCHEDULER_RULES_JAR`   | Jar file to load scheduling rules from (until user input to database) | `string` | /usr/src/app/merlin_file_store/scheduler_rules.jar |
+| Name                    | Description                                                           | Type     | Default                                             |
+| ----------------------- | --------------------------------------------------------------------- | -------- | --------------------------------------------------- |
+| `JAVA_OPTS`             | Configuration for the scheduler's logging level and output file       | `string` | log level: warn. output: stderr                     |
+| `MERLIN_GRAPHQL_URL`    | URI of the Merlin graphql interface to call                           | `string` | http://hasura:8080/v1/graphql                       |
+| `MERLIN_LOCAL_STORE`    | Local storage for Merlin in the container (for backdoor jar access)   | `string` | /usr/src/app/merlin_file_store                      |
+| `SCHEDULER_DB`          | The DB for scheduler                                                  | `string` | aerie_scheduler                                     |
+| `SCHEDULER_DB_PASSWORD` | Password of the DB instance                                           | `string` |                                                     |
+| `SCHEDULER_DB_PORT`     | The DB instance port number that scheduler will connect with          | `number` | 5432                                                |
+| `SCHEDULER_DB_SERVER`   | The DB instance that scheduler will connect with                      | `string` |                                                     |
+| `SCHEDULER_DB_USER`     | Username of the DB instance                                           | `string` |                                                     |
+| `SCHEDULER_LOCAL_STORE` | Local storage for scheduler in the container                          | `string` | /usr/src/app/scheduler_file_store                   |
+| `SCHEDULER_LOGGING`     | Whether or not you want Javalin to log server information             | `string` | true                                                |
+| `SCHEDULER_OUTPUT_MODE` | how scheduler output is sent back to aerie                            | `string` | UpdateInputPlanWithNewActivities                    |
+| `SCHEDULER_PORT`        | Port number for the scheduler server                                  | `number` | 27185                                               |
+| `SCHEDULER_RULES_JAR`   | Jar file to load scheduling rules from (until user input to database) | `string` | /usr/src/app/merlin_file_store/scheduler_rules.jar  |
 
 ## Aerie UI
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -17,19 +17,23 @@ Before you can deploy Aerie, you must install and configure the following produc
 
 ## Setting the Environment Variables
 
-Each container has environment variables that can be used to fine-tune your deployment. See the [environment variable documentation](./Environment.md) for the complete set of variables. See the example [docker-compose.yml](./docker-compose.yml) file for examples on how to set the environment variables.
+Each container has environment variables that can be used to fine-tune your deployment.
+See the [environment variable documentation](./Environment.md) for the complete set of variables.
+See the example [docker-compose.yml](./docker-compose.yml) file for examples on how to set the environment variables.
 
-Inside the [.env](./.env) there is a collection of variables that **must** be set in order to deploy Aerie using the default [init-aerie.sh](./postgres-init-db/init-aerie.sh) and [docker-compose.yml](./docker-compose.yml). They are, as follows:
+Inside the [.env](./.env) there is a collection of variables that **must** be set in order to deploy Aerie using the default [init-aerie.sh](./postgres-init-db/init-aerie.sh) and [docker-compose.yml](./docker-compose.yml).
+They are, as follows:
 
-| Name                  | Description                                                                  |
-|-----------------------|------------------------------------------------------------------------------|
-| REPOSITORY_DOCKER_URL | The URL used to fetch images of Aerie packages.                              |
-| DOCKER_TAG            | The version of the Aerie images to fetch.                                    |
-| AERIE_USERNAME        | The username used for Aerie services when they access the Postgres database. |
-| AERIE_PASSWORD        | The password used for Aerie services when they access the Postgres database. |
-| POSTGRES_DB           | The name of the Postgres database.                                           |
-| POSTGRES_USER         | The username of the superuser for the Postgres database.                     |
-| POSTGRES_PASSWORD     | The password of the superuser for the Postgres database.                     |
+| Name                    | Description                                                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `REPOSITORY_DOCKER_URL` | The URL used to fetch images of Aerie packages.                                                                              |
+| `DOCKER_TAG`            | The version of the Aerie images to fetch.                                                                                    |
+| `AERIE_USERNAME`        | The username used for Aerie services when they access the Postgres database.                                                 |
+| `AERIE_PASSWORD`        | The password used for Aerie services when they access the Postgres database.                                                 |
+| `POSTGRES_DB`           | The name of the Postgres database.                                                                                           |
+| `POSTGRES_USER`         | The username of the superuser for the Postgres database.                                                                     |
+| `POSTGRES_PASSWORD`     | The password of the superuser for the Postgres database.                                                                     |
+| `UNTRUE_PLAN_START`     | Temporary solution to provide plan start time to models, should be set to a time that models will not fail to initialize on. |
 
 ### **At minimum, you _must_ assign values to the environment variables already present in [.env](./.env) in order to deploy Aerie**.
 

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       JAVA_OPTS: >
         -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
         -Dorg.slf4j.simpleLogger.logFile=System.err
+      UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
     image: "${REPOSITORY_DOCKER_URL}/aerie-merlin:${DOCKER_TAG}"
     ports: ["27183:27183"]
     restart: always
@@ -72,6 +73,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=WARN
         -Dorg.slf4j.simpleLogger.logFile=System.err
+      UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
     image: "${REPOSITORY_DOCKER_URL}/aerie-merlin-worker:${DOCKER_TAG}"
     restart: always
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
+      UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
     image: aerie_merlin
     ports: ["27183:27183", "5005:5005"]
     restart: always
@@ -131,6 +132,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
+      UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
     ports: ["5007:5005", "27187:8080"]
     restart: always
     volumes:
@@ -153,6 +155,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
+      UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
     ports: ["5008:5005", "27188:8080"]
     restart: always
     volumes:

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -65,6 +65,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
+      UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
     image: aerie_merlin
     ports: ['27183:27183', '5005:5005']
     restart: always
@@ -132,6 +133,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
+      UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
     ports: ['5007:5005', '27187:8080']
     restart: always
     volumes:
@@ -154,6 +156,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
+      UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
     ports: ['5008:5005', '27188:8080']
     restart: always
     volumes:

--- a/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/SimulationUtility.java
+++ b/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/SimulationUtility.java
@@ -17,11 +17,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 public final class SimulationUtility {
-  private static MissionModel<?> makeMissionModel(final MissionModelBuilder builder, final Configuration config) {
+  private static MissionModel<?> makeMissionModel(final MissionModelBuilder builder, final Instant planStart, final Configuration config) {
     final var factory = new GeneratedMissionModelFactory();
     final var registry = DirectiveTypeRegistry.extract(factory);
     // TODO: [AERIE-1516] Teardown the model to release any system resources (e.g. threads).
-    final var model = factory.instantiate(registry.registry(), config, builder);
+    final var model = factory.instantiate(registry.registry(), planStart, config, builder);
     return builder.build(model, factory.getConfigurationType(), registry);
   }
 
@@ -29,8 +29,8 @@ public final class SimulationUtility {
   simulate(final Map<ActivityInstanceId, Pair<Duration, SerializedActivity>> schedule, final Duration simulationDuration) {
     final var dataPath = Path.of(SimulationUtility.class.getResource("data/lorem_ipsum.txt").getPath());
     final var config = new Configuration(Configuration.DEFAULT_PLANT_COUNT, Configuration.DEFAULT_PRODUCER, dataPath);
-    final var missionModel = makeMissionModel(new MissionModelBuilder(), config);
     final var startTime = Instant.now();
+    final var missionModel = makeMissionModel(new MissionModelBuilder(), Instant.EPOCH, config);
 
     return SimulationDriver.simulate(
         missionModel,

--- a/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/FooActivityTest.java
+++ b/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/FooActivityTest.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.foomissionmodel;
 
+import java.time.Instant;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.FooActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.generated.ActivityTypes;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
@@ -32,7 +33,7 @@ public final class FooActivityTest {
   // The `Registrar` does not need to be declared as a parameter, but will be injected if declared.
   public FooActivityTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
     // Model configuration can be provided directly, just as for a normal Java class constructor.
-    this.model = new Mission(ctx.registrar(), new Configuration());
+    this.model = new Mission(ctx.registrar(), Instant.EPOCH, new Configuration());
 
     // Activities must be registered explicitly in order to be used in testing.
     // The generated `ActivityTypes` helper class loads all declared activities,

--- a/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/MissionConfigurationTest.java
+++ b/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/MissionConfigurationTest.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.foomissionmodel;
 
+import java.time.Instant;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.FooActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.generated.ActivityTypes;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
@@ -26,12 +27,13 @@ public final class MissionConfigurationTest {
     private final Mission model;
 
     public Test1(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-      this.model = new Mission(ctx.registrar(), new Configuration());
+      this.model = new Mission(ctx.registrar(), Instant.EPOCH, new Configuration());
       ctx.use(model, ActivityTypes::register);
     }
 
     @Test
     public void test() {
+      assertThat(model.startingAfterUnixEpoch.get()).isEqualTo(false);
       spawn(new FooActivity());
       delay(1, Duration.SECOND);
       assertThat(model.sink.get()).isCloseTo(0.5, within(1e-9));
@@ -47,12 +49,13 @@ public final class MissionConfigurationTest {
     private final Mission model;
 
     public Test2(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-      this.model = new Mission(ctx.registrar(), new Configuration(2.0));
+      this.model = new Mission(ctx.registrar(), Instant.EPOCH.plusSeconds(1), new Configuration(2.0));
       ctx.use(model, ActivityTypes::register);
     }
 
     @Test
     public void test() {
+      assertThat(model.startingAfterUnixEpoch.get()).isEqualTo(true);
       spawn(new FooActivity());
       delay(1, Duration.SECOND);
       assertThat(model.sink.get()).isCloseTo(2.0, within(1e-9));

--- a/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/SimulateMapSchedule.java
+++ b/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/SimulateMapSchedule.java
@@ -29,23 +29,22 @@ public class SimulateMapSchedule {
   }
 
   private static MissionModel<RootModel<ActivityTypes, Mission>>
-  makeMissionModel(final MissionModelBuilder builder, final Configuration config) {
+  makeMissionModel(final MissionModelBuilder builder, final Instant planStart, final Configuration config) {
     final var factory = new GeneratedMissionModelFactory();
     final var registry = DirectiveTypeRegistry.extract(factory);
-    final var model = factory.instantiate(registry.registry(), config, builder);
+    final var model = factory.instantiate(registry.registry(), planStart, config, builder);
     return builder.build(model, factory.getConfigurationType(), registry);
   }
 
   private static
   void simulateWithMapSchedule() {
     final var config = new Configuration();
-    final var missionModel = makeMissionModel(new MissionModelBuilder(), config);
+    final var startTime = Instant.now();
+    final var simulationDuration = duration(25, SECONDS);
+    final var missionModel = makeMissionModel(new MissionModelBuilder(), Instant.EPOCH, config);
 
     try {
       final var schedule = loadSchedule();
-      final var startTime = Instant.now();
-      final var simulationDuration = duration(25, SECONDS);
-
       final var simulationResults = SimulationDriver.simulate(
           missionModel,
           schedule,

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -40,6 +40,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -191,6 +192,10 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                     .addParameter(
                         missionModel.getTypesName(),
                         "registry",
+                        Modifier.FINAL)
+                    .addParameter(
+                        ClassName.get(Instant.class),
+                       "simulationStart",
                         Modifier.FINAL)
                     .addParameter(
                         missionModel.modelConfigurationType

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/MissionModelRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/MissionModelRecord.java
@@ -13,17 +13,20 @@ public final class MissionModelRecord {
   public final TypeElement topLevelModel;
   public final List<TypeRule> typeRules;
   public final List<ActivityTypeRecord> activityTypes;
+  public final boolean expectsPlanStart;
   public final Optional<ConfigurationTypeRecord> modelConfigurationType;
 
   public MissionModelRecord(
       final PackageElement $package,
       final TypeElement topLevelModel,
+      final boolean expectsPlanStart,
       final Optional<ConfigurationTypeRecord> modelConfigurationType,
       final List<TypeRule> typeRules,
       final List<ActivityTypeRecord> activityTypes)
   {
     this.$package = Objects.requireNonNull($package);
     this.topLevelModel = Objects.requireNonNull(topLevelModel);
+    this.expectsPlanStart = expectsPlanStart;
     this.modelConfigurationType = Objects.requireNonNull(modelConfigurationType);
     this.typeRules = Objects.requireNonNull(typeRules);
     this.activityTypes = Objects.requireNonNull(activityTypes);

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/MissionModelFactory.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/MissionModelFactory.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.protocol.model;
 
+import java.time.Instant;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.DirectiveTypeRegistrar;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer;
 
@@ -8,5 +9,5 @@ public interface MissionModelFactory<Registry, Config, Model> {
 
   ConfigurationType<Config> getConfigurationType();
 
-  Model instantiate(Registry registry, Config configuration, Initializer builder);
+  Model instantiate(Registry registry, Instant planStart, Config configuration, Initializer builder);
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
@@ -40,15 +40,19 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Instant;
 
 public final class AerieAppDriver {
 
-  public static void main(final String[] args) throws InterruptedException {
+  public static void main(final String[] args) {
     // Fetch application configuration properties.
     final var configuration = loadConfiguration();
     final var stores = loadStores(configuration);
 
-    final var missionModelController = new LocalMissionModelService(configuration.merlinFileStore(), stores.missionModels());
+    final var missionModelController = new LocalMissionModelService(
+        configuration.merlinFileStore(),
+        stores.missionModels(),
+        configuration.untruePlanStart());
 
     final var typescriptCodeGenerationService = new TypescriptCodeGenerationServiceAdapter(missionModelController);
 
@@ -138,7 +142,7 @@ public final class AerieAppDriver {
     }
   }
 
-  private static final String getEnv(final String key, final String fallback){
+  private static String getEnv(final String key, final String fallback) {
     final var env = System.getenv(key);
     return env == null ? fallback : env;
   }
@@ -146,14 +150,15 @@ public final class AerieAppDriver {
   private static AppConfiguration loadConfiguration() {
     final var logger = LoggerFactory.getLogger(AerieAppDriver.class);
     return new AppConfiguration(
-        Integer.parseInt(getEnv("MERLIN_PORT","27183")),
+        Integer.parseInt(getEnv("MERLIN_PORT", "27183")),
         logger.isDebugEnabled(),
-        Path.of(getEnv("MERLIN_LOCAL_STORE","/usr/src/app/merlin_file_store")),
-        new PostgresStore(getEnv("MERLIN_DB_SERVER","postgres"),
-                          getEnv("MERLIN_DB_USER",""),
-                          Integer.parseInt(getEnv("MERLIN_DB_PORT","5432")),
-                          getEnv("MERLIN_DB_PASSWORD",""),
-                          getEnv("MERLIN_DB","aerie_merlin"))
+        Path.of(getEnv("MERLIN_LOCAL_STORE", "/usr/src/app/merlin_file_store")),
+        new PostgresStore(getEnv("MERLIN_DB_SERVER", "postgres"),
+                          getEnv("MERLIN_DB_USER", ""),
+                          Integer.parseInt(getEnv("MERLIN_DB_PORT", "5432")),
+                          getEnv("MERLIN_DB_PASSWORD", ""),
+                          getEnv("MERLIN_DB", "aerie_merlin")),
+        Instant.parse(getEnv("UNTRUE_PLAN_START", ""))
     );
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/config/AppConfiguration.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/config/AppConfiguration.java
@@ -1,16 +1,19 @@
 package gov.nasa.jpl.aerie.merlin.server.config;
 
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Objects;
 
 public record AppConfiguration (
     int httpPort,
     boolean enableJavalinDevLogging,
     Path merlinFileStore,
-    Store store
+    Store store,
+    Instant untruePlanStart
 ) {
   public AppConfiguration {
     Objects.requireNonNull(merlinFileStore);
     Objects.requireNonNull(store);
+    Objects.requireNonNull(untruePlanStart);
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/config/Store.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/config/Store.java
@@ -1,5 +1,5 @@
 package gov.nasa.jpl.aerie.merlin.server.config;
 
-public /*sealed*/ interface Store
-    /*permits PostgresStore*/
+public sealed interface Store
+    permits PostgresStore, InMemoryStore
 {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CreateSimulationMessage.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CreateSimulationMessage.java
@@ -10,7 +10,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 
-public final record CreateSimulationMessage(
+public record CreateSimulationMessage(
   String missionModelId,
   Instant startTime,
   Duration samplingDuration,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -189,7 +190,7 @@ public final class LocalMissionModelService implements MissionModelService {
     }
 
     // TODO: [AERIE-1516] Teardown the mission model after use to release any system resources (e.g. threads).
-    return loadConfiguredMissionModel(message.missionModelId(), SerializedValue.of(config))
+    return loadConfiguredMissionModel(message.missionModelId(), message.startTime(), SerializedValue.of(config))
         .simulate(message.activityInstances(), message.samplingDuration(), message.startTime());
   }
 
@@ -246,7 +247,7 @@ public final class LocalMissionModelService implements MissionModelService {
   private MissionModelFacade loadConfiguredMissionModel(final String missionModelId)
   throws NoSuchMissionModelException, MissionModelLoadException
   {
-    return loadConfiguredMissionModel(missionModelId, SerializedValue.of(Map.of()));
+    return loadConfiguredMissionModel(missionModelId, Instant.EPOCH, SerializedValue.of(Map.of()));
   }
 
   /**
@@ -259,13 +260,20 @@ public final class LocalMissionModelService implements MissionModelService {
    * it contains may not abide by the expected contract at load time.
    * @throws NoSuchMissionModelException If no mission model is known by the given ID.
    */
-  private MissionModelFacade loadConfiguredMissionModel(final String missionModelId, final SerializedValue configuration)
+  private MissionModelFacade loadConfiguredMissionModel(
+      final String missionModelId,
+      final Instant planStart,
+      final SerializedValue configuration)
   throws NoSuchMissionModelException, MissionModelLoadException
   {
     try {
       final var missionModelJar = this.missionModelRepository.getMissionModel(missionModelId);
-      final var missionModel =
-          MissionModelLoader.loadMissionModel(configuration, missionModelDataPath.resolve(missionModelJar.path), missionModelJar.name, missionModelJar.version);
+      final var missionModel = MissionModelLoader.loadMissionModel(
+          planStart,
+          configuration,
+          missionModelDataPath.resolve(missionModelJar.path),
+          missionModelJar.name,
+          missionModelJar.version);
       return new MissionModelFacade(missionModel);
     } catch (final MissionModelRepository.NoSuchMissionModelException ex) {
       throw new NoSuchMissionModelException(missionModelId, ex);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -34,13 +34,16 @@ public final class LocalMissionModelService implements MissionModelService {
 
   private final Path missionModelDataPath;
   private final MissionModelRepository missionModelRepository;
+  private final Instant untruePlanStart;
 
   public LocalMissionModelService(
       final Path missionModelDataPath,
-      final MissionModelRepository missionModelRepository
+      final MissionModelRepository missionModelRepository,
+      final Instant untruePlanStart
   ) {
     this.missionModelDataPath = missionModelDataPath;
     this.missionModelRepository = missionModelRepository;
+    this.untruePlanStart = untruePlanStart;
   }
 
   @Override
@@ -247,7 +250,7 @@ public final class LocalMissionModelService implements MissionModelService {
   private MissionModelFacade loadConfiguredMissionModel(final String missionModelId)
   throws NoSuchMissionModelException, MissionModelLoadException
   {
-    return loadConfiguredMissionModel(missionModelId, Instant.EPOCH, SerializedValue.of(Map.of()));
+    return loadConfiguredMissionModel(missionModelId, untruePlanStart, SerializedValue.of(Map.of()));
   }
 
   /**

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/DevAppDriver.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/DevAppDriver.java
@@ -17,6 +17,7 @@ import io.javalin.Javalin;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Instant;
 
 public final class DevAppDriver {
   private static final int HTTP_PORT = 27183;
@@ -24,7 +25,7 @@ public final class DevAppDriver {
   public static void main(final String[] args) {
     // Assemble the core non-web object graph.
     final var fixtures = new Fixtures();
-    final var missionModelController = new LocalMissionModelService(Path.of("/dev/null"), new InMemoryMissionModelRepository());
+    final var missionModelController = new LocalMissionModelService(Path.of("/dev/null"), new InMemoryMissionModelRepository(), Instant.EPOCH);
     final var planController = new LocalPlanService(fixtures.planRepository);
 
     final var typescriptCodeGenerationService = new TypescriptCodeGenerationServiceAdapter(missionModelController);

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
@@ -6,7 +6,7 @@ import gov.nasa.jpl.aerie.foomissionmodel.generated.GeneratedMissionModelFactory
 import gov.nasa.jpl.aerie.merlin.driver.DirectiveTypeRegistry;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
-import gov.nasa.jpl.aerie.merlin.protocol.model.TaskSpecType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InvalidArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +39,7 @@ public final class MissionModelTest {
     private static MissionModelFacade makeMissionModel(final MissionModelBuilder builder, final Configuration config) {
         final var factory = new GeneratedMissionModelFactory();
         final var registry = DirectiveTypeRegistry.extract(factory);
-        final var model = factory.instantiate(registry.registry(), config, builder);
+        final var model = factory.instantiate(registry.registry(), Instant.EPOCH, config, builder);
         return new MissionModelFacade(builder.build(model, factory.getConfigurationType(), registry));
     }
 

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
@@ -6,7 +6,6 @@ import gov.nasa.jpl.aerie.foomissionmodel.generated.GeneratedMissionModelFactory
 import gov.nasa.jpl.aerie.merlin.driver.DirectiveTypeRegistry;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InvalidArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;

--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
@@ -19,6 +19,7 @@ import gov.nasa.jpl.aerie.merlin.worker.postgres.PostgresSimulationNotificationP
 import io.javalin.Javalin;
 
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -49,7 +50,10 @@ public final class MerlinWorkerAppDriver {
         new PostgresMissionModelRepository(hikariDataSource),
         new PostgresResultsCellRepository(hikariDataSource));
 
-    final var missionModelController = new LocalMissionModelService(configuration.merlinFileStore(), stores.missionModels());
+    final var missionModelController = new LocalMissionModelService(
+        configuration.merlinFileStore(),
+        stores.missionModels(),
+        configuration.untruePlanStart());
     final var planController = new LocalPlanService(stores.plans());
     final var simulationAgent = new SynchronousSimulationAgent(planController, missionModelController);
 
@@ -91,12 +95,13 @@ public final class MerlinWorkerAppDriver {
 
   private static WorkerAppConfiguration loadConfiguration() {
     return new WorkerAppConfiguration(
-        Path.of(getEnv("MERLIN_WORKER_LOCAL_STORE","/usr/src/app/merlin_file_store")),
-        new PostgresStore(getEnv("MERLIN_WORKER_DB_SERVER","postgres"),
-                          getEnv("MERLIN_WORKER_DB_USER",""),
-                          Integer.parseInt(getEnv("MERLIN_WORKER_DB_PORT","5432")),
-                          getEnv("MERLIN_WORKER_DB_PASSWORD",""),
-                          getEnv("MERLIN_WORKER_DB","aerie_merlin"))
+        Path.of(getEnv("MERLIN_WORKER_LOCAL_STORE", "/usr/src/app/merlin_file_store")),
+        new PostgresStore(getEnv("MERLIN_WORKER_DB_SERVER", "postgres"),
+                          getEnv("MERLIN_WORKER_DB_USER", ""),
+                          Integer.parseInt(getEnv("MERLIN_WORKER_DB_PORT", "5432")),
+                          getEnv("MERLIN_WORKER_DB_PASSWORD", ""),
+                          getEnv("MERLIN_WORKER_DB", "aerie_merlin")),
+        Instant.parse(getEnv("UNTRUE_PLAN_START", ""))
     );
   }
 }

--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/WorkerAppConfiguration.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/WorkerAppConfiguration.java
@@ -3,14 +3,17 @@ package gov.nasa.jpl.aerie.merlin.worker;
 import gov.nasa.jpl.aerie.merlin.server.config.Store;
 
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Objects;
 
 public record WorkerAppConfiguration(
     Path merlinFileStore,
-    Store store
+    Store store,
+    Instant untruePlanStart
 ) {
   public WorkerAppConfiguration {
     Objects.requireNonNull(merlinFileStore);
     Objects.requireNonNull(store);
+    Objects.requireNonNull(untruePlanStart);
   }
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -304,7 +304,7 @@ public record SynchronousSchedulerAgent(
       final var missionConfig = SerializedValue.of(plan.modelConfiguration());
       final var modelJarPath = modelJarsDir.resolve(plan.modelPath());
       return new SchedulerMissionModel(
-          MissionModelLoader.loadMissionModel(missionConfig, modelJarPath, plan.modelName(), plan.modelVersion()),
+          MissionModelLoader.loadMissionModel(plan.horizon().getStartInstant(), missionConfig, modelJarPath, plan.modelName(), plan.modelVersion()),
           loadSchedulerModelProvider(modelJarPath, plan.modelName(), plan.modelVersion()).getSchedulerModel());
     } catch (MissionModelLoader.MissionModelLoadException | SchedulerModelLoadException e) {
       throw new ResultsProtocolFailure(e);

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.TestInstance;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -895,6 +896,7 @@ public class SchedulingIntegrationTests {
   throws MissionModelLoader.MissionModelLoadException
   {
     final var missionModel = MissionModelLoader.loadMissionModel(
+        Instant.EPOCH,
         SerializedValue.of(configuration),
         Path.of(jarPath),
         "",

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationUtility.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationUtility.java
@@ -10,23 +10,24 @@ import gov.nasa.jpl.aerie.merlin.framework.RootModel;
 import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 
 import java.nio.file.Path;
+import java.time.Instant;
 
 public final class SimulationUtility {
 
   private static MissionModel<?> makeMissionModel(final MissionModelBuilder builder, final Configuration config) {
     final var factory = new gov.nasa.jpl.aerie.banananation.generated.GeneratedMissionModelFactory();
     final var registry = DirectiveTypeRegistry.extract(factory);
-    final var model = factory.instantiate(registry.registry(), config, builder);
+    final var model = factory.instantiate(registry.registry(), Instant.EPOCH, config, builder);
     return builder.build(model, factory.getConfigurationType(), registry);
   }
 
   public static MissionModel<RootModel<ActivityTypes, Mission>>
   getFooMissionModel() {
-    final var conf = new gov.nasa.jpl.aerie.foomissionmodel.Configuration();
+    final var config = new gov.nasa.jpl.aerie.foomissionmodel.Configuration();
     final var factory = new gov.nasa.jpl.aerie.foomissionmodel.generated.GeneratedMissionModelFactory();
     final var registry = DirectiveTypeRegistry.extract(factory);
     final var builder = new MissionModelBuilder();
-    final var model = factory.instantiate(registry.registry(), conf, builder);
+    final var model = factory.instantiate(registry.registry(), Instant.EPOCH, config, builder);
     return builder.build(model, factory.getConfigurationType(), registry);
   }
 
@@ -42,5 +43,4 @@ public final class SimulationUtility {
   public static SchedulerModel getBananaSchedulerModel(){
     return new gov.nasa.jpl.aerie.banananation.generated.GeneratedSchedulerModel();
   }
-
 }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1935
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

Mission modelers currently don't have access to a plan's start time.
With this PR a plan start time `Instant` parameter can optionally be declared in the top-level mission model ("`Mission.java`") constructor.

If a top-level mission model defines a constructor with `Instant` as the 2nd argument then the sim. start time will be passed to the mission model upon instantiation. If the `Instant` parameter (or `Registrar` parameter and optionally a "`Configuration`" parameter) is declared out-of-order then an actionable error message is now presented at compile-time. See the section below for examples.

More concretely, the following top-level mission model constructor parameters are allowed (lifted from `MissionModelParser.java`):
```java
    // - (Registrar, Instant, Configuration)
    // - (Registrar, Configuration)
    // - (Registrar, Instant)
    // - (Registrar)
```
As seen above, both sim. start time and mission model configuration parameters are optional. However, if both are defined "`Configuration`" must be declared last. This ensures backwards compatibility with existing mission models while allowing future mission models to make use of this `Instant`.

See the future work section for a discussion on alternative approaches for this PR.

## Verification
See `foo-missionmodel`'s [`MissionConfigurationTest`](https://github.com/NASA-AMMOS/aerie/pull/278/files#diff-712240ebbae24ed064a056ff8435c69eead17d86455f9851be99df69b161ba6b).

<details>
<summary>Error Handling</summary>

When the following `Mission` constructor parameters are declared in an [allowable](https://github.com/NASA-AMMOS/aerie/commit/5d210cbfca8492d3aa08f9a9c08c98d19becfaa5#diff-39f6ee1b28c111fa143558449ea4f23227bea8393e1d1274503876dfec5d2f1cR91-R95) order no compile-time error is thrown:
```java
public Mission(final Registrar registrar, final Instant planStart, final Configuration config) {
  ...
}
```

However, when `Instant` (or any of the above parameters) are declared out of expected order a custom error message will appear:
```
.../foomissionmodel/package-info.java:21: error: The top-level model's constructor is expected to accept [gov.nasa.jpl.aerie.merlin.framework.Registrar, java.time.Instant, gov.nasa.jpl.aerie.foomissionmodel.Configuration], found: [gov.nasa.jpl.aerie.merlin.framework.Registrar, gov.nasa.jpl.aerie.foomissionmodel.Configuration, java.time.Instant]
```
In this example, `Mission`'s constructor was declared with a plan start `Instant` in the wrong expected order:
```java
public Mission(final Registrar registrar, final Configuration config, final Instant planStart) {
  ...
}
```

</details>

## Documentation

- See `deployment/Environment.md` and `deployment/README.md` for information on `UNTRUE_PLAN_START`.
- See https://github.com/NASA-AMMOS/aerie/wiki/Developing-a-Mission-Model#mission-model-class
- See https://github.com/NASA-AMMOS/aerie/wiki/Configuring-a-Mission-Model#mission-model

## Future work

Initially a `@PlanStart` annotation was considered but in prototyping this implementation it was found that this change would require plan information to be passed in at our GQL layer (to allow any configured context to have plan information).
This would break existing GQL queries and more tightly couple our plan and model "domains".

See [Slack thread](https://jpl.slack.com/archives/GJ07FGRPH/p1661280990248519) for more context and discussion on this.
