### PR TITLE
[AERIE-1982] feat: add user sequence table

### DIFF
--- a/command-expansion-server/sql/commanding/init.sql
+++ b/command-expansion-server/sql/commanding/init.sql
@@ -11,5 +11,6 @@ begin;
   \ir tables/activity_instance_commands.sql
   \ir tables/sequence.sql
   \ir tables/sequence_to_simulated_activity.sql
+  \ir tables/user_sequence.sql
 
 end;

--- a/command-expansion-server/sql/commanding/tables/user_sequence.sql
+++ b/command-expansion-server/sql/commanding/tables/user_sequence.sql
@@ -1,0 +1,39 @@
+create table user_sequence (
+  authoring_command_dict_id integer not null,
+  created_at timestamptz not null default now(),
+  definition text not null,
+  id integer generated always as identity,
+  name text not null,
+  owner text not null default 'unknown',
+  updated_at timestamptz not null default now(),
+
+  constraint user_sequence_primary_key primary key (id)
+);
+
+comment on column user_sequence.authoring_command_dict_id is e''
+  'Command dictionary the user sequence was created with.';
+comment on column user_sequence.created_at is e''
+  'Time the user sequence was created.';
+comment on column user_sequence.definition is e''
+  'The user sequence definition string.';
+comment on column user_sequence.id is e''
+  'ID of the user sequence.';
+comment on column user_sequence.name is e''
+  'Human-readable name of the user sequence.';
+comment on column user_sequence.owner is e''
+  'Username of the user sequence owner.';
+comment on column user_sequence.updated_at is e''
+  'Time the user sequence was last updated.';
+
+create or replace function user_sequence_set_updated_at()
+returns trigger
+security definer
+language plpgsql as $$begin
+  new.updated_at = now();
+  return new;
+end$$;
+
+create trigger set_timestamp
+before update on user_sequence
+for each row
+execute function user_sequence_set_updated_at();

--- a/deployment/hasura/metadata/databases/AerieCommanding/tables/public_user_sequence.yaml
+++ b/deployment/hasura/metadata/databases/AerieCommanding/tables/public_user_sequence.yaml
@@ -1,0 +1,13 @@
+table:
+  name: user_sequence
+  schema: public
+object_relationships:
+- name: command_dictionary
+  using:
+    manual_configuration:
+      remote_table:
+        schema: public
+        name: command_dictionary
+      insertion_order: null
+      column_mapping:
+        authoring_command_dict_id: id

--- a/deployment/hasura/metadata/databases/AerieCommanding/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieCommanding/tables/tables.yaml
@@ -8,3 +8,4 @@
 - "!include public_rule_expansion_set_view.yaml"
 - "!include public_sequence.yaml"
 - "!include public_sequence_to_simulated_activity.yaml"
+- "!include public_user_sequence.yaml"


### PR DESCRIPTION
* **Tickets addressed:** [AERIE-1982](https://jira.jpl.nasa.gov/browse/AERIE-1982)
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

- Add first-draft of `user_sequence` table for storing user-defined sequences for 0.13.0

## Verification

Test the `user_sequence` table is added to the commanding database

## Future work

Possible renaming:

- `aerie_commanding` database to `aerie_sequencing`
- `sequence` table to `expansion_sequence`
