### PR TITLE
[AERIE-2091] Fix "classic style" required `@Parameter` support

### DIFF
--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/activities/FooActivity.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/activities/FooActivity.java
@@ -23,6 +23,9 @@ public final class FooActivity {
   public String y = "test";
 
   @Parameter
+  public Integer z; // No default value specified, therefore this parameter is required
+
+  @Parameter
   public List<Vector3D> vecs = List.of(new Vector3D(0.0, 0.0, 0.0));
 
   @Validation("x cannot be exactly 99")

--- a/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/FooActivityTest.java
+++ b/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/FooActivityTest.java
@@ -1,11 +1,15 @@
 package gov.nasa.jpl.aerie.foomissionmodel;
 
 import java.time.Instant;
+import java.util.Map;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.FooActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.generated.ActivityTypes;
+import gov.nasa.jpl.aerie.foomissionmodel.generated.activities.FooActivityMapper;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinTestContext;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InvalidArgumentsException;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -13,8 +17,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static gov.nasa.jpl.aerie.foomissionmodel.generated.ActivityActions.spawn;
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
+import static org.assertj.core.api.Assertions.*;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public final class FooActivityTest {
@@ -50,5 +53,24 @@ public final class FooActivityTest {
     assertThat(model.simpleData.totalVolume.get()).isCloseTo(15.0, within(1e-9));
     delay(10, Duration.SECOND);
     assertThat(model.simpleData.totalVolume.get()).isCloseTo(147.558135, within(1e-9));
+  }
+
+  @Test
+  public void testActivityInstantiate() {
+
+    // Assert missing required argument throws exception
+    assertThatExceptionOfType(InvalidArgumentsException.class).isThrownBy(() ->
+    new FooActivityMapper().instantiate(Map.of(
+        "x", SerializedValue.of(42),
+        "y", SerializedValue.of("test")
+    )));
+
+    // Assert provided required argument throws no exception
+    assertThatNoException().isThrownBy(() ->
+        new FooActivityMapper().instantiate(Map.of(
+           "x", SerializedValue.of(42),
+           "y", SerializedValue.of("test"),
+           "z", SerializedValue.of(43)
+    )));
   }
 }

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllDefinedMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/AllDefinedMethodMaker.java
@@ -61,7 +61,9 @@ import java.util.Optional;
 
     methodBuilder = makeArgumentAssignments(methodBuilder, (builder, parameter) -> builder
         .addStatement(
-            "template.$L = this.mapper_$L.deserializeValue($L.getValue())$W.getSuccessOrThrow(failure -> new $T(\"$L\", failure))",
+            "$L = $T.ofNullable(template.$L = this.mapper_$L.deserializeValue($L.getValue())$W.getSuccessOrThrow(failure -> new $T(\"$L\", failure)))",
+            parameter.name,
+            Optional.class,
             parameter.name,
             parameter.name,
             "entry",

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelTest.java
@@ -24,150 +24,165 @@ public final class MissionModelTest {
 
   private DirectiveTypeRegistry<?, ?> registry;
 
-    @BeforeEach
-    public void initialize() {
-        this.registry = DirectiveTypeRegistry.extract(new GeneratedMissionModelFactory());
-    }
+  @BeforeEach
+  public void initialize() {
+      this.registry = DirectiveTypeRegistry.extract(new GeneratedMissionModelFactory());
+  }
 
-    @AfterEach
-    public void teardown() {
-      // TODO: [AERIE-1516] Teardown the model to release any system resources (e.g. threads).
-    }
+  @AfterEach
+  public void teardown() {
+    // TODO: [AERIE-1516] Teardown the model to release any system resources (e.g. threads).
+  }
 
-    @Test
-    public void shouldGetActivityTypeList() {
-        // GIVEN
-      final Map<String, ActivityType> expectedTypes = Map.of(
-            "foo", new ActivityType(
-                "foo",
-                List.of(
-                    new Parameter("x", ValueSchema.INT),
-                    new Parameter("y", ValueSchema.STRING),
-                    new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))),
-                List.of(),
-                ValueSchema.ofStruct(Map.of())
-            ));
+  @Test
+  public void shouldGetActivityTypeList() {
+    // GIVEN
+    final Map<String, ActivityType> expectedTypes = Map.of(
+          "foo", new ActivityType(
+              "foo",
+              List.of(
+                  new Parameter("x", ValueSchema.INT),
+                  new Parameter("y", ValueSchema.STRING),
+                  new Parameter("z", ValueSchema.INT),
+                  new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))),
+              List.of(),
+              ValueSchema.ofStruct(Map.of())
+          ));
 
-        // WHEN
-        final var activityTypes = new HashMap<String, ActivityType>();
-        registry.taskSpecTypes().forEach((name, specType) -> activityTypes.put(
-            name,
-            new ActivityType(name,
-                             specType.getParameters(),
-                             specType.getRequiredParameters(),
-                             specType.getReturnValueSchema())));
+    // WHEN
+    final var activityTypes = new HashMap<String, ActivityType>();
+    registry.taskSpecTypes().forEach((name, specType) -> activityTypes.put(
+        name,
+        new ActivityType(name,
+                         specType.getParameters(),
+                         specType.getRequiredParameters(),
+                         specType.getReturnValueSchema())));
 
-      // THEN
-        assertThat(activityTypes).containsAllEntriesOf(expectedTypes);
-    }
+    // THEN
+    assertThat(activityTypes).containsAllEntriesOf(expectedTypes);
+  }
 
