### PR TITLE
[AERIE 1815] Replace org.json dependency with javax.json.JsonObject dependency

### DIFF
--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -85,7 +85,6 @@ dependencies {
   implementation 'org.slf4j:slf4j-simple:1.7.26'
   implementation 'org.glassfish:javax.json:1.1.4'
   implementation 'org.apache.bcel:bcel:6.5.0'
-  implementation 'org.json:json:20220320'
 
   implementation 'com.impossibl.pgjdbc-ng:pgjdbc-ng:0.8.9'
   implementation 'com.zaxxer:HikariCP:5.0.1'

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -101,7 +101,6 @@ dependencies {
   implementation 'org.apache.commons:commons-lang3:3.12.0'
   implementation 'io.javalin:javalin:4.6.0'
   implementation 'org.eclipse:yasson:1.0.5'
-  implementation 'org.json:json:20220320'
   implementation 'org.apache.bcel:bcel:6.5.0'
 
   implementation 'com.impossibl.pgjdbc-ng:pgjdbc-ng:0.8.9'

--- a/scheduler/build.gradle
+++ b/scheduler/build.gradle
@@ -20,7 +20,6 @@ dependencies {
   compileOnly project(':contrib')
 
   implementation 'com.google.guava:guava:31.0.1-jre'
-  implementation 'org.json:json:20211205'
   implementation 'org.jfree:jfreechart:1.5.3'
   implementation 'com.google.code.gson:gson:2.8.9'
   implementation 'org.jgrapht:jgrapht-core:1.5.1'


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1815
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
When we write to the typescript compiling node process, we were using several calls to `org.json.JSONObject.quote()` to build up a string describing a JSON. This replaces those calls by using `javax.json` to build a `JsonObject` with the same entries. This also removes any references to `org.json` from the gradle files.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
- Ran the gradle tests
- Built the project and did a visual comparison between the output of both the original and the new techniques, confirming that they are functionally identical.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
We ought to consider giving `SchedulingDSLCompilationService.compileSchedulingGoalDSL()` and `ConstraintsDSLCompilationService.compileConstraintsDSL()` a timeout and/or the ability to be interrupted, because as of right now they block on `output.readline()` indefinitely until the node process outputs a new-line-terminated string.