### PR TITLE
[AERIE-1940]  scheduler populate source metadata field

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/PlanService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/PlanService.java
@@ -9,6 +9,7 @@ import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityInstanceId;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchActivityInstanceException;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.scheduler.server.http.InvalidJsonException;
+import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
 import gov.nasa.jpl.aerie.scheduler.server.models.MerlinPlan;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanMetadata;
@@ -75,7 +76,9 @@ public interface PlanService {
      */
     Pair<PlanId, Map<ActivityInstance, ActivityInstanceId>> createNewPlanWithActivities(
         final PlanMetadata planMetadata,
-        final Plan plan)
+        final Plan plan,
+        final Map<ActivityInstance, GoalId> activityToGoalId
+    )
     throws IOException, NoSuchPlanException, PlanServiceException;
 
     /**
@@ -117,7 +120,9 @@ public interface PlanService {
         PlanId planId,
         Map<SchedulingActivityInstanceId, ActivityInstanceId> idsFromInitialPlan,
         MerlinPlan initialPlan,
-        Plan plan)
+        Plan plan,
+        Map<ActivityInstance, GoalId> activityToGoalId
+    )
     throws IOException, NoSuchPlanException, PlanServiceException, NoSuchActivityInstanceException;
 
     /**
@@ -143,7 +148,11 @@ public interface PlanService {
      * @return
      * @throws NoSuchPlanException when the plan container does not exist in aerie
      */
-    Map<ActivityInstance, ActivityInstanceId> createAllPlanActivities(final PlanId planId, final Plan plan)
+    Map<ActivityInstance, ActivityInstanceId> createAllPlanActivities(
+        final PlanId planId,
+        final Plan plan,
+        final Map<ActivityInstance, GoalId> activityToGoalId
+    )
     throws IOException, NoSuchPlanException, PlanServiceException;
   }
 

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockMerlinService.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockMerlinService.java
@@ -14,6 +14,7 @@ import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityInstanceId;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchActivityInstanceException;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchMissionModelException;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
 import gov.nasa.jpl.aerie.scheduler.server.models.MerlinActivityInstance;
 import gov.nasa.jpl.aerie.scheduler.server.models.MerlinPlan;
 import gov.nasa.jpl.aerie.scheduler.server.models.MissionModelId;
@@ -96,7 +97,9 @@ class MockMerlinService implements MissionModelService, PlanService.OwnerRole {
   @Override
   public Pair<PlanId, Map<ActivityInstance, ActivityInstanceId>> createNewPlanWithActivities(
       final PlanMetadata planMetadata,
-      final Plan plan) throws IOException, NoSuchPlanException, PlanServiceException
+      final Plan plan,
+      final Map<ActivityInstance, GoalId> activityToGoal
+  ) throws IOException, NoSuchPlanException, PlanServiceException
   {
     return null;
   }
@@ -120,7 +123,8 @@ class MockMerlinService implements MissionModelService, PlanService.OwnerRole {
       final PlanId planId,
       final Map<SchedulingActivityInstanceId, ActivityInstanceId> idsFromInitialPlan,
       final MerlinPlan initialPlan,
-      final Plan plan
+      final Plan plan,
+      final Map<ActivityInstance, GoalId> activityToGoal
   )
   throws IOException, NoSuchPlanException, PlanServiceException, NoSuchActivityInstanceException
   {
@@ -146,7 +150,11 @@ class MockMerlinService implements MissionModelService, PlanService.OwnerRole {
   }
 
   @Override
-  public Map<ActivityInstance, ActivityInstanceId> createAllPlanActivities(final PlanId planId, final Plan plan)
+  public Map<ActivityInstance, ActivityInstanceId> createAllPlanActivities(
+      final PlanId planId,
+      final Plan plan,
+      final Map<ActivityInstance, GoalId> activityToGoalId
+  )
   throws IOException, NoSuchPlanException, PlanServiceException
   {
     return null;


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1940
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

Adjusted the GraphQL queries to use parameterized queries. Built a map of goals to activities, used that map to store the goal id for each activity that had a source goal.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Tested locally.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

None

## Future work
<!-- What next steps can we anticipate from here, if any? -->
There are a bunch more graphql queries that could really use some cleaning up.