### PR TITLE
docs: prefix public UI env vars

### DIFF
--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -71,32 +71,32 @@ This document provides detailed information about environment variables for each
 
 ## Aerie Scheduler
 
-| Name                    | Description                                                           | Type     | Default                                             |
-| ----------------------- | --------------------------------------------------------------------- | -------- | --------------------------------------------------- |
-| `JAVA_OPTS`             | Configuration for the scheduler's logging level and output file       | `string` | log level: warn. output: stderr                     |
-| `MERLIN_GRAPHQL_URL`    | URI of the Merlin graphql interface to call                           | `string` | http://hasura:8080/v1/graphql                       |
-| `MERLIN_LOCAL_STORE`    | Local storage for Merlin in the container (for backdoor jar access)   | `string` | /usr/src/app/merlin_file_store                      |
-| `SCHEDULER_DB`          | The DB for scheduler                                                  | `string` | aerie_scheduler                                     |
-| `SCHEDULER_DB_PASSWORD` | Password of the DB instance                                           | `string` |                                                     |
-| `SCHEDULER_DB_PORT`     | The DB instance port number that scheduler will connect with          | `number` | 5432                                                |
-| `SCHEDULER_DB_SERVER`   | The DB instance that scheduler will connect with                      | `string` |                                                     |
-| `SCHEDULER_DB_USER`     | Username of the DB instance                                           | `string` |                                                     |
-| `SCHEDULER_LOCAL_STORE` | Local storage for scheduler in the container                          | `string` | /usr/src/app/scheduler_file_store                   |
-| `SCHEDULER_LOGGING`     | Whether or not you want Javalin to log server information             | `string` | true                                                |
-| `SCHEDULER_OUTPUT_MODE` | how scheduler output is sent back to aerie                            | `string` | UpdateInputPlanWithNewActivities                    |
-| `SCHEDULER_PORT`        | Port number for the scheduler server                                  | `number` | 27185                                               |
-| `SCHEDULER_RULES_JAR`   | Jar file to load scheduling rules from (until user input to database) | `string` | /usr/src/app/merlin_file_store/scheduler_rules.jar  |
+| Name                    | Description                                                           | Type     | Default                                            |
+| ----------------------- | --------------------------------------------------------------------- | -------- | -------------------------------------------------- |
+| `JAVA_OPTS`             | Configuration for the scheduler's logging level and output file       | `string` | log level: warn. output: stderr                    |
+| `MERLIN_GRAPHQL_URL`    | URI of the Merlin graphql interface to call                           | `string` | http://hasura:8080/v1/graphql                      |
+| `MERLIN_LOCAL_STORE`    | Local storage for Merlin in the container (for backdoor jar access)   | `string` | /usr/src/app/merlin_file_store                     |
+| `SCHEDULER_DB`          | The DB for scheduler                                                  | `string` | aerie_scheduler                                    |
+| `SCHEDULER_DB_PASSWORD` | Password of the DB instance                                           | `string` |                                                    |
+| `SCHEDULER_DB_PORT`     | The DB instance port number that scheduler will connect with          | `number` | 5432                                               |
+| `SCHEDULER_DB_SERVER`   | The DB instance that scheduler will connect with                      | `string` |                                                    |
+| `SCHEDULER_DB_USER`     | Username of the DB instance                                           | `string` |                                                    |
+| `SCHEDULER_LOCAL_STORE` | Local storage for scheduler in the container                          | `string` | /usr/src/app/scheduler_file_store                  |
+| `SCHEDULER_LOGGING`     | Whether or not you want Javalin to log server information             | `string` | true                                               |
+| `SCHEDULER_OUTPUT_MODE` | how scheduler output is sent back to aerie                            | `string` | UpdateInputPlanWithNewActivities                   |
+| `SCHEDULER_PORT`        | Port number for the scheduler server                                  | `number` | 27185                                              |
+| `SCHEDULER_RULES_JAR`   | Jar file to load scheduling rules from (until user input to database) | `string` | /usr/src/app/merlin_file_store/scheduler_rules.jar |
 
 ## Aerie UI
 
