### PR TITLE
[HOTFIX] Corrects the order of the arguments to the Exception's message

### DIFF
--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/InvalidArgumentsException.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/InvalidArgumentsException.java
@@ -25,11 +25,12 @@ public final class InvalidArgumentsException extends Exception {
           "unconstructable arguments: %s, "+
           "missing arguments: %s, "+
           "valid arguments: %s"
-          ).formatted(metaName, containerName,
-              missingArguments,
-              extraneousArguments,
-              unconstructableArguments,
-              validArguments));
+          ).formatted(metaName,
+                      containerName,
+                      extraneousArguments,
+                      unconstructableArguments,
+                      missingArguments,
+                      validArguments));
 
     this.metaName = metaName;
     this.containerName = containerName;
@@ -85,11 +86,12 @@ public final class InvalidArgumentsException extends Exception {
             unconstructableArguments.isEmpty() &&
             missingArguments.isEmpty()))
       {
-        throw new InvalidArgumentsException(metaName, containerName,
-            extraneousArguments,
-            unconstructableArguments,
-            missingArguments,
-            validArguments);
+        throw new InvalidArgumentsException(metaName,
+                                            containerName,
+                                            extraneousArguments,
+                                            unconstructableArguments,
+                                            missingArguments,
+                                            validArguments);
       }
     }
   }


### PR DESCRIPTION
* **Tickets addressed:** hot fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The arguments to the string substitution for the exception message were out of order. Now they are correct. I also tweaked some formatting.

## Verification
I've checked this by forcing errors for the categories.

## Documentation
NA

## Future work
NA
