### PR TITLE
AERIE-2041 - TS convert functional programing UNIT to {}

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/serialization/mappers/UnitValueMapper.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/serialization/mappers/UnitValueMapper.java
@@ -1,0 +1,26 @@
+package gov.nasa.jpl.aerie.contrib.serialization.mappers;
+
+import gov.nasa.jpl.aerie.merlin.framework.Result;
+import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+
+import java.util.Map;
+
+public record UnitValueMapper() implements ValueMapper<Unit> {
+  @Override
+  public ValueSchema getValueSchema() {
+    return ValueSchema.ofStruct(Map.of());
+  }
+
+  @Override
+  public Result<Unit, String> deserializeValue(final SerializedValue serializedValue) {
+    return Result.success(Unit.UNIT);
+  }
+
+  @Override
+  public SerializedValue serializeValue(final Unit value) {
+    return SerializedValue.of(Map.of());
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/serialization/rulesets/BasicValueMappers.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/serialization/rulesets/BasicValueMappers.java
@@ -23,14 +23,21 @@ import gov.nasa.jpl.aerie.contrib.serialization.mappers.PrimitiveLongArrayValueM
 import gov.nasa.jpl.aerie.contrib.serialization.mappers.PrimitiveShortArrayValueMapper;
 import gov.nasa.jpl.aerie.contrib.serialization.mappers.ShortValueMapper;
 import gov.nasa.jpl.aerie.contrib.serialization.mappers.StringValueMapper;
+import gov.nasa.jpl.aerie.contrib.serialization.mappers.UnitValueMapper;
 import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
 
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
 public final class BasicValueMappers {
+
+  // Unit is an enum, so `$unit` needs to be defined before `$enum()`
+  // in order to override the latter's representation.
+  public static ValueMapper<Unit> $unit() { return new UnitValueMapper(); }
+
   public static ValueMapper<Boolean> $boolean() {
     return new BooleanValueMapper();
   }

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/Resolver.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/Resolver.java
@@ -64,7 +64,7 @@ public final class Resolver {
     return new ClassPattern(ClassName.get(ValueMapper.class), mapperArguments);
   }
 
-  private Optional<CodeBlock> applyRules(final TypePattern goal) {
+  public Optional<CodeBlock> applyRules(final TypePattern goal) {
     if (goal instanceof ClassPattern && ((ClassPattern)goal).name.equals(ClassName.get(Class.class))) {
       final var pattern = ((ClassPattern)goal).arguments.get(0);
       return Optional.of(

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -10,7 +10,6 @@ import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
-import gov.nasa.jpl.aerie.contrib.serialization.mappers.EnumValueMapper;
 import gov.nasa.jpl.aerie.merlin.framework.ModelActions;
 import gov.nasa.jpl.aerie.merlin.framework.RootModel;
 import gov.nasa.jpl.aerie.merlin.framework.Scoped;
@@ -18,6 +17,7 @@ import gov.nasa.jpl.aerie.merlin.framework.Scoping;
 import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
 import gov.nasa.jpl.aerie.merlin.processor.MissionModelProcessor;
 import gov.nasa.jpl.aerie.merlin.processor.Resolver;
+import gov.nasa.jpl.aerie.merlin.processor.TypePattern;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityTypeRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ConfigurationTypeRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.EffectModelRecord;
@@ -812,7 +812,10 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
       }
       computedAttributesTypeName = TypeName.get(typeMirror.get());
     } else {
-      effectModelReturnMapperBlock = Optional.of(CodeBlock.of("new $T($T.class)", EnumValueMapper.class, Unit.class));
+      effectModelReturnMapperBlock = new Resolver(
+          this.typeUtils, this.elementUtils, missionModel.typeRules).applyRules(
+          new TypePattern.ClassPattern(ClassName.get(ValueMapper.class),
+                                       List.of(new TypePattern.ClassPattern(ClassName.get(Unit.class), List.of()))));
       computedAttributesTypeName = TypeName.get(Unit.class);
     }
     return Optional.of(new ComputedAttributesCodeBlocks(

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
@@ -1,13 +1,12 @@
 package gov.nasa.jpl.aerie.merlin.server.models;
 
-import gov.nasa.jpl.aerie.contrib.serialization.mappers.EnumValueMapper;
+import gov.nasa.jpl.aerie.contrib.serialization.mappers.UnitValueMapper;
 import gov.nasa.jpl.aerie.foomissionmodel.generated.GeneratedMissionModelFactory;
 import gov.nasa.jpl.aerie.merlin.driver.DirectiveTypeRegistry;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InvalidArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
-import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService;
 import org.junit.jupiter.api.AfterEach;
@@ -47,18 +46,20 @@ public final class MissionModelTest {
                     new Parameter("y", ValueSchema.STRING),
                     new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))),
                 List.of(),
-                new EnumValueMapper<>(Unit.class).getValueSchema()
+                new UnitValueMapper().getValueSchema()
             ));
 
         // WHEN
         final var activityTypes = new HashMap<String, ActivityType>();
-        registry.taskSpecTypes().forEach((name, specType) -> {
-            activityTypes.put(name, new ActivityType(name, specType.getParameters(), specType.getRequiredParameters(), specType.getReturnValueSchema()));
-        });
-        final Map<String, ActivityType> typeList = activityTypes;
+        registry.taskSpecTypes().forEach((name, specType) -> activityTypes.put(
+            name,
+            new ActivityType(name,
+                             specType.getParameters(),
+                             specType.getRequiredParameters(),
+                             specType.getReturnValueSchema())));
 
-        // THEN
-        assertThat(typeList).containsAllEntriesOf(expectedTypes);
+      // THEN
+        assertThat(activityTypes).containsAllEntriesOf(expectedTypes);
     }
 
     @Test
@@ -71,7 +72,7 @@ public final class MissionModelTest {
                 new Parameter("y", ValueSchema.STRING),
                 new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))),
             List.of(),
-            new EnumValueMapper<>(Unit.class).getValueSchema()
+            new UnitValueMapper().getValueSchema()
         );
 
         // WHEN


### PR DESCRIPTION

* **Tickets addressed:** AERIE-2041
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
In the mission model, the activity's effect model that doesn't return a computed attribute (aka void run() method of the activity) uses UNIT which represents a non-null empty value. This is used internally by AERIE

https://en.wikipedia.org/wiki/Unit_type

This UNIT value will be exposed to our users when **command authoring**. Our users are not functional programmers so this causes confusion.

This will change the computed attribute to `{}` which makes more sense to the user.

## Verification
Ran the command expansion test locally without any issues

## Documentation
None

## Future work
None
