### PR TITLE
[AERIE-1977]  Update eDSL documentation

### DIFF
--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -33,9 +33,19 @@ task generateASTJsonSchema(type: NpmTask) {
   inputs.dir('src')
 }
 
+task generateDocumentation(type: NpmTask) {
+  dependsOn npmInstall
+  dependsOn processResources
+  dependsOn assembleConstraintsDSLCompiler
+  args = ['run', 'generate-doc']
+  inputs.files('package.json', 'package-lock.json', 'tsconfig.json')
+  inputs.dir('src')
+}
+
 assemble {
   dependsOn assembleConstraintsDSLCompiler
   dependsOn generateASTJsonSchema
+  dependsOn generateDocumentation
 }
 
 test {

--- a/merlin-server/constraints-dsl-compiler/package-lock.json
+++ b/merlin-server/constraints-dsl-compiler/package-lock.json
@@ -11,6 +11,7 @@
         "@nasa-jpl/aerie-ts-user-code-runner": "^0.3.1",
         "prettier": "^2.6.2",
         "source-map": "^0.7.3",
+        "typedoc": "^0.23.10",
         "typescript": "^4.5.5",
         "typescript-json-schema": "0.53.0"
       },
@@ -62,6 +63,45 @@
         "stack-trace": "^1.0.0-pre1",
         "typedoc": "^0.22.13",
         "typescript": "^4.6.2"
+      }
+    },
+    "node_modules/@nasa-jpl/aerie-ts-user-code-runner/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@nasa-jpl/aerie-ts-user-code-runner/node_modules/typedoc": {
+      "version": "0.22.18",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+      "dependencies": {
+        "glob": "^8.0.3",
+        "lunr": "^2.3.9",
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 12.10.0"
+      },
+      "peerDependencies": {
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -453,13 +493,12 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
+      "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
       "dependencies": {
-        "glob": "^8.0.3",
         "lunr": "^2.3.9",
-        "marked": "^4.0.16",
+        "marked": "^4.0.18",
         "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
       },
@@ -467,10 +506,10 @@
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 12.10.0"
+        "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
+        "typescript": "4.6.x || 4.7.x"
       }
     },
     "node_modules/typescript": {
@@ -674,6 +713,32 @@
         "stack-trace": "^1.0.0-pre1",
         "typedoc": "^0.22.13",
         "typescript": "^4.6.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "typedoc": {
+          "version": "0.22.18",
+          "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+          "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+          "requires": {
+            "glob": "^8.0.3",
+            "lunr": "^2.3.9",
+            "marked": "^4.0.16",
+            "minimatch": "^5.1.0",
+            "shiki": "^0.10.1"
+          }
+        }
       }
     },
     "@tsconfig/node10": {
@@ -962,13 +1027,12 @@
       }
     },
     "typedoc": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
+      "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
       "requires": {
-        "glob": "^8.0.3",
         "lunr": "^2.3.9",
-        "marked": "^4.0.16",
+        "marked": "^4.0.18",
         "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
       }

--- a/merlin-server/constraints-dsl-compiler/package.json
+++ b/merlin-server/constraints-dsl-compiler/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "test": "npm run build && node build/main.js",
     "generate-ast-schema": "npx typescript-json-schema src/libs/constraints-ast.ts \"*\" --aliasRefs --out ./build/constraints.schema.json",
