### PR TITLE
[FIX] Fix scheduler

### DIFF
--- a/e2e-tests/src/utilities/gql.ts
+++ b/e2e-tests/src/utilities/gql.ts
@@ -44,6 +44,14 @@ const gql = {
     }
   `,
 
+  CREATE_ACTIVITY_DIRECTIVE: `#graphql
+    mutation CreateActivityDirective($activityDirectiveInsertInput: activity_directive_insert_input!) {
+      createActivityDirective: insert_activity_directive_one(object: $activityDirectiveInsertInput) {
+        id
+      }
+    }
+  `,
+
   CREATE_SCHEDULING_GOAL: `#graphql
     mutation CreateSchedulingGoal($goal: scheduling_goal_insert_input!) {
       insert_scheduling_goal_one(object: $goal) {

--- a/e2e-tests/src/utilities/requests.ts
+++ b/e2e-tests/src/utilities/requests.ts
@@ -140,7 +140,6 @@ const req = {
     const { id: goal_id } = insert_scheduling_goal_one;
     return goal_id
   },
-
   async insertSchedulingSpecification(request: APIRequestContext, specificationInput: SchedulingSpecInsertInput) {
     const data = await req.hasura(request, gql.INSERT_SCHEDULING_SPECIFICATION, {scheduling_spec: specificationInput});
     const { insert_scheduling_specification_one } = data;
@@ -190,6 +189,13 @@ const req = {
       endTime: time.getDoyTimeFromDuration(startTime, plan.duration),
       startTime: time.getDoyTime(startTime),
     };
+  },
+
+  async insertActivity(request: APIRequestContext, activityInsertInput: ActivityInsertInput){
+    const data = await req.hasura(request, gql.CREATE_ACTIVITY_DIRECTIVE, { activityDirectiveInsertInput: activityInsertInput })
+    const { createActivityDirective } = data;
+    const {id : idCreatedActivity} = createActivityDirective;
+    return idCreatedActivity;
   },
 
 };

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -370,7 +370,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements PlanService.
       final Plan plan,
       final Map<ActivityInstance, GoalId> activityToGoalId
   )
-  throws IOException, NoSuchPlanException, NoSuchActivityInstanceException, PlanServiceException
+  throws IOException, NoSuchPlanException, PlanServiceException
   {
     final var ids = new HashMap<ActivityInstance, ActivityInstanceId>();
     //creation are done in batch as that's what the scheduler does the most
@@ -390,8 +390,8 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements PlanService.
         final var schedulerActIntoMerlinAct = new MerlinActivityInstance(activity.getType().getName(), activity.getStartTime(), activity.getArguments());
         final var activityInstanceId = idsFromInitialPlan.get(activity.getId());
         if (!schedulerActIntoMerlinAct.equals(actFromInitialPlan.get())) {
-          //update if it has changed
-          updateActivityDirective(planId, schedulerActIntoMerlinAct, activityInstanceId, activityToGoalId.get(activity));
+          throw new PlanServiceException("The scheduler should not be updating activity instances");
+          //updateActivityDirective(planId, schedulerActIntoMerlinAct, activityInstanceId, activityToGoalId.get(activity));
         }
         ids.put(activity, activityInstanceId);
       } else {
@@ -402,8 +402,8 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements PlanService.
     final var actsFromNewPlan = plan.getActivitiesById();
     for (final var idActInInitialPlan : idsFromInitialPlan.entrySet()) {
       if (!actsFromNewPlan.containsKey(idActInInitialPlan.getKey())) {
-        //activity has been removed by the scheduler, delete it
-        deleteActivityDirective(idActInInitialPlan.getValue());
+        throw new PlanServiceException("The scheduler should not be deleting activity instances");
+        //deleteActivityDirective(idActInInitialPlan.getValue());
       }
     }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/PlanService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/PlanService.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.scheduler.server.services;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InvalidArgumentsException;
 import gov.nasa.jpl.aerie.scheduler.model.ActivityInstance;
 import gov.nasa.jpl.aerie.scheduler.model.Plan;
 import gov.nasa.jpl.aerie.scheduler.model.Problem;
@@ -50,7 +51,7 @@ public interface PlanService {
      * @throws NoSuchPlanException when the plan container does not exist in aerie
      */
     MerlinPlan getPlanActivityDirectives(final PlanMetadata planMetadata, final Problem mission)
-    throws IOException, NoSuchPlanException, PlanServiceException, InvalidJsonException;
+    throws IOException, NoSuchPlanException, PlanServiceException, InvalidJsonException, InvalidArgumentsException;
 
     /**
      * confirms that the specified plan exists in the aerie database, throwing exception if not

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/model/ActivityInstance.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/model/ActivityInstance.java
@@ -380,7 +380,8 @@ public class ActivityInstance {
    * @param arguments a name/value map of arguments
    */
   public void setArguments(Map<String, SerializedValue> arguments) {
-    this.arguments = arguments;
+    this.arguments.clear();
+    this.arguments.putAll(arguments);
   }
   /**
    * Sets all the variable arguments of the activity instance
@@ -388,7 +389,8 @@ public class ActivityInstance {
    * @param variableArguments a name/value map of arguments
    */
   public void setVariableArguments(Map<String, VariableArgumentComputer> variableArguments) {
-    this.variableArguments = variableArguments;
+    this.variableArguments.clear();
+    this.variableArguments.putAll(variableArguments);
   }
 
   /**


### PR DESCRIPTION
* **Tickets addressed:** FIX
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
While trying to reproduce AERIE-1904, I found two issues that make the scheduler currently broken :
- it was possible to set the arguments of an activity instance by directly assigning to a map. Thus it was possible to pass an immutable map. We expect these maps to be mutable. 
- when the user creates an activity with a controllable duration and does not set its duration, the scheduler was updating its duration after running scheduling because it was not pulling effective arguments. 

Here is what I (with help from @mattdailis) have done (4 commits):
- clear and putall arguments of activity instance instead of copying the reference of passed maps. 
- use effective arguments in the scheduler which gets default values in case the user has not set some 
- prevent the scheduler from updating and deleting activities. Originally, the intent was to be general but it is not supposed to be supported yet. 
- add a test for this particular case in the e2e-tests 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Manual testing of the scheduler via the aerie-ui + a new test in e2e-tests.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None.