### PR TITLE
[FEAT](AERIE-2103) Convert seqJson to seq EDSL

### DIFF
--- a/command-expansion-server/src/app.ts
+++ b/command-expansion-server/src/app.ts
@@ -25,7 +25,7 @@ import { expansionBatchLoader } from './lib/batchLoaders/expansionBatchLoader.js
 import type { CacheItem, UserCodeError } from '@nasa-jpl/aerie-ts-user-code-runner';
 import { InheritedError } from './utils/InheritedError.js';
 import { defaultSeqBuilder } from './defaultSeqBuilder.js';
-import { Command, CommandSeqJson, Sequence } from './lib/codegen/CommandEDSLPreface.js';
+import { Command, CommandSeqJson, Sequence, SequenceSeqJson } from './lib/codegen/CommandEDSLPreface.js';
 import { assertOne } from './utils/assertions.js';
 import { Status } from './common.js';
 import { serializeWithTemporal } from './utils/temporalSerializers.js';
@@ -474,7 +474,7 @@ export interface SeqBuilder {
   ): Sequence;
 }
 
-//generate a sequence JSON from a sequence standalone file
+// Generate a sequence JSON from a sequence standalone file
 app.post('/get-seqjson-for-sequence-standalone', async (req, res, next) => {
   const commandDictionaryID = req.body.input.commandDictionaryID as number;
   const edslBody = req.body.input.edslBody as string;
@@ -613,6 +613,14 @@ app.post('/get-seqjson-for-seqid-and-simulation-dataset', async (req, res, next)
   const seqBuilder = defaultSeqBuilder;
 
   res.status(200).json(seqBuilder(sortedSimulatedActivitiesWithCommands, seqId, seqMetadata).toSeqJson());
+  return next();
+});
+
+// Generate Sequence EDSL from sequence JSON
+app.post('/get-edsl-for-seqjson', async (req, res, next) => {
+  const seqJson = req.body.input.seqJson as SequenceSeqJson;
+
+  res.json(Sequence.fromSeqJson(seqJson).toEDSLString());
   return next();
 });
 

--- a/command-expansion-server/src/lib/codegen/CommandEDSLPreface.spec.ts
+++ b/command-expansion-server/src/lib/codegen/CommandEDSLPreface.spec.ts
@@ -1,0 +1,208 @@
+import {
+  Command,
+  Sequence,
+  DOY_STRING,
+  doyToInstant,
+  HMS_STRING,
+  hmsToDuration,
+  TimingTypes,
+} from './CommandEDSLPreface';
+
+describe('Command', () => {
+  describe('fromSeqJson', () => {
+    it('should parse a command seqjson', () => {
+      const command = Command.fromSeqJson({
+        type: 'command',
+        stem: 'test',
+        metadata: {},
+        args: [],
+        time: { type: TimingTypes.COMMAND_COMPLETE }
+      });
+
+      expect(command).toBeInstanceOf(Command);
+      expect(command.stem).toBe('test');
+      expect(command.metadata).toEqual({});
+      expect(command.arguments).toEqual([]);
+    });
+  });
+
+  describe('toEDSLString()', () => {
+    it('should handle absolute time tagged commands', () => {
+      const command = Command.new({
+        stem: 'TEST',
+        arguments: ['string', 0, true],
+        absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
+      });
+
+      expect(command.toEDSLString()).toEqual("A`2020-001T00:00:00.000`.TEST('string', 0, true)");
+    });
+
+    it('should handle relative time tagged commands', () => {
+      const command = Command.new({
+        stem: 'TEST',
+        arguments: ['string', 0, true],
+        relativeTime: hmsToDuration('00:00:00.000' as HMS_STRING),
+      });
+
+      expect(command.toEDSLString()).toEqual("R`00:00:00.000`.TEST('string', 0, true)");
+    });
+
+    it('should handle epoch relative time tagged commands', () => {
+      const command = Command.new({
+        stem: 'TEST',
+        arguments: ['string', 0, true],
+        epochTime: hmsToDuration('00:00:00.000' as HMS_STRING),
+      });
+
+      expect(command.toEDSLString()).toEqual("E`00:00:00.000`.TEST('string', 0, true)");
+    });
+
+    it('should handle command complete commands', () => {
+      const command = Command.new({
+        stem: 'TEST',
+        arguments: ['string', 0, true],
+      });
+
+      expect(command.toEDSLString()).toEqual("C.TEST('string', 0, true)");
+    });
+
+    it('should handle commands without arguments', () => {
+      const command = Command.new({
+        stem: 'TEST',
+        arguments: [],
+      });
+
+      expect(command.toEDSLString()).toEqual("C.TEST");
+
+      const command2 = Command.new({
+        stem: 'TEST',
+        arguments: {},
+      });
+
+      expect(command2.toEDSLString()).toEqual("C.TEST");
+    });
+
+    it('should convert to EDSL string with array arguments', () => {
+      const command = Command.new({
+        stem: 'TEST',
+        arguments: ['string', 0, true],
+        absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
+      });
+
+      expect(command.toEDSLString()).toEqual("A`2020-001T00:00:00.000`.TEST('string', 0, true)");
+    });
+
+    it('should convert to EDSL string with named arguments', () => {
+      const command = Command.new({
+        stem: 'TEST',
+        arguments: {
+          string: 'string',
+          number: 0,
+          boolean: true,
+        },
+        absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
+      });
+
+      expect(command.toEDSLString()).toEqual("A`2020-001T00:00:00.000`.TEST({\n  string: 'string',\n  number: 0,\n  boolean: true,\n})");
+    });
+  });
+});
+
+describe('Sequence', () => {
+  describe('fromSeqJson', () => {
+    it('should parse a sequence seqjson', () => {
+      const sequence = Sequence.fromSeqJson({
+        id: 'test00000',
+        metadata: {},
+        steps: [
+          {
+            type: 'command',
+            stem: 'test',
+            metadata: {},
+            args: [],
+            time: { type: TimingTypes.COMMAND_COMPLETE }
+          },
+          {
+            type: 'command',
+            stem: 'test2',
+            metadata: {},
+            args: ['string', 0, true],
+            time: { type: TimingTypes.ABSOLUTE, tag: '2020-001T00:00:00.000' as DOY_STRING }
+          }
+        ],
+      });
+
+      expect(sequence).toBeInstanceOf(Sequence);
+      expect(sequence.seqId).toBe('test00000');
+      expect(sequence.metadata).toEqual({});
+      expect(sequence.commands.length).toEqual(2);
+
+      expect(sequence.commands[0]!).toBeInstanceOf(Command);
+      expect(sequence.commands[0]!.stem).toBe('test');
+      expect(sequence.commands[0]!.metadata).toEqual({});
+      expect(sequence.commands[0]!.arguments).toEqual([]);
+
+      expect(sequence.commands[1]!).toBeInstanceOf(Command);
+      expect(sequence.commands[1]!.stem).toBe('test2');
+      expect(sequence.commands[1]!.metadata).toEqual({});
+      expect(sequence.commands[1]!.arguments).toEqual(['string', 0, true]);
+    });
+  });
+
+  describe('toEDSLString()', () => {
+    it('should convert with no commands', () => {
+      const sequence = Sequence.new({
+        seqId: 'test',
+        metadata: {},
+        commands: [],
+      });
+
+      expect(sequence.toEDSLString()).toEqual(
+`export default () =>
+  Sequence.new({
+    seqId: 'test',
+    metadata: {},
+    commands: [
+    ],
+  });`);
+    });
+
+    it('should convert with commands', () => {
+      const sequence = Sequence.new({
+        seqId: 'test',
+        metadata: {},
+        commands: [
+          Command.new({
+            stem: 'TEST',
+            arguments: ['string', 0, true],
+            absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
+          }),
+          Command.new({
+            stem: 'TEST',
+            arguments: {
+              string: 'string',
+              number: 0,
+              boolean: true,
+            },
+            absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
+          }),
+        ],
+      });
+
+      expect(sequence.toEDSLString()).toEqual(
+          `export default () =>
+  Sequence.new({
+    seqId: 'test',
+    metadata: {},
+    commands: [
+      A\`2020-001T00:00:00.000\`.TEST('string', 0, true),
+      A\`2020-001T00:00:00.000\`.TEST({
+        string: 'string',
+        number: 0,
+        boolean: true,
+      }),
+    ],
+  });`);
+    });
+  });
+});

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -139,6 +139,12 @@ type Query {
   ): SequenceSeqJson!
 }
 
