### PR TITLE
[AERIE-1958] update example tables to reflect Ag-Grid definitions

### DIFF
--- a/deployment/postgres-init-db/data/ui/views/example_0.json
+++ b/deployment/postgres-init-db/data/ui/views/example_0.json
@@ -3,11 +3,12 @@
     "activityTables": [
       {
         "columnDefs": [
-          { "field": "id", "name": "ID", "sortable": true },
-          { "field": "type", "name": "Type", "sortable": true },
-          { "field": "start_time", "name": "Start Time", "sortable": true },
-          { "field": "duration", "name": "Duration", "sortable": true }
+          { "field": "id", "filter": "agTextColumnFilter", "headerName": "ID", "sortable": true, "resizable": true },
+          { "field": "type", "filter": "agTextColumnFilter", "headerName": "Type", "sortable": true, "resizable": true },
+          { "field": "start_time", "filter": "agTextColumnFilter", "headerName": "Start Time", "sortable": true, "resizable": true },
+          { "field": "duration", "filter": "agTextColumnFilter", "headerName": "Duration", "sortable": true, "resizable": true }
         ],
+        "columnStates": [],
         "id": 0
       }
     ],

--- a/deployment/postgres-init-db/data/ui/views/example_1.json
+++ b/deployment/postgres-init-db/data/ui/views/example_1.json
@@ -1,23 +1,7 @@
 {
   "plan": {
-    "activityTables": [
-      {
-        "columnDefs": [
-          { "field": "id", "name": "ID", "sortable": true },
-          { "field": "type", "name": "Type", "sortable": true },
-          { "field": "start_time", "name": "Start Time", "sortable": true },
-          { "field": "duration", "name": "Duration", "sortable": true }
-        ],
-        "id": 0
-      }
-    ],
-    "iFrames": [
-      {
-        "id": 0,
-        "src": "https://iss-sim.spacex.com/",
-        "title": "ISS-Docking-Simulator"
-      }
-    ],
+    "activityTables": [],
+    "iFrames": [],
     "layout": {
       "gridName": "View",
       "id": 0,


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1958
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
In order to support saving/loading user saved ActivityTable configurations, this change just updates the example JSON containing the default ActivityTable configuration to match what is now expected in the UI by the Ag-Grid library.

## Verification
Locally verified that the Aerie UI was able to load the updated table configuration.

## Documentation
None.

## Future work
None.
