### PR TITLE
[AERIE-2066] Report activity argument validations in `activity_directive_validations`

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
@@ -5,6 +5,13 @@ object_relationships:
 - name: plan
   using:
     foreign_key_constraint_on: plan_id
+- name: validations
+  using:
+    foreign_key_constraint_on:
+      column: directive_id
+      table:
+        name: activity_directive_validations
+        schema: public
 array_relationships:
 - name: simulated_activities
   using:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
@@ -26,3 +26,18 @@ remote_relationships:
         name: scheduling_goal
       field_mapping:
         source_scheduling_goal_id: id
+event_triggers:
+- definition:
+    enable_manual: false
+    insert:
+      columns:
+      - arguments
+    update:
+      columns:
+      - arguments
+  name: refreshActivityValidations
+  retry_conf:
+    interval_sec: 10
+    num_retries: 0
+    timeout_sec: 60
+  webhook: http://aerie_merlin:27183/refreshActivityValidations

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_validations.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_validations.yaml
@@ -1,0 +1,3 @@
+table:
+  name: activity_directive_validations
+  schema: public

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
@@ -1,4 +1,5 @@
 - "!include public_activity_directive.yaml"
+- "!include public_activity_directive_validations.yaml"
 - "!include public_activity_type.yaml"
 - "!include public_activity_directive_metadata_schema.yaml"
 - "!include public_condition.yaml"

--- a/merlin-server/sql/merlin/init.sql
+++ b/merlin-server/sql/merlin/init.sql
@@ -17,6 +17,7 @@ begin;
   \ir tables/activity_type.sql
   \ir tables/plan.sql
   \ir tables/activity_directive.sql
+  \ir tables/activity_directive_validations.sql
   \ir tables/simulation_template.sql
   \ir tables/simulation.sql
 

