### PR TITLE
[AERIE-2025] Reformat scanning artifacts with nasa-scrub

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,3 +73,15 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+
+    - name: NASA Scrub
+      run: |
+        pip install nasa-scrub
+        python3 -m scrub.tools.parsers.translate_results /home/runner/work/aerie/results/*.sarif /home/runner/work/aerie/results/codeql.scrub ${{ github.workspace }} scrub
+        python3 -m scrub.tools.parsers.csv_parser /home/runner/work/aerie/results
+
+    - name: Upload CodeQL Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: codeql-artifacts
+        path: /home/runner/work/aerie/results/*


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2025
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Uses the [utilities](https://nasa.github.io/scrub/utilities.html) provided by [nasa-scrub](https://github.com/nasa/scrub) to copy the CodeQL results from the sarif format to the scrub format. This is done so internal NASA pipelines can read our security scanning artifacts.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Ran manually using [act](https://github.com/nektos/act).

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Update other aerie repos (ui, gateway, etc) with this change. 