### PR TITLE
[AERIE-1967] Global Scheduling Conditions

### DIFF
--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_condition.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_condition.yaml
@@ -1,0 +1,3 @@
+table:
+  name: scheduling_condition
+  schema: public

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_specification_conditions.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_specification_conditions.yaml
@@ -1,0 +1,10 @@
+table:
+  name: scheduling_specification_conditions
+  schema: public
+object_relationships:
+- name: condition
+  using:
+    foreign_key_constraint_on: condition_id
+- name: specification
+  using:
+    foreign_key_constraint_on: specification_id

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/tables.yaml
@@ -8,3 +8,5 @@
 - "!include public_scheduling_goal_analysis.yaml"
 - "!include public_scheduling_goal_analysis_created_activities.yaml"
 - "!include public_scheduling_goal_analysis_satisfying_activities.yaml"
+- "!include public_scheduling_condition.yaml"
+- "!include public_scheduling_specification_conditions.yaml"

--- a/merlin-server/constraints-dsl-compiler/src/main.ts
+++ b/merlin-server/constraints-dsl-compiler/src/main.ts
@@ -42,14 +42,26 @@ async function handleRequest(data: Buffer) {
       missionModelGeneratedCode: string;
     };
 
-    const result = await codeRunner.executeUserCode<[], Constraint>(constraintCode, [], 'Constraint', [], 10000, [
-      ts.createSourceFile('constraints-ast.ts', constraintsAST, compilerTarget),
-      ts.createSourceFile('constraints-edsl-fluent-api.ts', constraintsEDSL, compilerTarget),
-      ts.createSourceFile('mission-model-generated-code.ts', missionModelGeneratedCode, compilerTarget),
-    ]);
+    const additionalSourceFiles: { 'filename': string, 'contents': string}[] = [
+      { 'filename': 'constraints-ast.ts', 'contents': constraintsAST },
+      { 'filename': 'constraints-edsl-fluent-api.ts', 'contents': constraintsEDSL },
+      { 'filename': 'mission-model-generated-code.ts', 'contents': missionModelGeneratedCode },
+    ];
+
+    const outputType = 'Constraint';
+
+    const result = await codeRunner.executeUserCode<[], Constraint>(
+        constraintCode,
+        [],
+        outputType,
+        [],
+        10000,
+        additionalSourceFiles.map(({filename, contents}) => ts.createSourceFile(filename, contents, compilerTarget))
+    );
 
     if (result.isErr()) {
-      process.stdout.write('error\n' + JSON.stringify(result.unwrapErr().map(err => err.toJSON())) + '\n');
+      process.stdout.write('error\n')
+      process.stdout.write(JSON.stringify(result.unwrapErr().map(err => err.toJSON())) + '\n');
       lineReader.once('line', handleRequest);
       return;
     }
