### PR TITLE
Include stack trace in failure reason

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/ResultsProtocol.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/ResultsProtocol.java
@@ -2,6 +2,9 @@ package gov.nasa.jpl.aerie.merlin.server;
 
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 public final class ResultsProtocol {
   private ResultsProtocol() {}
 
@@ -35,6 +38,12 @@ public final class ResultsProtocol {
     //   of the underlying resource in order to deallocate it.
     void succeedWith(SimulationResults results);
     void failWith(String reason);
+
+    default void failWith(final Throwable throwable) {
+      final var stringWriter = new StringWriter();
+      throwable.printStackTrace(new PrintWriter(stringWriter));
+      this.failWith(stringWriter.toString());
+    }
   }
 
   public interface OwnerRole extends ReaderRole, WriterRole {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ThreadedSimulationAgent.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ThreadedSimulationAgent.java
@@ -66,7 +66,7 @@ public final class ThreadedSimulationAgent implements SimulationAgent {
               this.simulationAgent.simulate(req.planId(), req.revisionData(), req.writer());
             } catch (final Throwable ex) {
               ex.printStackTrace(System.err);
-              req.writer().failWith(ex.toString());
+              req.writer().failWith(ex);
             }
             // continue
           } else if (request instanceof SimulationRequest.Terminate) {

--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
@@ -83,7 +83,7 @@ public final class MerlinWorkerAppDriver {
         simulationAgent.simulate(planId, revisionData, writer);
       } catch (final Throwable ex) {
         ex.printStackTrace(System.err);
-        writer.failWith(ex.toString());
+        writer.failWith(ex);
       }
     }
   }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/ResultsProtocol.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/ResultsProtocol.java
@@ -2,6 +2,9 @@ package gov.nasa.jpl.aerie.scheduler.server;
 
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleResults;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 /**
  * interfaces used to coordinate parties interested in the scheduling results
  *
@@ -88,6 +91,17 @@ public final class ResultsProtocol {
      * @param reason the reason that the scheduling run failed
      */
     void failWith(String reason);
+
+    /**
+     * convenience method for reporting an unhandled exception
+     *
+     * @param throwable the exception that caused the scheduling run to fail
+     */
+    default void failWith(final Throwable throwable) {
+      final var stringWriter = new StringWriter();
+      throwable.printStackTrace(new PrintWriter(stringWriter));
+      this.failWith(stringWriter.toString());
+    }
   }
 
   /**

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -218,7 +218,7 @@ public record SynchronousSchedulerAgent(
         IOException |
         PlanServiceException e) {
       // unwrap failure message from any anticipated exceptions and forward to subscribers
-      writer.failWith(e.toString());
+      writer.failWith(e);
     }
   }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ThreadedSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ThreadedSchedulerAgent.java
@@ -64,7 +64,7 @@ public final class ThreadedSchedulerAgent implements SchedulerAgent {
               this.schedulerAgent.schedule(req.request(), req.writer());
             } catch (final Throwable ex) {
               ex.printStackTrace(System.err);
-              req.writer().failWith(ex.getMessage());
+              req.writer().failWith(ex);
             }
             // continue
           } else if (request instanceof SchedulingRequest.Terminate) {


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
When simulation or scheduling fails, we set the status to "failed", and include a reason. When it fails in an unexpected way, we save only the name of the exception, or, in the best case, "exception.toString()". This makes diagnosing the issue into a game of 20 questions, wasting the time of everyone involved.

This PR adds a new variant of `failWith` that accepts a `Throwable`, collects the stack trace into a string, and passes it along to the existing `failWith(String)` method. I updated the small handful of places that were stringifying exceptions before calling `failWith`.

I got the approach for stringifying an exception from [this stackoverflow answer](https://stackoverflow.com/a/1149712).

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I intentionally introduced a typo into one of the database actions, and checked to see that the full stack trace was logged to the console:

<img width="1648" alt="Screen Shot 2022-09-22 at 8 48 17 PM" src="https://user-images.githubusercontent.com/1189602/191889106-a384029a-ff43-4e4c-af50-d787d2830918.png">


## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
We should describe our error visibility philosophy in some documentation at some point - in particular our differentiation between business logic errors intended to be addressed by users, and system errors intended to be addressed by deployment engineers or the Aerie team itself.

## Future work
<!-- What next steps can we anticipate from here, if any? -->

There is no distinction between the kinds of errors from the UI's perspective - we should distinguish between user error and system error, so we can display an informative toast for one, and log to the console for the other, perhaps displaying a toast with "something went wrong, please call for help".