+type Query {
+  getEdslForSeqJson(
+    seqJson: SequenceSeqJsonInput!
+  ): String!
+}
+
 enum MerlinSimulationStatus {
   complete
   failed
@@ -238,6 +244,11 @@ type SequenceSeqJson {
   steps: [CommandSeqJson!]!
 }
 
+input SequenceSeqJsonInput {
+  id: String!
+  metadata: Any!
+  steps: [CommandSeqJsonInput!]!
+}
 
 type CommandSeqJson {
   stem: String!,
@@ -247,7 +258,20 @@ type CommandSeqJson {
   args: [Any!]!
 }
 
+input CommandSeqJsonInput {
+  stem: String!,
+  time: CommandSeqJsonTimeInput!,
+  type: CommandSeqJsonType!,
+  metadata: Any!
+  args: [Any!]!
+}
+
 type CommandSeqJsonTime {
+  type: CommandSeqJsonTimeType!
+  tag: String
+}
+
+input CommandSeqJsonTimeInput {
   type: CommandSeqJsonTimeType!
   tag: String
 }

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -19,6 +19,10 @@ actions:
     definition:
       kind: synchronous
       handler: http://aerie_commanding:27184/expand-all-activity-instances
+  - name: getEdslForSeqJson
+    definition:
+      kind: synchronous
+      handler: http://aerie_commanding:27184/get-edsl-for-seqjson
   - name: getModelEffectiveArguments
     definition:
       kind: ""


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2103
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

Added endpoint to convert SeqJson to SeqEDSL `/get-edsl-for-seqjson`

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Added some tests for the seqjson -> sequence and sequence -> seqedsl conversions.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

- [ ] Need to add documentation on the new endpoint for API users

## Future work
<!-- What next steps can we anticipate from here, if any? -->

I think we need to have clear documentation that this is more of a migration tool than something to be generally relied upon as part of standard workflows, preferring instead the SeqEDSL for human centric use cases. It doesn't retain formatting and comments the same way our SeqEDSL does. I think the exception to this is programmatically generated sequences from other tooling where SeqJson is a more appropriate interchange format