@@ -58,11 +70,11 @@ async function handleRequest(data: Buffer) {
     if (stringified === undefined) {
       throw Error(JSON.stringify(result.unwrap()) + ' was not JSON serializable');
     }
-    process.stdout.write('success\n' + stringified + '\n');
+    process.stdout.write('success\n')
+    process.stdout.write(stringified + '\n');
   } catch (error: any) {
-    process.stdout.write(
-      'panic\n' + JSON.stringify(error.stack ?? error.message) + ' attempted to handle: ' + data.toString() + '\n',
-    );
+    process.stdout.write('panic\n');
+    process.stdout.write(JSON.stringify(error.stack ?? error.message) + ' attempted to handle: ' + data.toString() + '\n');
   }
   lineReader.once('line', handleRequest);
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
@@ -56,6 +56,7 @@ public class ConstraintsDSLCompilationService {
     final JsonObject messageJson = Json.createObjectBuilder()
         .add("constraintCode", constraintTypescript)
         .add("missionModelGeneratedCode", missionModelGeneratedCode)
+        .add("expectedReturnType", "Constraint")
         .build();
     /*
      * PROTOCOL:

--- a/scheduler-server/sql/scheduler/init.sql
+++ b/scheduler-server/sql/scheduler/init.sql
@@ -12,5 +12,6 @@ begin;
   \ir tables/scheduling_goal_analysis.sql
   \ir tables/scheduling_goal_analysis_created_activities.sql
   \ir tables/scheduling_goal_analysis_satisfying_activities.sql
-
+  \ir tables/scheduling_condition.sql
+  \ir tables/scheduling_specification_conditions.sql
 end;

--- a/scheduler-server/sql/scheduler/tables/scheduling_condition.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_condition.sql
@@ -1,0 +1,54 @@
+create table scheduling_condition (
+  id integer generated always as identity,
+  revision integer not null default 0,
+  name text not null,
+  definition text not null,
+
+  model_id integer not null,
+  description text null,
+  author text null,
+  last_modified_by text null,
+  created_date timestamptz not null default now(),
+  modified_date timestamptz not null default now(),
+
+  constraint scheduling_condition_synthetic_key
+    primary key (id)
+);
+
+comment on table scheduling_condition is e''
+  'A condition restricting scheduling of a plan.';
+comment on column scheduling_condition.id is e''
+  'The synthetic identifier for this scheduling condition.';
+comment on column scheduling_condition.revision is e''
+  'A monotonic clock that ticks for every change to this scheduling condition.';
+comment on column scheduling_condition.definition is e''
+  'The source code for a Typescript module defining this scheduling condition';
+comment on column scheduling_condition.model_id is e''
+  'The mission model used to which this scheduling condition is associated.';
+comment on column scheduling_condition.name is e''
+  'A short human readable name for this condition';
+comment on column scheduling_condition.description is e''
+  'A longer text description of this scheduling condition.';
+comment on column scheduling_condition.author is e''
+  'The original user who authored this scheduling condition.';
+comment on column scheduling_condition.last_modified_by is e''
+  'The last user who modified this scheduling condition.';
+comment on column scheduling_condition.created_date is e''
+  'The date this scheduling condition was created.';
+comment on column scheduling_condition.modified_date is e''
+  'The date this scheduling condition was last modified.';
+
+create function update_logging_on_update_scheduling_condition()
+  returns trigger
+  security definer
+language plpgsql as $$begin
+  new.revision = old.revision + 1;
+  new.modified_date = now();
+return new;
+end$$;
+
+create trigger update_logging_on_update_scheduling_condition_trigger
+  before update on scheduling_condition
+  for each row
+  when (pg_trigger_depth() < 1)
+  execute function update_logging_on_update_scheduling_condition();

--- a/scheduler-server/sql/scheduler/tables/scheduling_specification_conditions.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_specification_conditions.sql
@@ -1,0 +1,25 @@
+create table scheduling_specification_conditions (
+  specification_id integer not null,
+  condition_id integer not null,
+  enabled boolean default true,
+
+  constraint scheduling_specification_conditions_primary_key
+    primary key (specification_id, condition_id),
+  constraint scheduling_specification_conditions_references_scheduling_specification
+    foreign key (specification_id)
+      references scheduling_specification
+      on update cascade
+      on delete cascade,
+  constraint scheduling_specification_conditions_references_scheduling_conditions
+    foreign key (condition_id)
+      references scheduling_condition
+      on update cascade
+      on delete cascade
+);
+
+comment on table scheduling_specification_conditions is e''
+  'A join table associating scheduling specifications with scheduling conditions.';
+comment on column scheduling_specification_conditions.specification_id is e''
+  'The ID of the scheduling specification a scheduling goal is associated with.';
+comment on column scheduling_specification_conditions.condition_id is e''
+  'The ID of the condition a scheduling specification is associated with.';

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GlobalSchedulingConditionRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GlobalSchedulingConditionRecord.java
@@ -1,0 +1,9 @@
+package gov.nasa.jpl.aerie.scheduler.server.models;
+
+import gov.nasa.jpl.aerie.scheduler.model.ActivityTypeList;
+
+public record GlobalSchedulingConditionRecord(
+    GlobalSchedulingConditionSource source,
+    ActivityTypeList activityTypes,
+    boolean enabled
+) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GlobalSchedulingConditionSource.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GlobalSchedulingConditionSource.java
@@ -1,0 +1,6 @@
+package gov.nasa.jpl.aerie.scheduler.server.models;
+
+/**
+ * @param source The typescript code describing this global scheduling condition.
+ */
+public record GlobalSchedulingConditionSource(String source) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/Specification.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/Specification.java
@@ -12,5 +12,6 @@ public record Specification(
     Timestamp horizonStartTimestamp,
     Timestamp horizonEndTimestamp,
     Map<String, SerializedValue> simulationArguments,
-    boolean analysisOnly
+    boolean analysisOnly,
+    List<GlobalSchedulingConditionRecord> globalSchedulingConditions
 ) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetSpecificationConditionsAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetSpecificationConditionsAction.java
@@ -1,0 +1,52 @@
+package gov.nasa.jpl.aerie.scheduler.server.remotes.postgres;
+
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/*package-local*/ final class GetSpecificationConditionsAction implements AutoCloseable {
+  private final @Language("SQL") String sql = """
+    select
+      s.condition_id,
+      s.enabled,
+      c.name,
+      c.definition,
+      c.revision
+    from scheduling_specification_conditions as s
+      left join scheduling_condition as c
+      on s.specification_id = ?
+      and s.condition_id = c.id
+    """;
+
+  private final PreparedStatement statement;
+
+  public GetSpecificationConditionsAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public List<PostgresSchedulingConditionRecord> get(final long specificationId) throws SQLException {
+    this.statement.setLong(1, specificationId);
+    final var resultSet = this.statement.executeQuery();
+
+    final var goals = new ArrayList<PostgresSchedulingConditionRecord>();
+    while (resultSet.next()) {
+      final var id = resultSet.getLong("condition_id");
+      final var revision = resultSet.getLong("revision");
+      final var name = resultSet.getString("name");
+      final var definition = resultSet.getString("definition");
+      final var enabled = resultSet.getBoolean("enabled");
+      goals.add(new PostgresSchedulingConditionRecord(id, revision, name, definition, enabled));
+    }
+
+    return goals;
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSchedulingConditionRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSchedulingConditionRecord.java
@@ -1,0 +1,9 @@
+package gov.nasa.jpl.aerie.scheduler.server.remotes.postgres;
+
+public record PostgresSchedulingConditionRecord(
+    long id,
+    long revision,
+    String name,
+    String definition,
+    boolean enabled
+) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
@@ -57,7 +57,8 @@ public final class PostgresSpecificationRepository implements SpecificationRepos
         specificationRecord.horizonStartTimestamp(),
         specificationRecord.horizonEndTimestamp(),
         specificationRecord.simulationArguments(),
-        specificationRecord.analysisOnly()
+        specificationRecord.analysisOnly(),
+        List.of() // TODO this will be loaded from the database in an upcoming commit
     );
   }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationService.java
@@ -1,5 +1,7 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.constraints.tree.Expression;
 import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.scheduler.server.http.InvalidEntityException;
@@ -18,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import static gov.nasa.jpl.aerie.constraints.json.ConstraintParsers.windowsExpressionP;
 
 public class SchedulingDSLCompilationService {
 
@@ -44,6 +48,10 @@ public class SchedulingDSLCompilationService {
 
   public void close() {
     this.nodeProcess.destroy();
+  }
+
+  public SchedulingDSLCompilationResult<Expression<Windows>> compileGlobalSchedulingCondition(final MissionModelService missionModelService, final PlanId planId, final String conditionTypescript) {
+    return compile(missionModelService, planId, conditionTypescript, windowsExpressionP, "Windows");
   }
 
   /**

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationService.java
@@ -65,6 +65,7 @@ public class SchedulingDSLCompilationService {
         .add("goalCode", goalTypescript)
         .add("schedulerGeneratedCode", schedulerGeneratedCode)
         .add("constraintsGeneratedCode", constraintsGeneratedCode)
+        .add("expectedReturnType", "Goal")
         .build();
 
     /*

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -136,9 +136,9 @@ public record SynchronousSchedulerAgent(
             planMetadata.planId(),
             goalRecord.definition(),
             schedulingDSLCompilationService);
-        if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
-          compiledGoals.add(Pair.of(goalRecord.id(), r.goalSpecifier()));
-        } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+        if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success<SchedulingDSL.GoalSpecifier> r) {
+          compiledGoals.add(Pair.of(goalRecord.id(), r.value()));
+        } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
           failedGoals.add(Pair.of(goalRecord.id(), r.errors()));
         } else {
           throw new Error("Unhandled variant of %s: %s".formatted(SchedulingDSLCompilationService.SchedulingDSLCompilationResult.class.getSimpleName(), result));
@@ -198,7 +198,7 @@ public record SynchronousSchedulerAgent(
     }
   }
 
-  private static SchedulingDSLCompilationService.SchedulingDSLCompilationResult compileGoalDefinition(
+  private static SchedulingDSLCompilationService.SchedulingDSLCompilationResult<SchedulingDSL.GoalSpecifier> compileGoalDefinition(
       final MissionModelService missionModelService,
       final PlanId planId,
       final GoalSource goalDefinition,

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -1,5 +1,7 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.constraints.tree.Expression;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelLoader;
@@ -13,6 +15,7 @@ import gov.nasa.jpl.aerie.scheduler.constraints.scheduling.GlobalConstraint;
 import gov.nasa.jpl.aerie.scheduler.goals.Goal;
 import gov.nasa.jpl.aerie.scheduler.model.ActivityInstance;
 import gov.nasa.jpl.aerie.scheduler.model.ActivityType;
+import gov.nasa.jpl.aerie.scheduler.model.SchedulingCondition;
 import gov.nasa.jpl.aerie.scheduler.model.Plan;
 import gov.nasa.jpl.aerie.scheduler.model.PlanInMemory;
 import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
@@ -120,7 +123,28 @@ public record SynchronousSchedulerAgent(
       problem.setInitialPlan(loadedPlanComponents.schedulerPlan());
 
       //apply constraints/goals to the problem
-      loadConstraints(planMetadata, schedulerMissionModel.missionModel()).forEach(problem::add);
+      final var compiledGlobalSchedulingConditions = new ArrayList<SchedulingCondition>();
+      final var failedGlobalSchedulingConditions = new ArrayList<List<SchedulingCompilationError.UserCodeError>>();
+      specification.globalSchedulingConditions().forEach($ -> {
+        if (!$.enabled()) return;
+        final var result = schedulingDSLCompilationService.compileGlobalSchedulingCondition(
+            missionModelService,
+            planMetadata.planId(),
+            $.source().source());
+        if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success<Expression<Windows>> r) {
+          compiledGlobalSchedulingConditions.add(new SchedulingCondition(r.value(), $.activityTypes()));
+        } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<Expression<Windows>> r) {
+          failedGlobalSchedulingConditions.add(r.errors());
+        } else {
+          throw new Error("Unhandled variant of %s: %s".formatted(SchedulingDSLCompilationService.SchedulingDSLCompilationResult.class.getSimpleName(), result));
+        }
+      });
+
+      if (!failedGlobalSchedulingConditions.isEmpty()) {
+        writer.failWith(failedGlobalSchedulingConditions.toString());
+      }
+
+      compiledGlobalSchedulingConditions.forEach(problem::add);
 
       //TODO: workaround to get the Cardinality goal working. To remove once we have global constraints in the eDSL
       problem.getActivityTypes().forEach(at -> problem.add(BinaryMutexConstraint.buildMutexConstraint(at, at)));

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
 import gov.nasa.jpl.aerie.constraints.tree.GreaterThan;
+import gov.nasa.jpl.aerie.constraints.tree.LessThan;
 import gov.nasa.jpl.aerie.constraints.tree.LongerThan;
 import gov.nasa.jpl.aerie.constraints.tree.RealResource;
 import gov.nasa.jpl.aerie.constraints.tree.RealValue;
@@ -57,8 +58,7 @@ class SchedulingDSLCompilationServiceTests {
   @Test
   void testSchedulingDSL_basic()
   {
-    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult result;
-    result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+    final var result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
         missionModelService,
         PLAN_ID, """
                 export default function myGoal() {
@@ -86,9 +86,9 @@ class SchedulingDSLCompilationServiceTests {
         ),
         Duration.HOUR
     );
-    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
-      assertEquals(expectedGoalDefinition, r.goalSpecifier());
-    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success<SchedulingDSL.GoalSpecifier> r) {
+      assertEquals(expectedGoalDefinition, r.value());
+    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
       fail(r.toString());
     }
   }
@@ -96,8 +96,7 @@ class SchedulingDSLCompilationServiceTests {
   @Test
   void testSchedulingDSL_helper_function()
   {
-    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult result;
-    result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+    final var result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
         missionModelService,
         PLAN_ID, """
                 export default function myGoal() {
@@ -128,16 +127,16 @@ class SchedulingDSLCompilationServiceTests {
         ),
         Duration.HOUR);
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
-      assertEquals(expectedGoalDefinition, r.goalSpecifier());
-    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+      assertEquals(expectedGoalDefinition, r.value());
+    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
       fail(r.toString());
     }
   }
 
   @Test
   void testSchedulingDSL_variable_not_defined() {
-    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error actualErrors;
-    actualErrors = (SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error) schedulingDSLCompilationService.compileSchedulingGoalDSL(
+    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> actualErrors;
+    actualErrors = (SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier>) schedulingDSLCompilationService.compileSchedulingGoalDSL(
         missionModelService,
           PLAN_ID, """
                 export default function myGoal() {
@@ -165,8 +164,7 @@ class SchedulingDSLCompilationServiceTests {
   @Test
   void testSchedulingDSL_applyWhen()
   {
-    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult result;
-    result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+    final var result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
         missionModelService,
         PLAN_ID, """
         export default function myGoal() {
@@ -205,16 +203,16 @@ class SchedulingDSLCompilationServiceTests {
         )
     );
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
-      assertEquals(expectedGoalDefinition, r.goalSpecifier());
-    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+      assertEquals(expectedGoalDefinition, r.value());
+    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
       fail(r.toString());
     }
   }
 
   @Test
   void testSchedulingDSL_wrong_return_type() {
-    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error actualErrors;
-    actualErrors = (SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error) schedulingDSLCompilationService.compileSchedulingGoalDSL(
+    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> actualErrors;
+    actualErrors = (SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier>) schedulingDSLCompilationService.compileSchedulingGoalDSL(
         missionModelService,
           PLAN_ID, """
                 export default function myGoal() {
@@ -231,8 +229,7 @@ class SchedulingDSLCompilationServiceTests {
   @Test
   void testHugeGoal() {
     // This test is intended to create a Goal that is bigger than the node subprocess's standard input buffer
-    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult result;
-    result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+    final var result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
         missionModelService,
         PLAN_ID, """
                 export default function myGoal() {
@@ -261,8 +258,8 @@ class SchedulingDSLCompilationServiceTests {
         Duration.HOUR
     );
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
-      assertEquals(expectedGoalDefinition, r.goalSpecifier());
-    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+      assertEquals(expectedGoalDefinition, r.value());
+    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
       fail(r.toString());
     }
   }
@@ -302,9 +299,9 @@ class SchedulingDSLCompilationServiceTests {
               Optional.of(new SchedulingDSL.ActivityTimingConstraint(TimeAnchor.START, TimeUtility.Operator.PLUS, Duration.of(100000000, Duration.MICROSECONDS), true)),
               Optional.empty()
           ),
-          r.goalSpecifier()
+          r.value()
       );
-    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
       fail(r.toString());
     }
   }
@@ -336,7 +333,7 @@ class SchedulingDSLCompilationServiceTests {
           }
         """);
 
-    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
       assertEquals(r.errors().size(), 1);
       assertEquals(
           "TypeError: TS2741 Incorrect return type. Expected: 'Goal', Actual: 'FakeGoal'.",
@@ -364,7 +361,7 @@ class SchedulingDSLCompilationServiceTests {
           }
         """);
 
-    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
       assertEquals(1, r.errors().size());
       assertEquals(
           "TypeError: TS2345 Argument of type 'string' is not assignable to parameter of type 'number'.",
@@ -376,8 +373,7 @@ class SchedulingDSLCompilationServiceTests {
   @Test
   void testSchedulingDSL_emptyActivityCorrect()
   {
-    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult result;
-    result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+    final var result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
         missionModelService,
         PLAN_ID, """
                 export default function myGoal() {
@@ -395,8 +391,8 @@ class SchedulingDSLCompilationServiceTests {
         Duration.HOUR
     );
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
-      assertEquals(expectedGoalDefinition, r.goalSpecifier());
-    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+      assertEquals(expectedGoalDefinition, r.value());
+    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
       fail(r.toString());
     }
   }
@@ -404,8 +400,7 @@ class SchedulingDSLCompilationServiceTests {
   @Test
   void testSchedulingDSL_emptyActivityBogus()
   {
-    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult result;
-    result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+    final var result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
         missionModelService,
         PLAN_ID, """
                 export default function myGoal() {
@@ -422,7 +417,7 @@ class SchedulingDSLCompilationServiceTests {
         ),
         Duration.HOUR
     );
-    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
       assertEquals(1, r.errors().size());
       assertEquals(
           "TypeError: TS2554 Expected 0 arguments, but got 1.",
@@ -430,7 +425,7 @@ class SchedulingDSLCompilationServiceTests {
       );
     }
     else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
-      fail(r.goalSpecifier().toString());
+      fail(r.value().toString());
     }
   }
 
@@ -470,7 +465,7 @@ class SchedulingDSLCompilationServiceTests {
               Optional.of(new SchedulingDSL.ActivityTimingConstraint(TimeAnchor.END, TimeUtility.Operator.PLUS, Duration.ZERO, true)),
               Optional.empty()
           ),
-          r.goalSpecifier()
+          r.value()
       );
     } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
       fail(r.toString());
@@ -479,8 +474,7 @@ class SchedulingDSLCompilationServiceTests {
 
   @Test
   void testAndGoal(){
-    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult result;
-    result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+    final var result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
         missionModelService,
         PLAN_ID, """
                 export default function myGoal() {
@@ -512,7 +506,7 @@ class SchedulingDSLCompilationServiceTests {
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
       assertEquals(
           expectedGoalDefinition,
-          r.goalSpecifier()
+          r.value()
       );
     } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
       fail(r.toString());
@@ -521,8 +515,7 @@ class SchedulingDSLCompilationServiceTests {
 
   @Test
   void testOrGoal(){
-    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult result;
-    result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+    final var result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
         missionModelService,
         PLAN_ID, """
                 export default function myGoal() {
@@ -551,10 +544,10 @@ class SchedulingDSLCompilationServiceTests {
             ),
             Duration.HOUR.times(2)
         )));
-    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
+    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success<SchedulingDSL.GoalSpecifier> r) {
       assertEquals(
           expectedGoalDefinition,
-          r.goalSpecifier()
+          r.value()
       );
     } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
       fail(r.toString());

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
@@ -467,6 +467,23 @@ class SchedulingDSLCompilationServiceTests {
           ),
           r.value()
       );
+    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
+      fail(r.toString());
+    }
+  }
+
+  @Test
+  void testWindowsExpression() {
+    final var result = schedulingDSLCompilationService.compileGlobalSchedulingCondition(
+        missionModelService,
+        PLAN_ID,
+        """
+          export default function() {
+            return Real.Resource("/sample/resource/1").lessThan(5.0);
+          }
+        """);
+    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
+      assertEquals(new LessThan(new RealResource("/sample/resource/1"), new RealValue(5.0)), r.value());
     } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
       fail(r.toString());
     }

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -108,7 +108,7 @@ public class SchedulingIntegrationTests {
             activityTemplate: ActivityTemplates.PeelBanana({
               peelDirection: "fromStem",
             }),
-            interval: -25 // one day in microseconds
+            interval: -25 // intentionally invalid interval
           })
           """, true)), PLANNING_HORIZON);
     }

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -43,6 +43,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SchedulingIntegrationTests {
 
+  public static final PlanningHorizon PLANNING_HORIZON = new PlanningHorizon(
+      TimeUtility.fromDOY("2021-001T00:00:00"),
+      TimeUtility.fromDOY("2021-005T00:00:00"));
+
   private record MissionModelDescription(String name, Map<String, SerializedValue> config, Path libPath) {}
 
   private record SchedulingGoal(GoalId goalId, String definition, boolean enabled) {};
@@ -61,23 +65,20 @@ public class SchedulingIntegrationTests {
 
   @Test
   void testEmptyPlanEmptySpecification() {
-    final var results = runScheduler(BANANANATION, List.of(), List.of());
+    final var results = runScheduler(BANANANATION, List.of(), List.of(), PLANNING_HORIZON);
     assertEquals(Map.of(), results.scheduleResults.goalResults());
   }
 
   @Test
   void testEmptyPlanSimpleRecurrenceGoal() {
-    final var results = runScheduler(
-        BANANANATION,
-        List.of(),
-        List.of(new SchedulingGoal(new GoalId(0L), """
-          export default () => Goal.ActivityRecurrenceGoal({
-            activityTemplate: ActivityTemplates.PeelBanana({
-              peelDirection: "fromStem",
-            }),
-            interval: 24 * 60 * 60 * 1000 * 1000 // one day in microseconds
-          })
-          """, true)));
+    final var results = runScheduler(BANANANATION, List.of(), List.of(new SchedulingGoal(new GoalId(0L), """
+        export default () => Goal.ActivityRecurrenceGoal({
+          activityTemplate: ActivityTemplates.PeelBanana({
+            peelDirection: "fromStem",
+          }),
+          interval: 24 * 60 * 60 * 1000 * 1000 // one day in microseconds
+        })
+        """, true)), PLANNING_HORIZON);
     assertEquals(1, results.scheduleResults.goalResults().size());
     final var goalResult = results.scheduleResults.goalResults().get(new GoalId(0L));
     assertTrue(goalResult.satisfied());
@@ -99,17 +100,14 @@ public class SchedulingIntegrationTests {
   @Test
   void testRecurrenceGoalNegative() {
     try {
-      final var results = runScheduler(
-          BANANANATION,
-          List.of(),
-          List.of(new SchedulingGoal(new GoalId(0L), """
-              export default () => Goal.ActivityRecurrenceGoal({
-                activityTemplate: ActivityTemplates.PeelBanana({
-                  peelDirection: "fromStem",
-                }),
-                interval: -25 // one day in microseconds
-              })
-              """, true)));
+      final var results = runScheduler(BANANANATION, List.of(), List.of(new SchedulingGoal(new GoalId(0L), """
+          export default () => Goal.ActivityRecurrenceGoal({
+            activityTemplate: ActivityTemplates.PeelBanana({
+              peelDirection: "fromStem",
+            }),
+            interval: -25 // one day in microseconds
+          })
+          """, true)), PLANNING_HORIZON);
     }
     catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("Duration passed to RecurrenceGoal as the goal's minimum recurrence interval cannot be negative!"));
@@ -121,19 +119,17 @@ public class SchedulingIntegrationTests {
 
   @Test
   void testEmptyPlanDurationCardinalityGoal() {
-    final var results = runScheduler(BANANANATION,
-        List.of(),
-        List.of(new SchedulingGoal(new GoalId(0L), """
-                  export default function myGoal() {
-                                    return Goal.CardinalityGoal({
-                                      activityTemplate: ActivityTemplates.GrowBanana({
-                                        quantity: 1,
-                                        growingDuration: 1000000,
-                                      }),
-                                      specification : {duration: 10 * 1000000}
-                                    })
-                  }
-                    """, true)));
+    final var results = runScheduler(BANANANATION, List.of(), List.of(new SchedulingGoal(new GoalId(0L), """
+        export default function myGoal() {
+                          return Goal.CardinalityGoal({
+                            activityTemplate: ActivityTemplates.GrowBanana({
+                              quantity: 1,
+                              growingDuration: 1000000,
+                            }),
+                            specification : {duration: 10 * 1000000}
+                          })
+        }
+          """, true)), PLANNING_HORIZON);
     assertEquals(1, results.scheduleResults.goalResults().size());
     final var goalResult = results.scheduleResults.goalResults().get(new GoalId(0L));
 
@@ -162,19 +158,17 @@ public class SchedulingIntegrationTests {
 
   @Test
   void testEmptyPlanOccurrenceCardinalityGoal() {
-    final var results = runScheduler(BANANANATION,
-        List.of(),
-        List.of(new SchedulingGoal(new GoalId(0L), """
-                  export default function myGoal() {
-                                    return Goal.CardinalityGoal({
-                                      activityTemplate: ActivityTemplates.GrowBanana({
-                                        quantity: 1,
-                                        growingDuration: 1000000,
-                                      }),
-                                      specification : {occurrence: 10}
-                                    })
-                  }
-                    """, true)));
+    final var results = runScheduler(BANANANATION, List.of(), List.of(new SchedulingGoal(new GoalId(0L), """
+        export default function myGoal() {
+                          return Goal.CardinalityGoal({
+                            activityTemplate: ActivityTemplates.GrowBanana({
+                              quantity: 1,
+                              growingDuration: 1000000,
+                            }),
+                            specification : {occurrence: 10}
+                          })
+        }
+          """, true)), PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     final var goalResult = results.scheduleResults.goalResults().get(new GoalId(0L));
@@ -207,13 +201,16 @@ public class SchedulingIntegrationTests {
   void testSingleActivityPlanSimpleRecurrenceGoal() {
     final var results = runScheduler(
         BANANANATION,
-        List.of(new MockMerlinService.PlannedActivityInstance("BiteBanana", Map.of("biteSize", SerializedValue.of(1)), Duration.ZERO)),
+        List.of(new MockMerlinService.PlannedActivityInstance("BiteBanana",
+                                                              Map.of("biteSize", SerializedValue.of(1)),
+                                                              Duration.ZERO)),
         List.of(new SchedulingGoal(new GoalId(0L), """
-          export default () => Goal.ActivityRecurrenceGoal({
-            activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
-            interval: 24 * 60 * 60 * 1000 * 1000 // one day in microseconds
-          })
-          """, true)));
+            export default () => Goal.ActivityRecurrenceGoal({
+              activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
+              interval: 24 * 60 * 60 * 1000 * 1000 // one day in microseconds
+            })
+            """, true)),
+        PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     final var goalResult = results.scheduleResults.goalResults().get(new GoalId(0L));
@@ -259,7 +256,8 @@ public class SchedulingIntegrationTests {
             activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
             startsAt: TimingConstraint.singleton(WindowProperty.END).plus(5 * 60 * 1000 * 1000)
           })
-          """, true)));
+          """, true)),
+        PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     final var goalResult = results.scheduleResults.goalResults().get(new GoalId(0L));
@@ -304,7 +302,8 @@ public class SchedulingIntegrationTests {
             activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
             endsWithin: TimingConstraint.range(WindowProperty.END, Operator.PLUS, 5 * 60 * 1000 * 1000)
           })
-          """, true)));
+          """, true)),
+        PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     final var goalResult = results.scheduleResults.goalResults().get(new GoalId(0L));
@@ -340,26 +339,24 @@ public class SchedulingIntegrationTests {
     // PickBanana removes 100
     // Between the end of the GrowBanana, and the beginning of the PickBanana, the StateConstraint is satisfied
     final var growBananaDuration = Duration.of(1, Duration.HOUR);
-    final var results = runScheduler(
-        BANANANATION,
-        List.of(new MockMerlinService.PlannedActivityInstance(
+    final var results = runScheduler(BANANANATION, List.of(
+        new MockMerlinService.PlannedActivityInstance(
             "GrowBanana",
             Map.of(
                 "quantity", SerializedValue.of(100),
                 "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
             Duration.of(2, Duration.HOURS)),
-                new MockMerlinService.PlannedActivityInstance(
-                    "PickBanana",
-                    Map.of("quantity", SerializedValue.of(100)),
-                    Duration.of(4, Duration.HOURS))),
-        List.of(new SchedulingGoal(new GoalId(0L), """
-                export default (): Goal => {
-                 return Goal.CoexistenceGoal({
-                   activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
-                   forEach: Real.Resource("/plant").greaterThan(201.0),
-                   startsAt: TimingConstraint.singleton(WindowProperty.START)
-                 })
-               }""", true)));
+        new MockMerlinService.PlannedActivityInstance(
+            "PickBanana",
+            Map.of("quantity", SerializedValue.of(100)),
+            Duration.of(4, Duration.HOURS))), List.of(new SchedulingGoal(new GoalId(0L), """
+         export default (): Goal => {
+          return Goal.CoexistenceGoal({
+            activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
+            forEach: Real.Resource("/plant").greaterThan(201.0),
+            startsAt: TimingConstraint.singleton(WindowProperty.START)
+          })
+        }""", true)), PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     assertEquals(3, results.updatedPlan().size());
@@ -399,7 +396,8 @@ public class SchedulingIntegrationTests {
                    forEach: Real.Resource("/plant").lessThan(199.0),
                    startsAt: TimingConstraint.singleton(WindowProperty.START)
                  })
-               }""", true)));
+               }""", true)),
+        PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     assertEquals(3, results.updatedPlan().size());
@@ -417,30 +415,26 @@ public class SchedulingIntegrationTests {
     // Initial fruit count is 4.0 in default configuration
     // BiteBanana takes away 1.0
     // The constraint should be satisfied between the two BiteBananaActivities
-    final var results = runScheduler(
-        BANANANATION,
-        List.of(
-            new MockMerlinService.PlannedActivityInstance(
-                "BiteBanana",
-                Map.of("biteSize", SerializedValue.of(1.0)),
-                Duration.of(2, Duration.HOURS)),
-            new MockMerlinService.PlannedActivityInstance(
-                "BiteBanana",
-                Map.of("biteSize", SerializedValue.of(1.0)),
-                Duration.of(4, Duration.HOURS))
-        ),
-
-        List.of(new SchedulingGoal(new GoalId(0L), """
-                export default (): Goal => {
-                 return Goal.CoexistenceGoal({
-                   activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
-                   forEach: Windows.All(
-                     Real.Resource("/fruit").lessThan(4.0),
-                     Real.Resource("/fruit").greaterThan(2.0)
-                   ),
-                   startsAt: TimingConstraint.singleton(WindowProperty.START)
-                 })
-               }""", true)));
+    final var results = runScheduler(BANANANATION, List.of(
+        new MockMerlinService.PlannedActivityInstance(
+            "BiteBanana",
+            Map.of("biteSize", SerializedValue.of(1.0)),
+            Duration.of(2, Duration.HOURS)),
+        new MockMerlinService.PlannedActivityInstance(
+            "BiteBanana",
+            Map.of("biteSize", SerializedValue.of(1.0)),
+            Duration.of(4, Duration.HOURS))
+    ), List.of(new SchedulingGoal(new GoalId(0L), """
+         export default (): Goal => {
+          return Goal.CoexistenceGoal({
+            activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
+            forEach: Windows.All(
+              Real.Resource("/fruit").lessThan(4.0),
+              Real.Resource("/fruit").greaterThan(2.0)
+            ),
+            startsAt: TimingConstraint.singleton(WindowProperty.START)
+          })
+        }""", true)), PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     assertEquals(3, results.updatedPlan().size());
@@ -475,7 +469,8 @@ public class SchedulingIntegrationTests {
                    ),
                    startsAt: TimingConstraint.singleton(WindowProperty.START)
                  })
-               }""", true)));
+               }""", true)),
+        PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     assertEquals(2, results.updatedPlan().size());
@@ -513,7 +508,8 @@ public class SchedulingIntegrationTests {
                    forEach: Real.Resource("/plant").equal(100.0),
                    startsAt: TimingConstraint.singleton(WindowProperty.START)
                  })
-               }""", true)));
+               }""", true)),
+        PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     assertEquals(3, results.updatedPlan().size());
@@ -553,7 +549,8 @@ public class SchedulingIntegrationTests {
                    forEach: Real.Resource("/plant").equal(100.0),
                    startsAt: TimingConstraint.singleton(WindowProperty.START)
                  })
-               }""", true)));
+               }""", true)),
+        PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     assertEquals(2, results.updatedPlan().size());
@@ -591,7 +588,8 @@ public class SchedulingIntegrationTests {
                    forEach: Real.Resource("/plant").notEqual(200.0),
                    startsAt: TimingConstraint.singleton(WindowProperty.START)
                  })
-               }""", true)));
+               }""", true)),
+        PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     assertEquals(3, results.updatedPlan().size());
@@ -634,7 +632,8 @@ public class SchedulingIntegrationTests {
                    ),
                    startsAt: TimingConstraint.singleton(WindowProperty.START)
                  })
-               }""", true)));
+               }""", true)),
+        PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     assertEquals(3, results.updatedPlan().size());
@@ -677,7 +676,8 @@ public class SchedulingIntegrationTests {
                    ),
                    startsAt: TimingConstraint.singleton(WindowProperty.START)
                  })
-               }""", true)));
+               }""", true)),
+        PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     assertEquals(3, results.updatedPlan().size());
@@ -695,21 +695,18 @@ public class SchedulingIntegrationTests {
     // Initial producer is "Chiquita"
     // ChangeProducer sets producer to "Dole"
     // The PeelBanana should be placed at the same time as the ChangeProducer
-    final var results = runScheduler(
-        BANANANATION,
-        List.of(
-            new MockMerlinService.PlannedActivityInstance(
-                "ChangeProducer",
-                Map.of(),
-                Duration.of(2, Duration.HOURS))),
-        List.of(new SchedulingGoal(new GoalId(0L), """
-                export default (): Goal => {
-                 return Goal.CoexistenceGoal({
-                   activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
-                   forEach: Discrete.Resource(Resources["/producer"]).transition("Chiquita", "Dole"),
-                   startsAt: TimingConstraint.singleton(WindowProperty.START)
-                 })
-               }""", true)));
+    final var results = runScheduler(BANANANATION, List.of(
+        new MockMerlinService.PlannedActivityInstance(
+            "ChangeProducer",
+            Map.of(),
+            Duration.of(2, Duration.HOURS))), List.of(new SchedulingGoal(new GoalId(0L), """
+         export default (): Goal => {
+          return Goal.CoexistenceGoal({
+            activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
+            forEach: Discrete.Resource(Resources["/producer"]).transition("Chiquita", "Dole"),
+            startsAt: TimingConstraint.singleton(WindowProperty.START)
+          })
+        }""", true)), PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     assertEquals(2, results.updatedPlan().size());
@@ -725,21 +722,18 @@ public class SchedulingIntegrationTests {
     // Initial producer is "Chiquita"
     // ChangeProducer sets producer to "Dole"
     // The PeelBanana should be placed at the same time as the ChangeProducer
-    final var results = runScheduler(
-        BANANANATION,
-        List.of(
-            new MockMerlinService.PlannedActivityInstance(
-                "ChangeProducer",
-                Map.of("producer", SerializedValue.of("Fyffes")),
-                Duration.of(2, Duration.HOURS))),
-        List.of(new SchedulingGoal(new GoalId(0L), """
-                export default (): Goal => {
-                 return Goal.CoexistenceGoal({
-                   activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
-                   forEach: Discrete.Resource(Resources["/producer"]).transition("Chiquita", "Dole"),
-                   startsAt: TimingConstraint.singleton(WindowProperty.START)
-                 })
-               }""", true)));
+    final var results = runScheduler(BANANANATION, List.of(
+        new MockMerlinService.PlannedActivityInstance(
+            "ChangeProducer",
+            Map.of("producer", SerializedValue.of("Fyffes")),
+            Duration.of(2, Duration.HOURS))), List.of(new SchedulingGoal(new GoalId(0L), """
+         export default (): Goal => {
+          return Goal.CoexistenceGoal({
+            activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
+            forEach: Discrete.Resource(Resources["/producer"]).transition("Chiquita", "Dole"),
+            startsAt: TimingConstraint.singleton(WindowProperty.START)
+          })
+        }""", true)), PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     assertEquals(1, results.updatedPlan().size());
@@ -785,7 +779,8 @@ public class SchedulingIntegrationTests {
                       activityTemplate: ActivityTemplates.ChangeProducer({producer: "Morpheus"}),
                       interval: 24 * 60 * 60 * 1000 * 1000
                     }).applyWhen(Real.Resource("/plant").greaterThan(1.0))""", true)
-        )
+        ),
+        PLANNING_HORIZON
     );
 
     for (MockMerlinService.PlannedActivityInstance i : results.updatedPlan().stream().toList()) {
@@ -830,15 +825,6 @@ public class SchedulingIntegrationTests {
     final var files = libPath.toFile().listFiles(pathname -> pathname.getName().endsWith(".jar"));
     Arrays.sort(files, Comparator.comparingLong(File::lastModified).reversed());
     return files[0];
-  }
-
-  private SchedulingRunResults runScheduler(
-      final MissionModelDescription desc,
-      final List<MockMerlinService.PlannedActivityInstance> plannedActivities,
-      final Iterable<SchedulingGoal> goals){
-     return runScheduler(desc, plannedActivities, goals, new PlanningHorizon(
-         TimeUtility.fromDOY("2021-001T00:00:00"),
-         TimeUtility.fromDOY("2021-005T00:00:00")));
   }
 
   private SchedulingRunResults runScheduler(
@@ -1051,7 +1037,8 @@ public class SchedulingIntegrationTests {
                              startsAt: TimingConstraint.singleton(WindowProperty.START)
                            })
                         )
-               }""", true)));
+               }""", true)),
+        PLANNING_HORIZON);
 
     assertEquals(1, results.scheduleResults.goalResults().size());
     assertTrue(results.scheduleResults.goalResults().entrySet().iterator().next().getValue().satisfied());

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -864,7 +864,8 @@ public class SchedulingIntegrationTests {
         new Timestamp(planningHorizon.getStartInstant()),
         new Timestamp(planningHorizon.getEndInstant()),
         Map.of(),
-        false)));
+        false,
+        List.of())));
     final var agent = new SynchronousSchedulerAgent(
         specificationService,
         mockMerlinService,

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/BinaryMutexConstraint.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/BinaryMutexConstraint.java
@@ -14,7 +14,7 @@ import gov.nasa.jpl.aerie.scheduler.conflicts.MissingActivityTemplateConflict;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class BinaryMutexConstraint implements GlobalConstraint {
+public class BinaryMutexConstraint implements GlobalConstraintWithIntrospection {
 
   ActivityType actType;
   ActivityType otherActType;
@@ -31,6 +31,7 @@ public class BinaryMutexConstraint implements GlobalConstraint {
   }
 
 
+  @Override
   public Windows findWindows(Plan plan, Windows windows, Conflict conflict, SimulationResults simulationResults) {
     if (conflict instanceof MissingActivityInstanceConflict) {
       return findWindows(plan, windows, ((MissingActivityInstanceConflict) conflict).getInstance().getType(), simulationResults);

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/BinaryMutexConstraint.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/BinaryMutexConstraint.java
@@ -14,7 +14,7 @@ import gov.nasa.jpl.aerie.scheduler.conflicts.MissingActivityTemplateConflict;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class BinaryMutexConstraint extends GlobalConstraint {
+public class BinaryMutexConstraint implements GlobalConstraint {
 
   ActivityType actType;
   ActivityType otherActType;

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/CardinalityConstraint.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/CardinalityConstraint.java
@@ -14,7 +14,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-public class CardinalityConstraint extends GlobalConstraintWithIntrospection {
+public class CardinalityConstraint implements GlobalConstraintWithIntrospection {
 
   private int max;
   private Interval interval;

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/GlobalConstraint.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/GlobalConstraint.java
@@ -5,15 +5,15 @@ import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.scheduler.model.Plan;
 
 /**
- * Abstract class defining methods that must be implemented by global constraints such as mutex or cardinality
+ * Interface defining methods that must be implemented by global constraints such as mutex or cardinality
  * Also provides a directory for creating these constraints
  */
-public abstract class GlobalConstraint {
+public interface GlobalConstraint {
 
   //todo: probably needs a domain
 
   //is the constraint enforced on its domain
-  public abstract ConstraintState isEnforced(Plan plan, Windows windows, SimulationResults simulationResults);
+  ConstraintState isEnforced(Plan plan, Windows windows, SimulationResults simulationResults);
 
 
 }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/GlobalConstraintWithIntrospection.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/GlobalConstraintWithIntrospection.java
@@ -6,14 +6,14 @@ import gov.nasa.jpl.aerie.scheduler.model.Plan;
 import gov.nasa.jpl.aerie.scheduler.conflicts.Conflict;
 
 /**
- * Abstract class defining methods that must be implemented by global constraints such as mutex or cardinality
+ * Interface defining methods that must be implemented by global constraints such as mutex or cardinality
  * Also provides a directory for creating these constraints
  */
-public abstract class GlobalConstraintWithIntrospection extends GlobalConstraint {
+public interface GlobalConstraintWithIntrospection extends GlobalConstraint {
 
   //specific to introspectable constraint : find the windows in which we can insert activities without violating
   //the constraint
-  public abstract Windows findWindows(Plan plan, Windows windows, Conflict conflict, SimulationResults simulationResults);
+  Windows findWindows(Plan plan, Windows windows, Conflict conflict, SimulationResults simulationResults);
 
 
 }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/NAryMutexConstraint.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/scheduling/NAryMutexConstraint.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 /**
  * Class implementing a n-ary mutex constraint between activity types
  */
-public class NAryMutexConstraint extends GlobalConstraintWithIntrospection {
+public class NAryMutexConstraint implements GlobalConstraintWithIntrospection {
 
   Set<ActivityExpression> activityExpressions;
 
@@ -29,6 +29,7 @@ public class NAryMutexConstraint extends GlobalConstraintWithIntrospection {
     this.activityExpressions = new HashSet<>(Arrays.asList(activityExpressions));
   }
 
+  @Override
   public Windows findWindows(Plan plan, Windows windows, Conflict conflict, final SimulationResults simulationResults) {
     if (conflict instanceof MissingActivityInstanceConflict) {
       return findWindows(plan, windows, ((MissingActivityInstanceConflict) conflict).getInstance().getType(), simulationResults);

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/model/ActivityTypeList.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/model/ActivityTypeList.java
@@ -1,0 +1,21 @@
+package gov.nasa.jpl.aerie.scheduler.model;
+
+import java.util.List;
+
+public interface ActivityTypeList {
+  record Whitelist(List<ActivityType> activityExpressions) implements ActivityTypeList {}
+
+  record Blacklist(List<ActivityType> activityExpressions) implements ActivityTypeList {}
+
+  static ActivityTypeList whitelist(final List<ActivityType> activityExpressions) {
+    return new Whitelist(activityExpressions);
+  }
+
+  static ActivityTypeList blacklist(final List<ActivityType> activityExpressions) {
+    return new Blacklist(activityExpressions);
+  }
+
+  static ActivityTypeList empty() {
+    return whitelist(List.of());
+  }
+}

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/model/ActivityTypeList.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/model/ActivityTypeList.java
@@ -15,6 +15,10 @@ public interface ActivityTypeList {
     return new Blacklist(activityExpressions);
   }
 
+  static ActivityTypeList matchAny() {
+    return blacklist(List.of());
+  }
+
   static ActivityTypeList empty() {
     return whitelist(List.of());
   }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/model/SchedulingCondition.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/model/SchedulingCondition.java
@@ -1,0 +1,69 @@
+package gov.nasa.jpl.aerie.scheduler.model;
+
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.constraints.tree.Expression;
+import gov.nasa.jpl.aerie.scheduler.conflicts.Conflict;
+import gov.nasa.jpl.aerie.scheduler.conflicts.MissingActivityInstanceConflict;
+import gov.nasa.jpl.aerie.scheduler.conflicts.MissingActivityTemplateConflict;
+import gov.nasa.jpl.aerie.scheduler.constraints.scheduling.ConstraintState;
+import gov.nasa.jpl.aerie.scheduler.constraints.scheduling.GlobalConstraintWithIntrospection;
+
+import java.util.List;
+
+public record SchedulingCondition(
+    Expression<Windows> expression,
+    ActivityTypeList activityTypes
+) implements GlobalConstraintWithIntrospection
+{
+  @Override
+  public Windows findWindows(
+      final Plan plan,
+      final Windows windows,
+      final Conflict conflict,
+      final SimulationResults simulationResults)
+  {
+    final ActivityType type;
+    if (conflict instanceof MissingActivityInstanceConflict c) {
+      type = c.getInstance().getType();
+    } else if (conflict instanceof MissingActivityTemplateConflict c) {
+      type = c.getActTemplate().getType();
+    } else {
+      throw new Error("Unsupported conflict %s".formatted(conflict));
+    }
+    if (this.activityTypes instanceof ActivityTypeList.Whitelist a) {
+      if (!anyMatch(a.activityExpressions(), type)) {
+        return new Windows();
+      }
+    } else if (this.activityTypes instanceof ActivityTypeList.Blacklist a) {
+      if (anyMatch(a.activityExpressions(), type)) {
+        return new Windows();
+      }
+    } else {
+      throw new Error("Unhandled subtype of ActivityExpressionList %s".formatted(this.activityTypes));
+    }
+    return this.expression.evaluate(simulationResults);
+  }
+
+  @Override
+  public ConstraintState isEnforced(
+      final Plan plan,
+      final Windows windows,
+      final SimulationResults simulationResults)
+  {
+    // A SchedulingCondition is never "violated" per se - if there are no windows in which
+    // activities can be placed, that does not mean that it has been violated.
+    // TODO: As of writing isEnforced is unused. Either remove or come up with a more coherent plan for GlobalConstraints.
+    return new ConstraintState(this, false, null);
+  }
+
+  static boolean anyMatch(final List<ActivityType> activityTypes, final ActivityType type) {
+    // TODO we may want to handle more complex activity expressions, not just type.
+    for (final var activityType : activityTypes) {
+      if (type.equals(activityType)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -4,22 +4,21 @@ import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Segment;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.constraints.tree.Expression;
-import gov.nasa.jpl.aerie.scheduler.model.ActivityInstance;
-import gov.nasa.jpl.aerie.scheduler.model.Plan;
-import gov.nasa.jpl.aerie.scheduler.model.PlanInMemory;
-import gov.nasa.jpl.aerie.scheduler.model.Problem;
 import gov.nasa.jpl.aerie.scheduler.conflicts.Conflict;
 import gov.nasa.jpl.aerie.scheduler.conflicts.MissingActivityConflict;
 import gov.nasa.jpl.aerie.scheduler.conflicts.MissingActivityInstanceConflict;
 import gov.nasa.jpl.aerie.scheduler.conflicts.MissingActivityTemplateConflict;
 import gov.nasa.jpl.aerie.scheduler.conflicts.MissingAssociationConflict;
-import gov.nasa.jpl.aerie.scheduler.constraints.scheduling.BinaryMutexConstraint;
 import gov.nasa.jpl.aerie.scheduler.constraints.scheduling.GlobalConstraint;
-import gov.nasa.jpl.aerie.scheduler.constraints.scheduling.NAryMutexConstraint;
+import gov.nasa.jpl.aerie.scheduler.constraints.scheduling.GlobalConstraintWithIntrospection;
 import gov.nasa.jpl.aerie.scheduler.goals.ActivityTemplateGoal;
 import gov.nasa.jpl.aerie.scheduler.goals.CompositeAndGoal;
 import gov.nasa.jpl.aerie.scheduler.goals.Goal;
 import gov.nasa.jpl.aerie.scheduler.goals.OptionGoal;
+import gov.nasa.jpl.aerie.scheduler.model.ActivityInstance;
+import gov.nasa.jpl.aerie.scheduler.model.Plan;
+import gov.nasa.jpl.aerie.scheduler.model.PlanInMemory;
+import gov.nasa.jpl.aerie.scheduler.model.Problem;
 import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -688,10 +687,10 @@ public class PrioritySolver implements Solver {
     //make sure the simulation results cover the domain
     simulationFacade.computeSimulationResultsUntil(tmp.maxTrueTimePoint().get().getKey());
     for (GlobalConstraint gc : constraints) {
-      if (gc instanceof BinaryMutexConstraint) {
-        tmp = ((BinaryMutexConstraint) gc).findWindows(plan, tmp, mac, simulationFacade.getLatestConstraintSimulationResults());
-      } else if (gc instanceof NAryMutexConstraint){
-        tmp = ((NAryMutexConstraint) gc).findWindows(plan, tmp, mac, simulationFacade.getLatestConstraintSimulationResults());
+      if (gc instanceof GlobalConstraintWithIntrospection c) {
+        tmp = c.findWindows(plan, tmp, mac, simulationFacade.getLatestConstraintSimulationResults());
+      } else {
+        throw new Error("Unhandled variant of GlobalConstraint: %s".formatted(gc));
       }
     }
   return tmp;


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1967
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

Use case: Users want to help the scheduler avoid violating constraints. Currently, the scheduler has no knowledge of constraints (in the merlin sense of "constraints").

While it would be straightforward to give the scheduler access to merlin's constraints, we argue this would not provide much benefit with respect to the use case above. While the scheduler could _check_ that, after placing an activity, it has violated a constraint, it cannot _predict_ which regions of the plan would be safe for placing a given activity. We believe that a "guess and check" approach would be intractable - the scheduler needs some more help from the user.

This "help" that the user can provide the scheduler comes in the form of a "Global Scheduling Condition". This is a piece of typescript code, akin to a goal. Like a goal, it can be added to a scheduling specification, enabled, and disabled. Unlike a goal, it returns a `Windows` object, which uses the Constraints language to establish windows in which the scheduler is allowed to place activities. Also, unlike goals, Global Scheduling Conditions have no notion of priority.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
This PR has been validated through a rather tedious manual test. If I can get someone to pair with me, I'd love to turn this into an e2e test.
<details>
<summary>Test procedure</summary>

1. Clean build
2. Upload banananation
3. Check mission model id, you'll need it later
4. Create a new plan
5. Check the scheduling spec id, you'll need it later.
6. Create a new Goal
```typescript
export default (): Goal => {
  return Goal.ActivityRecurrenceGoal({
    activityTemplate: ActivityTemplates.BiteBanana({biteSize: 1}),
    interval: 24 * 60 * 60 * 1000 * 1000
  })
}
```
7. Run the following (fill in your model_id):
```graphql
mutation InsertGSC {
  insert_scheduling_condition_one(object:{
    model_id: 1
    name: "My first scheduling condition"
    definition: "export default (): Windows => Real.Resource('/fruit').greaterThan(5.0)"
  }) {
    id
  }
}
```
Note the id returned.
8. Run the following (fill in your spec id and condition id)
```graphql
insert_scheduling_specification_conditions_one(object:{
  condition_id: 1
  specification_id: 1
  enabled: true
}) {
  __typename
}
```
9. Run scheduling, check that it has not placed any activities.
10. Run the following to change the threshold from 5 to 1:
```graphql
mutation UpdateGSC {
  update_scheduling_condition_by_pk(
    pk_columns: {id:1},
    _set: {
      definition: "export default (): Windows => Real.Resource('/fruit').greaterThan(0.0)"
    }
  ) {
    __typename
  }
}
```
11. Run scheduling, check that it has placed activities. (Note that it should stop placing activities when the /fruit resource reaches 0.0)
</details>

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
- [x] Docs have not been written, but absolutely should be before merging this PR.

UPDATE: I have added a "Global Scheduling Conditions" section to the [scheduling guide](https://github.com/NASA-AMMOS/aerie/wiki/Scheduling-Guide)

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- This PR lays some groundwork for associating scheduling conditions with particular activity types (e.g. do not place "battery intensive" activities when the battery is low, but it's okay to place a "recharge" activity)