### PR TITLE
[AERIRE 1918] Add schema property to real profiles

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationResults.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationResults.java
@@ -17,7 +17,7 @@ import java.util.SortedMap;
 
 public final class SimulationResults {
   public final Instant startTime;
-  public final Map<String, List<Pair<Duration, RealDynamics>>> realProfiles;
+  public final Map<String, Pair<ValueSchema, List<Pair<Duration, RealDynamics>>>> realProfiles;
   public final Map<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>> discreteProfiles;
   public final Map<String, List<Pair<Duration, SerializedValue>>> resourceSamples;
   public final Map<ActivityInstanceId, SimulatedActivity> simulatedActivities;
@@ -26,7 +26,7 @@ public final class SimulationResults {
   public final Map<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>> events;
 
     public SimulationResults(
-        final Map<String, List<Pair<Duration, RealDynamics>>> realProfiles,
+        final Map<String, Pair<ValueSchema, List<Pair<Duration, RealDynamics>>>> realProfiles,
         final Map<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>> discreteProfiles,
         final Map<ActivityInstanceId, SimulatedActivity> simulatedActivities,
         final Map<ActivityInstanceId, UnfinishedActivity> unfinishedActivities,
@@ -46,13 +46,14 @@ public final class SimulationResults {
 
   private static Map<String, List<Pair<Duration, SerializedValue>>>
   takeSamples(
-      final Map<String, List<Pair<Duration, RealDynamics>>> realProfiles,
+      final Map<String, Pair<ValueSchema, List<Pair<Duration, RealDynamics>>>> realProfiles,
       final Map<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>> discreteProfiles)
   {
     final var samples = new HashMap<String, List<Pair<Duration, SerializedValue>>>();
 
-    realProfiles.forEach((name, profile) -> {
+    realProfiles.forEach((name, p) -> {
       var elapsed = Duration.ZERO;
+      var profile = p.getRight();
 
       final var timeline = new ArrayList<Pair<Duration, SerializedValue>>();
       for (final var piece : profile) {

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -433,7 +433,7 @@ public final class SimulationEngine implements AutoCloseable {
     }
 
     // Extract profiles for every resource.
-    final var realProfiles = new HashMap<String, List<Pair<Duration, RealDynamics>>>();
+    final var realProfiles = new HashMap<String, Pair<ValueSchema, List<Pair<Duration, RealDynamics>>>>();
     final var discreteProfiles = new HashMap<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>>();
 
     for (final var entry : engine.resources.entrySet()) {
@@ -446,12 +446,14 @@ public final class SimulationEngine implements AutoCloseable {
       switch (resource.getType()) {
         case "real" -> realProfiles.put(
             name,
-            serializeProfile(elapsedTime, state, SimulationEngine::extractRealDynamics));
+            Pair.of(
+                resource.getSchema(),
+                serializeProfile(elapsedTime, state, SimulationEngine::extractRealDynamics)));
 
         case "discrete" -> discreteProfiles.put(
             name,
             Pair.of(
-                state.resource().getSchema(),
+                resource.getSchema(),
                 serializeProfile(elapsedTime, state, Resource::serialize)));
 
         default ->

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ProfileSet.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ProfileSet.java
@@ -10,11 +10,11 @@ import java.util.List;
 import java.util.Map;
 
 public final record ProfileSet(
-    Map<String, List<Pair<Duration, RealDynamics>>> realProfiles,
+    Map<String, Pair<ValueSchema, List<Pair<Duration, RealDynamics>>>> realProfiles,
     Map<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>> discreteProfiles
 ) {
   public static ProfileSet of(
-      final Map<String, List<Pair<Duration, RealDynamics>>> realProfiles,
+      final Map<String, Pair<ValueSchema, List<Pair<Duration, RealDynamics>>>> realProfiles,
       final Map<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>> discreteProfiles
   ) {
     return new ProfileSet(realProfiles, discreteProfiles);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/RealProfile.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/RealProfile.java
@@ -2,8 +2,11 @@ package gov.nasa.jpl.aerie.merlin.server.models;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 
-public final record RealProfile(List<Pair<Duration, RealDynamics>> segments) {}
+public record RealProfile(
+    ValueSchema schema,
+    List<Pair<Duration, RealDynamics>> segments) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostProfilesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostProfilesAction.java
@@ -36,14 +36,14 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
   ) throws SQLException {
     final var resourceNames = new ArrayList<String>();
     final var resourceTypes = new ArrayList<Pair<String, ValueSchema>>();
-    final var realResourceType = Pair.<String, ValueSchema>of("real", null);
-    final var serializedRealResourceType = realProfileTypeP.unparse(realResourceType).toString();
     for (final var resource : realProfiles.keySet()) {
+      final var schema = realProfiles.get(resource).getLeft();
+      final var realResourceType = Pair.of("real", schema);
       resourceNames.add(resource);
       resourceTypes.add(realResourceType);
       this.statement.setLong(1, datasetId);
       this.statement.setString(2, resource);
-      this.statement.setString(3, serializedRealResourceType);
+      this.statement.setString(3, realProfileTypeP.unparse(realResourceType).toString());
       this.statement.addBatch();
     }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostProfilesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostProfilesAction.java
@@ -31,7 +31,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
 
   public Map<String, ProfileRecord> apply(
       final long datasetId,
-      final Map<String, List<Pair<Duration, RealDynamics>>> realProfiles,
+      final Map<String, Pair<ValueSchema, List<Pair<Duration, RealDynamics>>>> realProfiles,
       final Map<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>> discreteProfiles
   ) throws SQLException {
     final var resourceNames = new ArrayList<String>();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
@@ -37,9 +37,10 @@ public final class PostgresParsers {
   public static final JsonParser<Pair<String, ValueSchema>> realProfileTypeP =
       productP
           .field("type", literalP("real"))
+          .field("schema", valueSchemaP)
           .map(Iso.of(
-              type -> Pair.of("real", null),
-              $ -> Unit.UNIT));
+              untuple((type, schema) -> Pair.of("real", schema)),
+              $ -> tuple(Unit.UNIT, $.getRight())));
 
   static final JsonParser<Pair<String, ValueSchema>> profileTypeP =
       chooseP(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ProfileRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ProfileRepository.java
@@ -23,13 +23,16 @@ import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.se
       final long datasetId,
       final Window simulationWindow
   ) throws SQLException {
-    final var realProfiles = new HashMap<String, List<Pair<Duration, RealDynamics>>>();
+    final var realProfiles = new HashMap<String, Pair<ValueSchema, List<Pair<Duration, RealDynamics>>>>();
     final var discreteProfiles = new HashMap<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>>();
 
     final var profileRecords = getProfileRecords(connection, datasetId);
     for (final var record : profileRecords) {
       switch (record.type().getLeft()) {
-        case "real" -> realProfiles.put(record.name(), getRealProfileSegments(connection, record.datasetId(), record.id(), simulationWindow));
+        case "real" -> realProfiles.put(record.name(),
+                                        Pair.of(
+                                            record.type().getRight(),
+                                            getRealProfileSegments(connection, record.datasetId(), record.id(), simulationWindow)));
         case "discrete" -> discreteProfiles.put(record.name(),
                                                 Pair.of(
                                                     record.type().getRight(),
@@ -109,7 +112,7 @@ import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.se
             connection,
             datasetId,
             record,
-            realProfiles.get(resource),
+            realProfiles.get(resource).getRight(),
             simulationStart);
         case "discrete" -> postDiscreteProfileSegments(
             connection,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -145,10 +145,10 @@ public final class GetSimulationResultsAction {
         .orElseGet(Collections::emptyMap);
     final var realProfiles = new HashMap<String, LinearProfile>();
     for (final var entry : _realProfiles.entrySet()) {
-      final var pieces = new ArrayList<LinearProfilePiece>(entry.getValue().size());
+      final var pieces = new ArrayList<LinearProfilePiece>(entry.getValue().getRight().size());
 
       var elapsed = Duration.ZERO;
-      for (final var piece : entry.getValue()) {
+      for (final var piece : entry.getValue().getRight()) {
         final var extent = piece.getLeft();
         final var value = piece.getRight();
 

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -208,11 +208,11 @@ public class SimulationFacade {
    * @return a real profile suitable for a constraint model SimulationResult, starting from the zero duration
    */
   private LinearProfile convertToConstraintModelLinearProfile(
-      List<Pair<Duration, RealDynamics>> driverProfile)
+      Pair<ValueSchema, List<Pair<Duration, RealDynamics>>> driverProfile)
   {
-    final var pieces = new ArrayList<LinearProfilePiece>(driverProfile.size());
+    final var pieces = new ArrayList<LinearProfilePiece>(driverProfile.getRight().size());
     var elapsed = Duration.ZERO;
-    for (final var piece : driverProfile) {
+    for (final var piece : driverProfile.getRight()) {
       final var extent = piece.getLeft();
       final var value = piece.getRight();
       pieces.add(new LinearProfilePiece(Window.betweenClosedOpen(elapsed, elapsed.plus(extent)), value.initial, value.rate));

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationTest.java
@@ -37,7 +37,7 @@ public class IncrementalSimulationTest {
   public void simulationResultsTest(){
     //ensures that simulation results are generated until the end of the last act;
     var simResults = incrementalSimulationDriver.getSimulationResults();
-    assert(simResults.realProfiles.get("/utcClock").get(0).getLeft().isEqualTo(endOfLastAct));
+    assert(simResults.realProfiles.get("/utcClock").getRight().get(0).getLeft().isEqualTo(endOfLastAct));
     /*ensures that when current simulation results cover more than the asked period and that nothing has happened
     between two requests, the same results are returned*/
     var simResults2 = incrementalSimulationDriver.getSimulationResultsUpTo(Duration.of(7,SECONDS));


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1918
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Unlike discrete profiles, real profiles weren't posting their schemas in the `profile` table, just their type. RealProfiles were modified to keep track of their ValueSchema, and their JSON parser was changed to return the type and schema in a pair similar to how DiscreteProfiles are processed. They now appear like so in the database:

![image](https://user-images.githubusercontent.com/62574120/185239340-3da6f969-7b6a-4793-8deb-641c7c6ba712.png)


## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
The test `simulationResultsTest` in `IncrementalSimulationTest.java` was updated to reflect the change in the structure of RealProfiles. Besides that, the changes were ran and tested locally.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
There's an open discussion regarding setting up simulation end-to-end tests.