-    "reformat": "npx prettier --config ./.prettierrc -w ./src"
+    "reformat": "npx prettier --config ./.prettierrc -w ./src",
+    "generate-doc": "npx typedoc src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Constraints eDSL documentation\""
   },
   "author": "",
   "dependencies": {
@@ -15,7 +16,8 @@
     "prettier": "^2.6.2",
     "source-map": "^0.7.3",
     "typescript": "^4.5.5",
-    "typescript-json-schema": "0.53.0"
+    "typescript-json-schema": "0.53.0",
+    "typedoc": "^0.23.10"
   },
   "devDependencies": {
     "@tsconfig/node16-strictest-esm": "^1.0.2",

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -1,17 +1,36 @@
+/**
+ * This module contains the elements you need to write constraints via {@link Constraint}, window expressions via {@link Windows} and {@link Spans}.
+ * Resource can be accessed via {@link Real} or {@link Discrete} depending on their types.
+ *
+ * As activity types and resources are generated per mission model, some elements here are shown here with generic non-accessible types.
+ *
+ * @module Constraint eDSL
+ * @packageDocumentation
+ */
+
 import * as AST from './constraints-ast.js';
 import type * as Gen from './mission-model-generated-code.js';
 import {ActivityType, ActivityTypeParameterMap} from "./mission-model-generated-code.js";
 
 export class Constraint {
   /** Internal AST node */
+  /** @internal **/
   public readonly __astNode: AST.Constraint;
 
+  /** @internal **/
   private static __numGeneratedAliases: number = 0;
 
+  /** @internal **/
   public constructor(astNode: AST.Constraint) {
     this.__astNode = astNode;
   }
 
+  /**
+   * Forbid instances of two activity types from overlapping with each other.
+   * @param activityType1
+   * @param activityType2
+   * @constructor
+   */
   public static ForbiddenActivityOverlap(activityType1: Gen.ActivityType, activityType2: Gen.ActivityType): Constraint {
     return Constraint.ForEachActivity(
         activityType1,
@@ -22,6 +41,13 @@ export class Constraint {
     )
   }
 
+  /**
+   * Check a constraint for each instance of an activity type.
+   *
+   * @param activityType activity type to check
+   * @param expression function of an activity instance that returns a Constraint
+   * @constructor
+   */
   public static ForEachActivity<A extends Gen.ActivityType>(
     activityType: A,
     expression: (instance: ActivityInstance<A>) => Constraint,
@@ -39,18 +65,35 @@ export class Constraint {
 
 export class Windows {
   /** Internal AST node */
+  /** @internal **/
   public readonly __astNode: AST.WindowsExpression;
 
+  /** @internal **/
   public constructor(expression: AST.WindowsExpression) {
     this.__astNode = expression;
   }
 
+  /**
+   * Produce a window when all arguments produce a window.
+   *
+   * Performs the intersection of the argument windows.
+   *
+   * @param windows any number of windows expressions
+   */
   public static All(...windows: Windows[]): Windows {
     return new Windows({
       kind: AST.NodeKind.WindowsExpressionAll,
       expressions: [...windows.map(other => other.__astNode)],
     });
   }
+
+  /**
+   * Produce a window when any argument produces a window.
+   *
+   * Performs the union of the argument windows.
+   *
+   * @param windows one or more windows expressions
+   */
   public static Any(...windows: Windows[]): Windows {
     return new Windows({
       kind: AST.NodeKind.WindowsExpressionAny,
@@ -58,6 +101,11 @@ export class Windows {
     });
   }
 
+  /**
+   * Only check this expression of the condition argument produces a window.
+   *
+   * @param condition
+   */
   public if(condition: Windows): Windows {
     return new Windows({
       kind: AST.NodeKind.WindowsExpressionAny,
@@ -71,6 +119,9 @@ export class Windows {
     });
   }
 
+  /**
+   * Invert all the windows produced this.
+   */
   public invert(): Windows {
     return new Windows({
       kind: AST.NodeKind.WindowsExpressionInvert,
@@ -78,6 +129,12 @@ export class Windows {
     });
   }
 
+  /**
+   * Produce a constraint violation whenever this does NOT produce a window.
+   *
+   * Essentially, express the condition you want to be satisfied, then use
+   * this method to produce a violation whenever it is NOT satisfied.
+   */
   public violations(): Constraint {
     return new Constraint({
       kind: AST.NodeKind.ViolationsOf,
@@ -85,6 +142,10 @@ export class Windows {
     });
   }
 
+  /**
+   *  Return all windows with a duration longer than the argument
+   * @param duration the duration
+   */
   public longerThan(duration: Duration) : Windows {
     return new Windows({
       kind: AST.NodeKind.WindowsExpressionLongerThan,
@@ -93,6 +154,10 @@ export class Windows {
     })
   }
 
+  /**
+   * Returns all windows with a duration shorter than the argument
+   * @param duration the duration
+   */
   public shorterThan(duration: Duration) : Windows {
     return new Windows({
       kind: AST.NodeKind.WindowsExpressionShorterhan,
@@ -101,6 +166,11 @@ export class Windows {
     })
   }
 
+  /**
+   * Shift start and end of all windows by a duration
+   * @param fromStart duration to add from the start of the window
+   * @param fromEnd duration to add from the end of the window
+   */
   public shiftBy(fromStart: Duration, fromEnd: Duration) : Windows {
     return new Windows({
       kind: AST.NodeKind.WindowsExpressionShiftBy,
@@ -119,8 +189,10 @@ export class Windows {
 }
 
 export class Spans {
+  /** @internal **/
   public readonly __astNode: AST.SpansExpression;
 
+  /** @internal **/
   public constructor(expression: AST.SpansExpression) {
     this.__astNode = expression;
   }
@@ -134,18 +206,31 @@ export class Spans {
 }
 
 export class Real {
+  /** @internal **/
   public readonly __astNode: AST.RealProfileExpression;
 
+  /** @internal **/
   public constructor(profile: AST.RealProfileExpression) {
     this.__astNode = profile;
   }
 
+  /**
+   * Reference the real profile associated with a resource.
+   * @param name
+   * @constructor
+   */
   public static Resource(name: Gen.RealResourceName): Real {
     return new Real({
       kind: AST.NodeKind.RealProfileResource,
       name,
     });
   }
+
+  /**
+   * Create a constant real profile for all time.
+   * @param value
+   * @constructor
+   */
   public static Value(value: number): Real {
     return new Real({
       kind: AST.NodeKind.RealProfileValue,
@@ -153,12 +238,20 @@ export class Real {
     });
   }
 
+  /**
+   * Create a real profile from this profile's derivative.
+   */
   public rate(): Real {
     return new Real({
       kind: AST.NodeKind.RealProfileRate,
       profile: this.__astNode,
     });
   }
+
+  /**
+   * Create a real profile by multiplying this profile by a constant
+   * @param multiplier
+   */
   public times(multiplier: number): Real {
     return new Real({
       kind: AST.NodeKind.RealProfileTimes,
@@ -166,6 +259,11 @@ export class Real {
       profile: this.__astNode,
     });
   }
+
+  /**
+   * Create a real profile by adding this and another real profile together.
+   * @param other
+   */
   public plus(other: Real | number): Real {
     if (!(other instanceof Real)) {
       other = Real.Value(other);
@@ -177,6 +275,10 @@ export class Real {
     });
   }
 
+  /**
+   * Produce a window whenever this profile is less than another real profile.
+   * @param other
+   */
   public lessThan(other: Real | number): Windows {
     if (!(other instanceof Real)) {
       other = Real.Value(other);
@@ -187,6 +289,11 @@ export class Real {
       right: other.__astNode,
     });
   }
+
+  /**
+   * Produce a window whenever this profile is less than or equal to another real profile.
+   * @param other
+   */
   public lessThanOrEqual(other: Real | number): Windows {
     if (!(other instanceof Real)) {
       other = Real.Value(other);
@@ -197,6 +304,11 @@ export class Real {
       right: other.__astNode,
     });
   }
+
+  /**
+   * Produce a window whenever this profile is greater than to another real profile.
+   * @param other
+   */
   public greaterThan(other: Real | number): Windows {
     if (!(other instanceof Real)) {
       other = Real.Value(other);
@@ -207,6 +319,11 @@ export class Real {
       right: other.__astNode,
     });
   }
+
+  /**
+   * Produce a window whenever this profile is greater than or equal to another real profile.
+   * @param other
+   */
   public greaterThanOrEqual(other: Real | number): Windows {
     if (!(other instanceof Real)) {
       other = Real.Value(other);
@@ -218,6 +335,10 @@ export class Real {
     });
   }
 
+  /**
+   * Produce a window whenever this profile is equal to another real profile.
+   * @param other
+   */
   public equal(other: Real | number): Windows {
     if (!(other instanceof Real)) {
       other = Real.Value(other);
@@ -228,6 +349,11 @@ export class Real {
       right: other.__astNode,
     });
   }
+
+  /**
+   * Produce a window whenever this profile is not equal to another real profile.
+   * @param other
+   */
   public notEqual(other: Real | number): Windows {
     if (!(other instanceof Real)) {
       other = Real.Value(other);
@@ -239,6 +365,9 @@ export class Real {
     });
   }
 
+  /**
+   * Produce an instantaneous window whenever this profile changes.
+   */
   public changes(): Windows {
     return new Windows({
       kind: AST.NodeKind.ProfileChanges,
@@ -248,18 +377,31 @@ export class Real {
 }
 
 export class Discrete<Schema> {
+  /** @internal **/
   public readonly __astNode: AST.DiscreteProfileExpression;
 
+  /** @internal **/
   public constructor(profile: AST.DiscreteProfileExpression) {
     this.__astNode = profile;
   }
 
+  /**
+   * Reference the discrete profile associated with a resource.
+   * @param name
+   * @constructor
+   */
   public static Resource<R extends Gen.ResourceName>(name: R): Discrete<Gen.Resource[R]> {
     return new Discrete({
       kind: AST.NodeKind.DiscreteProfileResource,
       name,
     });
   }
+
+  /**
+   * Create a constant discrete profile for all time.
+   * @param value
+   * @constructor
+   */
   public static Value<Schema>(value: Schema): Discrete<Schema> {
     return new Discrete({
       kind: AST.NodeKind.DiscreteProfileValue,
@@ -267,6 +409,12 @@ export class Discrete<Schema> {
     });
   }
 
+  /**
+   * Produce an instantaneous window whenever this profile makes a specific transition.
+   *
+   * @param from initial value
+   * @param to final value
+   */
   public transition(from: Schema, to: Schema): Windows {
     return new Windows({
       kind: AST.NodeKind.DiscreteProfileTransition,
@@ -276,6 +424,10 @@ export class Discrete<Schema> {
     });
   }
 
+  /**
+   * Produce a window whenever this profile is equal to another discrete profile.
+   * @param other
+   */
   public equal(other: Schema | Discrete<Schema>): Windows {
     if (!(other instanceof Discrete)) {
       other = Discrete.Value(other);
@@ -286,6 +438,11 @@ export class Discrete<Schema> {
       right: other.__astNode,
     });
   }
+
+  /**
+   * Produce a window whenever this profile is not equal to another discrete profile.
+   * @param other
+   */
   public notEqual(other: Schema | Discrete<Schema>): Windows {
     if (!(other instanceof Discrete)) {
       other = Discrete.Value(other);
@@ -297,6 +454,9 @@ export class Discrete<Schema> {
     });
   }
 
+  /**
+   * Produce an instantaneous window whenever this profile changes.
+   */
   public changes(): Windows {
     return new Windows({
       kind: AST.NodeKind.ProfileChanges,

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -48,9 +48,20 @@ task generateASTJsonSchema(type: NpmTask) {
   inputs.dir('src')
 }
 
+task generateDocumentation(type: NpmTask) {
+  dependsOn npmInstall
+  dependsOn processResources
+  dependsOn copyConstraintsTypescript
+  dependsOn assembleSchedulingDSLCompiler
+  args = ['run', 'generate-doc']
+  inputs.files('package.json', 'package-lock.json', 'tsconfig.json')
+  inputs.dir('src')
+}
+
 assemble {
   dependsOn assembleSchedulingDSLCompiler
   dependsOn generateASTJsonSchema
+  dependsOn generateDocumentation
 }
 
 test {

--- a/scheduler-server/scheduling-dsl-compiler/package-lock.json
+++ b/scheduler-server/scheduling-dsl-compiler/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@nasa-jpl/aerie-ts-user-code-runner": "^0.3.1",
         "source-map": "^0.7.3",
+        "typedoc": "^0.23.10",
         "typescript": "^4.5.5",
         "typescript-json-schema": "0.53.0"
       },
@@ -61,6 +62,45 @@
         "stack-trace": "^1.0.0-pre1",
         "typedoc": "^0.22.13",
         "typescript": "^4.6.2"
+      }
+    },
+    "node_modules/@nasa-jpl/aerie-ts-user-code-runner/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@nasa-jpl/aerie-ts-user-code-runner/node_modules/typedoc": {
+      "version": "0.22.18",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+      "dependencies": {
+        "glob": "^8.0.3",
+        "lunr": "^2.3.9",
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 12.10.0"
+      },
+      "peerDependencies": {
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -438,13 +478,12 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
+      "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
       "dependencies": {
-        "glob": "^8.0.3",
         "lunr": "^2.3.9",
-        "marked": "^4.0.16",
+        "marked": "^4.0.18",
         "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
       },
@@ -452,10 +491,10 @@
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 12.10.0"
+        "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
+        "typescript": "4.6.x || 4.7.x"
       }
     },
     "node_modules/typescript": {
@@ -659,6 +698,32 @@
         "stack-trace": "^1.0.0-pre1",
         "typedoc": "^0.22.13",
         "typescript": "^4.6.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "typedoc": {
+          "version": "0.22.18",
+          "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+          "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+          "requires": {
+            "glob": "^8.0.3",
+            "lunr": "^2.3.9",
+            "marked": "^4.0.16",
+            "minimatch": "^5.1.0",
+            "shiki": "^0.10.1"
+          }
+        }
       }
     },
     "@tsconfig/node10": {
@@ -942,13 +1007,12 @@
       }
     },
     "typedoc": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
+      "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
       "requires": {
-        "glob": "^8.0.3",
         "lunr": "^2.3.9",
-        "marked": "^4.0.16",
+        "marked": "^4.0.18",
         "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
       }

--- a/scheduler-server/scheduling-dsl-compiler/package.json
+++ b/scheduler-server/scheduling-dsl-compiler/package.json
@@ -6,14 +6,16 @@
   "scripts": {
     "build": "tsc",
     "test": "npm run build && node build/main.js",
-    "generate-ast-schema": "npx typescript-json-schema src/libs/scheduler-ast.ts \"*\" --aliasRefs --out ./build/scheduler.schema.json"
+    "generate-ast-schema": "npx typescript-json-schema src/libs/scheduler-ast.ts \"*\" --aliasRefs --out ./build/scheduler.schema.json",
+    "generate-doc": "npx typedoc src/libs/scheduler-edsl-fluent-api.ts src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Scheduling eDSL documentation\""
   },
   "author": "",
   "dependencies": {
     "@nasa-jpl/aerie-ts-user-code-runner": "^0.3.1",
     "source-map": "^0.7.3",
     "typescript": "^4.5.5",
-    "typescript-json-schema": "0.53.0"
+    "typescript-json-schema": "0.53.0",
+    "typedoc": "^0.23.10"
   },
   "devDependencies": {
     "@tsconfig/node16-strictest-esm": "^1.0.2",

--- a/scheduler-server/scheduling-dsl-compiler/src/libs/README.md
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/README.md
@@ -1,2 +1,13 @@
+# Scheduling eDSL API 
+
+This is the documentation of the API of the Aerie scheduling eDSL. 
+
+You can find another documentation on automated scheduling in Aerie [here](https://github.com/NASA-AMMOS/aerie/wiki/Scheduling-Guide).
+
+## Known general issues
+
+Activities with uncontrollable durations have been found to behave somewhat unpredictably, in terms of when they are placed. This has to do with how temporal constraints interact with the unpredictability of the durations. Finding when an activity will start while subject to temporal constraint involves search.
+
+## For developers 
 Files in the ./constraints directory are copied from the constraints-dsl-compiler using a gradle action.
 These files should not be edited, or committed to version control.

--- a/scheduler-server/scheduling-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -1,3 +1,10 @@
 // This is a placeholder file. The real file is copied into the constraints directory
+/**
+ * This module contains the elements you need to write constraints via {@link Constraint}, window expressions via {@link Windows} and {@link Spans}.
+ * Resource can be accessed via {@link Real} or {@link Discrete} depending on their types.
+ *
+ * @module Constraint eDSL
+ * @packageDocumentation
+ */
 
 export * from './constraints/constraints-edsl-fluent-api.js'

--- a/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
@@ -506,7 +506,12 @@ declare global {
      */
     public or(...others: Goal[]): Goal
 
-    public static applyWhen(window: WindowsEDSL.Windows): Goal
+    /**
+     * Restricts the windows on which a goal is applied
+     * @param windows the windows on which this goal applies
+     * @returns a new goal applying on a restricted horizon
+     */
+    public applyWhen(window: WindowsEDSL.Windows): Goal
 
     /**
      * Creates an ActivityRecurrenceGoal

--- a/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
@@ -1,3 +1,10 @@
+/**
+ * This module contains the elements you need to write scheduling goals. To start, navigate to {@link Goal } to find the goal constructors.
+ *
+ * @module Scheduling eDSL
+ * @packageDocumentation
+ */
+
 import * as AST from "./scheduler-ast.js";
 import type * as WindowsEDSL from "./constraints-edsl-fluent-api.js";
 import type {ActivityType} from "./scheduler-mission-model-generated-code.js";
@@ -5,21 +12,53 @@ import type {ActivityType} from "./scheduler-mission-model-generated-code.js";
 type WindowProperty = AST.WindowProperty
 type TimingConstraintOperator = AST.TimingConstraintOperator
 
-interface ActivityRecurrenceGoal extends Goal {}
-interface ActivityCoexistenceGoal extends Goal {}
-interface ActivityCardinalityGoal extends Goal {}
+export type { CardinalityGoalArguments, WindowProperty, TimingConstraintOperator} from "./scheduler-ast.js";
 
+/**
+ * This class represents allows to represent and specify goals.
+ */
 export class Goal {
+  /** @internal **/
   public readonly __astNode: AST.GoalSpecifier;
 
+  /** @internal **/
   private constructor(__astNode: AST.GoalSpecifier) {
     this.__astNode = __astNode;
   }
 
+  /** @internal **/
   private static new(__astNode: AST.GoalSpecifier): Goal {
     return new Goal(__astNode);
   }
 
+  /**
+   *
+   * The AND Goal aggregates several goals together and specifies that at least one of them must be satisfied.
+   *
+   * #### Inputs
+   * - **goals**: an ordered list of goals (here below referenced as the subgoals)
+   *
+   * #### Behavior
+   * The scheduler will try to satisfy each subgoal in the list. If a subgoal is only partially satisfied, the scheduler will not backtrack and will let the inserted activities in the plan. If all the subgoals are satisfied, the AND goal will appear satisfied. If one or several subgoals have not been satisfied, the AND goal will appear unsatisfied.
+   *
+   * #### Examples
+   *
+   * ```typescript
+   * export default function myGoal() {
+   *     return Goal.CoexistenceGoal({
+   *       forEach: Real.Resource("/fruit").equal(4.0),
+   *       activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
+   *       endsAt: TimingConstraint.singleton(WindowProperty.END).plus(5 * 60 * 1000 * 1000)
+   *      }).and(
+   *       Goal.CardinalityGoal({
+   *             activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
+   *             specification: { occurrence : 10 }
+   *        }))
+   * }
+   * ```
+   * The AND goal above has two subgoals. The coexistence goal will place activities of type `PeelBanana` everytime the `/fruit` resource is equal to 4. The second goal will place 10 occurrences of the same kind of activities `PeelBanana`. The first subgoal will be evaluated first and will place a certain number of `PeelBanana` activities in the plan. When the second goal will be evaluated, it will count already present `PeelBanana` activities and insert the missing number. Imagine the first goals leads to inserting 2 activities. The second goal will then have to place 8 activities to be satisfied.
+   * @param others the list of goals
+   */
   public and(...others: Goal[]): Goal {
     return Goal.new({
       kind: AST.NodeKind.GoalAnd,
@@ -30,6 +69,42 @@ export class Goal {
     });
   }
 
+  /**
+   *
+   * The OR Goal aggregates several goals together and specifies that at least one of them must be satisfied.
+   *
+   * #### Inputs
+   * - **goals**: a list of goals (here below referenced as the subgoals)
+   *
+   * #### Behavior
+   * The scheduler will try to satisfy each subgoal in the list until one is satisfied. If a subgoal is only partially satisfied, the scheduler will not backtrack and will let the inserted activities in the plan.
+   *
+   * #### Examples
+   *
+   * ```typescript
+   * export default function myGoal() {
+   *     return Goal.CardinalityGoal({
+   *              activityTemplate: ActivityTemplates.GrowBanana({
+   *                quantity: 1,
+   *                growingDuration: 1000 * 1000 * 60 * 60, //1 hour in microseconds
+   *            }),
+   *           specification: { occurrence : 10 }
+   *           }).or(
+   *            Goal.ActivityRecurrenceGoal({
+   *             activityTemplate: ActivityTemplates.GrowBanana({
+   *             quantity: 1,
+   *             growingDuration: 1 * 60 * 60 * 1000 * 1000, //1 hour in microseconds
+   *           }),
+   *           interval: 2 * 60 * 60 * 1000 * 1000 // 2 hours in microseconds
+   *         }))
+   * }
+   * ```
+   *
+   * If the plan has a 24-hour planning horizon, the OR goal above will try placing activities of the `GrowBanana` type. The first subgoal will try placing 10 1-hour occurrences. If it fails to do so, because the planning horizon is maybe too short, it will then try to schedule 1 activity every 2 hours for the duration of the planning horizon.
+   *
+   * It may fail to achieve both subgoals but as the scheduler does not backtrack for now, activities inserted by any of the subgoals are kept in the plan.
+   * @param others the list of goals
+   */
   public or(...others: Goal[]): Goal {
     return Goal.new({
       kind: AST.NodeKind.GoalOr,
@@ -40,25 +115,154 @@ export class Goal {
     });
   }
 
-  public applyWhen(window: WindowsEDSL.Windows): Goal {
+  /**
+   * Restricts the windows on which a goal is applied
+   *
+   *
+   * By default, a goal applies on the whole planning horizon. The Aerie scheduler provides support for restricting _when_ a goal applies with the `.applyWhen()` method in the `Goal` class. This node allows users to provide a set of windows (`Windows`, see [documentation](https://github.com/NASA-AMMOS/aerie/wiki/Constraints#windows)) which could be a time or a resource-based window.
+   *
+   * The `.applyWhen()` method, takes one argument: the windows (in the form of an expression) that the goal should apply over. What follows is an example that applies a daily recurrence goal only when a given resource is greater than 2. If the resource is less than two, then the goal is no longer applied.
+   *
+   * ```typescript
+   * export default function myGoal() {
+   *     return Goal.ActivityRecurrenceGoal({
+   *             activityTemplate: ActivityTemplates.GrowBanana({
+   *             quantity: 1,
+   *             growingDuration: 1 * 60 * 60 * 1000 * 1000, //1 hour in microseconds
+   *           }),
+   *           interval: 2 * 60 * 60 * 1000 * 1000 // 2 hours in microseconds
+   *         }).applyWhen(Real.Resource("/fruit").greaterThan(2))
+   * }
+   * ```
+   *
+   * #### Notes on boundaries:
+   * * If you are trying to schedule an activity, or a recurrence within a window but that window cuts off either the activity or the recurrence interval (depending on the goal type), it will not be scheduled. For example, if you had a recurrence interval of 3 seconds, scheduling a 2 second activity each recurrence, and had the following window, you'd get the following:
+   * ```
+   * RECURRENCE INTERVAL: [++-++-++-]
+   * GOAL WINDOW:         [+++++----]
+   * RESULT:              [++-------]
+   * ```
+   * That, is, the second activity won't be scheduled as the goal window cuts off its recurrence interval.
+   * * Scheduling is _local_, not global. This means for every window that is matched (as it is possible to have disjoint windows, imagine a resource that fluctuates upward and downward but only applying that goal when the resource is over a certain value), the goal is applied individually. So, for that same recurrence interval setup as before, we could have:
+   * ```
+   * RECURRENCE INTERVAL: [++-++-++-++-]
+   * GOAL WINDOW:         [+++++--+++--]
+   * RESULT:              [++-----++---] //(the second one is applied independently of the first!)
+   * ```
+   * * When mapping out a temporal window to apply a goal over, keep in mind that the ending boundary of the goal is _exclusive_, i.e. if I want to apply a goal in the window of 10-12 seconds, it will apply only on seconds 10 and 11. This is in line with the [fencepost problem](https://icarus.cs.weber.edu/~dab/cs1410/textbook/3.Control/fencepost.html).
+   *
+   * @param windows the windows on which this goal applies
+   * @returns a new goal applying on a restricted horizon
+   */
+  public applyWhen(windows: WindowsEDSL.Windows): Goal {
     return Goal.new({
       kind: AST.NodeKind.ApplyWhen,
       goal: this.__astNode,
-      window: window.__astNode
+      window: windows.__astNode
     });
   }
 
-  public static ActivityRecurrenceGoal(opts: { activityTemplate: ActivityTemplate, interval: Duration }): ActivityRecurrenceGoal {
+  /**
+   * Creates an ActivityRecurrenceGoal
+   *
+   * The Activity Recurrence Goal (sometimes referred to as a "frequency goal") specifies that a certain activity should occur repeatedly throughout the plan, at some given interval.
+   *
+   * #### Inputs
+   * - activityTemplate: the description of the activity whose recurrence we're interested in.
+   * - interval: a Duration of time specifying how often this activity must occur
+   *
+   * #### Behavior
+   * This interval is treated as an upper bound - so if the activity occurs more frequently, that is not considered a failure.
+   *
+   * The scheduler will find places in the plan where the given activity has not occurred within the given interval, and it will place an instance of that activity there.
+   *
+   * > Note: The interval is measured between the _start times_ of two activity instances. Neither the duration, nor the end time of the activity are examined by this goal.
+   *
+   * #### Example
+   * ```typescript
+   * export default function myGoal() {
+   *     return Goal.ActivityRecurrenceGoal({
+   *             activityTemplate: ActivityTemplates.GrowBanana({
+   *             quantity: 1,
+   *             growingDuration: 1 * 60 * 60 * 1000 * 1000, //1 hour in microseconds
+   *           }),
+   *           interval: 2 * 60 * 60 * 1000 * 1000 // 2 hours in microseconds
+   *         })
+   * }
+   * ```
+   *
+   * The goal above will place a `GrowBanana` activity in every 2-hour period of time that does not already contain one with the exact same parameters.
+   *
+   * @param opts an object containing the activity template and the interval at which the activities must be placed
+   */
+  public static ActivityRecurrenceGoal(opts: { activityTemplate: ActivityTemplate, interval: Duration }): Goal {
     return Goal.new({
       kind: AST.NodeKind.ActivityRecurrenceGoal,
       activityTemplate: opts.activityTemplate,
       interval: opts.interval,
     });
   }
+
+  /**
+   * Creates a coexistence goal. The coexistence goal places one activity for each passed window.
+   * The start and end time of each activity can be parametrized relatively to its coexisting window with temporal constraints.
+   *
+   * The Coexistence Goal specifies that a certain activity should occur once **for each** occurrence of some condition.
+   *
+   * #### Inputs
+   * - **forEach**: a set of time windows (`Windows`, see [documentation](https://github.com/NASA-AMMOS/aerie/wiki/Constraints#windows) on how to produce such an expression) or a set of activities (`ActivityExpression`)
+   * - **activityTemplate**: the description of the activity to insert after each activity identified by `forEach`
+   * - **startsAt**: optionally specify a specific time when the activity should start relative to the window
+   * - **startsWithin**: optionally specify a range when the activity should start relative to the window
+   * - **endsAt**: optionally specify a specific time when the activity should end relative to the window
+   * - **endsWithin**: optionally specify a range when the activity should end relative to the window
+   *
+   * NOTE: Either the start or end of the activity must be constrained. This means that at least **1** of the 4 properties `startsAt`, `startsWithin`, `endsAt`, `endsWithin` must be given.
+   *
+   *
+   * #### Behavior
+   * The scheduler will find places in the plan where the `forEach` condition is true, and if not, it will insert a new instance using the given `activityTemplate` and temporal constraints.
+   *
+   * #### Examples
+   *
+   * ```typescript
+   * export default () => Goal.CoexistenceGoal({
+   *   forEach: ActivityExpression.ofType(ActivityTypes.GrowBanana),
+   *   activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
+   *   startsAt: TimingConstraint.singleton(WindowProperty.END).plus(5 * 60 * 1000 * 1000)
+   * })
+   * ```
+   * Behavior: for each activity A of type `GrowBanana` present in the plan when the goal is evaluated, place an activity of type `PeelBanana` starting exactly at the end of A + 5 minutes.
+   *
+   * ```typescript
+   * export default () => Goal.CoexistenceGoal({
+   *   forEach: ActivityExpression.ofType(ActivityTypes.GrowBanana),
+   *   activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
+   *   startsWithin: TimingConstraint.range(WindowProperty.END, Operator.PLUS, 5 * 60 * 1000 * 1000),
+   *   endsWithin: TimingConstraint.range(WindowProperty.END, Operator.PLUS, 6 * 60 * 1000 * 1000)
+   * })
+   * ```
+   *
+   * Behavior: for each activity A of type `GrowBanana` present in the plan when the goal is evaluated, place an activity of type `PeelBanana` starting in the interval [end of A, end of A + 5 minutes] and ending in the interval [end of A, end of A + 6 minutes].
+   *
+   *
+   * ```typescript
+   * export default () => Goal.CoexistenceGoal({
+   *   forEach: Real.Resource("/fruit").equal(4.0),
+   *   activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
+   *   endsAt: TimingConstraint.singleton(WindowProperty.END).plus(5 * 60 * 1000 * 1000)
+   * })
+   * ```
+   * Behavior: for each continuous period of time during which the `/fruit` resource is equal to 4, place an activity of type `PeelBanana` ending exactly at the end of A + 6 minutes. Note that the scheduler will allow a default timing error of 500 milliseconds for temporal constraints. This parameter will be configurable in an upcoming release.
+   *
+   * KNOWN ISSUE: If the end is unconstrained while the activity has an uncontrollable duration, the scheduler may fail to place the activity. To work around this, add an `endsWithin` constraint that encompasses your expectation for the duration of the activity - this will help the scheduler narrow the search space.
+   *
+   * @param opts an object containing the activity template, a set of windows, and optionnally temporal constraints.
+   */
   public static CoexistenceGoal(opts: {
     activityTemplate: ActivityTemplate,
     forEach: WindowsEDSL.Windows | ActivityExpression,
-  } & CoexistenceGoalTimingConstraints): ActivityCoexistenceGoal {
+  } & CoexistenceGoalTimingConstraints): Goal {
     return Goal.new({
       kind: AST.NodeKind.ActivityCoexistenceGoal,
       activityTemplate: opts.activityTemplate,
@@ -67,7 +271,66 @@ export class Goal {
       endConstraint: (("endsAt" in opts) ? opts.endsAt.__astNode : ("endsWithin" in opts) ? opts.endsWithin.__astNode : undefined),
     });
   }
-  public static CardinalityGoal(opts: { activityTemplate: ActivityTemplate, specification: AST.CardinalityGoalArguments }): ActivityCardinalityGoal {
+
+  /**
+   * The Cardinality Goal specifies that a certain activity should occur in the plan either a certain number of times, or for a certain total duration.
+   * #### Inputs
+   * - **activityTemplate**: the description of the activity whose recurrence we're interested in.
+   * - **specification**: an object with either an `occurrence` field, a `duration` field, or both (see examples below).
+   *
+   * #### Behavior
+   * The duration and occurrence are treated as lower bounds - so if the activity occurs more times, or for a longer duration, that is not considered a failure, and the scheduler will not add any more activities.
+   *
+   * The scheduler will identify whether it not the plan has enough occurrences or total duration of the given activity template. If not, it will add activities until satisfaction.
+   *
+   * #### Examples
+   *
+   * Setting a lower bound on the total duration:
+   *
+   * ```typescript
+   * export default function myGoal() {
+   *     return Goal.CardinalityGoal({
+   *         activityTemplate: ActivityTemplates.GrowBanana({
+   *             quantity: 1,
+   *             growingDuration: 1000000,
+   *         }),
+   *         specification: { duration: 10 * 1000000 }
+   *     })
+   * }
+   * ```
+   *
+   * Setting a lower bound on the number of occurrences:
+   *
+   * ```typescript
+   * export default function myGoal() {
+   *     return Goal.CardinalityGoal({
+   *         activityTemplate: ActivityTemplates.GrowBanana({
+   *             quantity: 1,
+   *             growingDuration: 1000000,
+   *         }),
+   *         specification: { occurrence: 10 }
+   *     })
+   * }
+   * ```
+   *
+   * Combining the two:
+   *
+   * ```typescript
+   * export default function myGoal() {
+   *     return Goal.CardinalityGoal({
+   *         activityTemplate: ActivityTemplates.GrowBanana({
+   *             quantity: 1,
+   *             growingDuration: 1000000,
+   *         }),
+   *         specification: { occurrence: 10, duration: 10 * 1000000 }
+   *     })
+   * }
+   * ```
+   *
+   * NOTE: In order to avoid placing multiple activities at the same start time, the Cardinality goal introduces an assumed mutual exclusion constraint - namely that new activities will not be allowed to overlap with existing activities.
+   * @param opts an object containing the activity template and a  {@link ActivityCardinalityGoal} specification of what kind of cardinality is considered
+   */
+  public static CardinalityGoal(opts: { activityTemplate: ActivityTemplate, specification: AST.CardinalityGoalArguments }): Goal {
     return Goal.new({
       kind: AST.NodeKind.ActivityCardinalityGoal,
       activityTemplate: opts.activityTemplate,
@@ -76,21 +339,37 @@ export class Goal {
   }
 }
 
-type StartTimingConstraint = { startsAt: SingletonTimingConstraint | SingletonTimingConstraintNoOperator } | { startsWithin: RangeTimingConstraint }
-type EndTimingConstraint = { endsAt: SingletonTimingConstraint | SingletonTimingConstraintNoOperator } | {endsWithin: RangeTimingConstraint }
-type CoexistenceGoalTimingConstraints = StartTimingConstraint | EndTimingConstraint | (StartTimingConstraint & EndTimingConstraint)
+/**
+ * An StartTimingConstraint is a constraint applying on the start time of an activity template.
+ */
+export type StartTimingConstraint = { startsAt: SingletonTimingConstraint | SingletonTimingConstraintNoOperator } | { startsWithin: RangeTimingConstraint }
+/**
+ * An EndTimingConstraint is a constraint applying on the end time of an activity template.
+ */
+export type EndTimingConstraint = { endsAt: SingletonTimingConstraint | SingletonTimingConstraintNoOperator } | {endsWithin: RangeTimingConstraint }
+/**
+ * An CoexistenceGoalTimingConstraints is a constraint that can be used to constrain the start or end times of activities in coexistence goals.
+ */
+export type CoexistenceGoalTimingConstraints = StartTimingConstraint | EndTimingConstraint | (StartTimingConstraint & EndTimingConstraint)
 
-class ActivityExpression {
+export class ActivityExpression {
+  /** @internal **/
   public readonly __astNode: AST.ActivityExpression;
 
+  /** @internal **/
   private constructor(__astNode: AST.ActivityExpression) {
     this.__astNode = __astNode;
   }
 
+  /** @internal **/
   private static new(__astNode: AST.ActivityExpression): ActivityExpression {
     return new ActivityExpression(__astNode);
   }
 
+  /**
+   * Creates an actvity expression of a type
+   * @param activityType the type
+   */
   public static ofType(activityType: ActivityType): ActivityExpression {
     return ActivityExpression.new({
       kind: AST.NodeKind.ActivityExpression,
@@ -99,10 +378,26 @@ class ActivityExpression {
   }
 }
 
-class TimingConstraint {
+export class TimingConstraint {
+  /** @internal **/
+  private constructor() {}
+  /**
+   * The singleton timing constraint represents a precise time point
+   * at some offset from either the start or end of a window.
+   * @param windowProperty either WindowProperty.START or WindowProperty.END
+   */
   public static singleton(windowProperty: WindowProperty): SingletonTimingConstraintNoOperator {
     return SingletonTimingConstraintNoOperator.new(windowProperty);
   }
+  /**
+   * The range timing constraint represents a range of acceptable times
+   * relative to either the start or end of the window. The range will
+   * be between the window "anchor" and the new point defined by the operator
+   * and the offset.
+   * @param windowProperty either WindowProperty.START or WindowProperty.END
+   * @param operator either Operator.PLUS or Operator.MINUS
+   * @param operand the duration offset
+   */
   public static range(windowProperty: WindowProperty, operator: TimingConstraintOperator, operand: Duration): RangeTimingConstraint {
     return RangeTimingConstraint.new({
       windowProperty,
@@ -113,11 +408,17 @@ class TimingConstraint {
   }
 }
 
-class SingletonTimingConstraintNoOperator {
+/**
+ * Represents an operation on a timepoint.
+ */
+export class SingletonTimingConstraintNoOperator {
+  /** @internal **/
   public readonly __astNode: AST.ActivityTimingConstraintSingleton
+  /** @internal **/
   private constructor(__astNode: AST.ActivityTimingConstraintSingleton) {
     this.__astNode = __astNode;
   }
+  /** @internal **/
   public static new(windowProperty: WindowProperty): SingletonTimingConstraintNoOperator {
     return new SingletonTimingConstraintNoOperator({
       windowProperty,
@@ -126,6 +427,11 @@ class SingletonTimingConstraintNoOperator {
       singleton: true
     });
   }
+
+  /**
+   * Adds a duration to a timepoint
+   * @param operand the duration to add
+   */
   public plus(operand: Duration): SingletonTimingConstraint {
     return SingletonTimingConstraint.new({
       ...this.__astNode,
@@ -133,6 +439,11 @@ class SingletonTimingConstraintNoOperator {
       operand
     })
   }
+
+  /**
+   * Subtract a duration from a timepoint
+   * @param operand the duration to subtract
+   */
   public minus(operand: Duration): SingletonTimingConstraint {
     return SingletonTimingConstraint.new({
       ...this.__astNode,
@@ -141,22 +452,33 @@ class SingletonTimingConstraintNoOperator {
     })
   }
 }
-
-class SingletonTimingConstraint {
+/**
+ * A singleton timing constraint specifies that the start or the end time of an activity must be exaxctly equal to a timepoint. Use {@link TimingConstraint.singleton} to create such a constraint.
+ */
+export class SingletonTimingConstraint {
+  /** @internal **/
   public readonly __astNode: AST.ActivityTimingConstraintSingleton
+  /** @internal **/
   private constructor(__astNode: AST.ActivityTimingConstraintSingleton) {
     this.__astNode = __astNode;
   }
+  /** @internal **/
   public static new(__astNode: AST.ActivityTimingConstraintSingleton): SingletonTimingConstraint {
     return new SingletonTimingConstraint(__astNode);
   }
 }
 
-class RangeTimingConstraint {
+/**
+ * A range timing constraint specifies that the start or the end time of an activity must be comprised in an interval. Use {@link TimingConstraint.range} to create such a constraint.
+ */
+export class RangeTimingConstraint {
+  /** @internal **/
   public readonly __astNode: AST.ActivityTimingConstraintRange
+  /** @internal **/
   private constructor(__astNode: AST.ActivityTimingConstraintRange) {
     this.__astNode = __astNode;
   }
+  /** @internal **/
   public static new(__astNode: AST.ActivityTimingConstraintRange): RangeTimingConstraint {
     return new RangeTimingConstraint(__astNode);
   }
@@ -165,13 +487,32 @@ class RangeTimingConstraint {
 declare global {
   class Goal {
     public readonly __astNode: AST.GoalSpecifier;
+
+    /**
+     * Aggregates the goal with another list of goals to form a conjunction of goals
+     *
+     * All goals in the conjunction must be satisfied in order for the conjunction to be satisfied
+     *
+     * @param others the list of goals
+     */
     public and(...others: Goal[]): Goal
 
+    /**
+     * Aggregates the goal with another list of goals to form a disjunction of goals
+     *
+     * If any subgoal is satisfied, the goal will stop processing and appear satisfied.
+     *
+     * @param others the list of goals
+     */
     public or(...others: Goal[]): Goal
 
     public static applyWhen(window: WindowsEDSL.Windows): Goal
 
-    public static ActivityRecurrenceGoal(opts: { activityTemplate: ActivityTemplate, interval: Duration }): ActivityRecurrenceGoal
+    /**
+     * Creates an ActivityRecurrenceGoal
+     * @param opts an object containing the activity template and the interval at which the activities must be placed
+     */
+    public static ActivityRecurrenceGoal(opts: { activityTemplate: ActivityTemplate, interval: Duration }): Goal
 
     /**
      * The CoexistenceGoal places one activity (defined by activityTemplate) per window (defined by forEach).
@@ -180,11 +521,20 @@ declare global {
     public static CoexistenceGoal(opts: {
       activityTemplate: ActivityTemplate,
       forEach: WindowsEDSL.Windows | ActivityExpression,
-    } & CoexistenceGoalTimingConstraints): ActivityCoexistenceGoal
+    } & CoexistenceGoalTimingConstraints): Goal
 
-    public static CardinalityGoal(opts: { activityTemplate: ActivityTemplate, specification: AST.CardinalityGoalArguments }): ActivityCardinalityGoal
+    /**
+     * Creates a CardinalityGoal
+     * @param opts an object containing the activity template and a specification of what type of CardinalityGoal is required
+     * @constructor
+     */
+    public static CardinalityGoal(opts: { activityTemplate: ActivityTemplate, specification: AST.CardinalityGoalArguments }): Goal
   }
-  class ActivityExpression {
+  export class ActivityExpression {
+    /**
+     * Creates an actvity expression of a type
+     * @param activityType the type
+     */
     public static ofType(activityType: ActivityType): ActivityExpression
   }
   class TimingConstraint {
@@ -213,7 +563,17 @@ declare global {
   type Integer = number;
 }
 
+/**
+ * Represents a continuous closed-open interval (start value is included, end value is not included)
+ */
 export interface ClosedOpenInterval extends AST.ClosedOpenInterval {}
+
+/**
+ * An ActivityTemplate specifies the type of an activity, as well as the arguments it should be given.
+ *
+ *  Activity templates are generated for each mission model. You can get the full list of activity templates by typing `ActivityTemplates.` (note the period) into the scheduling goal editor, and viewing the auto-complete options.
+ *
+ * If the activity has parameters, pass them into the constructor in a dictionary as key-value pairs (i.e. `ActivityTemplate.ParamActivity({ param:1 }))`. If the activity has no parameters, do not pass a dictionary (i.e. `ActivityTemplate.ParameterlessActivity()`). */
 export interface ActivityTemplate extends AST.ActivityTemplate {}
 
 // Make Goal available on the global object

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
@@ -318,6 +318,7 @@ class SchedulingDSLCompilationServiceTests {
           interface FakeGoal {
             and(...others: FakeGoal[]): FakeGoal;
             or(...others: FakeGoal[]): FakeGoal;
+            applyWhen(window: Windows): FakeGoal;
           }
           export default function() {
             const myFakeGoal: FakeGoal = {
@@ -325,6 +326,9 @@ class SchedulingDSLCompilationServiceTests {
                 return myFakeGoal;
               },
               or: (...others: FakeGoal[]) => {
+                return myFakeGoal;
+              },
+              applyWhen: (window: Windows) => {
                 return myFakeGoal;
               },
             };


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1977
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
(1) I have made revisions to https://github.com/NASA-AMMOS/aerie/wiki/Scheduling-Guide

(2) I have added automated generation of documentation for both the constraints and scheduling eDSL
- all private members are hidden
- everything marked with the @internal tag is hidden
- annoyance: to make intellisense AND typedoc work at the same time, I had to duplicate all comments that were previously only present in the `declare global` blocks. If we only move them, intellisense does not see the comments anymore.
- for the scheduling edsl: **all** the current descriptions/examples and such under https://github.com/NASA-AMMOS/aerie/wiki/Scheduling-Guide#scheduling-dsl-documentation has been inserted directly in the appropriate comments of the code and thus appear in the typedoc doc

(3) I fixed a small issue with `Goal.applyWhen` in the second commit.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
None.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Documentation was updated !

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Remove everything under under https://github.com/NASA-AMMOS/aerie/wiki/Scheduling-Guide#scheduling-dsl-documentation and serve the typedoc directly in github ?
- Probably enrich descriptions/comments/introduction and such, I have no inspiration right now
- Add examples to the constraints edsl documentation 