### PR TITLE
[AERIE-1997] Add custom PR logic action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,14 @@
+name: "Aerie PR Action"
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+jobs:
+  pr_logic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nasa-ammos/aerie-pr-action@main


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1997
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The following is a description of the underlying action, as this PR just brings [aerie-pr-action](https://github.com/NASA-AMMOS/aerie-pr-action) into the `aerie` repo.

`aerie-pr-action` currently does two main things. On PR creation it will automatically assign the PR opener as the assignee. This is done so that Github assignees are treated akin to Jira assignees, i.e. the person mainly responsible for commits, testing, and pushing the PR over the finish line.

Secondly, on label or unlabed triggers, this action will automatically give one PR approval to PRs labeled with either `documentation` or `hotfix`. This is done so that the PR will only need one additional approval from a "real human" i.e. codeowner, speeding up the merge velocity for small PRs.

Architecturally, this action was designed to be somewhat monolithic, i.e. it handles multiple paths of custom logic and switches based on the type of trigger event, e.g. `opened` or `labeled`. This was done so that we could easily add new logic to this action, e.g. commenting a welcome message with a link to `CONTRIBUTING.md` for PRs opened by new contributors, without having to create and add several new actions to `aerie` workflows.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Lots of manual verification. Testing framework has been setup for the underlying action, which can be added to as we add more custom logic. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None invalidated, although this new functionality could be documented in e.g. `CONTRIBUTING.md` for new open source contributors.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Any additional custom PR logic we desire can be added to this action.