-| Name                    | Description                                                                                               | Type     | Default                          |
-| ----------------------- | --------------------------------------------------------------------------------------------------------- | -------- | -------------------------------- |
-| `GATEWAY_CLIENT_URL`    | Url of the Gateway as called from the client (i.e. web browser)                                           | `string` | http://localhost:9000            |
-| `GATEWAY_SERVER_URL`    | Url of the Gateway as called from the server (i.e. Node.js container)                                     | `string` | http://localhost:9000            |
-| `HASURA_CLIENT_URL`     | Url of Hasura as called from the client (i.e. web browser)                                                | `string` | http://localhost:8080/v1/graphql |
-| `HASURA_SERVER_URL`     | Url of Hasura as called from the server (i.e. Node.js container)                                          | `string` | http://localhost:8080/v1/graphql |
-| `HASURA_WEB_SOCKET_URL` | Url of Hasura called to establish a web-socket connection from the client                                 | `string` | ws://localhost:8080/v1/graphql   |
-| `ORIGIN`                | Url of where the UI is served from. See the [Svelte Kit Adapter Node docs][svelte-kit-adapter-node-docs]. | `string` | http://localhost                 |
+| Name                           | Description                                                                                               | Type     | Default                          |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------- | -------- | -------------------------------- |
+| `ORIGIN`                       | Url of where the UI is served from. See the [Svelte Kit Adapter Node docs][svelte-kit-adapter-node-docs]. | `string` | http://localhost                 |
+| `PUBLIC_GATEWAY_CLIENT_URL`    | Url of the Gateway as called from the client (i.e. web browser)                                           | `string` | http://localhost:9000            |
+| `PUBLIC_GATEWAY_SERVER_URL`    | Url of the Gateway as called from the server (i.e. Node.js container)                                     | `string` | http://localhost:9000            |
+| `PUBLIC_HASURA_CLIENT_URL`     | Url of Hasura as called from the client (i.e. web browser)                                                | `string` | http://localhost:8080/v1/graphql |
+| `PUBLIC_HASURA_SERVER_URL`     | Url of Hasura as called from the server (i.e. Node.js container)                                          | `string` | http://localhost:8080/v1/graphql |
+| `PUBLIC_HASURA_WEB_SOCKET_URL` | Url of Hasura called to establish a web-socket connection from the client                                 | `string` | ws://localhost:8080/v1/graphql   |
 
 ## Hasura
 

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -105,13 +105,13 @@ services:
     container_name: aerie_ui
     depends_on: ["postgres"]
     environment:
-      AUTH_TYPE: none
-      GATEWAY_CLIENT_URL: http://localhost:9000
-      GATEWAY_SERVER_URL: http://aerie_gateway:9000
-      HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
-      HASURA_SERVER_URL: http://hasura:8080/v1/graphql
-      HASURA_WEB_SOCKET_URL: ws://localhost:8080/v1/graphql
       ORIGIN: http://localhost
+      PUBLIC_AUTH_TYPE: none
+      PUBLIC_GATEWAY_CLIENT_URL: http://localhost:9000
+      PUBLIC_GATEWAY_SERVER_URL: http://aerie_gateway:9000
+      PUBLIC_HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
+      PUBLIC_HASURA_SERVER_URL: http://hasura:8080/v1/graphql
+      PUBLIC_HASURA_WEB_SOCKET_URL: ws://localhost:8080/v1/graphql
     image: "${REPOSITORY_DOCKER_URL}/aerie-ui:${DOCKER_TAG}"
     ports: ["80:80"]
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,14 +103,14 @@ services:
     container_name: aerie_ui
     depends_on: ["postgres"]
     environment:
-      AUTH_TYPE: none
-      GATEWAY_CLIENT_URL: http://localhost:9000
-      GATEWAY_SERVER_URL: http://aerie_gateway:9000
-      HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
-      HASURA_SERVER_URL: http://hasura:8080/v1/graphql
-      HASURA_WEB_SOCKET_URL: ws://localhost:8080/v1/graphql
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
       ORIGIN: http://localhost
+      PUBLIC_AUTH_TYPE: none
+      PUBLIC_GATEWAY_CLIENT_URL: http://localhost:9000
+      PUBLIC_GATEWAY_SERVER_URL: http://aerie_gateway:9000
+      PUBLIC_HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
+      PUBLIC_HASURA_SERVER_URL: http://hasura:8080/v1/graphql
+      PUBLIC_HASURA_WEB_SOCKET_URL: ws://localhost:8080/v1/graphql
     image: "ghcr.io/nasa-ammos/aerie-ui:develop"
     ports: ["80:80"]
     restart: always

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -15,10 +15,10 @@ services:
       MERLIN_GRAPHQL_URL: http://hasura:8080/v1/graphql
       COMMANDING_SERVER_PORT: 27184
       COMMANDING_DB: aerie_commanding
