### PR TITLE
[AERIE-2002]  Generate a standalone sequence seqjson

### DIFF
--- a/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/command-expansion-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -61,7 +61,10 @@ export interface SequenceSeqJson {
 }
 
 declare global {
-  class Command<A extends ArgType[] | { [argName: string]: any } = [] | {}> {
+  class Command<
+    A extends ArgType[] | { [argName: string]: any } = [] | {},
+    M extends Record<string, any> = Record<string, any>,
+  > {
     public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): Command<A>;
 
     public toSeqJson(): CommandSeqJson;
@@ -72,6 +75,17 @@ declare global {
 
     public relativeTiming(relativeTime: Temporal.Duration): Command<A>;
   }
+
+  class Sequence {
+    public readonly seqId: string;
+    public readonly metadata: Record<string, any>;
+    public readonly commands: Command[];
+
+    public static new(opts: { seqId: string; metadata: Record<string, any>; commands: Command[] }): Sequence;
+
+    public toSeqJson(): SequenceSeqJson;
+  }
+
   type Context = {};
   type ExpansionReturn = Arrayable<Command>;
 

--- a/command-expansion-server/src/lib/codegen/CommandTypeCodegen.ts
+++ b/command-expansion-server/src/lib/codegen/CommandTypeCodegen.ts
@@ -33,7 +33,7 @@ export const Commands = {${dictionary.fswCommands
     .map(fswCommand => `\t\t${fswCommand.stem}: ${fswCommand.stem},\n`)
     .join('')}};
 
-Object.assign(globalThis, Commands, { A:A, R:R, E:E, C:Commands});
+Object.assign(globalThis, Commands, { A:A, R:R, E:E, C:Commands, Sequence});
 `;
 
   return {

--- a/command-expansion-server/src/worker.ts
+++ b/command-expansion-server/src/worker.ts
@@ -20,7 +20,7 @@ const temporalPolyfillTypes = fs.readFileSync(
 );
 const tsConfig = JSON.parse(fs.readFileSync(new URL('../tsconfig.json', import.meta.url).pathname, 'utf-8'));
 const { options } = ts.parseJsonConfigFileContent(tsConfig, ts.sys, '');
-const compilerTarget = options.target ?? ts.ScriptTarget.ES2021
+const compilerTarget = options.target ?? ts.ScriptTarget.ES2021;
 
 const codeRunner = new UserCodeRunner();
 
@@ -92,7 +92,7 @@ export async function executeExpansion(opts: {
       }
       const commandsFlat = commands.flat() as Command[];
       for (const command of commandsFlat) {
-        (command as Mutable<Command>).metadata  = {
+        (command as Mutable<Command>).metadata = {
           ...command.metadata,
           simulatedActivityId: activityInstance.id,
         };

--- a/command-expansion-server/test/testUtils/Sequence.ts
+++ b/command-expansion-server/test/testUtils/Sequence.ts
@@ -1,4 +1,5 @@
 import { gql, GraphQLClient } from 'graphql-request';
+import type { SequenceSeqJson } from '../../src/lib/codegen/CommandEDSLPreface';
 import { convertActivityDirectiveIdToSimulatedActivityId } from './ActivityDirective';
 
 export async function insertSequence(
@@ -28,6 +29,39 @@ export async function insertSequence(
     },
   );
   return { seqId: res.insert_sequence_one.seq_id, simulationDatasetId: res.insert_sequence_one.simulation_dataset_id };
+}
+
+export async function generateSequenceEDSL(
+  graphqlClient: GraphQLClient,
+  commandDictionaryID: number,
+  edslBody: string,
+): Promise<SequenceSeqJson> {
+  const res = await graphqlClient.request<{ getUserSequenceSeqJson: SequenceSeqJson }>(
+    gql`
+      query generateSequence($commandDictionaryID: Int!, $edslBody: String!) {
+        getUserSequenceSeqJson(commandDictionaryID: $commandDictionaryID, edslBody: $edslBody) {
+          id
+          metadata
+          steps {
+            args
+            metadata
+            stem
+            time {
+              tag
+              type
+            }
+            type
+          }
+        }
+      }
+    `,
+    {
+      commandDictionaryID: commandDictionaryID,
+      edslBody: edslBody,
+    },
+  );
+
+  return res.getUserSequenceSeqJson;
 }
 
 export async function removeSequence(

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -132,6 +132,13 @@ type Query {
   ): SequenceSeqJson!
 }
 
+type Query {
+  getUserSequenceSeqJson(
+    commandDictionaryID: Int!
+    edslBody: String!
+  ): SequenceSeqJson!
+}
+
 enum MerlinSimulationStatus {
   complete
   failed

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -38,7 +38,11 @@ actions:
   - name: getSequenceSeqJson
     definition:
       kind: ""
-      handler: http://aerie_commanding:27184/get-seqjson-for-sequence
+      handler: http://aerie_commanding:27184/get-seqjson-for-seqid-and-simulation-dataset
+  - name: getUserSequenceSeqJson
+    definition:
+      kind: ""
+      handler: http://aerie_commanding:27184/get-seqjson-for-sequence-standalone
   - name: resourceTypes
     definition:
       kind: ""


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2002 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Some users will like to a create sequence files outside of the Falcon Editor using their own tool suite or text editor. These users will need to have a way to generate a sequence seqjson file out of these standalone sequences. 

Below is the standard file format that should be followed by the falcon editor when saving sequences files into AERIE. The Falcon editor should be able to wrap a UI around this format. The users working outside of AERIE should use this format in their sequence file. 

```
export default () =>
  Sequence.new({
    seqId: "test_00001",
    metadata: {},
    commands: [
        BAKE_BREAD,
        A`2020-060T03:45:19`.PREHEAT_OVEN(100),
    ],
  });
```

When generating a sequence seqjson, the Command Expansion server will need a command dictionary and sequence file like the one above.

Here is the GQL call 

```
query GenerateEDSL($commandDictionaryID: Int!, $edslBody: String!) {
  generateSequenceSeqJsonEDSL(commandDictionaryID: $commandDictionaryID, edslBody: $edslBody) {
    id
    metadata
    steps {
      args
      metadata
      stem
      time {
        tag
        type
      }
      type
    }
  }
}

{
  "commandDictionaryID": 1,
  "edslBody": "export default () =>\n  Sequence.new({\n    seqId: \"test_00001\",\n    metadata: {},\n    commands: [\n        BAKE_BREAD,\n        A`2020-060T03:45:19`.PREHEAT_OVEN(100),\n    ],\n  });"
}

```

The above GQL call will generate the sequence seqjson file below:

```
{
      "id": "test_00001",
      "metadata": {},
      "steps": [
        {
          "args": [],
          "metadata": {},
          "stem": "BAKE_BREAD",
          "time": {
            "type": "COMMAND_COMPLETE"
          },
          "type": "command"
        },
        {
          "args": [
            100
          ],
          "metadata": {},
          "stem": "PREHEAT_OVEN",
          "time": {
            "tag": "2020-060T03:45:19.000",
            "type": "ABSOLUTE"
          },
          "type": "command"
        }
      ]
    }
```


## Verification
I wrote a `Unit test` to test the new endpoint in the Command Expansion Server. Also, you can run the GQL above and get the same output.


## Documentation
I will have to add a new documentation page on the Command Expansion Wiki addressing the generating of a sequence seqjson file outside of AERIE. 


## Future work
Probably hook this up to Falcon editor at some point. 
