### PR TITLE
fix: remove unused gateway env var

### DIFF
--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -27,20 +27,19 @@ This document provides detailed information about environment variables for each
 
 ## Aerie Gateway
 
-| Name                          | Description                                              | Type     | Default                          |
-| ----------------------------- | -------------------------------------------------------- | -------- | -------------------------------- |
-| `GQL_API_URL`                 | URL of GraphQL API for the GraphQL Playground.           | `string` | http://localhost:8080/v1/graphql |
-| `LOG_FILE`                    | Either an output filepath to log to, or 'console'.       | `string` | console                          |
-| `LOG_LEVEL`                   | Logging level for filtering logs.                        | `string` | warn                             |
-| `PORT`                        | Port the Gateway server listens on.                      | `number` | 9000                             |
-| `POSTGRES_AERIE_MERLIN_DB`    | Name of Merlin Postgres database.                        | `string` | aerie_merlin                     |
-| `POSTGRES_AERIE_SCHEDULER_DB` | Name of scheduler Postgres database.                     | `string` | aerie_scheduler                  |
-| `POSTGRES_HOST`               | Hostname of Postgres instance.                           | `string` | localhost                        |
-| `POSTGRES_PASSWORD`           | Password of Postgres instance.                           | `string` |                                  |
-| `POSTGRES_PORT`               | Port of Postgres instance.                               | `number` | 5432                             |
-| `POSTGRES_USER`               | User of Postgres instance.                               | `string` |                                  |
-| `RATE_LIMITER_FILES_MAX`      | Max requests allowed every 15 minutes to file endpoints  | `number` | 1000                             |
-| `RATE_LIMITER_LOGIN_MAX`      | Max requests allowed every 15 minutes to login endpoints | `number` | 1000                             |
+| Name                       | Description                                              | Type     | Default                          |
+| -------------------------- | -------------------------------------------------------- | -------- | -------------------------------- |
+| `GQL_API_URL`              | URL of GraphQL API for the GraphQL Playground.           | `string` | http://localhost:8080/v1/graphql |
+| `LOG_FILE`                 | Either an output filepath to log to, or 'console'.       | `string` | console                          |
+| `LOG_LEVEL`                | Logging level for filtering logs.                        | `string` | warn                             |
+| `PORT`                     | Port the Gateway server listens on.                      | `number` | 9000                             |
+| `POSTGRES_AERIE_MERLIN_DB` | Name of Merlin Postgres database.                        | `string` | aerie_merlin                     |
+| `POSTGRES_HOST`            | Hostname of Postgres instance.                           | `string` | localhost                        |
+| `POSTGRES_PASSWORD`        | Password of Postgres instance.                           | `string` |                                  |
+| `POSTGRES_PORT`            | Port of Postgres instance.                               | `number` | 5432                             |
+| `POSTGRES_USER`            | User of Postgres instance.                               | `string` |                                  |
+| `RATE_LIMITER_FILES_MAX`   | Max requests allowed every 15 minutes to file endpoints  | `number` | 1000                             |
+| `RATE_LIMITER_LOGIN_MAX`   | Max requests allowed every 15 minutes to login endpoints | `number` | 1000                             |
 
 ## Aerie Merlin
 

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -29,7 +29,6 @@ services:
       LOG_LEVEL: warn
       PORT: 9000
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin
-      POSTGRES_AERIE_SCHEDULER_DB: aerie_scheduler
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: "${AERIE_PASSWORD}"
       POSTGRES_PORT: 5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
       PORT: 9000
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin
-      POSTGRES_AERIE_SCHEDULER_DB: aerie_scheduler
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: "${AERIE_PASSWORD}"
       POSTGRES_PORT: 5432

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -36,7 +36,6 @@ services:
       NODE_TLS_REJECT_UNAUTHORIZED: '0'
       PORT: 9000
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin
-      POSTGRES_AERIE_SCHEDULER_DB: aerie_scheduler
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: '${AERIE_PASSWORD}'
       POSTGRES_PORT: 5432


### PR DESCRIPTION
## Description

Just removes old env var that has not been in the gateway for a long time.
