### PR TITLE
[REFACTOR] Move Scheduling Goal compilation out of Database Driver

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
@@ -77,9 +77,11 @@ public final class SchedulerAppDriver {
         "scheduler-agent",
         new SynchronousSchedulerAgent(specificationService,
                                       merlinService,
+                                      merlinService,
                                       config.merlinFileStore(),
                                       config.missionRuleJarPath(),
-                                      config.outputMode()));
+                                      config.outputMode(),
+                                      schedulingDSLCompilationService));
     final var schedulerService = new CachedSchedulerService(stores.results(), scheduleAgent);
     final var scheduleAction = new ScheduleAction(specificationService, schedulerService);
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
@@ -19,7 +19,6 @@ import gov.nasa.jpl.aerie.scheduler.server.services.CachedSchedulerService;
 import gov.nasa.jpl.aerie.scheduler.server.services.GenerateSchedulingLibAction;
 import gov.nasa.jpl.aerie.scheduler.server.services.GraphQLMerlinService;
 import gov.nasa.jpl.aerie.scheduler.server.services.LocalSpecificationService;
-import gov.nasa.jpl.aerie.scheduler.server.services.MissionModelService;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleAction;
 import gov.nasa.jpl.aerie.scheduler.server.services.SchedulingDSLCompilationService;
 import gov.nasa.jpl.aerie.scheduler.server.services.SynchronousSchedulerAgent;
