### PR TITLE
feat: increase command expansion server body parser limit

### DIFF
--- a/command-expansion-server/src/app.ts
+++ b/command-expansion-server/src/app.ts
@@ -37,7 +37,7 @@ const PORT: number = parseInt(getEnv().PORT, 10) ?? 27184;
 const app: Application = express();
 // WARNING: bodyParser.json() is vulnerable to a string too long issue. Iff that occurs,
 // we should switch to a stream parser like https://www.npmjs.com/package/stream-json
-app.use(bodyParser.json({ limit: '25mb' }));
+app.use(bodyParser.json({ limit: '100mb' }));
 
 DbExpansion.init();
 const db = DbExpansion.getDb();


### PR DESCRIPTION
## Description

- When trying to upload a `27mb` command dictionary I got a ` request entity too large` error
- This commit just allows for much larger command dictionaries by increasing the max body size limit for the upload server
 
