### PR TITLE
[AERIE-2001]  Pass along Computed Attributes

### DIFF
--- a/command-expansion-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
+++ b/command-expansion-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
@@ -141,6 +141,14 @@ export interface SimulatedActivityAttributes<
 > {
   arguments: ActivityArguments;
   directiveId: number | undefined;
+  computed: ActivityComputedAttributes | undefined;
+}
+export interface GraphQLSimulatedActivityAttributes<
+  ActivityArguments extends Record<string, unknown> = Record<string, unknown>,
+  ActivityComputedAttributes extends Record<string, unknown> = Record<string, unknown>,
+> {
+  arguments: ActivityArguments;
+  directiveId: number | undefined;
   computedAttributes: ActivityComputedAttributes | undefined;
 }
 
@@ -171,7 +179,7 @@ export interface GraphQLSimulatedActivityInstance<
       };
     };
   };
-  attributes: SimulatedActivityAttributes<ActivityArguments, ActivityComputedAttributes>;
+  attributes: GraphQLSimulatedActivityAttributes<ActivityArguments, ActivityComputedAttributes>;
   duration: string;
   start_offset: string;
   start_time: string;
@@ -200,7 +208,9 @@ export function mapGraphQLActivityInstance(
         return acc;
       }, {} as { [attributeName: string]: any }),
       directiveId: activityInstance.attributes.directiveId,
-      computedAttributes: undefined, // TODO: Need to handle computed attributes
+      computed: activityInstance.attributes.computedAttributes
+        ? convertType(activityInstance.attributes.computedAttributes, activitySchema.computed_attributes_value_schema)
+        : null,
     },
   };
 }

--- a/command-expansion-server/test/sequence-generation.spec.ts
+++ b/command-expansion-server/test/sequence-generation.spec.ts
@@ -639,19 +639,24 @@ describe('expansion regressions', () => {
   }, 10000);
 });
 
-it('should provide start and end times on activities', async () => {
+it('should provide start, end, and computed attributes on activities', async () => {
   // Setup
 
-  const activityId = await insertActivity(graphqlClient, planId, 'BiteBanana', '1 hours');
+  const activityId = await insertActivity(graphqlClient, planId, 'BakeBananaBread', '1 hours', {
+    tbSugar: 1,
+    glutenFree: false,
+    temperature: 350,
+  });
   const simulationArtifactPk = await executeSimulation(graphqlClient, planId);
   const expansionId = await insertExpansion(
     graphqlClient,
-    'BiteBanana',
+    'BakeBananaBread',
     `
     export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
       return [
-        BAKE_BREAD.absoluteTiming(props.activityInstance.startTime),
-        BAKE_BREAD.absoluteTiming(props.activityInstance.endTime),
+        A(props.activityInstance.startTime).BAKE_BREAD,
+        A(props.activityInstance.endTime).BAKE_BREAD,
+        C.ECHO("Computed attributes: " + props.activityInstance.attributes.computed),
       ];
     }
     `,
@@ -711,6 +716,13 @@ it('should provide start and end times on activities', async () => {
       stem: 'BAKE_BREAD',
       time: { type: TimingTypes.ABSOLUTE, tag: '2020-001T01:00:00.000' },
       args: [],
+      metadata: { simulatedActivityId: simulatedActivityId3 },
+    },
+    {
+      type: 'command',
+      stem: 'ECHO',
+      time: { type: 'COMMAND_COMPLETE' },
+      args: ['Computed attributes: 198'],
       metadata: { simulatedActivityId: simulatedActivityId3 },
     },
   ]);

--- a/command-expansion-server/test/testUtils/Activity.ts
+++ b/command-expansion-server/test/testUtils/Activity.ts
@@ -9,6 +9,7 @@ export async function insertActivity(
   planId: number,
   activityType: string,
   startOffset: string = '30 seconds 0 milliseconds',
+  args: any = {},
 ): Promise<number> {
   const res = await graphqlClient.request<{
     insert_activity_one: { id: number };
@@ -26,7 +27,7 @@ export async function insertActivity(
       planId: planId,
       activityType,
       startOffset: startOffset,
-      arguments: {},
+      arguments: args,
     },
   );
   return res.insert_activity_one.id;


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2001
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
When updating the wiki to show examples of authoring logic with computed attributes, I realized that we are not passing the computed attributes of an activity to the worker. I made a small change in the code and updated the unit test. 

## Verification
Locally I verified that more complex data structures work with computed attributes by changing `BakeBananaBread's` computed attribute to a `HashMap`. 

I also ran the unit test and received no errors

## Documentation
I will update the documentation on how to use the computed attributes when this PR is merged in.

## Future work
none