-    @Test
-    public void shouldGetActivityType() throws MissionModelService.NoSuchActivityTypeException {
-        // GIVEN
-      final ActivityType expectedType = new ActivityType(
-            "foo",
-            List.of(
-                new Parameter("x", ValueSchema.INT),
-                new Parameter("y", ValueSchema.STRING),
-                new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))),
-            List.of(),
-            ValueSchema.ofStruct(Map.of())
-        );
+  @Test
+  public void shouldGetActivityType() throws MissionModelService.NoSuchActivityTypeException {
+    // GIVEN
+    final ActivityType expectedType = new ActivityType(
+          "foo",
+          List.of(
+              new Parameter("x", ValueSchema.INT),
+              new Parameter("y", ValueSchema.STRING),
+              new Parameter("z", ValueSchema.INT),
+              new Parameter("vecs", ValueSchema.ofSeries(ValueSchema.ofSeries(ValueSchema.REAL)))),
+          List.of(),
+          ValueSchema.ofStruct(Map.of())
+      );
 
-        // WHEN
-        final var typeName = expectedType.name();
+    // WHEN
+    final var typeName = expectedType.name();
+    final var specType = Optional
+        .ofNullable(registry.taskSpecTypes().get(typeName))
+        .orElseThrow(() -> new MissionModelService.NoSuchActivityTypeException(typeName));
+
+    final var type = new ActivityType(
+        typeName,
+        specType.getParameters(),
+        specType.getRequiredParameters(),
+        specType.getReturnValueSchema());
+
+    // THEN
+    assertThat(type).isEqualTo(expectedType);
+  }
+
+  @Test
+  public void shouldNotGetActivityTypeForNonexistentActivityType() {
+    // GIVEN
+    final String activityId = "nonexistent activity type";
+
+    // WHEN
+    final var thrown = catchThrowable(() -> {
         final var specType = Optional
-            .ofNullable(registry.taskSpecTypes().get(typeName))
-            .orElseThrow(() -> new MissionModelService.NoSuchActivityTypeException(typeName));
+            .ofNullable(registry.taskSpecTypes().get(activityId))
+            .orElseThrow(() -> new MissionModelService.NoSuchActivityTypeException(activityId));
 
-        final var type = new ActivityType(
-            typeName,
+        new ActivityType(
+            activityId,
             specType.getParameters(),
             specType.getRequiredParameters(),
             specType.getReturnValueSchema());
+    });
 
-        // THEN
-        assertThat(type).isEqualTo(expectedType);
-    }
+    // THEN
+    assertThat(thrown).isInstanceOf(MissionModelService.NoSuchActivityTypeException.class);
+  }
 