-      COMMANDING_DB_PASSWORD: "${AERIE_PASSWORD}"
+      COMMANDING_DB_PASSWORD: '${AERIE_PASSWORD}'
       COMMANDING_DB_PORT: 5432
       COMMANDING_DB_SERVER: postgres
-      COMMANDING_DB_USER: "${AERIE_USERNAME}"
+      COMMANDING_DB_USER: '${AERIE_USERNAME}'
       COMMANDING_LOCAL_STORE: /usr/src/app/commanding_file_store
     image: aerie_commanding
     ports: ['27184:27184']
@@ -38,9 +38,9 @@ services:
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin
       POSTGRES_AERIE_SCHEDULER_DB: aerie_scheduler
       POSTGRES_HOST: postgres
-      POSTGRES_PASSWORD: "${AERIE_PASSWORD}"
+      POSTGRES_PASSWORD: '${AERIE_PASSWORD}'
       POSTGRES_PORT: 5432
-      POSTGRES_USER: "${AERIE_USERNAME}"
+      POSTGRES_USER: '${AERIE_USERNAME}'
     image: 'ghcr.io/nasa-ammos/aerie-gateway:develop'
     ports: ['9000:9000']
     restart: always
@@ -54,10 +54,10 @@ services:
     depends_on: ['postgres']
     environment:
       MERLIN_DB: 'aerie_merlin'
-      MERLIN_DB_PASSWORD: "${AERIE_PASSWORD}"
+      MERLIN_DB_PASSWORD: '${AERIE_PASSWORD}'
       MERLIN_DB_PORT: 5432
       MERLIN_DB_SERVER: postgres
-      MERLIN_DB_USER: "${AERIE_USERNAME}"
+      MERLIN_DB_USER: '${AERIE_USERNAME}'
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
       MERLIN_PORT: 27183
       JAVA_OPTS: >
@@ -65,7 +65,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
-      UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
+      UNTRUE_PLAN_START: '2000-01-01T11:58:55.816Z'
     image: aerie_merlin
     ports: ['27183:27183', '5005:5005']
     restart: always
@@ -81,10 +81,10 @@ services:
       MERLIN_GRAPHQL_URL: http://hasura:8080/v1/graphql
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
       SCHEDULER_DB: 'aerie_scheduler'
-      SCHEDULER_DB_PASSWORD: "${AERIE_PASSWORD}"
+      SCHEDULER_DB_PASSWORD: '${AERIE_PASSWORD}'
       SCHEDULER_DB_PORT: 5432
       SCHEDULER_DB_SERVER: postgres
-      SCHEDULER_DB_USER: "${AERIE_USERNAME}"
+      SCHEDULER_DB_USER: '${AERIE_USERNAME}'
       SCHEDULER_LOCAL_STORE: /usr/src/app/scheduler_file_store
       SCHEDULER_LOGGING: 'true'
       SCHEDULER_OUTPUT_MODE: UpdateInputPlanWithNewActivities
@@ -104,14 +104,14 @@ services:
     container_name: aerie_ui
     depends_on: ['postgres']
     environment:
-      AUTH_TYPE: none
-      GATEWAY_CLIENT_URL: http://localhost:9000
-      GATEWAY_SERVER_URL: http://aerie_gateway:9000
-      HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
-      HASURA_SERVER_URL: http://hasura:8080/v1/graphql
-      HASURA_WEB_SOCKET_URL: ws://localhost:8080/v1/graphql
       NODE_TLS_REJECT_UNAUTHORIZED: '0'
       ORIGIN: http://localhost
+      PUBLIC_AUTH_TYPE: none
+      PUBLIC_GATEWAY_CLIENT_URL: http://localhost:9000
+      PUBLIC_GATEWAY_SERVER_URL: http://aerie_gateway:9000
+      PUBLIC_HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
+      PUBLIC_HASURA_SERVER_URL: http://hasura:8080/v1/graphql
+      PUBLIC_HASURA_WEB_SOCKET_URL: ws://localhost:8080/v1/graphql
     image: 'ghcr.io/nasa-ammos/aerie-ui:develop'
     ports: ['80:80']
     restart: always
