### PR TITLE
[AERIE-1924] Implement transpilation caching in command expansion

### DIFF
--- a/command-expansion-server/src/worker.ts
+++ b/command-expansion-server/src/worker.ts
@@ -4,15 +4,13 @@ import vm from 'node:vm';
 import * as fs from 'node:fs';
 
 import ts from 'typescript';
-import { UserCodeError, UserCodeRunner } from '@nasa-jpl/aerie-ts-user-code-runner';
+import { CacheItem, UserCodeError, UserCodeRunner } from '@nasa-jpl/aerie-ts-user-code-runner';
 
-import getLogger from './utils/logger.js';
 import type { SimulatedActivity } from './lib/batchLoaders/simulatedActivityBatchLoader.js';
 import type { Command, SequenceSeqJson } from './lib/codegen/CommandEDSLPreface.js';
 import type { Mutable } from './lib/codegen/CodegenHelpers';
 import { deserializeWithTemporal } from './utils/temporalSerializers.js';
-
-const logger = getLogger('worker');
+import { Result, SerializedResult } from '@nasa-jpl/aerie-ts-user-code-runner/build/utils/monads.js';
 
 const temporalPolyfillTypes = fs.readFileSync(
   new URL('../src/TemporalPolyfillTypes.ts', import.meta.url).pathname,
@@ -28,123 +26,101 @@ export async function typecheckExpansion(opts: {
   expansionLogic: string;
   commandTypes: string;
   activityTypes: string;
-}): Promise<{
-  errors: ReturnType<UserCodeError['toJSON']>[];
-}> {
-  try {
-    const result = await codeRunner.preProcess(
-      opts.expansionLogic,
-      'ExpansionReturn',
-      ['{ activityInstance: ActivityType }'],
-      [
-        ts.createSourceFile('command-types.ts', opts.commandTypes, compilerTarget),
-        ts.createSourceFile('activity-types.ts', opts.activityTypes, compilerTarget),
-        ts.createSourceFile('TemporalPolyfillTypes.ts', temporalPolyfillTypes, compilerTarget),
-      ],
-    );
-    if (result.isOk()) {
-      return { errors: [] };
-    } else {
-      return { errors: result.unwrapErr().map(e => e.toJSON()) };
-    }
-  } catch (e: any) {
-    logger.error(e);
-    return { errors: [e?.message ?? 'Unexpected error'] };
+}): Promise<SerializedResult<
+    CacheItem,
+    ReturnType<UserCodeError['toJSON']>[]
+>> {
+  const result = await codeRunner.preProcess(
+    opts.expansionLogic,
+    'ExpansionReturn',
+    ['{ activityInstance: ActivityType }'],
+    [
+      ts.createSourceFile('command-types.ts', opts.commandTypes, compilerTarget),
+      ts.createSourceFile('activity-types.ts', opts.activityTypes, compilerTarget),
+      ts.createSourceFile('TemporalPolyfillTypes.ts', temporalPolyfillTypes, compilerTarget),
+    ],
+  );
+  if (result.isOk()) {
+    return Result.Ok(result.unwrap()).toJSON();
+  }
+  else {
+    return Result.Err(result.unwrapErr().map(err => err.toJSON())).toJSON();
   }
 }
 
-export async function executeExpansion(opts: {
-  expansionLogic: string;
+export async function executeEDSL(opts: {
+  edslBody: string;
+  commandTypes: string,
+}): Promise<SerializedResult<
+  SequenceSeqJson,
+  ReturnType<UserCodeError['toJSON']>[]
+>> {
+  const result = await codeRunner.executeUserCode(
+    opts.edslBody,
+    [],
+    'Sequence',
+    [],
+    1000,
+    [
+      ts.createSourceFile('command-types.ts', opts.commandTypes, compilerTarget),
+      ts.createSourceFile('TemporalPolyfillTypes.ts', temporalPolyfillTypes, compilerTarget),
+    ],
+    vm.createContext({
+      Temporal,
+    }),
+  );
+
+  if (result.isOk()) {
+    let sequence = result.unwrap() as Sequence;
+    return Result.Ok(sequence.toSeqJson()).toJSON();
+  }
+  else {
+    return Result.Err(result.unwrapErr().map(err => err.toJSON())).toJSON();
+  }
+}
+
+export async function executeExpansionFromBuildArtifacts(opts: {
+  buildArtifacts: CacheItem;
   serializedActivityInstance: SimulatedActivity;
-  commandTypes: string;
-  activityTypes: string;
-}): Promise<{
-  activityInstance: SimulatedActivity;
-  commands: ReturnType<Command['toSeqJson']>[] | null;
-  errors: ReturnType<UserCodeError['toJSON']>[];
-}> {
+}): Promise<SerializedResult<
+    ReturnType<Command['toSeqJson']>[],
+    ReturnType<UserCodeError['toJSON']>[]
+    >> {
   const activityInstance = deserializeWithTemporal(opts.serializedActivityInstance) as SimulatedActivity;
-  try {
-    const result = await codeRunner.executeUserCode<[{ activityInstance: SimulatedActivity }], ExpansionReturn>(
-      opts.expansionLogic,
+  const result = await codeRunner.executeUserCodeFromArtifacts<
+      [{
+        activityInstance: SimulatedActivity;
+      }],
+      ExpansionReturn
+      >(
+      opts.buildArtifacts.jsFileMap,
+      opts.buildArtifacts.userCodeSourceMap,
       [
         {
           activityInstance,
         },
       ],
-      'ExpansionReturn',
-      ['{ activityInstance: ActivityType }'],
       3000,
-      [
-        ts.createSourceFile('command-types.ts', opts.commandTypes, compilerTarget),
-        ts.createSourceFile('activity-types.ts', opts.activityTypes, compilerTarget),
-        ts.createSourceFile('TemporalPolyfillTypes.ts', temporalPolyfillTypes, compilerTarget),
-      ],
       vm.createContext({
         Temporal,
       }),
-    );
+  )
 
-    if (result.isOk()) {
-      let commands = result.unwrap();
-      if (!Array.isArray(commands)) {
-        commands = [commands];
-      }
-      const commandsFlat = commands.flat() as Command[];
-      for (const command of commandsFlat) {
-        (command as Mutable<Command>).metadata = {
-          ...command.metadata,
-          simulatedActivityId: activityInstance.id,
-        };
-      }
-      return { activityInstance, commands: commandsFlat.map(c => c.toSeqJson()), errors: [] };
-    } else {
-      return {
-        activityInstance,
-        commands: null,
-        errors: result.unwrapErr().map(err => err.toJSON()),
+  if (result.isOk()) {
+    let commands = result.unwrap();
+    if (!Array.isArray(commands)) {
+      commands = [commands];
+    }
+    const commandsFlat = commands.flat() as Command[];
+    for (const command of commandsFlat) {
+      (command as Mutable<Command>).metadata = {
+        ...command.metadata,
+        simulatedActivityId: activityInstance.id,
       };
     }
-  } catch (e: any) {
-    logger.error(e);
-    return { activityInstance, commands: null, errors: [e?.message ?? 'Unexpected error'] };
+    return Result.Ok(commandsFlat.map(c => c.toSeqJson())).toJSON();
   }
-}
-
-export async function executeEDSL(opts: { edslBody: string; commandTypes: string }): Promise<{
-  sequenceJson: SequenceSeqJson | null;
-  errors: ReturnType<UserCodeError['toJSON']>[];
-}> {
-  try {
-    const result = await codeRunner.executeUserCode(
-      opts.edslBody,
-      [],
-      'Sequence',
-      [],
-      1000,
-      [
-        ts.createSourceFile('command-types.ts', opts.commandTypes, compilerTarget),
-        ts.createSourceFile('TemporalPolyfillTypes.ts', temporalPolyfillTypes, compilerTarget),
-      ],
-      vm.createContext({
-        Temporal,
-      }),
-    );
-
-    if (result.isOk()) {
-      let sequence = result.unwrap() as Sequence;
-      return {
-        sequenceJson: sequence.toSeqJson(),
-        errors: [],
-      };
-    } else {
-      return {
-        sequenceJson: null,
-        errors: result.unwrapErr().map(err => err.toJSON()),
-      };
-    }
-  } catch (e: any) {
-    logger.error(e);
-    return { sequenceJson: null, errors: [e?.message ?? 'Unexpected error'] };
+  else {
+    return Result.Err(result.unwrapErr().map(err => err.toJSON())).toJSON();
   }
 }


### PR DESCRIPTION
Implements caching for a single call to expand a plan

* **Tickets addressed:** AERIE-1924
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

Added a cache of transpilation outputs that is scoped to a single plan expansion call.

Also added a commit to use Result return types for more clean/intentional error handling code.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Tests passing

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

No tests need

## Future work
<!-- What next steps can we anticipate from here, if any? -->

Will need to reconcile this with #324
