### PR TITLE
[HOTFIX] Scanning action detecting vulnerabilities shouldn't fail publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           image-ref: ${{ env.REGISTRY }}/nasa-ammos/aerie-merlin:${{ github.sha }}
           format: 'table'
-          exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
           severity: 'CRITICAL'
       - name: Push aerie-merlin Docker image
@@ -89,7 +89,7 @@ jobs:
         with:
           image-ref: ${{ env.REGISTRY }}/nasa-ammos/aerie-merlin-worker:${{ github.sha }}
           format: 'table'
-          exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
           severity: 'CRITICAL'
       - name: Push aerie-merlin-worker Docker image
@@ -116,7 +116,7 @@ jobs:
         with:
           image-ref: ${{ env.REGISTRY }}/nasa-ammos/aerie-scheduler:${{ github.sha }}
           format: 'table'
-          exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
           severity: 'CRITICAL'
       - name: Push aerie-scheduler Docker image
@@ -143,7 +143,7 @@ jobs:
         with:
           image-ref: ${{ env.REGISTRY }}/nasa-ammos/aerie-commanding:${{ github.sha }}
           format: 'table'
-          exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
           severity: 'CRITICAL'
       - name: Push aerie-commanding Docker image


### PR DESCRIPTION
This is done so that last minute dependency vulnerabilities don't
interfere with publishing. Scan results can (and should) still be viewed and acted
upon with a separate PR.

* **Tickets addressed:** AERIE-HOTFIX
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
As it currently stands, last minute transitive dependencies with vulnerabilities can fail our publish pipeline, and require dependency updates right before a point release.

This PR makes `trivy` exit with code 0 even if vulns are detected, so that we can continue publishing and fix dependency vulnerabilities at a more convenient time.

## Future work
AERIE-2042 will upload these scan results in the SARIF format as an artifact so we see failed scans in the Github Security page for the repo
