### PR TITLE
[HOTFIX] Ensure Duration is Long prior to serialization

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -558,7 +558,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements PlanService.
       final var insertionObjectArguments = Json.createObjectBuilder();
       if(act.getType().getDurationType() instanceof DurationType.Controllable durationType){
         if(!act.getArguments().containsKey(durationType.parameterName())){
-          insertionObjectArguments.add(durationType.parameterName(), serializeForGql(act.getDuration()));
+          insertionObjectArguments.add(durationType.parameterName(), act.getDuration().in(Duration.MICROSECOND));
         }
       }
 
@@ -732,17 +732,6 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements PlanService.
     //TODO: (defensive) should escape contents of bare strings, eg internal quotes
     //NB: Time::toString will format correctly as HH:MM:SS.sss, just need to quote it here
     return "\"" + s + "\"";
-  }
-
-  /**
-   * serialize the given duration in a manner that can be used as a graphql argument value
-   * @param d the duration to serialize
-   * @return a serialization of the object suitable for use as a graphql value
-   */
-  public String serializeForGql(final Duration d) {
-    //TODO: can probably leverage some serializers from aerie
-    //NB: merlin uses durations in microseconds! (inconsistent with start_offset as a HH:MM:SS.sss string)
-    return Long.toString(d.in(Duration.MICROSECOND));
   }
 
   public String serializeForGql(final SerializedValue value) {


### PR DESCRIPTION
* **Tickets addressed:** hot fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The Duration parameter for a controllable activity was being double quoted. 1st converted to a string, and then secondly being serialized by the JsonObject builder. This resulted in the Duration activity parameter in microseconds being inserted into the activity-directives table arguments jsonb column as a JSON string, and not the expected JSON number. As a result simulation would fail when trying to instantiate the scheduler created activity directives because the arguments to the duration parameters were Strings and not the expected Long.

This change removes the initial conversion to a String.

## Verification
I tested this but I'm creating a ticket to add a set of end-to-end tests on this aspect for the scheduler. 
Prior to testing the insert resulted in { "duration": "1800000000" }. With this change the json entered into the db is { "duration": 1800000000 }

## Documentation
NA

## Future work
None
