### PR TITLE
[REFACTOR] Simplify builder chaining code codegen

### DIFF
--- a/merlin-server/Dockerfile
+++ b/merlin-server/Dockerfile
@@ -9,7 +9,7 @@ FROM eclipse-temurin:18-focal
 ENV NODE_VERSION=16.14.0
 ENV NVM_DIR=/usr/src/.nvm
 ENV PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin:${PATH}"
-RUN apt install --no-install-recommends -y curl \
+RUN apt update && apt install --no-install-recommends -y curl \
     && mkdir -p $NVM_DIR \
     && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash \
     &&. "$NVM_DIR/nvm.sh" \

--- a/scheduler-server/Dockerfile
+++ b/scheduler-server/Dockerfile
@@ -9,7 +9,7 @@ FROM eclipse-temurin:18-focal
 ENV NODE_VERSION=16.14.0
 ENV NVM_DIR=/usr/src/.nvm
 ENV PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin:${PATH}"
-RUN apt install --no-install-recommends -y curl \
+RUN apt update && apt install --no-install-recommends -y curl \
     && mkdir -p $NVM_DIR \
     && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash \
     &&. "$NVM_DIR/nvm.sh" \


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2005
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
"Hotfix" follow-up to simplify some of the `ActivityTypes.Builder` code generation. Motivated by https://github.com/NASA-AMMOS/aerie/pull/281#discussion_r943981202. This PR does not change the generated code, it just organizes the existing code generation logic to be easier to follow and more logical.