@@ -69,7 +68,7 @@ public final class SchedulerAppDriver {
 
     Runtime.getRuntime().addShutdownHook(new Thread(schedulingDSLCompilationService::close));
 
-    final var stores = loadStores(config, schedulingDSLCompilationService, merlinService);
+    final var stores = loadStores(config);
 
     //create objects in each service abstraction layer (mirroring MerlinApp)
     final var specificationService = new LocalSpecificationService(stores.specifications());
@@ -116,9 +115,7 @@ public final class SchedulerAppDriver {
   private record Stores(SpecificationRepository specifications, ResultsCellRepository results) { }
 
   private static Stores loadStores(
-      final AppConfiguration config,
-      final SchedulingDSLCompilationService schedulingDSLCompilationService,
-      final MissionModelService missionModelService) {
+      final AppConfiguration config) {
     final var store = config.store();
     if (store instanceof final PostgresStore pgStore) {
       final var pgDataSource = new PGDataSource();
@@ -135,7 +132,7 @@ public final class SchedulerAppDriver {
       final var hikariDataSource = new HikariDataSource(hikariConfig);
 
       return new Stores(
-          new PostgresSpecificationRepository(hikariDataSource, schedulingDSLCompilationService, missionModelService),
+          new PostgresSpecificationRepository(hikariDataSource),
           new PostgresResultsCellRepository(hikariDataSource));
     } else if (store instanceof InMemoryStore) {
       final var inMemorySchedulerRepository = new InMemorySpecificationRepository();

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GoalRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GoalRecord.java
@@ -1,3 +1,3 @@
 package gov.nasa.jpl.aerie.scheduler.server.models;
 
-public record GoalRecord(GoalId id, SchedulingDSL.GoalSpecifier definition, boolean enabled) {}
+public record GoalRecord(GoalId id, GoalSource definition, boolean enabled) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GoalSource.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GoalSource.java
@@ -1,0 +1,6 @@
+package gov.nasa.jpl.aerie.scheduler.server.models;
+
+/**
+ * @param source The typescript code describing this goal.
+ */
+public record GoalSource(String source) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
@@ -1,7 +1,6 @@
 package gov.nasa.jpl.aerie.scheduler.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchSpecificationException;
-import gov.nasa.jpl.aerie.scheduler.server.exceptions.SpecificationLoadException;
 import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
 import gov.nasa.jpl.aerie.scheduler.server.models.GoalRecord;
 import gov.nasa.jpl.aerie.scheduler.server.models.GoalSource;
@@ -9,9 +8,7 @@ import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
 import gov.nasa.jpl.aerie.scheduler.server.models.Specification;
 import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
 import gov.nasa.jpl.aerie.scheduler.server.remotes.SpecificationRepository;
-import gov.nasa.jpl.aerie.scheduler.server.services.MissionModelService;
 import gov.nasa.jpl.aerie.scheduler.server.services.RevisionData;
-import gov.nasa.jpl.aerie.scheduler.server.services.SchedulingDSLCompilationService;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
@@ -19,18 +16,14 @@ import java.util.List;
 
 public final class PostgresSpecificationRepository implements SpecificationRepository {
   private final DataSource dataSource;
-  private final SchedulingDSLCompilationService schedulingDSLCompilationService;
-  private final MissionModelService missionModelService;
 
-  public PostgresSpecificationRepository(final DataSource dataSource, final SchedulingDSLCompilationService schedulingDSLCompilationService, final MissionModelService missionModelService) {
+  public PostgresSpecificationRepository(final DataSource dataSource) {
     this.dataSource = dataSource;
-    this.schedulingDSLCompilationService = schedulingDSLCompilationService;
-    this.missionModelService = missionModelService;
   }
 
   @Override
   public Specification getSpecification(final SpecificationId specificationId)
-  throws NoSuchSpecificationException, SpecificationLoadException
+  throws NoSuchSpecificationException
   {
     final SpecificationRecord specificationRecord;
     final PlanId planId;

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -56,6 +56,7 @@ import java.util.stream.Collectors;
  * agent that handles posed scheduling requests by blocking the requester thread until scheduling is complete
  *
  * @param planService interface for querying plan details from merlin
+ * @param missionModelService interface for querying mission model details from merlin
  * @param modelJarsDir path to parent directory for mission model jars (interim backdoor jar file access)
  * @param goalsJarPath path to jar file to load scheduling goals from (interim solution for user input goals)
  * @param outputMode how the scheduling output should be returned to aerie (eg overwrite or new container)
@@ -64,16 +65,20 @@ import java.util.stream.Collectors;
 public record SynchronousSchedulerAgent(
     SpecificationService specificationService,
     PlanService.OwnerRole planService,
+    MissionModelService missionModelService,
     Path modelJarsDir,
     Path goalsJarPath,
-    PlanOutputMode outputMode
+    PlanOutputMode outputMode,
+    SchedulingDSLCompilationService schedulingDSLCompilationService
 )
     implements SchedulerAgent
 {
   public SynchronousSchedulerAgent {
     Objects.requireNonNull(planService);
+    Objects.requireNonNull(missionModelService);
     Objects.requireNonNull(modelJarsDir);
     Objects.requireNonNull(goalsJarPath);
+    Objects.requireNonNull(schedulingDSLCompilationService);
   }
 
   /**

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -872,9 +872,11 @@ public class SchedulingIntegrationTests {
     final var agent = new SynchronousSchedulerAgent(
         specificationService,
         mockMerlinService,
+        mockMerlinService,
         desc.libPath(),
         Path.of(""),
-        PlanOutputMode.UpdateInputPlanWithNewActivities);
+        PlanOutputMode.UpdateInputPlanWithNewActivities,
+        schedulingDSLCompiler);
     // Scheduling Goals -> Scheduling Specification
     final var writer = new MockResultsProtocolWriter();
     agent.schedule(new ScheduleRequest(new SpecificationId(1L), $ -> RevisionData.MatchResult.success()), writer);

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -10,6 +10,7 @@ import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
 import gov.nasa.jpl.aerie.scheduler.server.config.PlanOutputMode;
 import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
 import gov.nasa.jpl.aerie.scheduler.server.models.GoalRecord;
+import gov.nasa.jpl.aerie.scheduler.server.models.GoalSource;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
 import gov.nasa.jpl.aerie.scheduler.server.models.Specification;
 import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
@@ -854,12 +855,7 @@ public class SchedulingIntegrationTests {
     final var goalsByPriority = new ArrayList<GoalRecord>();
 
     for (final var goal : goals) {
-      final var goalResult = schedulingDSLCompiler.compileSchedulingGoalDSL(mockMerlinService, planId, goal.definition());
-      if (goalResult instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success s) {
-        goalsByPriority.add(new GoalRecord(goal.goalId(), s.goalSpecifier(), goal.enabled()));
-      } else if (goalResult instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error e) {
-        fail(e.toString());
-      }
+      goalsByPriority.add(new GoalRecord(goal.goalId(), new GoalSource(goal.definition()), goal.enabled()));
     }
     final var specificationService = new MockSpecificationService(Map.of(new SpecificationId(1L), new Specification(
         planId,


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Scheduling Goals (defined in typescript) are compiled into Java `GoalSpecifier` objects. Currently, this compilation takes place in the `PostgresSpecificationRepository`'s `getSpecification` method. This is a bit awkward - it's quite surprising to learn that your repository's `getSpecification` method is doing much more than simply loading the scheduling specification. 

This PR introduces the concept of `GoalSource`, which represents the as-yet-uncompiled typescript code. (It could just as easily have been a string, but I believe the name provides additional clarity. Feel free to push back on that if you think otherwise).

Review by commit - I've done my best to make each commit as easy to review as possible. Let me know if you find otherwise!
1. Simple variable renaming for clarity (helps disambiguate "planService" from "missionModelService")
2. Introduces GoalSource and uses it locally in PostgresSpecificationRepository
3. Wires up SynchronousSchedulerAgent to be able to use the compiler
4. Moves the code that calls the compiler into the scheduler agent
5. Cleans up unused references to the compiler in PostgresSpecificationRepository

This change was first discussed here: https://github.com/NASA-AMMOS/aerie/pull/213#issuecomment-1152596142

This is the first of two PRs towards Global Scheduling Conditions.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
If the integration and e2e tests pass on this PR, I consider that sufficient verification for this change.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
This is an internal refactoring, and should not affect any user-facing documentation. We currently lack any developer-facing documentation... perhaps I should remedy that?

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Next steps:
- Make it possible to specify scheduling conditions and have them be compiled in a similar manner.
