### PR TITLE
[HOTFIX] Allow `ValidationResponse.errors` to be null (when `success` false)

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -163,7 +163,7 @@ type MerlinSimulationResponse {
 }
 
 type ValidationResponse {
-  errors: [ValidationNotice!]!
+  errors: [ValidationNotice!]
   success: Boolean!
 }
 


### PR DESCRIPTION
* **Tickets addressed:** AERIE-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

#317 accidentally added a `!` to the `errors` array. This should instead have no `!` since the field is not preset when `success` is true.