--- a/merlin-server/sql/merlin/tables/activity_directive.sql
+++ b/merlin-server/sql/merlin/tables/activity_directive.sql
@@ -10,7 +10,6 @@ create table activity_directive (
   start_offset interval not null,
   type text not null,
   arguments merlin_argument_set not null,
-  validations jsonb default '{}'::jsonb,
   metadata merlin_activity_directive_metadata_set default '{}'::jsonb,
 
   constraint activity_directive_synthetic_key

--- a/merlin-server/sql/merlin/tables/activity_directive.sql
+++ b/merlin-server/sql/merlin/tables/activity_directive.sql
@@ -10,6 +10,7 @@ create table activity_directive (
   start_offset interval not null,
   type text not null,
   arguments merlin_argument_set not null,
+  validations jsonb default '{}'::jsonb,
   metadata merlin_activity_directive_metadata_set default '{}'::jsonb,
 
   constraint activity_directive_synthetic_key

--- a/merlin-server/sql/merlin/tables/activity_directive_validations.sql
+++ b/merlin-server/sql/merlin/tables/activity_directive_validations.sql
@@ -1,0 +1,21 @@
+create table activity_directive_validations (
+  directive_id integer not null,
+  
+  validations jsonb default '{}'::jsonb,
+
+  constraint activity_directive_validations_natural_key
+    primary key (directive_id),
+  constraint activity_directive_validations_owned_by_activity_directive
+    foreign key (directive_id)
+    references activity_directive
+    on update cascade
+    on delete cascade
+);
+
+comment on table activity_directive_validations is e''
+  'The activity validations extracted from an activity directive.';
+
+comment on column activity_directive_validations.directive_id is e''
+  'The activity directive these validations are extracted from.';
+comment on column activity_directive_validations.validations is e''
+  'The argument validations extracted from an activity directive.';

--- a/merlin-server/sql/merlin/tables/activity_directive_validations.sql
+++ b/merlin-server/sql/merlin/tables/activity_directive_validations.sql
@@ -1,6 +1,7 @@
 create table activity_directive_validations (
   directive_id integer not null,
-  
+
+  last_modified_at timestamptz not null default now(),
   validations jsonb default '{}'::jsonb,
 
   constraint activity_directive_validations_natural_key
@@ -17,5 +18,7 @@ comment on table activity_directive_validations is e''
 
 comment on column activity_directive_validations.directive_id is e''
   'The activity directive these validations are extracted from.';
+comment on column activity_directive_validations.last_modified_at is e''
+  'The time at which these argument validations were last modified.';
 comment on column activity_directive_validations.validations is e''
   'The argument validations extracted from an activity directive.';

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
@@ -20,6 +20,7 @@ import static gov.nasa.jpl.aerie.merlin.server.http.MerlinParsers.planIdP;
 import static gov.nasa.jpl.aerie.merlin.server.http.MerlinParsers.timestampP;
 import static gov.nasa.jpl.aerie.merlin.server.http.ProfileParsers.profileSetP;
 import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.serializedValueP;
+import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.pgTimestampP;
 
 public abstract class HasuraParsers {
   private HasuraParsers() {}
@@ -75,14 +76,15 @@ public abstract class HasuraParsers {
                   .field("id", longP)
                   .field("type", stringP)
                   .field("arguments", mapP(serializedValueP))
+                  .field("last_modified_arguments_at", pgTimestampP)
                   .rest())
               .rest())
           .rest())
       .rest()
       .map(
-          untuple((planId, activityDirectiveId, type, arguments) ->
-              new HasuraActivityDirectiveEvent(new PlanId(planId), new ActivityDirectiveId(activityDirectiveId), type, arguments)),
-          $ -> tuple($.planId().id(), $.activityDirectiveId().id(), $.activityTypeName(), $.arguments()));
+          untuple((planId, activityDirectiveId, type, arguments, argumentsModifiedTime) ->
+              new HasuraActivityDirectiveEvent(new PlanId(planId), new ActivityDirectiveId(activityDirectiveId), type, arguments, argumentsModifiedTime)),
+          $ -> tuple($.planId().id(), $.activityDirectiveId().id(), $.activityTypeName(), $.arguments(), $.argumentsModifiedTime()));
 
   private static final JsonParser<HasuraAction.MissionModelArgumentsInput> hasuraMissionModelArgumentsInputP
       = productP

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -20,7 +20,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.*;
+import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraActivityActionP;
+import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraActivityDirectiveEventTriggerP;
+import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraExternalDatasetActionP;
+import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelActionP;
+import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelArgumentsActionP;
+import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelEventTriggerP;
+import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraPlanActionP;
 import static io.javalin.apibuilder.ApiBuilder.before;
 import static io.javalin.apibuilder.ApiBuilder.path;
 import static io.javalin.apibuilder.ApiBuilder.post;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -393,6 +393,13 @@ public final class ResponseSerializers {
         .build();
   }
 
+  public static JsonValue serializeNoSuchActivityDirectiveException(final MissionModelService.NoSuchActivityDirectiveException ex) {
+    // TODO: Improve diagnostic information
+    return Json.createObjectBuilder()
+        .add("message", "no such activity directive")
+        .build();
+  }
+
   public static JsonValue serializeNoSuchMissionModelException(final MissionModelService.NoSuchMissionModelException ex) {
     // TODO: Improve diagnostic information
     return Json.createObjectBuilder()

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -393,20 +393,12 @@ public final class ResponseSerializers {
         .build();
   }
 
-  public static JsonValue serializeNoSuchActivityDirectiveException(final MissionModelService.NoSuchActivityDirectiveException ex) {
-    // TODO: Improve diagnostic information
-    return Json.createObjectBuilder()
-        .add("message", "no such activity directive")
-        .build();
-  }
-
   public static JsonValue serializeNoSuchMissionModelException(final MissionModelService.NoSuchMissionModelException ex) {
     // TODO: Improve diagnostic information
     return Json.createObjectBuilder()
                .add("message", "no such mission model")
                .build();
   }
-
 
   private static final class ValueSchemaSerializer implements ValueSchema.Visitor<JsonValue> {
     @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryMissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryMissionModelRepository.java
@@ -2,9 +2,11 @@ package gov.nasa.jpl.aerie.merlin.server.mocks;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
+import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelJar;
+import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.remotes.MissionModelAccessException;
 import gov.nasa.jpl.aerie.merlin.server.remotes.MissionModelRepository;
 
@@ -63,8 +65,7 @@ public final class InMemoryMissionModelRepository implements MissionModelReposit
     }
 
     @Override
-    public void updateActivityDirectiveValidations(final String activityDirectiveId, final List<ValidationNotice> notices)
-    throws NoSuchActivityDirectiveException
+    public void updateActivityDirectiveValidations(final ActivityDirectiveId directiveId, final Timestamp argumentsModifiedTime, final List<ValidationNotice> notices)
     {
     }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryMissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryMissionModelRepository.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.mocks;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelJar;
@@ -58,6 +59,12 @@ public final class InMemoryMissionModelRepository implements MissionModelReposit
     @Override
     public void updateActivityTypes(final String missionModelId, final Map<String, ActivityType> activityTypes)
     throws NoSuchMissionModelException
+    {
+    }
+
+    @Override
+    public void updateActivityDirectiveValidations(final String activityDirectiveId, final List<ValidationNotice> notices)
+    throws NoSuchActivityDirectiveException
     {
     }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityDirective.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityDirective.java
@@ -1,0 +1,10 @@
+package gov.nasa.jpl.aerie.merlin.server.models;
+
+import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
+
+public record ActivityDirective
+(
+    ActivityDirectiveId id,
+    Timestamp argumentsModifiedTime,
+    SerializedActivity activity
+) { }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityDirectiveId.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityDirectiveId.java
@@ -1,0 +1,3 @@
+package gov.nasa.jpl.aerie.merlin.server.models;
+
+public record ActivityDirectiveId(long id) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraActivityDirectiveEvent.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraActivityDirectiveEvent.java
@@ -8,5 +8,6 @@ public record HasuraActivityDirectiveEvent
     PlanId planId,
     ActivityDirectiveId activityDirectiveId,
     String activityTypeName,
-    Map<String, SerializedValue> arguments
+    Map<String, SerializedValue> arguments,
+    Timestamp argumentsModifiedTime
 ) { }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraActivityDirectiveEvent.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraActivityDirectiveEvent.java
@@ -1,0 +1,12 @@
+package gov.nasa.jpl.aerie.merlin.server.models;
+
+import java.util.Map;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+
+public record HasuraActivityDirectiveEvent
+(
+    PlanId planId,
+    ActivityDirectiveId activityDirectiveId,
+    String activityTypeName,
+    Map<String, SerializedValue> arguments
+) { }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/MissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/MissionModelRepository.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelJar;
@@ -18,6 +19,9 @@ public interface MissionModelRepository {
     // Mutations
     void updateModelParameters(String missionModelId, final List<Parameter> modelParameters) throws NoSuchMissionModelException;
     void updateActivityTypes(String missionModelId, final Map<String, ActivityType> activityTypes) throws NoSuchMissionModelException;
+    void updateActivityDirectiveValidations(final String activityDirectiveId, final List<ValidationNotice> notices)
+    throws NoSuchActivityDirectiveException;
 
-    class NoSuchMissionModelException extends Exception {}
+    final class NoSuchMissionModelException extends Exception {}
+    final class NoSuchActivityDirectiveException extends Exception {}
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/MissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/MissionModelRepository.java
@@ -2,9 +2,11 @@ package gov.nasa.jpl.aerie.merlin.server.remotes;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
+import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelJar;
+import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 
 import java.util.List;
 import java.util.Map;
@@ -19,8 +21,7 @@ public interface MissionModelRepository {
     // Mutations
     void updateModelParameters(String missionModelId, final List<Parameter> modelParameters) throws NoSuchMissionModelException;
     void updateActivityTypes(String missionModelId, final Map<String, ActivityType> activityTypes) throws NoSuchMissionModelException;
-    void updateActivityDirectiveValidations(final String activityDirectiveId, final List<ValidationNotice> notices)
-    throws NoSuchActivityDirectiveException;
+    void updateActivityDirectiveValidations(final ActivityDirectiveId directiveId, final Timestamp argumentsModifiedTime, final List<ValidationNotice> notices);
 
     final class NoSuchMissionModelException extends Exception {}
     final class NoSuchActivityDirectiveException extends Exception {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresMissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresMissionModelRepository.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelJar;
@@ -127,6 +128,21 @@ public final class PostgresMissionModelRepository implements MissionModelReposit
     }
   }
 
+  @Override
+  public void updateActivityDirectiveValidations(String activityDirectiveId, List<ValidationNotice> notices)
+  throws NoSuchActivityDirectiveException
+  {
+    try (final var connection = this.dataSource.getConnection()) {
+      try (final var updateActivityDirectiveValidationsAction = new UpdateActivityDirectiveValidationsAction(connection)) {
+        final var directiveId = toActivityDirectiveId(activityDirectiveId);
+        updateActivityDirectiveValidationsAction.apply(directiveId, notices);
+      }
+    } catch (final SQLException ex) {
+      throw new DatabaseException(
+          "Failed to update derived data for activity directive with id `%s`".formatted(activityDirectiveId), ex);
+    }
+  }
+
   private static long toMissionModelId(final String modelId)
   throws NoSuchMissionModelException
   {
@@ -134,6 +150,16 @@ public final class PostgresMissionModelRepository implements MissionModelReposit
       return Long.parseLong(modelId, 10);
     } catch (final NumberFormatException ex) {
       throw new NoSuchMissionModelException();
+    }
+  }
+
+  private static long toActivityDirectiveId(final String directiveId)
+  throws NoSuchActivityDirectiveException
+  {
+    try {
+      return Long.parseLong(directiveId, 10);
+    } catch (final NumberFormatException ex) {
+      throw new NoSuchActivityDirectiveException();
     }
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
@@ -3,31 +3,76 @@ package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 import com.impossibl.postgres.api.data.Interval;
 import gov.nasa.jpl.aerie.json.JsonParseResult;
 import gov.nasa.jpl.aerie.json.JsonParser;
+import gov.nasa.jpl.aerie.json.SchemaCache;
 import gov.nasa.jpl.aerie.json.Unit;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
+import gov.nasa.jpl.aerie.merlin.server.services.UnexpectedSubtypeError;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
 import java.util.Map;
 
-import static gov.nasa.jpl.aerie.json.BasicParsers.chooseP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.intP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.literalP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.longP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.mapP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.*;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
 import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
 import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.serializedValueP;
 import static gov.nasa.jpl.aerie.merlin.driver.json.ValueSchemaJsonParser.valueSchemaP;
 
 public final class PostgresParsers {
+
+  public static final JsonParser<Timestamp> pgTimestampP = new JsonParser<>() {
+    private static final DateTimeFormatter format =
+        new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+            .toFormatter();
+
+    @Override
+    public JsonObject getSchema(final SchemaCache anchors) {
+      return Json
+          .createObjectBuilder(stringP.getSchema())
+          .add("format", "date-time")
+          .build();
+    }
+
+    @Override
+    public JsonParseResult<Timestamp> parse(final JsonValue json) {
+      final var result = stringP.parse(json);
+      if (result instanceof JsonParseResult.Success<String> s) {
+        try {
+          final var instant = LocalDateTime.parse(s.result(), format).atZone(ZoneOffset.UTC);
+          return JsonParseResult.success(new Timestamp(instant));
+        } catch (DateTimeParseException e) {
+          return JsonParseResult.failure("invalid timestamp format "+e);
+        }
+      } else if (result instanceof JsonParseResult.Failure<?> f) {
+        return f.cast();
+      } else {
+        throw new UnexpectedSubtypeError(JsonParseResult.class, result);
+      }
+    }
+
+    @Override
+    public JsonValue unparse(final Timestamp value) {
+      final var s = format.format(value.toInstant().atZone(ZoneOffset.UTC));
+      return stringP.unparse(s);
+    }
+  };
+
   public static final JsonParser<Pair<String, ValueSchema>> discreteProfileTypeP =
       productP
           .field("type", literalP("discrete"))

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
@@ -26,7 +26,13 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.util.Map;
 
-import static gov.nasa.jpl.aerie.json.BasicParsers.*;
+import static gov.nasa.jpl.aerie.json.BasicParsers.chooseP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.intP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.literalP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.longP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.mapP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
 import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
 import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.serializedValueP;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PreparedStatements.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PreparedStatements.java
@@ -37,9 +37,8 @@ public final class PreparedStatements {
     statement.setString(parameter, ResponseSerializers.serializeStringList(requiredParameters).toString());
   }
 
-  public static void setValidationNotices(final PreparedStatement statement, final List<Integer> parameters, final List<ValidationNotice> notices)
+  public static void setValidationNotices(final PreparedStatement statement, final int parameter, final List<ValidationNotice> notices)
   throws SQLException {
-    final var serializedNotices = ResponseSerializers.serializeValidationNotices(notices).toString();
-    for (final var p : parameters) statement.setString(p, serializedNotices);
+    statement.setString(parameter, ResponseSerializers.serializeValidationNotices(notices).toString());
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PreparedStatements.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PreparedStatements.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.server.http.ResponseSerializers;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 
@@ -34,5 +35,10 @@ public final class PreparedStatements {
   public static void setRequiredParameters(final PreparedStatement statement, final int parameter, final List<String> requiredParameters)
   throws SQLException {
     statement.setString(parameter, ResponseSerializers.serializeStringList(requiredParameters).toString());
+  }
+
+  public static void setValidationNotices(final PreparedStatement statement, final int parameter, final List<ValidationNotice> notices)
+  throws SQLException {
+    statement.setString(parameter, ResponseSerializers.serializeValidationNotices(notices).toString());
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PreparedStatements.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PreparedStatements.java
@@ -37,8 +37,9 @@ public final class PreparedStatements {
     statement.setString(parameter, ResponseSerializers.serializeStringList(requiredParameters).toString());
   }
 
-  public static void setValidationNotices(final PreparedStatement statement, final int parameter, final List<ValidationNotice> notices)
+  public static void setValidationNotices(final PreparedStatement statement, final List<Integer> parameters, final List<ValidationNotice> notices)
   throws SQLException {
-    statement.setString(parameter, ResponseSerializers.serializeValidationNotices(notices).toString());
+    final var serializedNotices = ResponseSerializers.serializeValidationNotices(notices).toString();
+    for (final var p : parameters) statement.setString(p, serializedNotices);
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateActivityDirectiveValidationsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateActivityDirectiveValidationsAction.java
@@ -10,9 +10,9 @@ import java.util.List;
 
 /*package-local*/ final class UpdateActivityDirectiveValidationsAction implements AutoCloseable {
   private static final @Language("SQL") String sql = """
-    update activity_directive
-    set validations = ?::json
-    where id = ?
+    insert into activity_directive_validations (directive_id, validations)
+    values (?, ?::json)
+    on conflict (directive_id) do update set validations = ?::json
   """;
 
   private final PreparedStatement statement;
@@ -24,8 +24,8 @@ import java.util.List;
   public void apply(final long directiveId, final List<ValidationNotice> notices)
   throws SQLException, FailedUpdateException
   {
-    PreparedStatements.setValidationNotices(this.statement, 1, notices);
-    this.statement.setLong(2, directiveId);
+    this.statement.setLong(1, directiveId);
+    PreparedStatements.setValidationNotices(this.statement, List.of(2, 3), notices);
 
     statement.executeUpdate();
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateActivityDirectiveValidationsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateActivityDirectiveValidationsAction.java
@@ -1,0 +1,37 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+/*package-local*/ final class UpdateActivityDirectiveValidationsAction implements AutoCloseable {
+  private static final @Language("SQL") String sql = """
+    update activity_directive
+    set validations = ?::json
+    where id = ?
+  """;
+
+  private final PreparedStatement statement;
+
+  public UpdateActivityDirectiveValidationsAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public void apply(final long directiveId, final List<ValidationNotice> notices)
+  throws SQLException, FailedUpdateException
+  {
+    PreparedStatements.setValidationNotices(this.statement, 1, notices);
+    this.statement.setLong(2, directiveId);
+
+    statement.executeUpdate();
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateActivityDirectiveValidationsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateActivityDirectiveValidationsAction.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
+import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
@@ -10,9 +11,14 @@ import java.util.List;
 
 /*package-local*/ final class UpdateActivityDirectiveValidationsAction implements AutoCloseable {
   private static final @Language("SQL") String sql = """
-    insert into activity_directive_validations (directive_id, validations)
-    values (?, ?::json)
-    on conflict (directive_id) do update set validations = ?::json
+    insert into activity_directive_validations
+        as validation (directive_id, last_modified_at, validations)
+    values (?, ?::timestamptz, ?::json)
+    on conflict (directive_id) do update
+        set
+            last_modified_at = excluded.last_modified_at,
+            validations = excluded.validations
+        where validation.last_modified_at < excluded.last_modified_at
   """;
 
   private final PreparedStatement statement;
@@ -21,11 +27,12 @@ import java.util.List;
     this.statement = connection.prepareStatement(sql);
   }
 
-  public void apply(final long directiveId, final List<ValidationNotice> notices)
+  public void apply(final long directiveId, final Timestamp argumentsModifiedTime, final List<ValidationNotice> notices)
   throws SQLException, FailedUpdateException
   {
     this.statement.setLong(1, directiveId);
-    PreparedStatements.setValidationNotices(this.statement, List.of(2, 3), notices);
+    PreparedStatements.setTimestamp(this.statement, 2, argumentsModifiedTime);
+    PreparedStatements.setValidationNotices(this.statement, 3, notices);
 
     statement.executeUpdate();
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -256,6 +256,18 @@ public final class LocalMissionModelService implements MissionModelService {
     }
   }
 
+  @Override
+  public void refreshActivityValidations(final String missionModelId, final String activityDirectiveId, final SerializedActivity activity)
+  throws NoSuchMissionModelException, NoSuchActivityDirectiveException, InvalidArgumentsException
+  {
+    try {
+      final var notices = validateActivityArguments(missionModelId, activity);
+      this.missionModelRepository.updateActivityDirectiveValidations(activityDirectiveId, notices);
+    } catch (final MissionModelRepository.NoSuchActivityDirectiveException ex) {
+      throw new NoSuchActivityDirectiveException(activityDirectiveId, ex);
+    }
+  }
+
   private MissionModelFactory<?, ?, ?> loadMissionModelFactory(final String missionModelId)
   throws NoSuchMissionModelException, MissionModelLoadException
   {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -13,6 +13,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirective;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelJar;
@@ -257,15 +258,11 @@ public final class LocalMissionModelService implements MissionModelService {
   }
 
   @Override
-  public void refreshActivityValidations(final String missionModelId, final String activityDirectiveId, final SerializedActivity activity)
-  throws NoSuchMissionModelException, NoSuchActivityDirectiveException, InvalidArgumentsException
+  public void refreshActivityValidations(final String missionModelId, final ActivityDirective directive)
+  throws NoSuchMissionModelException, InvalidArgumentsException
   {
-    try {
-      final var notices = validateActivityArguments(missionModelId, activity);
-      this.missionModelRepository.updateActivityDirectiveValidations(activityDirectiveId, notices);
-    } catch (final MissionModelRepository.NoSuchActivityDirectiveException ex) {
-      throw new NoSuchActivityDirectiveException(activityDirectiveId, ex);
-    }
+    final var notices = validateActivityArguments(missionModelId, directive.activity());
+    this.missionModelRepository.updateActivityDirectiveValidations(directive.id(), directive.argumentsModifiedTime(), notices);
   }
 
   private MissionModelFactory<?, ?, ?> loadMissionModelFactory(final String missionModelId)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -64,6 +64,8 @@ public interface MissionModelService {
 
   void refreshModelParameters(String missionModelId) throws NoSuchMissionModelException;
   void refreshActivityTypes(String missionModelId) throws NoSuchMissionModelException;
+  void refreshActivityValidations(String missionModelId, String activityDirectiveId, SerializedActivity activity)
+  throws NoSuchMissionModelException, NoSuchActivityDirectiveException, InvalidArgumentsException;
 
   final class NoSuchMissionModelException extends Exception {
     public final String missionModelId;
@@ -74,6 +76,17 @@ public interface MissionModelService {
     }
 
     public NoSuchMissionModelException(final String missionModelId) { this(missionModelId, null); }
+  }
+
+  final class NoSuchActivityDirectiveException extends Exception {
+    public final String activityDirectiveId;
+
+    public NoSuchActivityDirectiveException(final String activityDirectiveId, final Throwable cause) {
+      super("No activity directive exists with id `" + activityDirectiveId + "`", cause);
+      this.activityDirectiveId = activityDirectiveId;
+    }
+
+    public NoSuchActivityDirectiveException(final String activityDirectiveId) { this(activityDirectiveId, null); }
   }
 
   final class NoSuchActivityTypeException extends Exception {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -9,6 +9,8 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirective;
+import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelJar;
@@ -64,8 +66,8 @@ public interface MissionModelService {
 
   void refreshModelParameters(String missionModelId) throws NoSuchMissionModelException;
   void refreshActivityTypes(String missionModelId) throws NoSuchMissionModelException;
-  void refreshActivityValidations(String missionModelId, String activityDirectiveId, SerializedActivity activity)
-  throws NoSuchMissionModelException, NoSuchActivityDirectiveException, InvalidArgumentsException;
+  void refreshActivityValidations(String missionModelId, ActivityDirective directive)
+  throws NoSuchMissionModelException, InvalidArgumentsException;
 
   final class NoSuchMissionModelException extends Exception {
     public final String missionModelId;
@@ -76,17 +78,6 @@ public interface MissionModelService {
     }
 
     public NoSuchMissionModelException(final String missionModelId) { this(missionModelId, null); }
-  }
-
-  final class NoSuchActivityDirectiveException extends Exception {
-    public final String activityDirectiveId;
-
-    public NoSuchActivityDirectiveException(final String activityDirectiveId, final Throwable cause) {
-      super("No activity directive exists with id `" + activityDirectiveId + "`", cause);
-      this.activityDirectiveId = activityDirectiveId;
-    }
-
-    public NoSuchActivityDirectiveException(final String activityDirectiveId) { this(activityDirectiveId, null); }
   }
 
   final class NoSuchActivityTypeException extends Exception {

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsersTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsersTest.java
@@ -3,22 +3,28 @@ package gov.nasa.jpl.aerie.merlin.server.http;
 import gov.nasa.jpl.aerie.json.JsonParseResult;
 import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.merlin.server.models.HasuraAction;
+import gov.nasa.jpl.aerie.merlin.server.models.HasuraActivityDirectiveEvent;
 import gov.nasa.jpl.aerie.merlin.server.models.HasuraMissionModelEvent;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.junit.jupiter.api.Test;
 
 import javax.json.Json;
 import javax.json.JsonValue;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static gov.nasa.jpl.aerie.json.BasicParsers.listP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.longP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.recursiveP;
-import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelActionP;
-import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelEventTriggerP;
+import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.*;
 import static gov.nasa.jpl.aerie.merlin.server.http.MerlinParsersTest.NestedLists.nestedList;
 import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.serializedValueP;
+import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.pgTimestampP;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class MerlinParsersTest {
@@ -165,5 +171,35 @@ public final class MerlinParsersTest {
     final var expected = new HasuraMissionModelEvent("1");
 
     assertThat(hasuraMissionModelEventTriggerP.parse(json).getSuccessOrThrow()).isEqualTo(expected);
+  }
+
+  @Test
+  public void testHasuraActivityDirectiveEventParser() {
+    final var now = new Timestamp(Instant.now());
+
+    final var json = Json
+        .createObjectBuilder()
+        .add("event", Json
+            .createObjectBuilder()
+            .add("data", Json
+                .createObjectBuilder()
+                .add("new", Json
+                    .createObjectBuilder()
+                    .add("plan_id", 1)
+                    .add("id", 1)
+                    .add("type", "Test")
+                    .add("arguments", Json.createObjectBuilder().add("A", 42).build())
+                    .add("last_modified_arguments_at", pgTimestampP.unparse(now))
+                    .build())
+                .add("old", JsonValue.NULL)
+                .build())
+            .add("op", "INSERT")
+            .build())
+        .add("id", "8907a407-28a5-440a-8de6-240b80c58a8b")
+        .build();
+
+    final var expected = new HasuraActivityDirectiveEvent(new PlanId(1), new ActivityDirectiveId(1), "Test", Map.of("A", SerializedValue.of(42)), now);
+
+    assertThat(hasuraActivityDirectiveEventTriggerP.parse(json).getSuccessOrThrow()).isEqualTo(expected);
   }
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -212,4 +212,9 @@ public final class StubMissionModelService implements MissionModelService {
   public void refreshActivityTypes(final String missionModelId) throws NoSuchMissionModelException
   {
   }
+
+  @Override
+  public void refreshActivityValidations(final String missionModelId, final String activityDirectiveId, final SerializedActivity activity)
+  {
+  }
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -7,6 +7,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirective;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelJar;
@@ -214,7 +215,7 @@ public final class StubMissionModelService implements MissionModelService {
   }
 
   @Override
-  public void refreshActivityValidations(final String missionModelId, final String activityDirectiveId, final SerializedActivity activity)
+  public void refreshActivityValidations(final String missionModelId, final ActivityDirective directive)
   {
   }
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsersTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsersTest.java
@@ -1,0 +1,19 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import javax.json.Json;
+import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.pgTimestampP;
+import static org.assertj.core.api.Assertions.assertThat;
+import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
+import org.junit.jupiter.api.Test;
+
+public final class PostgresParsersTest {
+
+  @Test
+  public void testTimestampParser() {
+    final var timestamp = "2022-01-01T23:43:59.83237+00:00";
+    final var expected = Timestamp.fromString("2022-001T23:43:59.83237");
+    final var actual = pgTimestampP.parse(Json.createValue(timestamp)).getSuccessOrThrow();
+
+    assertThat(expected).isEqualTo(actual);
+  }
+}


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2066
* **Review:** By file  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds a Hasura event trigger triggered off of inserts/updates to `activity_directive.arguments` to update the `activity_directive_validations` table.

Suggested to review by file since some refactoring commits were layered on top of each other to incrementally verify PGSQL & Hasura metadata correctness.

## Verification

Upon creation of a `BakeBananaBread` activity with valid arguments the `activity_directive` table now contains:
![Screen Shot 2022-09-16 at 6 47 30 PM](https://user-images.githubusercontent.com/2623817/190835809-f6e26981-45a2-41d3-b4c1-94a3459971c2.png)

Upon creation of a `BakeBananaBread` activity with invalid arguments (a `temperature` of `-2`) the associated `activity_directive_validations.validations` now contains:
```json
{
    "errors": [
        {
            "message": "Temperature must be positive",
            "subjects": [
                "temperature"
            ]
        }
    ],
    "success": false
}
```

## Documentation
TODO will start documentation when the approach made in this PR is roughly accepted.

## Future work
- UI will make use of this new column (@camargo).
- Should we consider removing the `validateActivityArguments` Hasura action since the UI will no longer rely on this action?
- Maybe we should consider adding a `mission_model_parameters.validations` column for symmetry.
  - This could also remove the need for a `validateModelArguments` Hasura action.