### PR TITLE
[HOTFIX] Fix malformed HTML

### DIFF
--- a/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/json/package-info.java
+++ b/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/json/package-info.java
@@ -101,7 +101,7 @@
  * which specifies a JSON object whose fields are described by other parsers -- rather than using {@code integerExprP}
  * directly. There are two reasons for this! First, we want parsers to be "productive", which means that they should
  * consume some part of the input before descending into a subparser. This is not always a hard-and-fast rule, but since
- * our grammar is recursive, we <i>>must</i make progress on the input before cycling back to the same point in the
+ * our grammar is recursive, we <i>must</i> make progress on the input before cycling back to the same point in the
  * grammar. Otherwise, we will have an infinite loop on our hands! </p>
  *
  * <p> The other reason not to use `integerExprP` directly is because the operators described by these parsers are


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
There's a malformed HTML tag in the JSON parsing library's javadocs. I noticed it when running `./gradlew javadoc` while working on documenting the simulation system. This might have impacted doc generation for 0.13.0?

## Verification
`./gradlew javadoc` succeeds with no fatal errors.