-    @Test
-    public void shouldNotGetActivityTypeForNonexistentActivityType() {
-        // GIVEN
-        final String activityId = "nonexistent activity type";
+  @Test
+  public void shouldInstantiateActivityInstance()
+  throws MissionModelService.NoSuchActivityTypeException, InvalidArgumentsException
+  {
+    // GIVEN
+    final var typeName = "foo";
+    final var parameters = new HashMap<>(Map.of("x", SerializedValue.of(0),
+                                                "y", SerializedValue.of("test"),
+                                                "z", SerializedValue.of(1)));
 
-        // WHEN
-        final var thrown = catchThrowable(() -> {
-            final var specType = Optional
-                .ofNullable(registry.taskSpecTypes().get(activityId))
-                .orElseThrow(() -> new MissionModelService.NoSuchActivityTypeException(activityId));
+    // WHEN
+    final var activity = new SerializedActivity(typeName, parameters);
+    final var specType = Optional
+        .ofNullable(registry.taskSpecTypes().get(activity.getTypeName()))
+        .orElseThrow(() -> new MissionModelService.NoSuchActivityTypeException(activity.getTypeName()));
+    final var failures = specType.validateArguments(activity.getArguments());
 
-            new ActivityType(
-                activityId,
-                specType.getParameters(),
-                specType.getRequiredParameters(),
-                specType.getReturnValueSchema());
-        });
+    // THEN
+    assertThat(failures).isEmpty();
+  }
 
-        // THEN
-        assertThat(thrown).isInstanceOf(MissionModelService.NoSuchActivityTypeException.class);
-    }
+  @Test
+  public void shouldNotInstantiateActivityInstanceWithIncorrectParameterType() {
+    // GIVEN
+    final var typeName = "foo";
+    final var parameters = new HashMap<>(Map.of("x", SerializedValue.of(0),
+                                                "y", SerializedValue.of(1.0)));
 
-    @Test
-    public void shouldInstantiateActivityInstance()
-    throws MissionModelService.NoSuchActivityTypeException, InvalidArgumentsException
-    {
-        // GIVEN
-        final var typeName = "foo";
-        final var parameters = new HashMap<>(Map.of("x", SerializedValue.of(0),
-                                                    "y", SerializedValue.of("test")));
-
-        // WHEN
+    // WHEN
+    final var thrown = catchThrowable(() -> {
         final var activity = new SerializedActivity(typeName, parameters);
         final var specType = Optional
             .ofNullable(registry.taskSpecTypes().get(activity.getTypeName()))
             .orElseThrow(() -> new MissionModelService.NoSuchActivityTypeException(activity.getTypeName()));
-        final var failures = specType.validateArguments(activity.getArguments());
+        specType.validateArguments(activity.getArguments());
+    });
 
-        // THEN
-        assertThat(failures).isEmpty();
+    // THEN
+    assertThat(thrown).isInstanceOf(InvalidArgumentsException.class);
+    if (thrown instanceof final InvalidArgumentsException e) {
+      assertThat(e.extraneousArguments).isEmpty();
+      assertThat(e.missingArguments).map(args -> args.parameterName()).isEqualTo(List.of("z"));
+      assertThat(e.unconstructableArguments).map(args -> args.parameterName()).isEqualTo(List.of("y"));
+      assertThat(e.validArguments).map(args -> args.parameterName()).isEqualTo(List.of("x", "y", "vecs"));
     }
+  }
 
-    @Test
-    public void shouldNotInstantiateActivityInstanceWithIncorrectParameterType() {
-        // GIVEN
-        final var typeName = "foo";
-        final var parameters = new HashMap<>(Map.of("x", SerializedValue.of(0),
-                                                    "y", SerializedValue.of(1.0)));
+  @Test
+  public void shouldNotInstantiateActivityInstanceWithExtraParameter() {
+    // GIVEN
+    final var typeName = "foo";
+    final var parameters = new HashMap<>(Map.of("Nonexistent", SerializedValue.of("")));
 
-        // WHEN
-        final var thrown = catchThrowable(() -> {
-            final var activity = new SerializedActivity(typeName, parameters);
-            final var specType = Optional
-                .ofNullable(registry.taskSpecTypes().get(activity.getTypeName()))
-                .orElseThrow(() -> new MissionModelService.NoSuchActivityTypeException(activity.getTypeName()));
-            specType.validateArguments(activity.getArguments());
-        });
+    // WHEN
+    final var thrown = catchThrowable(() -> {
+        final var activity = new SerializedActivity(typeName, parameters);
+        final var specType = Optional
+            .ofNullable(registry.taskSpecTypes().get(activity.getTypeName()))
+            .orElseThrow(() -> new MissionModelService.NoSuchActivityTypeException(activity.getTypeName()));
+        specType.validateArguments(activity.getArguments());
+    });
 
-        // THEN
-        assertThat(thrown).isInstanceOf(InvalidArgumentsException.class);
+    // THEN
+    assertThat(thrown).isInstanceOf(InvalidArgumentsException.class);
+    if (thrown instanceof final InvalidArgumentsException e) {
+      assertThat(e.extraneousArguments).map(args -> args.parameterName()).isEqualTo(List.of("Nonexistent"));
+      assertThat(e.missingArguments).map(args -> args.parameterName()).isEqualTo(List.of("z"));
+      assertThat(e.unconstructableArguments).isEmpty();
+      assertThat(e.validArguments).map(args -> args.parameterName()).isEqualTo(List.of("x", "y", "vecs"));
     }
-
-    @Test
-    public void shouldNotInstantiateActivityInstanceWithExtraParameter() {
-        // GIVEN
-        final var typeName = "foo";
-        final var parameters = new HashMap<>(Map.of("Nonexistent", SerializedValue.of("")));
-
-        // WHEN
-        final var thrown = catchThrowable(() -> {
-            final var activity = new SerializedActivity(typeName, parameters);
-            final var specType = Optional
-                .ofNullable(registry.taskSpecTypes().get(activity.getTypeName()))
-                .orElseThrow(() -> new MissionModelService.NoSuchActivityTypeException(activity.getTypeName()));
-            specType.validateArguments(activity.getArguments());
-        });
-
-        // THEN
-        assertThat(thrown).isInstanceOf(InvalidArgumentsException.class);
-    }
+  }
 }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2091
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

Previously the following required parameter would always result in an `InvalidArgumentsException` due to the internal argument value not being reassigned from (planner) provided arguments:
```java
@Parameter
public Integer z; // No default value specified, therefore this parameter is required
```

"Classic style" activities (defined by the `AllDefinedMethodMaker.java` generator) now correctly perform this assignment.

## Verification
Updated `MissionModelTest` and added a new `FooActivityTest` test.

`FooActivityMapper` now contains the following logic:
```java
          case "z":
            z = Optional.ofNullable(template.z = this.mapper_z.deserializeValue(entry.getValue())
                .getSuccessOrThrow(failure -> new UnconstructableArgumentException("z", failure)));
```
Previously the internal `z` value was not being reassigned:
```java
          case "z":
            template.z = this.mapper_z.deserializeValue(entry.getValue())
                .getSuccessOrThrow(failure -> new UnconstructableArgumentException("z", failure));
```

There's a chance that this bug was not caught sooner due to some ostensibly "required" parameters not actually being "required" due to their type being a Java primitive `int`/`long`/etc with a default value of `0`.

## Documentation
None.

## Future work
We could present the user with a warning message at compile time if they define a class member of a primitive Java type (`int`/`long`/etc.) with a `@Parameter` annotation and no assignment statement. For example:
```java
@Parameter
public int z; // No default value *explicitly* specified, however the type is `int` so this parameter will not be considered "required" by the planner
```