### PR TITLE
[AERIE-2067] Return associated parameters in validation responses

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -163,8 +163,13 @@ type MerlinSimulationResponse {
 }
 
 type ValidationResponse {
-  errors: [String!]
+  errors: [ValidationNotice!]!
   success: Boolean!
+}
+
+type ValidationNotice {
+  subjects: [String!]!
+  message: String!
 }
 
 type EffectiveArgumentsResponse {

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -131,6 +131,7 @@ custom_types:
     - name: ResourceType
     - name: MerlinSimulationResponse
     - name: ValidationResponse
+    - name: ValidationNotice
     - name: EffectiveArgumentsResponse
     - name: AddExternalDatasetResponse
     - name: SchedulingResponse

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BakeBananaBreadActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BakeBananaBreadActivity.java
@@ -10,8 +10,15 @@ import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.WithDefaults;
 public record BakeBananaBreadActivity(double temperature, int tbSugar, boolean glutenFree) {
 
   @Validation("Temperature must be positive")
+  @Validation.Subject({"temperature"})
   public boolean validateTemperature() {
     return this.temperature() > 0;
+  }
+
+  @Validation("Gluten-free bread must be baked at a temperature >= 100")
+  @Validation.Subject({"glutenFree", "temperature"})
+  public boolean validateGlutenFreeTemperature() {
+    return !glutenFree || temperature >= 100;
   }
 
   @EffectModel

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BiteBananaActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BiteBananaActivity.java
@@ -21,6 +21,7 @@ public final class BiteBananaActivity {
   public double biteSize = 1.0;
 
   @Validation("bite size must be positive")
+  @Validation.Subject({"biteSize"})
   public boolean validateBiteSize() {
     return this.biteSize > 0;
   }

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ParameterValidationRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ParameterValidationRecord.java
@@ -1,13 +1,3 @@
 package gov.nasa.jpl.aerie.merlin.processor.metamodel;
 
-import java.util.Objects;
-
-public final class ParameterValidationRecord {
-  public final String methodName;
-  public final String failureMessage;
-
-  public ParameterValidationRecord(final String methodName, final String failureMessage) {
-    this.methodName = Objects.requireNonNull(methodName);
-    this.failureMessage = Objects.requireNonNull(failureMessage);
-  }
-}
+public record ParameterValidationRecord(String methodName, String[] subjects, String failureMessage) { }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/EmptyConfigurationType.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/EmptyConfigurationType.java
@@ -5,6 +5,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.InvalidArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 
 import java.util.List;
 import java.util.Map;
@@ -37,7 +38,7 @@ public final class EmptyConfigurationType implements ConfigurationType<Unit> {
   }
 
   @Override
-  public List<String> getValidationFailures(final Unit configuration) {
+  public List<ValidationNotice> getValidationFailures(final Unit configuration) {
     return List.of();
   }
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/Export.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/Export.java
@@ -32,5 +32,11 @@ public @interface Export {
   @Target(ElementType.METHOD)
   @interface Validation {
     String value();
+
+    @Retention(RetentionPolicy.CLASS)
+    @Target(ElementType.METHOD)
+    @interface Subject {
+      String[] value();
+    }
   }
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/ConfigurationType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/ConfigurationType.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.protocol.model;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InvalidArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 
 import java.util.List;
 import java.util.Map;
@@ -15,7 +16,7 @@ public interface ConfigurationType<Config> {
   throws InvalidArgumentsException;
 
   Map<String, SerializedValue> getArguments(Config configuration);
-  List<String> getValidationFailures(Config configuration);
+  List<ValidationNotice> getValidationFailures(Config configuration);
 
   final class UnconstructableConfigurationException extends Exception {
     public UnconstructableConfigurationException() {
@@ -33,7 +34,7 @@ public interface ConfigurationType<Config> {
    * return this.getValidationFailures(this.instantiate(arguments));
    * }
    */
-  default List<String> validateArguments(final Map<String, SerializedValue> arguments)
+  default List<ValidationNotice> validateArguments(final Map<String, SerializedValue> arguments)
   throws InvalidArgumentsException
   {
     return this.getValidationFailures(this.instantiate(arguments));

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/TaskSpecType.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.protocol.model;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InvalidArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
 import java.util.List;
@@ -16,7 +17,7 @@ public interface TaskSpecType<Model, Specification, Return> {
   throws InvalidArgumentsException;
 
   Map<String, SerializedValue> getArguments(Specification taskSpec);
-  List<String> getValidationFailures(Specification taskSpec);
+  List<ValidationNotice> getValidationFailures(Specification taskSpec);
 
   Task<Return> createTask(Model model, Specification taskSpec);
   ValueSchema getReturnValueSchema();
@@ -34,7 +35,7 @@ public interface TaskSpecType<Model, Specification, Return> {
    * return this.getValidationFailures(this.instantiate(activity));
    * }
    */
-  default List<String> validateArguments(final Map<String, SerializedValue> arguments)
+  default List<ValidationNotice> validateArguments(final Map<String, SerializedValue> arguments)
   throws InvalidArgumentsException {
     return this.getValidationFailures(this.instantiate(arguments));
   }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/ValidationNotice.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/ValidationNotice.java
@@ -1,0 +1,5 @@
+package gov.nasa.jpl.aerie.merlin.protocol.types;
+
+import java.util.List;
+
+public record ValidationNotice(List<String> subjects, String message) { }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -223,9 +223,9 @@ public final class MerlinBindings implements Plugin {
 
       final var serializedActivity = new SerializedActivity(activityTypeName, activityArguments);
 
-      final var failures = this.missionModelService.validateActivityArguments(missionModelId, serializedActivity);
+      final var notices = this.missionModelService.validateActivityArguments(missionModelId, serializedActivity);
 
-      ctx.result(ResponseSerializers.serializeFailures(failures).toString());
+      ctx.result(ResponseSerializers.serializeValidationNotices(notices).toString());
     } catch (final InvalidArgumentsException ex) {
       ctx.status(400)
          .result(ResponseSerializers.serializeFailures(List.of(ex.getMessage())).toString());
@@ -244,9 +244,9 @@ public final class MerlinBindings implements Plugin {
 
       final var missionModelId = input.missionModelId();
       final var arguments = input.arguments();
-      final var failures = this.missionModelService.validateModelArguments(missionModelId, arguments);
+      final var notices = this.missionModelService.validateModelArguments(missionModelId, arguments);
 
-      ctx.result(ResponseSerializers.serializeFailures(failures).toString());
+      ctx.result(ResponseSerializers.serializeValidationNotices(notices).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
     } catch (final InvalidArgumentsException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -10,6 +10,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InvalidArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.remotes.MissionModelAccessException;
@@ -282,6 +283,26 @@ public final class ResponseSerializers {
                  .add("success", JsonValue.TRUE)
                  .build();
     }
+  }
+
+  public static JsonValue serializeValidationNotices(final List<ValidationNotice> notices) {
+    if (notices.size() > 0) {
+      return Json.createObjectBuilder()
+          .add("success", JsonValue.FALSE)
+          .add("errors", serializeIterable(ResponseSerializers::serializeValidationNotice, notices))
+          .build();
+    } else {
+      return Json.createObjectBuilder()
+          .add("success", JsonValue.TRUE)
+          .build();
+}
+  }
+
+  private static JsonValue serializeValidationNotice(final ValidationNotice notice) {
+    return Json.createObjectBuilder()
+        .add("subjects", serializeStringList(notice.subjects()))
+        .add("message", notice.message())
+        .build();
   }
 
   public static JsonValue serializeInvalidArgumentsException(final InvalidArgumentsException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -11,6 +11,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.MissionModelFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InvalidArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
@@ -120,14 +121,14 @@ public final class LocalMissionModelService implements MissionModelService {
    * it contains may not abide by the expected contract at load time.
    */
   @Override
-  public List<String> validateActivityArguments(final String missionModelId, final SerializedActivity activity)
+  public List<ValidationNotice> validateActivityArguments(final String missionModelId, final SerializedActivity activity)
   throws NoSuchMissionModelException, MissionModelLoadException, InvalidArgumentsException
   {
     // TODO: [AERIE-1516] Teardown the missionModel after use to release any system resources (e.g. threads).
     final var factory = this.loadMissionModelFactory(missionModelId);
     final var registry = DirectiveTypeRegistry.extract(factory);
     final var specType = registry.taskSpecTypes().get(activity.getTypeName());
-    if (specType == null) return List.of("unknown activity type");
+    if (specType == null) return List.of(new ValidationNotice(List.of(), "unknown activity type"));
     return specType.validateArguments(activity.getArguments());
   }
 
@@ -173,7 +174,7 @@ public final class LocalMissionModelService implements MissionModelService {
   }
 
   @Override
-  public List<String> validateModelArguments(final String missionModelId, final Map<String, SerializedValue> arguments)
+  public List<ValidationNotice> validateModelArguments(final String missionModelId, final Map<String, SerializedValue> arguments)
   throws NoSuchMissionModelException,
          MissionModelLoadException,
          InvalidArgumentsException

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -7,6 +7,7 @@ import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InvalidArgumentsException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
@@ -34,7 +35,7 @@ public interface MissionModelService {
   Map<String, ActivityType> getActivityTypes(String missionModelId)
   throws NoSuchMissionModelException;
   // TODO: Provide a finer-scoped validation return type. Mere strings make all validations equally severe.
-  List<String> validateActivityArguments(String missionModelId, SerializedActivity activity)
+  List<ValidationNotice> validateActivityArguments(String missionModelId, SerializedActivity activity)
   throws NoSuchMissionModelException, InvalidArgumentsException;
 
   Map<ActivityInstanceId, String> validateActivityInstantiations(String missionModelId, Map<ActivityInstanceId, SerializedActivity> activities)
@@ -45,7 +46,7 @@ public interface MissionModelService {
          NoSuchActivityTypeException,
          InvalidArgumentsException;
 
-  List<String> validateModelArguments(String missionModelId, Map<String, SerializedValue> arguments)
+  List<ValidationNotice> validateModelArguments(String missionModelId, Map<String, SerializedValue> arguments)
   throws NoSuchMissionModelException,
          LocalMissionModelService.MissionModelLoadException,
          InvalidArgumentsException;

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -7,6 +7,7 @@ import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
@@ -17,7 +18,6 @@ import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService;
 
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,9 +61,13 @@ public final class StubMissionModelService implements MissionModelService {
 
   public static final Map<String, ValueSchema> RESOURCES;
 
-  public static final List<String> NO_SUCH_ACTIVITY_TYPE_FAILURES = List.of("no such activity type");
-  public static final List<String> INVALID_ACTIVITY_INSTANCE_FAILURES = List.of("just wrong");
-  public static final List<String> UNCONSTRUCTABLE_ACTIVITY_INSTANCE_FAILURES = List.of(
+  public static final ValidationNotice NO_SUCH_ACTIVITY_TYPE_FAILURE = new ValidationNotice(List.of(),
+      "no such activity type");
+
+  public static final ValidationNotice INVALID_ACTIVITY_INSTANCE_FAILURE = new ValidationNotice(List.of(),
+      "just wrong");
+
+  public static final ValidationNotice UNCONSTRUCTABLE_ACTIVITY_INSTANCE_FAILURE = new ValidationNotice(List.of(),
       "Unconstructable activity instance");
 
   public static final SimulationResults SUCCESSFUL_SIMULATION_RESULTS = new SimulationResults(
@@ -136,7 +140,7 @@ public final class StubMissionModelService implements MissionModelService {
   }
 
   @Override
-  public List<String> validateActivityArguments(final String missionModelId, final SerializedActivity activity)
+  public List<ValidationNotice> validateActivityArguments(final String missionModelId, final SerializedActivity activity)
   throws NoSuchMissionModelException
   {
     if (!Objects.equals(missionModelId, EXISTENT_MISSION_MODEL_ID)) {
@@ -144,13 +148,13 @@ public final class StubMissionModelService implements MissionModelService {
     }
 
     if (Objects.equals(activity.getTypeName(), NONEXISTENT_ACTIVITY_INSTANCE.getTypeName())) {
-      return NO_SUCH_ACTIVITY_TYPE_FAILURES;
+      return List.of(NO_SUCH_ACTIVITY_TYPE_FAILURE);
     } else if (Objects.equals(activity, UNCONSTRUCTABLE_ACTIVITY_INSTANCE)) {
-      return UNCONSTRUCTABLE_ACTIVITY_INSTANCE_FAILURES;
+      return List.of(UNCONSTRUCTABLE_ACTIVITY_INSTANCE_FAILURE);
     } else if (Objects.equals(activity, INVALID_ACTIVITY_INSTANCE)) {
-      return INVALID_ACTIVITY_INSTANCE_FAILURES;
+      return List.of(INVALID_ACTIVITY_INSTANCE_FAILURE);
     } else {
-      return Collections.emptyList();
+      return List.of();
     }
   }
 
@@ -172,7 +176,7 @@ public final class StubMissionModelService implements MissionModelService {
   }
 
   @Override
-  public List<String> validateModelArguments(final String missionModelId, final Map<String, SerializedValue> arguments)
+  public List<ValidationNotice> validateModelArguments(final String missionModelId, final Map<String, SerializedValue> arguments)
   throws LocalMissionModelService.MissionModelLoadException
   {
     return List.of();


### PR DESCRIPTION
* **Tickets addressed:** [AERIE-2067](https://jira.jpl.nasa.gov/browse/AERIE-2067)
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

This PR introduces `@Validation.Subject` to associated existing `@Validation` annotations with parameter names. These associated validation failures are now reported through the `validateActivityArguments` and `validateModelArguments` Hasura endpoints. With this PR the UI may now display per-parameter validation messages.

## Verification
<details>
<summary>Validation Failure</summary>

```java
  @Validation("Gluten-free bread must be baked at a temperature >= 100")
  @Validation.Subject({"glutenFree", "temperature"})
  public boolean validateGlutenFreeTemperature() {
    return !glutenFree || temperature >= 100;
  }
```
With:
```graphql
  validateActivityArguments
  (
    missionModelId: 1,
    activityTypeName: "BakeBananaBread",
    activityArguments: { tbSugar: 34, glutenFree: true, temperature: 99 }
  ) {
    success
    errors {
      subjects
      message
    }
  }
```
Results in:
```json
{
  "data": {
    "validateActivityArguments": {
      "success": false,
      "errors": [
        {
          "subjects": [
            "glutenFree",
            "temperature"
          ],
          "message": "Gluten-free bread must be baked at a temperature >= 100"
        }
      ]
    }
  }
}
```
</details>

<details>
<summary>Invalid Associated Parameter Name</summary>

Upon `javac` compilation
```java
  @Validation("Temperature must be positive")
  @Validation.Subject({"no_such", "temperature", "bad"})
  public boolean validateTemperature() {
    return this.temperature() > 0;
  }
```
Results in:
```
.../BakeBananaBreadActivity.java:10: error: Validation subjects for validation "validateTemperature" do not exist: "bad", "no_such"
public record BakeBananaBreadActivity(double temperature, int tbSugar, boolean glutenFree) {
       ^
...
```

</details>

## Documentation

TODO: will complete documentation prior to full PR approval & merge.

## Future work

- Report activity argument validations in `activity_directive.validations` (https://jira.jpl.nasa.gov/browse/AERIE-2066).
- Update UI to ingest new `validateActivityArguments` and `validateModelArguments` response type with `subjects` and `message` fields (@camargo).