@@ -123,17 +123,17 @@ services:
     depends_on: ['postgres']
     environment:
       MERLIN_WORKER_DB: 'aerie_merlin'
-      MERLIN_WORKER_DB_PASSWORD: "${AERIE_PASSWORD}"
+      MERLIN_WORKER_DB_PASSWORD: '${AERIE_PASSWORD}'
       MERLIN_WORKER_DB_PORT: 5432
       MERLIN_WORKER_DB_SERVER: postgres
-      MERLIN_WORKER_DB_USER: "${AERIE_USERNAME}"
+      MERLIN_WORKER_DB_USER: '${AERIE_USERNAME}'
       MERLIN_WORKER_LOCAL_STORE: /usr/src/app/merlin_file_store
       JAVA_OPTS: >
         -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
-      UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
+      UNTRUE_PLAN_START: '2000-01-01T11:58:55.816Z'
     ports: ['5007:5005', '27187:8080']
     restart: always
     volumes:
@@ -146,17 +146,17 @@ services:
     depends_on: ['postgres']
     environment:
       MERLIN_WORKER_DB: 'aerie_merlin'
-      MERLIN_WORKER_DB_PASSWORD: "${AERIE_PASSWORD}"
+      MERLIN_WORKER_DB_PASSWORD: '${AERIE_PASSWORD}'
       MERLIN_WORKER_DB_PORT: 5432
       MERLIN_WORKER_DB_SERVER: postgres
-      MERLIN_WORKER_DB_USER: "${AERIE_USERNAME}"
+      MERLIN_WORKER_DB_USER: '${AERIE_USERNAME}'
       MERLIN_WORKER_LOCAL_STORE: /usr/src/app/merlin_file_store
       JAVA_OPTS: >
         -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
-      UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
+      UNTRUE_PLAN_START: '2000-01-01T11:58:55.816Z'
     ports: ['5008:5005', '27188:8080']
     restart: always
     volumes:
@@ -165,17 +165,17 @@ services:
     container_name: hasura
     depends_on: ['postgres']
     environment:
-      AERIE_MERLIN_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_merlin"
-      AERIE_SCHEDULER_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_scheduler"
-      AERIE_COMMANDING_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_commanding"
-      AERIE_UI_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_ui"
+      AERIE_MERLIN_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_merlin'
+      AERIE_SCHEDULER_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_scheduler'
+      AERIE_COMMANDING_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_commanding'
+      AERIE_UI_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_ui'
       HASURA_GRAPHQL_DEV_MODE: 'true'
       HASURA_GRAPHQL_ENABLE_CONSOLE: 'true'
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
       HASURA_GRAPHQL_LOG_LEVEL: info
-      HASURA_GRAPHQL_METADATA_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_hasura"
+      HASURA_GRAPHQL_METADATA_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_hasura'
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: "hasura/graphql-engine:v2.8.4.cli-migrations-v3"
+    image: 'hasura/graphql-engine:v2.8.4.cli-migrations-v3'
     ports: ['8080:8080']
     restart: always
     volumes:
@@ -184,10 +184,10 @@ services:
     container_name: postgres
     environment:
       POSTGRES_DB: postgres
-      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
-      POSTGRES_USER: "${POSTGRES_USER}"
-      AERIE_USERNAME: "${AERIE_USERNAME}"
-      AERIE_PASSWORD: "${AERIE_PASSWORD}"
+      POSTGRES_PASSWORD: '${POSTGRES_PASSWORD}'
+      POSTGRES_USER: '${POSTGRES_USER}'
+      AERIE_USERNAME: '${AERIE_USERNAME}'
+      AERIE_PASSWORD: '${AERIE_PASSWORD}'
     image: postgres:14.1
     ports: ['5432:5432']
     restart: always


### PR DESCRIPTION
* **Tickets addressed:** [AERIE-2109](https://jira.jpl.nasa.gov/browse/AERIE-2109)
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

- Updates docs and docker-compose files to use new prefix for Aerie UI env vars.
- Prettier auto-formatting for docker-compose files (single-quote strings)
- See: https://github.com/NASA-AMMOS/aerie-ui/pull/147
