### PR TITLE
Avoid leaking an open JarFile

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelLoader.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelLoader.java
@@ -91,8 +91,7 @@ public final class MissionModelLoader {
 
     private static String getImplementingClassName(final Path jarPath, final String name, final String version)
     throws MissionModelLoadException {
-        try {
-            final var jarFile = new JarFile(jarPath.toFile());
+        try (final var jarFile = new JarFile(jarPath.toFile())) {
             final var jarEntry = jarFile.getEntry("META-INF/services/" + MerlinPlugin.class.getCanonicalName());
             final var inputStream = jarFile.getInputStream(jarEntry);
 


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
I noticed an IntelliJ warning about a `JarFile` not being used with `try-with-resources`. I doubt this is a significant leak, but given the recent effort to reduce memory leaks, this PR ensures that the `JarFile` gets closed promptly.

## Verification
Tests pass.