### PR TITLE
[AERIE-1961] External profiles in constraints

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfile.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfile.java
@@ -2,11 +2,16 @@ package gov.nasa.jpl.aerie.constraints.model;
 
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import static gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity.Exclusive;
+import static gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity.Inclusive;
 
 public final class DiscreteProfile implements Profile<DiscreteProfile> {
   public final List<DiscreteProfilePiece> profilePieces;
@@ -129,6 +134,23 @@ public final class DiscreteProfile implements Profile<DiscreteProfile> {
     }
 
     return transitionPoints.select(bounds);
+  }
+
+  public static DiscreteProfile fromExternalProfile(final Duration offsetFromPlanStart, final List<Pair<Duration, SerializedValue>> externalProfile) {
+    final var result = new ArrayList<DiscreteProfilePiece>(externalProfile.size());
+    var cursor = offsetFromPlanStart;
+    for (final var pair: externalProfile) {
+      final var nextCursor = cursor.plus(pair.getKey());
+
+      result.add(new DiscreteProfilePiece(
+          Interval.between(cursor, Inclusive, nextCursor, Exclusive),
+          pair.getValue()
+      ));
+
+      cursor = nextCursor;
+    }
+
+    return new DiscreteProfile(result);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/EvaluationEnvironment.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/EvaluationEnvironment.java
@@ -4,9 +4,11 @@ import java.util.Map;
 
 /** A container for additional context needed for Constraints AST evaluation. */
 public record EvaluationEnvironment(
-    Map<String, ActivityInstance> activityInstances
+    Map<String, ActivityInstance> activityInstances,
+    Map<String, LinearProfile> realExternalProfiles,
+    Map<String, DiscreteProfile> discreteExternalProfiles
 ) {
   public EvaluationEnvironment() {
-    this(Map.of());
+    this(Map.of(), Map.of(), Map.of());
   }
 }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/EvaluationEnvironment.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/EvaluationEnvironment.java
@@ -1,0 +1,12 @@
+package gov.nasa.jpl.aerie.constraints.model;
+
+import java.util.Map;
+
+/** A container for additional context needed for Constraints AST evaluation. */
+public record EvaluationEnvironment(
+    Map<String, ActivityInstance> activityInstances
+) {
+  public EvaluationEnvironment() {
+    this(Map.of());
+  }
+}

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ActivityWindow.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ActivityWindow.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Segment;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -18,8 +17,8 @@ public final class ActivityWindow implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
-    final var activity = environment.get(this.activityAlias);
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+    final var activity = environment.activityInstances().get(this.activityAlias);
     return new Windows(
         Segment.of(Interval.FOREVER, false),
         Segment.of(activity.interval, true)

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/All.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/All.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -23,7 +22,7 @@ public final class All implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     Windows windows = new Windows(bounds, true);
     for (final var expression : this.expressions) {
       windows = windows.and(expression.evaluate(results, bounds, environment));

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Any.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Any.java
@@ -1,11 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -22,7 +22,7 @@ public final class Any implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     Windows windows = new Windows();
     for (final var expression : this.expressions) {
       windows = windows.or(

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Changes.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Changes.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.Profile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -18,7 +17,7 @@ public final class Changes<P extends Profile<P>> implements Expression<Windows> 
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     return this.expression.evaluate(results, bounds, environment).changePoints(bounds);
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteParameter.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteParameter.java
@@ -1,13 +1,12 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfilePiece;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -21,8 +20,8 @@ public final class DiscreteParameter implements Expression<DiscreteProfile> {
   }
 
   @Override
-  public DiscreteProfile evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
-    final var activity = environment.get(this.activityAlias);
+  public DiscreteProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+    final var activity = environment.activityInstances().get(this.activityAlias);
     return new DiscreteProfile(
         List.of(
             new DiscreteProfilePiece(bounds, activity.parameters.get(this.parameterName))));

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteResource.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteResource.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.InputMismatchException;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 
@@ -18,7 +19,7 @@ public final class DiscreteResource implements Expression<DiscreteProfile> {
   }
 
   @Override
-  public DiscreteProfile evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public DiscreteProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     if (results.discreteProfiles.containsKey(this.name)) {
       return results.discreteProfiles.get(this.name);
     } else if (results.realProfiles.containsKey(this.name)) {

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteResource.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteResource.java
@@ -1,13 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
 import gov.nasa.jpl.aerie.constraints.InputMismatchException;
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteResource.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteResource.java
@@ -22,7 +22,9 @@ public final class DiscreteResource implements Expression<DiscreteProfile> {
   public DiscreteProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     if (results.discreteProfiles.containsKey(this.name)) {
       return results.discreteProfiles.get(this.name);
-    } else if (results.realProfiles.containsKey(this.name)) {
+    } else if (environment.discreteExternalProfiles().containsKey(this.name)) {
+      return environment.discreteExternalProfiles().get(this.name);
+    } else if (results.realProfiles.containsKey(this.name) || environment.realExternalProfiles().containsKey(this.name)) {
       throw new InputMismatchException(String.format("%s is a real resource, cannot interpret as discrete", this.name));
     }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteValue.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteValue.java
@@ -1,14 +1,13 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfilePiece;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -20,7 +19,7 @@ public final class DiscreteValue implements Expression<DiscreteProfile> {
   }
 
   @Override
-  public DiscreteProfile evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public DiscreteProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     return new DiscreteProfile(List.of(new DiscreteProfilePiece(bounds, this.value)));
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/EndOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/EndOf.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Segment;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -18,8 +17,8 @@ public final class EndOf implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
-    final var activity = environment.get(this.activityAlias);
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+    final var activity = environment.activityInstances().get(this.activityAlias);
     return new Windows(
         Segment.of(Interval.FOREVER, false),
         Segment.of(Interval.at(activity.interval.end), true)

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Ends.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Ends.java
@@ -1,11 +1,10 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.IntervalContainer;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -17,7 +16,7 @@ public final class Ends<I extends IntervalContainer<I>> implements Expression<I>
   }
 
   @Override
-  public I evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public I evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var expression = this.expression.evaluate(results, bounds, environment);
     return expression.ends();
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Equal.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Equal.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.Profile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -20,7 +19,7 @@ public final class Equal<P extends Profile<P>> implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var leftProfile = this.left.evaluate(results, bounds, environment);
     final var rightProfile = this.right.evaluate(results, bounds, environment);
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Expression.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Expression.java
@@ -1,28 +1,27 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 
-import java.util.Map;
 import java.util.Set;
 
 public interface Expression<T> {
-  T evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment);
+  T evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment);
   String prettyPrint(final String prefix);
   /** Add the resources referenced by this expression to the given set. **/
   void extractResources(Set<String> names);
 
-  default T evaluate(final SimulationResults results, final Map<String, ActivityInstance> environment){
+  default T evaluate(final SimulationResults results, final EvaluationEnvironment environment){
     return this.evaluate(results, results.bounds, environment);
   }
 
   default T evaluate(final SimulationResults results, final Interval bounds){
-    return this.evaluate(results, results.bounds, Map.of());
+    return this.evaluate(results, bounds, new EvaluationEnvironment());
   }
 
   default T evaluate(final SimulationResults results) {
-    return this.evaluate(results, Map.of());
+    return this.evaluate(results, new EvaluationEnvironment());
   }
   default String prettyPrint() {
     return this.prettyPrint("");

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivity.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivity.java
@@ -31,7 +31,11 @@ public final class ForEachActivity implements Expression<List<Violation>> {
     final var violations = new ArrayList<Violation>();
     for (final var activity : results.activities) {
       if (activity.type.equals(this.activityType)) {
-        final var newEnvironment = new EvaluationEnvironment(new HashMap<>(environment.activityInstances()));
+        final var newEnvironment = new EvaluationEnvironment(
+            new HashMap<>(environment.activityInstances()),
+            environment.realExternalProfiles(),
+            environment.discreteExternalProfiles()
+        );
         newEnvironment.activityInstances().put(this.alias, activity);
 
         final var expressionViolations = this.expression.evaluate(results, bounds, newEnvironment);

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivity.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivity.java
@@ -1,6 +1,6 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.model.Violation;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
@@ -8,7 +8,6 @@ import gov.nasa.jpl.aerie.constraints.time.Interval;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -28,13 +27,12 @@ public final class ForEachActivity implements Expression<List<Violation>> {
   }
 
   @Override
-  public List<Violation> evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public List<Violation> evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var violations = new ArrayList<Violation>();
     for (final var activity : results.activities) {
       if (activity.type.equals(this.activityType)) {
-        final var newEnvironment = new HashMap<String, ActivityInstance>();
-        newEnvironment.put(this.alias, activity);
-        newEnvironment.putAll(environment);
+        final var newEnvironment = new EvaluationEnvironment(new HashMap<>(environment.activityInstances()));
+        newEnvironment.activityInstances().put(this.alias, activity);
 
         final var expressionViolations = this.expression.evaluate(results, bounds, newEnvironment);
         for (final var violation : expressionViolations) {

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/GreaterThan.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/GreaterThan.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -20,7 +19,7 @@ public final class GreaterThan implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var leftProfile = this.left.evaluate(results, bounds, environment);
     final var rightProfile = this.right.evaluate(results, bounds, environment);
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/GreaterThanOrEqual.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/GreaterThanOrEqual.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -20,7 +19,7 @@ public final class GreaterThanOrEqual implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var leftProfile = this.left.evaluate(results, bounds, environment);
     final var rightProfile = this.right.evaluate(results, bounds, environment);
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Invert.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Invert.java
@@ -1,11 +1,10 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -17,7 +16,7 @@ public final class Invert implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     return this.expression.evaluate(results, bounds, environment).not();
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LessThan.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LessThan.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -20,7 +19,7 @@ public final class LessThan implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     LinearProfile leftProfile = this.left.evaluate(results, bounds, environment);
     LinearProfile rightProfile = this.right.evaluate(results, bounds, environment);
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LessThanOrEqual.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LessThanOrEqual.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -20,7 +19,7 @@ public final class LessThanOrEqual implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var leftProfile = this.left.evaluate(results, bounds, environment);
     final var rightProfile = this.right.evaluate(results, bounds, environment);
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LongerThan.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LongerThan.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -20,7 +19,7 @@ public final class LongerThan implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var windows = this.windows.evaluate(results, bounds, environment);
     return windows.filterByDuration(this.duration, Duration.MAX_VALUE);
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/NotEqual.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/NotEqual.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.Profile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -20,7 +19,7 @@ public final class NotEqual<P extends Profile<P>> implements Expression<Windows>
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var leftProfile = this.left.evaluate(results, bounds, environment);
     final var rightProfile = this.right.evaluate(results, bounds, environment);
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Plus.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Plus.java
@@ -1,11 +1,10 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -19,7 +18,7 @@ public final class Plus implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     return left.evaluate(results, bounds, environment)
                .plus(right.evaluate(results, bounds, environment));
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ProfileExpression.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ProfileExpression.java
@@ -1,11 +1,10 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.Profile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -17,7 +16,7 @@ public final class ProfileExpression<P extends Profile<P>> implements Expression
   }
 
   @Override
-  public Profile<P> evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Profile<P> evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     return this.expression.evaluate(results, bounds, environment);
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Rate.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Rate.java
@@ -1,11 +1,10 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -18,7 +17,7 @@ public final class Rate implements Expression<LinearProfile> {
 
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     return this.profile.evaluate(results, bounds, environment).rate();
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealParameter.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealParameter.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 
 import gov.nasa.jpl.aerie.constraints.InputMismatchException;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
@@ -22,8 +23,8 @@ public final class RealParameter implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
-    final var activity = environment.get(this.activityAlias);
+  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+    final var activity = environment.activityInstances().get(this.activityAlias);
     final var parameter = activity.parameters.get(this.parameterName);
     final var value = parameter.asReal().orElseThrow(
         () -> new InputMismatchException(

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealResource.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealResource.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 import gov.nasa.jpl.aerie.constraints.InputMismatchException;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
@@ -21,7 +22,7 @@ public final class RealResource implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     if (results.realProfiles.containsKey(this.name)) {
       return results.realProfiles.get(this.name);
     } else if (results.discreteProfiles.containsKey(this.name)) {

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealResource.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealResource.java
@@ -27,6 +27,10 @@ public final class RealResource implements Expression<LinearProfile> {
       return results.realProfiles.get(this.name);
     } else if (results.discreteProfiles.containsKey(this.name)) {
       return convertDiscreteProfile(results.discreteProfiles.get(this.name));
+    } else if (environment.realExternalProfiles().containsKey(this.name)) {
+      return environment.realExternalProfiles().get(this.name);
+    } else if (environment.discreteExternalProfiles().containsKey(this.name)) {
+      return convertDiscreteProfile(environment.discreteExternalProfiles().get(this.name));
     }
 
     throw new InputMismatchException(String.format("%s is not a valid resource", this.name));

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealValue.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealValue.java
@@ -1,13 +1,12 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -19,7 +18,7 @@ public final class RealValue implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     return new LinearProfile(
         List.of(
             new LinearProfilePiece(bounds, this.value, 0.0)

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShiftBy.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShiftBy.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -22,7 +21,7 @@ public final class ShiftBy implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var windows = this.windows.evaluate(results, bounds, environment);
     return windows.shiftBy(this.fromStart, this.fromEnd);
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShorterThan.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShorterThan.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -20,7 +19,7 @@ public final class ShorterThan implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var windows = this.windows.evaluate(results, bounds, environment);
     return windows.filterByDuration(Duration.ZERO, duration);
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansFromWindows.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansFromWindows.java
@@ -1,19 +1,17 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
-import gov.nasa.jpl.aerie.constraints.time.Spans;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.Spans;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 public record SpansFromWindows(Expression<Windows> expression) implements Expression<Spans> {
 
   @Override
-  public Spans evaluate(SimulationResults results, final Interval bounds, Map<String, ActivityInstance> environment) {
+  public Spans evaluate(SimulationResults results, final Interval bounds, EvaluationEnvironment environment) {
     final var windows = this.expression.evaluate(results, bounds, environment);
     return windows.intoSpans();
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Split.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Split.java
@@ -1,13 +1,12 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
-import gov.nasa.jpl.aerie.constraints.time.IntervalContainer;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity;
+import gov.nasa.jpl.aerie.constraints.time.IntervalContainer;
 import gov.nasa.jpl.aerie.constraints.time.Spans;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -28,7 +27,7 @@ public final class Split<I extends IntervalContainer<?>> implements Expression<S
   }
 
   @Override
-  public Spans evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Spans evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var intervals = this.intervals.evaluate(results, bounds, environment);
     return intervals.split(this.numberOfSubIntervals, this.internalStartInclusivity, this.internalEndInclusivity);
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/StartOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/StartOf.java
@@ -1,12 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Segment;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -18,8 +17,8 @@ public final class StartOf implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
-    final var activity = environment.get(this.activityAlias);
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+    final var activity = environment.activityInstances().get(this.activityAlias);
     return new Windows(
         Segment.of(Interval.FOREVER, false),
         Segment.of(Interval.at(activity.interval.start), true)

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Starts.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Starts.java
@@ -1,11 +1,10 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.IntervalContainer;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -17,7 +16,7 @@ public final class Starts<I extends IntervalContainer<I>> implements Expression<
   }
 
   @Override
-  public I evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public I evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var expression = this.expression.evaluate(results, bounds, environment);
     return expression.starts();
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Times.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Times.java
@@ -1,11 +1,10 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -19,7 +18,7 @@ public final class Times implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     return this.profile.evaluate(results, bounds, environment).times(this.multiplier);
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Transition.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Transition.java
@@ -1,13 +1,12 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -23,7 +22,7 @@ public final class Transition implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     return this.profile.evaluate(results, bounds, environment).transitions(oldState, newState, bounds);
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ViolationsOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ViolationsOf.java
@@ -1,13 +1,12 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.model.Violation;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -19,7 +18,7 @@ public final class ViolationsOf implements Expression<List<Violation>> {
   }
 
   @Override
-  public List<Violation> evaluate(SimulationResults results, final Interval bounds, Map<String, ActivityInstance> environment) {
+  public List<Violation> evaluate(SimulationResults results, final Interval bounds, EvaluationEnvironment environment) {
     final var boundsW = new Windows(bounds, true);
     final var satisfiedWindows = this.expression.evaluate(results, bounds, environment);
     return List.of(new Violation(satisfiedWindows.not().and(boundsW)));

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsFromSpans.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsFromSpans.java
@@ -1,19 +1,17 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Spans;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 public record WindowsFromSpans(Expression<Spans> expression) implements Expression<Windows> {
 
   @Override
-  public Windows evaluate(SimulationResults results, final Interval bounds, Map<String, ActivityInstance> environment) {
+  public Windows evaluate(SimulationResults results, final Interval bounds, EvaluationEnvironment environment) {
     final var spans = this.expression.evaluate(results, bounds, environment);
     return spans.intoWindows();
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsOf.java
@@ -1,13 +1,12 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.model.Violation;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -19,7 +18,7 @@ public final class WindowsOf implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(SimulationResults results, final Interval bounds, Map<String, ActivityInstance> environment) {
+  public Windows evaluate(SimulationResults results, final Interval bounds, EvaluationEnvironment environment) {
     var ret = new Windows(bounds, false);
     final var unsatisfiedWindows = this.expression.evaluate(results, bounds, environment);
     for(var unsatisfiedWindow : unsatisfiedWindows){

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsWrapperExpression.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsWrapperExpression.java
@@ -1,11 +1,10 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
-import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
-import java.util.Map;
 import java.util.Set;
 
 public class WindowsWrapperExpression implements Expression<Windows> {
@@ -14,7 +13,7 @@ public class WindowsWrapperExpression implements Expression<Windows> {
   public WindowsWrapperExpression(final Windows windows) { this.windows = windows; }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     return windows;
   }
 

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfileTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfileTest.java
@@ -2,7 +2,9 @@ package gov.nasa.jpl.aerie.constraints.model;
 
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -10,7 +12,9 @@ import java.util.List;
 import static gov.nasa.jpl.aerie.constraints.Assertions.assertEquivalent;
 import static gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity.Exclusive;
 import static gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity.Inclusive;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECOND;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 public class DiscreteProfileTest {
@@ -99,5 +103,24 @@ public class DiscreteProfileTest {
     		.set(Interval.at(15, SECONDS), true);
 
     assertIterableEquals(expected, result);
+  }
+
+  @Test
+  public void testConvertFromExternalFormat() {
+    final var externalProfile = List.of(
+        Pair.of(Duration.of(1, SECOND), SerializedValue.of(true)),
+        Pair.of(Duration.of(1, SECOND), SerializedValue.of(false))
+    );
+
+    final var profile = DiscreteProfile.fromExternalProfile(Duration.of(1, SECOND), externalProfile);
+
+    final var expected = new DiscreteProfile(
+        new DiscreteProfilePiece(Interval.between(1, Inclusive, 2, Exclusive, SECONDS), SerializedValue.of(true)),
+        new DiscreteProfilePiece(Interval.between(2, Inclusive, 3, Exclusive, SECONDS), SerializedValue.of(false))
+    );
+
+    assertIterableEquals(
+        expected.profilePieces, profile.profilePieces
+    );
   }
 }

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/LinearProfileTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/LinearProfileTest.java
@@ -2,12 +2,19 @@ package gov.nasa.jpl.aerie.constraints.model;
 
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static gov.nasa.jpl.aerie.constraints.Assertions.assertEquivalent;
 import static gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity.Exclusive;
 import static gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity.Inclusive;
 import static gov.nasa.jpl.aerie.constraints.time.Interval.interval;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECOND;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
@@ -284,10 +291,29 @@ public class LinearProfileTest {
     final var result = profile.notEqualTo(other, Interval.between(0, 20, SECONDS));
 
     final var expected = new Windows(interval(0, 20, SECONDS), false)
-    		.set(Interval.between(2, Exclusive, 6, Exclusive, SECONDS), true)
-    		.set(Interval.between(8, Exclusive, 14, Exclusive, SECONDS), true)
-    		.set(Interval.between(14, Exclusive, 16, Exclusive, SECONDS), true);
+        .set(Interval.between(2, Exclusive, 6, Exclusive, SECONDS), true)
+        .set(Interval.between(8, Exclusive, 14, Exclusive, SECONDS), true)
+        .set(Interval.between(14, Exclusive, 16, Exclusive, SECONDS), true);
 
     assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testConvertFromExternalFormat() {
+    final var externalProfile = List.of(
+        Pair.of(Duration.of(1, SECOND), RealDynamics.linear(1, 1)),
+        Pair.of(Duration.of(1, SECOND), RealDynamics.linear(5, -1))
+    );
+
+    final var profile = LinearProfile.fromExternalProfile(Duration.of(1, SECOND), externalProfile);
+
+    final var expected = new LinearProfile(
+        new LinearProfilePiece(Interval.between(1, Inclusive, 2, Exclusive, SECONDS), 1, 1),
+        new LinearProfilePiece(Interval.between(2, Inclusive, 3, Exclusive, SECONDS), 5, -1)
+    );
+
+    assertIterableEquals(
+        expected.profilePieces, profile.profilePieces
+    );
   }
 }

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
 import gov.nasa.jpl.aerie.constraints.InputMismatchException;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.time.UnsplittableSpanException;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
@@ -50,7 +51,7 @@ public class ASTTests {
         .set(Interval.between(10, Exclusive, 15, Exclusive, SECONDS), false)
         .set(Interval.at(20, SECONDS), true);
 
-    final var result = new Invert(Supplier.of(windows)).evaluate(simResults, Map.of());
+    final var result = new Invert(Supplier.of(windows)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between(0, Inclusive, 5, Exclusive, SECONDS), false)
@@ -76,7 +77,7 @@ public class ASTTests {
         .set(Interval.between(2, Exclusive, 3, Inclusive, SECONDS), true)
         .set(Interval.between(100, 101, SECONDS), true);
 
-    final var result = new Starts<>(Supplier.of(windows)).evaluate(simResults, Map.of());
+    final var result = new Starts<>(Supplier.of(windows)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between(Duration.MIN_VALUE, Inclusive, Duration.MIN_VALUE.plus(Duration.HOUR), Inclusive), false)
@@ -104,7 +105,7 @@ public class ASTTests {
         .set(Interval.between(2, Inclusive, 3, Exclusive, SECONDS), true)
         .set(Interval.between(100, 101, SECONDS), true);
 
-    final var result = new Ends<>(Supplier.of(windows)).evaluate(simResults, Map.of());
+    final var result = new Ends<>(Supplier.of(windows)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between(Duration.MAX_VALUE.minus(Duration.HOUR), Inclusive, Duration.MAX_VALUE, Inclusive), false)
@@ -130,7 +131,7 @@ public class ASTTests {
     spans.add(Interval.between(0, Exclusive, 5, Exclusive, SECONDS));
     spans.add(Interval.at(20, SECONDS));
 
-    final var result = new Starts<>(Supplier.of(spans)).evaluate(simResults, Map.of());
+    final var result = new Starts<>(Supplier.of(spans)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Spans();
     expected.add(Interval.at(0, SECONDS));
@@ -154,7 +155,7 @@ public class ASTTests {
     spans.add(Interval.between(0, Exclusive, 5, Inclusive, SECONDS));
     spans.add(Interval.at(20, SECONDS));
 
-    final var result = new Ends<>(Supplier.of(spans)).evaluate(simResults, Map.of());
+    final var result = new Ends<>(Supplier.of(spans)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Spans();
     expected.add(Interval.at(5, SECONDS));
@@ -177,7 +178,7 @@ public class ASTTests {
         .set(Interval.between(0, Inclusive, 5, Exclusive, SECONDS), true)
         .set(Interval.between(10000000, Exclusive, 15000001, Exclusive, MICROSECONDS), true);
 
-    final var result = new WindowsFromSpans(new Split<>(Supplier.of(windows), 3, Exclusive, Exclusive)).evaluate(simResults, Map.of());
+    final var result = new WindowsFromSpans(new Split<>(Supplier.of(windows), 3, Exclusive, Exclusive)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows(false)
     		.set(Interval.between(0, Inclusive, 1666666, Exclusive, MICROSECONDS), true)
@@ -204,7 +205,7 @@ public class ASTTests {
     spans.add(Interval.between(0, Inclusive, 5, Exclusive, SECONDS));
     spans.add(Interval.between(0, Exclusive, 5000001, Inclusive, MICROSECONDS));
 
-    final var result = new Split<>(Supplier.of(spans), 3, Inclusive, Exclusive).evaluate(simResults, Map.of());
+    final var result = new Split<>(Supplier.of(spans), 3, Inclusive, Exclusive).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Spans();
     expected.add(Interval.between(0, Inclusive, 1666666, Exclusive, MICROSECONDS));
@@ -231,7 +232,7 @@ public class ASTTests {
         Interval.at(5, SECONDS)
     );
 
-    assertThrows(UnsplittableSpanException.class, () -> new Split<Spans>(Supplier.of(spans), 3, Inclusive, Exclusive).evaluate(simResults, Map.of()));
+    assertThrows(UnsplittableSpanException.class, () -> new Split<Spans>(Supplier.of(spans), 3, Inclusive, Exclusive).evaluate(simResults, new EvaluationEnvironment()));
   }
 
   @Test
@@ -256,7 +257,7 @@ public class ASTTests {
         .set(Interval.between(10, Inclusive, 12, Inclusive, SECONDS), true)
         .set(Interval.between(15, Inclusive, 20, Exclusive, SECONDS), true);
 
-    final var result = new All(Supplier.of(left), Supplier.of(right)).evaluate(simResults, Map.of());
+    final var result = new All(Supplier.of(left), Supplier.of(right)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between( 0, Inclusive,  5, Exclusive, SECONDS), true)
@@ -288,7 +289,7 @@ public class ASTTests {
         .set(Interval.between(10, Inclusive, 12, Inclusive, SECONDS), true)
         .set(Interval.between(15, Inclusive, 20, Exclusive, SECONDS), true);
 
-    final var result = new Any(Supplier.of(left), Supplier.of(right)).evaluate(simResults, Map.of());
+    final var result = new Any(Supplier.of(left), Supplier.of(right)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between(  0, Inclusive,   5, Inclusive, SECONDS), true)
@@ -319,7 +320,7 @@ public class ASTTests {
     final var expandByFromStart = Duration.of(-1, SECONDS);
     final var expandByFromEnd = Duration.of(0, SECONDS);
 
-    final var result = new ShiftBy(Supplier.of(left), expandByFromStart, expandByFromEnd).evaluate(simResults, Map.of());
+    final var result = new ShiftBy(Supplier.of(left), expandByFromStart, expandByFromEnd).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between(-1, Inclusive, 7, Inclusive, SECONDS), true)
@@ -351,7 +352,7 @@ public class ASTTests {
     final var clampFromStart = Duration.of(1, SECONDS);
     final var clampFromEnd = Duration.negate(Duration.of(1, SECONDS));
 
-    final var result = new ShiftBy(Supplier.of(left), clampFromStart, clampFromEnd).evaluate(simResults, Map.of());
+    final var result = new ShiftBy(Supplier.of(left), clampFromStart, clampFromEnd).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between(1, Inclusive, 4, Exclusive, SECONDS), true)
@@ -372,7 +373,7 @@ public class ASTTests {
         Map.of()
     );
 
-    final var result = new RealValue(7).evaluate(simResults, Map.of());
+    final var result = new RealValue(7).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new LinearProfile(
         new LinearProfilePiece(simResults.bounds, 7, 0));
@@ -389,7 +390,7 @@ public class ASTTests {
         Map.of()
     );
 
-    final var result = new DiscreteValue(SerializedValue.of("IDLE")).evaluate(simResults, Map.of());
+    final var result = new DiscreteValue(SerializedValue.of("IDLE")).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new DiscreteProfile(
         List.of(
@@ -413,7 +414,7 @@ public class ASTTests {
         Map.of(),
         Map.of()
     );
-    final var environment = Map.of("act", act);
+    final var environment = new EvaluationEnvironment(Map.of("act", act));
 
     final var result = new RealParameter("act", "p1").evaluate(simResults, environment);
 
@@ -441,7 +442,7 @@ public class ASTTests {
         )
     );
 
-    final var result = new DiscreteResource("discrete2").evaluate(simResults, Map.of());
+    final var result = new DiscreteResource("discrete2").evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = simResults.discreteProfiles.get("discrete2");
 
@@ -465,7 +466,7 @@ public class ASTTests {
         )
     );
 
-    final var result = new RealResource("real2").evaluate(simResults, Map.of());
+    final var result = new RealResource("real2").evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = simResults.realProfiles.get("real2");
 
@@ -489,7 +490,7 @@ public class ASTTests {
         )
     );
 
-    final var result = new RealResource("discrete2").evaluate(simResults, Map.of());
+    final var result = new RealResource("discrete2").evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new LinearProfile(new LinearProfilePiece(Interval.at(5, SECONDS), 2, 0));
 
@@ -514,7 +515,7 @@ public class ASTTests {
     );
 
     try {
-      new RealResource("discrete1").evaluate(simResults, Map.of());
+      new RealResource("discrete1").evaluate(simResults, new EvaluationEnvironment());
     } catch (final InputMismatchException e) {
       return;
     }
@@ -531,7 +532,7 @@ public class ASTTests {
     );
 
     try {
-      new RealResource("does_not_exist").evaluate(simResults, Map.of());
+      new RealResource("does_not_exist").evaluate(simResults, new EvaluationEnvironment());
     } catch (final InputMismatchException e) {
       return;
     }
@@ -556,7 +557,7 @@ public class ASTTests {
         "TypeA",
         "act",
         new Supplier<>(List.of(violation))
-    ).evaluate(simResults, Map.of());
+    ).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = List.of(
         new Violation(List.of(1L), List.of(), new Windows(interval(4, 6, SECONDS), true)),
@@ -587,7 +588,7 @@ public class ASTTests {
             "act",
             new Supplier<>(List.of(violation))
         )
-    ).evaluate(simResults, Map.of());
+    ).evaluate(simResults, new EvaluationEnvironment());
 
     // We expect two violations because there are two activities of TypeA
     // The details of the violation will be the same, since we are using a supplier
@@ -611,7 +612,7 @@ public class ASTTests {
         .set(Interval.between(1, 4, SECONDS), true)
         .set(Interval.between(7,20, SECONDS), true);
 
-    final var result = new ViolationsOf(new Supplier<>(windows)).evaluate(simResults, Map.of());
+    final var result = new ViolationsOf(new Supplier<>(windows)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = List.of(new Violation(windows.not().and(new Windows(simResults.bounds, true))));
 
@@ -627,13 +628,15 @@ public class ASTTests {
         Map.of()
     );
 
-    final var environment = Map.of(
-        "act",
-        new ActivityInstance(
-            1,
-            "TypeA",
-            Map.of(),
-            Interval.between(4, 8, SECONDS))
+    final var environment = new EvaluationEnvironment(
+        Map.of(
+            "act",
+            new ActivityInstance(
+                1,
+                "TypeA",
+                Map.of(),
+                Interval.between(4, 8, SECONDS))
+        )
     );
 
     final var result = new ActivityWindow("act").evaluate(simResults, environment);
@@ -655,13 +658,15 @@ public class ASTTests {
         Map.of()
     );
 
-    final var environment = Map.of(
-        "act",
-        new ActivityInstance(
-            1,
-            "TypeA",
-            Map.of(),
-            Interval.between(4, 8, SECONDS))
+    final var environment = new EvaluationEnvironment(
+        Map.of(
+            "act",
+            new ActivityInstance(
+                1,
+                "TypeA",
+                Map.of(),
+                Interval.between(4, 8, SECONDS))
+        )
     );
 
     final var result = new StartOf("act").evaluate(simResults, environment);
@@ -683,13 +688,15 @@ public class ASTTests {
         Map.of()
     );
 
-    final var environment = Map.of(
-        "act",
-        new ActivityInstance(
-            1,
-            "TypeA",
-            Map.of(),
-            Interval.between(4, 8, SECONDS))
+    final var environment = new EvaluationEnvironment(
+        Map.of(
+            "act",
+            new ActivityInstance(
+                1,
+                "TypeA",
+                Map.of(),
+                Interval.between(4, 8, SECONDS))
+        )
     );
 
     final var result = new EndOf("act").evaluate(simResults, environment);
@@ -721,7 +728,7 @@ public class ASTTests {
         .set(interval(24, 30, SECONDS), false);
 
     final var right = Duration.of(2, SECONDS);
-    final var result = new LongerThan(Supplier.of(left), right).evaluate(simResults, Map.of());
+    final var result = new LongerThan(Supplier.of(left), right).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between(0, Inclusive, 5, Exclusive, SECONDS), true)
@@ -754,7 +761,7 @@ public class ASTTests {
         .set(interval(24, 30, SECONDS), false);
 
     final var right = Duration.of(2, SECONDS);
-    final var result = new ShorterThan(Supplier.of(left), right).evaluate(simResults, Map.of());
+    final var result = new ShorterThan(Supplier.of(left), right).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between(0, Inclusive, 5, Exclusive, SECONDS), false)
@@ -777,7 +784,7 @@ public class ASTTests {
 
 
     @Override
-    public T evaluate(final SimulationResults results, final Interval bounds, final Map<String, ActivityInstance> environment) {
+    public T evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
       return this.value;
     }
 

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -414,7 +414,7 @@ public class ASTTests {
         Map.of(),
         Map.of()
     );
-    final var environment = new EvaluationEnvironment(Map.of("act", act));
+    final var environment = new EvaluationEnvironment(Map.of("act", act), Map.of(), Map.of());
 
     final var result = new RealParameter("act", "p1").evaluate(simResults, environment);
 
@@ -636,7 +636,9 @@ public class ASTTests {
                 "TypeA",
                 Map.of(),
                 Interval.between(4, 8, SECONDS))
-        )
+        ),
+        Map.of(),
+        Map.of()
     );
 
     final var result = new ActivityWindow("act").evaluate(simResults, environment);
@@ -666,7 +668,9 @@ public class ASTTests {
                 "TypeA",
                 Map.of(),
                 Interval.between(4, 8, SECONDS))
-        )
+        ),
+        Map.of(),
+        Map.of()
     );
 
     final var result = new StartOf("act").evaluate(simResults, environment);
@@ -696,7 +700,9 @@ public class ASTTests {
                 "TypeA",
                 Map.of(),
                 Interval.between(4, 8, SECONDS))
-        )
+        ),
+        Map.of(),
+        Map.of()
     );
 
     final var result = new EndOf("act").evaluate(simResults, environment);
@@ -771,6 +777,66 @@ public class ASTTests {
         .set(Interval.at(20, SECONDS), true)
         .set(interval(22, 23, SECONDS), false)
         .set(interval(24, 30, SECONDS), false);
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testExternalDiscreteResource() {
+    final var simResults = new SimulationResults(
+        Interval.between(0, 20, SECONDS),
+        List.of(),
+        Map.of(),
+        Map.of()
+    );
+
+    final var environment = new EvaluationEnvironment(
+        Map.of(),
+        Map.of(
+            "real1", new LinearProfile(new LinearProfilePiece(Interval.at(1, SECONDS), 0, 1)),
+            "real2", new LinearProfile(new LinearProfilePiece(Interval.at(2, SECONDS), 0, 1)),
+            "real3", new LinearProfile(new LinearProfilePiece(Interval.at(3, SECONDS), 0, 1))
+        ),
+        Map.of(
+            "discrete1", new DiscreteProfile(new DiscreteProfilePiece(Interval.at(4, SECONDS), SerializedValue.of("one"))),
+            "discrete2", new DiscreteProfile(new DiscreteProfilePiece(Interval.at(5, SECONDS), SerializedValue.of("two"))),
+            "discrete3", new DiscreteProfile(new DiscreteProfilePiece(Interval.at(6, SECONDS), SerializedValue.of("three")))
+        )
+    );
+
+    final var result = new DiscreteResource("discrete2").evaluate(simResults, environment);
+
+    final var expected = environment.discreteExternalProfiles().get("discrete2");
+
+    assertEquivalent(expected, result);
+  }
+
+  @Test
+  public void testExternalRealResource() {
+    final var simResults = new SimulationResults(
+        Interval.between(0, 20, SECONDS),
+        List.of(),
+        Map.of(),
+        Map.of()
+    );
+
+    final var environment = new EvaluationEnvironment(
+        Map.of(),
+        Map.of(
+            "real1", new LinearProfile(new LinearProfilePiece(Interval.at(1, SECONDS), 0, 1)),
+            "real2", new LinearProfile(new LinearProfilePiece(Interval.at(2, SECONDS), 0, 1)),
+            "real3", new LinearProfile(new LinearProfilePiece(Interval.at(3, SECONDS), 0, 1))
+        ),
+        Map.of(
+            "discrete1", new DiscreteProfile(new DiscreteProfilePiece(Interval.at(4, SECONDS), SerializedValue.of("one"))),
+            "discrete2", new DiscreteProfile(new DiscreteProfilePiece(Interval.at(5, SECONDS), SerializedValue.of("two"))),
+            "discrete3", new DiscreteProfile(new DiscreteProfilePiece(Interval.at(6, SECONDS), SerializedValue.of("three")))
+        )
+    );
+
+    final var result = new RealResource("real2").evaluate(simResults, environment);
+
+    final var expected = environment.realExternalProfiles().get("real2");
 
     assertEquivalent(expected, result);
   }

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -96,7 +96,8 @@ type Query {
 
 type Query {
   constraintsDslTypescript(
-    missionModelId: ID!
+    missionModelId: ID!,
+    planId: Int
   ): DslTypescriptResponse
 }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
@@ -53,8 +53,9 @@ public final class AerieAppDriver {
         configuration.merlinFileStore(),
         stores.missionModels(),
         configuration.untruePlanStart());
+    final var planController = new LocalPlanService(stores.plans());
 
-    final var typescriptCodeGenerationService = new TypescriptCodeGenerationServiceAdapter(missionModelController);
+    final var typescriptCodeGenerationService = new TypescriptCodeGenerationServiceAdapter(missionModelController, planController);
 
     final ConstraintsDSLCompilationService constraintsDSLCompilationService;
     try {
@@ -66,7 +67,6 @@ public final class AerieAppDriver {
     Runtime.getRuntime().addShutdownHook(new Thread(constraintsDSLCompilationService::close));
 
     // Assemble the core non-web object graph.
-    final var planController = new LocalPlanService(stores.plans());
     final var simulationAgent = ThreadedSimulationAgent.spawn(
         "simulation-agent",
         new SynchronousSimulationAgent(planController, missionModelController));

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 import static gov.nasa.jpl.aerie.json.BasicParsers.longP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.mapP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.nullableP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
@@ -52,6 +53,21 @@ public abstract class HasuraParsers {
       .map(
           untuple((name, planId, session, requestQuery) -> new HasuraAction<>(name, new HasuraAction.PlanInput(planId), session)),
           $ -> tuple($.name(), $.input().planId(), $.session(), ""));
+
+  public static final JsonParser<HasuraAction<HasuraAction.ConstraintsInput>> hasuraConstraintsCodeAction
+      = hasuraActionP(
+          productP
+              .field("missionModelId", stringP)
+              .optionalField("planId", nullableP(planIdP))
+              .map(
+                  untuple((modelId, planId) -> new HasuraAction.ConstraintsInput(modelId, planId.flatMap($ -> $))),
+                  $ -> tuple($.missionModelId(), Optional.of($.planId()))
+              )
+      )
+      .map(
+          untuple((name, input, session, requestQuery) -> new HasuraAction<>(name, input, session)),
+          $ -> tuple($.name(), $.input(), $.session(), "")
+      );
 
   public static final JsonParser<HasuraMissionModelEvent> hasuraMissionModelEventTriggerP
       = productP

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraActivityActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraActivityDirectiveEventTriggerP;
+import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraConstraintsCodeAction;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraExternalDatasetActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelArgumentsActionP;
@@ -383,10 +384,11 @@ public final class MerlinBindings implements Plugin {
    */
   private void getConstraintsDslTypescript(final Context ctx) {
     try {
-      final var body = parseJson(ctx.body(), hasuraMissionModelActionP);
+      final var body = parseJson(ctx.body(), hasuraConstraintsCodeAction);
       final var missionModelId = body.input().missionModelId();
+      final var planId = body.input().planId();
 
-      final var response = this.generateConstraintsLibAction.run(missionModelId);
+      final var response = this.generateConstraintsLibAction.run(missionModelId, planId);
       final String resultString;
       if (response instanceof GenerateConstraintsLibAction.Response.Success r) {
         var files = Json.createArrayBuilder();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.mocks;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchActivityInstanceException;
@@ -159,7 +160,7 @@ public final class InMemoryPlanRepository implements PlanRepository {
   }
 
   @Override
-  public List<Pair<Timestamp, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
+  public List<Pair<Duration, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
     return List.of();
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.server.mocks;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchActivityInstanceException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityInstance;
@@ -155,6 +156,16 @@ public final class InMemoryPlanRepository implements PlanRepository {
   throws NoSuchPlanException
   {
     return 0;
+  }
+
+  @Override
+  public List<Pair<Timestamp, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
+    return List.of();
+  }
+
+  @Override
+  public Map<String, ValueSchema> getExternalResourceSchemas(final PlanId planId) throws NoSuchPlanException {
+    return Map.of();
   }
 
   private class MockPlanTransaction implements PlanTransaction {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.server.models;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.util.Map;
+import java.util.Optional;
 
 public record HasuraAction<I extends HasuraAction.Input>(String name, I input, Session session)
 {
@@ -20,4 +21,6 @@ public record HasuraAction<I extends HasuraAction.Input>(String name, I input, S
   public record UploadExternalDatasetInput(PlanId planId,
                                            Timestamp datasetStart,
                                            ProfileSet profileSet) implements Input {}
+
+  public record ConstraintsInput(String missionModelId, Optional<PlanId> planId) implements Input {}
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchActivityInstanceException;
@@ -36,7 +37,7 @@ public interface PlanRepository {
   Map<String, Constraint> getAllConstraintsInPlan(PlanId planId) throws NoSuchPlanException;
 
   long addExternalDataset(PlanId planId, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
-  List<Pair<Timestamp, ProfileSet>> getExternalDatasets(PlanId planId) throws NoSuchPlanException;
+  List<Pair<Duration, ProfileSet>> getExternalDatasets(PlanId planId) throws NoSuchPlanException;
   Map<String, ValueSchema> getExternalResourceSchemas(PlanId planId) throws NoSuchPlanException;
 
   record CreatedPlan(PlanId planId, List<ActivityInstanceId> activityIds) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.server.remotes;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchActivityInstanceException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityInstance;
@@ -11,6 +12,7 @@ import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.services.RevisionData;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 import java.util.Map;
@@ -34,6 +36,8 @@ public interface PlanRepository {
   Map<String, Constraint> getAllConstraintsInPlan(PlanId planId) throws NoSuchPlanException;
 
   long addExternalDataset(PlanId planId, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
+  List<Pair<Timestamp, ProfileSet>> getExternalDatasets(PlanId planId) throws NoSuchPlanException;
+  Map<String, ValueSchema> getExternalResourceSchemas(PlanId planId) throws NoSuchPlanException;
 
   record CreatedPlan(PlanId planId, List<ActivityInstanceId> activityIds) {}
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanDatasetsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanDatasetsAction.java
@@ -1,0 +1,48 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.parseOffset;
+
+/*package-local*/ final class GetPlanDatasetsAction implements AutoCloseable {
+  private final @Language("SQL") String sql = """
+      select
+        p.dataset_id,
+        p.offset_from_plan_start
+      from plan_dataset as p
+      where
+        p.plan_id = ?
+    """;
+
+  private final PreparedStatement statement;
+
+  public GetPlanDatasetsAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public List<PlanDatasetRecord> get(final PlanId planId, final Timestamp planStart) throws SQLException {
+    final var records = new ArrayList<PlanDatasetRecord>();
+    this.statement.setLong(1, planId.id());
+    final var resultSet = statement.executeQuery();
+    while (resultSet.next()) {
+      final var datasetId = resultSet.getLong(1);
+      final var offsetFromPlanStart = parseOffset(resultSet, 2, planStart);
+      records.add(new PlanDatasetRecord(planId.id(), datasetId, offsetFromPlanStart));
+    }
+
+    return records;
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -212,14 +212,14 @@ public final class PostgresPlanRepository implements PlanRepository {
   }
 
   @Override
-  public List<Pair<Timestamp, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
+  public List<Pair<Duration, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
     try (final var connection = this.dataSource.getConnection()) {
       final var plan = getPlanRecord(connection, planId);
       final var planDatasets = ProfileRepository.getAllPlanDatasetsForPlan(connection, planId, plan.startTime());
-      final var result = new ArrayList<Pair<Timestamp, ProfileSet>>();
+      final var result = new ArrayList<Pair<Duration, ProfileSet>>();
       for (final var planDataset: planDatasets) {
         result.add(Pair.of(
-            plan.startTime().plusMicros(planDataset.offsetFromPlanStart().in(Duration.MICROSECOND)),
+            planDataset.offsetFromPlanStart(),
             ProfileRepository.getProfiles(connection, planDataset.datasetId(), new Window(plan.startTime(), plan.endTime()))
         ));
       }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -2,7 +2,9 @@ package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.http.InvalidEntityException;
 import gov.nasa.jpl.aerie.merlin.server.http.InvalidJsonException;
@@ -14,6 +16,7 @@ import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.remotes.MissionModelRepository.NoSuchMissionModelException;
 import gov.nasa.jpl.aerie.merlin.server.remotes.PlanRepository;
+import org.apache.commons.lang3.tuple.Pair;
 
 import javax.json.Json;
 import javax.json.JsonReader;
@@ -22,6 +25,7 @@ import javax.sql.DataSource;
 import java.io.StringReader;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -204,6 +208,43 @@ public final class PostgresPlanRepository implements PlanRepository {
     } catch (final SQLException ex) {
       throw new DatabaseException(
           "Failed to add external dataset to plan with id `%s`".formatted(planId), ex);
+    }
+  }
+
+  @Override
+  public List<Pair<Timestamp, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
+    try (final var connection = this.dataSource.getConnection()) {
+      final var plan = getPlanRecord(connection, planId);
+      final var planDatasets = ProfileRepository.getAllPlanDatasetsForPlan(connection, planId, plan.startTime());
+      final var result = new ArrayList<Pair<Timestamp, ProfileSet>>();
+      for (final var planDataset: planDatasets) {
+        result.add(Pair.of(
+            plan.startTime().plusMicros(planDataset.offsetFromPlanStart().in(Duration.MICROSECOND)),
+            ProfileRepository.getProfiles(connection, planDataset.datasetId(), new Window(plan.startTime(), plan.endTime()))
+        ));
+      }
+      return result;
+    } catch (final SQLException ex) {
+      throw new DatabaseException(
+          "Failed to get external datasets for plan with id `%s`".formatted(planId), ex);
+    }
+  }
+
+  @Override
+  public Map<String, ValueSchema> getExternalResourceSchemas(final PlanId planId) throws NoSuchPlanException {
+    try (final var connection = this.dataSource.getConnection()) {
+      final var plan = getPlanRecord(connection, planId);
+      final var planDatasets = ProfileRepository.getAllPlanDatasetsForPlan(connection, planId, plan.startTime());
+      final var result = new HashMap<String, ValueSchema>();
+      for (final var planDataset: planDatasets) {
+        final var schemas = ProfileRepository.getProfileSchemas(connection, planDataset.datasetId());
+        result.putAll(schemas);
+      }
+      return result;
+    } catch (final SQLException ex) {
+      throw new DatabaseException(
+          "Failed to get external resource schemas for plan with id `%s`".formatted(planId), ex
+      );
     }
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ProfileRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ProfileRepository.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;
@@ -42,6 +43,26 @@ import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.se
     }
 
     return new ProfileSet(realProfiles, discreteProfiles);
+  }
+
+  static Map<String, ValueSchema> getProfileSchemas(
+      final Connection connection,
+      final long datasetId
+  ) throws SQLException {
+    final var results = new HashMap<String, ValueSchema>();
+
+    final var profileRecords = getProfileRecords(connection, datasetId);
+    for (final var record : profileRecords) {
+      results.put(record.name(), record.type().getRight());
+    }
+
+    return results;
+  }
+
+  static List<PlanDatasetRecord> getAllPlanDatasetsForPlan(final Connection connection, final PlanId planId, final Timestamp planStartTime) throws SQLException {
+    try (final var getPlanDatasetsAction = new GetPlanDatasetsAction(connection)) {
+      return getPlanDatasetsAction.get(planId, planStartTime);
+    }
   }
 
   static List<ProfileRecord> getProfileRecords(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsCodeGenService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsCodeGenService.java
@@ -1,6 +1,11 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+
+import java.util.Optional;
+
 public interface ConstraintsCodeGenService {
-  String generateTypescriptTypesFromMissionModel(String missionModelId)
-  throws MissionModelService.NoSuchMissionModelException;
+  String generateTypescriptTypes(String missionModelId, Optional<PlanId> planId)
+  throws MissionModelService.NoSuchMissionModelException, NoSuchPlanException;
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
@@ -3,10 +3,12 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 import gov.nasa.jpl.aerie.constraints.model.Violation;
 import gov.nasa.jpl.aerie.constraints.tree.Expression;
 import gov.nasa.jpl.aerie.json.JsonParser;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.http.InvalidEntityException;
 import gov.nasa.jpl.aerie.merlin.server.http.InvalidJsonException;
 import gov.nasa.jpl.aerie.merlin.server.models.ConstraintsCompilationError;
 import gov.nasa.jpl.aerie.constraints.json.ConstraintParsers;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -16,6 +18,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class ConstraintsDSLCompilationService {
 
@@ -49,10 +52,10 @@ public class ConstraintsDSLCompilationService {
   /**
    * NOTE: This method is not re-entrant (assumes only one call to this method is running at any given time)
    */
-  synchronized public ConstraintsDSLCompilationResult compileConstraintsDSL(final String missionModelId, final String constraintTypescript)
-  throws MissionModelService.NoSuchMissionModelException
+  synchronized public ConstraintsDSLCompilationResult compileConstraintsDSL(final String missionModelId, final Optional<PlanId> planId, final String constraintTypescript)
+  throws MissionModelService.NoSuchMissionModelException, NoSuchPlanException
   {
-    final var missionModelGeneratedCode = this.typescriptCodeGenerationService.generateTypescriptTypesFromMissionModel(missionModelId);
+    final var missionModelGeneratedCode = this.typescriptCodeGenerationService.generateTypescriptTypes(missionModelId, planId);
     final JsonObject messageJson = Json.createObjectBuilder()
         .add("constraintCode", constraintTypescript)
         .add("missionModelGeneratedCode", missionModelGeneratedCode)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -86,14 +86,14 @@ public final class GetSimulationResultsAction {
     final var plan = this.planService.getPlan(planId);
     final var revisionData = this.planService.getPlanRevisionData(planId);
 
-    final var constraintJsons = new HashMap<String, Constraint>();
+    final var constraintCode = new HashMap<String, Constraint>();
 
     try {
       this.missionModelService.getConstraints(plan.missionModelId).forEach(
-          (name, constraint) -> constraintJsons.put("model/" + name, constraint)
+          (name, constraint) -> constraintCode.put("model/" + name, constraint)
       );
       this.planService.getConstraintsForPlan(planId).forEach(
-          (name, constraint) -> constraintJsons.put("plan/" + name, constraint)
+          (name, constraint) -> constraintCode.put("plan/" + name, constraint)
       );
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       throw new RuntimeException("Assumption falsified -- mission model for existing plan does not exist");
@@ -174,7 +174,7 @@ public final class GetSimulationResultsAction {
         discreteProfiles);
 
     final var violations = new HashMap<String, List<Violation>>();
-    for (final var entry : constraintJsons.entrySet()) {
+    for (final var entry : constraintCode.entrySet()) {
 
       // Pipeline switch
       // To remove the old constraints pipeline, delete the `useNewConstraintPipeline` variable

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.constraints.InputMismatchException;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfilePiece;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.Violation;
@@ -124,44 +125,33 @@ public final class GetSimulationResultsAction {
         .orElseGet(Collections::emptyMap);
     final var discreteProfiles = new HashMap<String, DiscreteProfile>(_discreteProfiles.size());
     for (final var entry : _discreteProfiles.entrySet()) {
-      final var pieces = new ArrayList<DiscreteProfilePiece>(entry.getValue().getRight().size());
-
-      var elapsed = Duration.ZERO;
-      for (final var piece : entry.getValue().getRight()) {
-        final var extent = piece.getLeft();
-        final var value = piece.getRight();
-
-        pieces.add(new DiscreteProfilePiece(
-            Interval.between(elapsed, elapsed.plus(extent)),
-            value));
-
-        elapsed = elapsed.plus(extent);
-      }
-
-      discreteProfiles.put(entry.getKey(), new DiscreteProfile(pieces));
+      discreteProfiles.put(entry.getKey(), DiscreteProfile.fromExternalProfile(Duration.ZERO, entry.getValue().getRight()));
     }
     final var _realProfiles = results$
         .map(r -> r.realProfiles)
         .orElseGet(Collections::emptyMap);
     final var realProfiles = new HashMap<String, LinearProfile>();
     for (final var entry : _realProfiles.entrySet()) {
-      final var pieces = new ArrayList<LinearProfilePiece>(entry.getValue().getRight().size());
-
-      var elapsed = Duration.ZERO;
-      for (final var piece : entry.getValue().getRight()) {
-        final var extent = piece.getLeft();
-        final var value = piece.getRight();
-
-        pieces.add(new LinearProfilePiece(
-            Interval.between(elapsed, elapsed.plus(extent)),
-            value.initial,
-            value.rate));
-
-        elapsed = elapsed.plus(extent);
-      }
-
-      realProfiles.put(entry.getKey(), new LinearProfile(pieces));
+      realProfiles.put(entry.getKey(), LinearProfile.fromExternalProfile(Duration.ZERO, entry.getValue().getRight()));
     }
+
+    final var externalDatasets = this.planService.getExternalDatasets(planId);
+    final var realExternalProfiles = new HashMap<String, LinearProfile>();
+    final var discreteExternalProfiles = new HashMap<String, DiscreteProfile>();
+
+    for (final var pair: externalDatasets) {
+      final var offsetFromPlanStart = pair.getLeft();
+      final var profileSet = pair.getRight();
+
+      for (final var profile: profileSet.discreteProfiles().entrySet()) {
+        discreteExternalProfiles.put(profile.getKey(), DiscreteProfile.fromExternalProfile(offsetFromPlanStart, profile.getValue().getRight()));
+      }
+      for (final var profile: profileSet.realProfiles().entrySet()) {
+        realExternalProfiles.put(profile.getKey(), LinearProfile.fromExternalProfile(offsetFromPlanStart, profile.getValue().getRight()));
+      }
+    }
+
+    final var environment = new EvaluationEnvironment(Map.of(), realExternalProfiles, discreteExternalProfiles);
 
     final var planDuration = Duration.of(
         plan.startTimestamp.toInstant().until(plan.endTimestamp.toInstant(), ChronoUnit.MICROS),
@@ -199,7 +189,7 @@ public final class GetSimulationResultsAction {
 
       final var violationEvents = new ArrayList<Violation>();
       try {
-        violationEvents.addAll(expression.evaluate(preparedResults));
+        violationEvents.addAll(expression.evaluate(preparedResults, environment));
       } catch (final InputMismatchException ex) {
         // @TODO Need a better way to catch and propagate the exception to the
         // front end and to log the evaluation failure. This is captured in AERIE-1285.

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public final class GetSimulationResultsAction {
   public sealed interface Response {
@@ -184,6 +185,7 @@ public final class GetSimulationResultsAction {
       // TODO: cache these results
       final var constraintCompilationResult = constraintsDSLCompilationService.compileConstraintsDSL(
           plan.missionModelId,
+          Optional.of(planId),
           constraint.definition()
       );
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
@@ -7,7 +8,9 @@ import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.remotes.PlanRepository;
+import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.List;
 import java.util.Map;
 
 public final class LocalPlanService implements PlanService {
@@ -39,5 +42,15 @@ public final class LocalPlanService implements PlanService {
   throws NoSuchPlanException
   {
     return this.planRepository.addExternalDataset(planId, datasetStart, profileSet);
+  }
+
+  @Override
+  public List<Pair<Timestamp, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
+    return this.planRepository.getExternalDatasets(planId);
+  }
+
+  @Override
+  public Map<String, ValueSchema> getExternalResourceSchemas(final PlanId planId) throws NoSuchPlanException {
+    return this.planRepository.getExternalResourceSchemas(planId);
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
@@ -45,7 +46,7 @@ public final class LocalPlanService implements PlanService {
   }
 
   @Override
-  public List<Pair<Timestamp, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
+  public List<Pair<Duration, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
     return this.planRepository.getExternalDatasets(planId);
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
@@ -19,6 +20,6 @@ public interface PlanService {
   Map<String, Constraint> getConstraintsForPlan(PlanId planId) throws NoSuchPlanException;
 
   long addExternalDataset(PlanId planId, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
-  List<Pair<Timestamp, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException;
+  List<Pair<Duration, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException;
   Map<String, ValueSchema> getExternalResourceSchemas(final PlanId planId) throws NoSuchPlanException;
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
@@ -1,12 +1,15 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
+import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.List;
 import java.util.Map;
 
 public interface PlanService {
@@ -16,4 +19,6 @@ public interface PlanService {
   Map<String, Constraint> getConstraintsForPlan(PlanId planId) throws NoSuchPlanException;
 
   long addExternalDataset(PlanId planId, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
+  List<Pair<Timestamp, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException;
+  Map<String, ValueSchema> getExternalResourceSchemas(final PlanId planId) throws NoSuchPlanException;
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceAdapter.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceAdapter.java
@@ -3,20 +3,24 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.constraints.TypescriptCodeGenerationService;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public class TypescriptCodeGenerationServiceAdapter implements ConstraintsCodeGenService {
   private final MissionModelService missionModelService;
+  private final PlanService planService;
 
-  public TypescriptCodeGenerationServiceAdapter(final MissionModelService missionModelService) {
+  public TypescriptCodeGenerationServiceAdapter(final MissionModelService missionModelService, final PlanService planService) {
     this.missionModelService = missionModelService;
+    this.planService = planService;
   }
 
   @Override
-  public String generateTypescriptTypesFromMissionModel(final String missionModelId)
-  throws MissionModelService.NoSuchMissionModelException
+  public String generateTypescriptTypes(final String missionModelId, final Optional<PlanId> planId)
+  throws MissionModelService.NoSuchMissionModelException, NoSuchPlanException
   {
     return TypescriptCodeGenerationService
         .generateTypescriptTypes(
@@ -24,11 +28,11 @@ public class TypescriptCodeGenerationServiceAdapter implements ConstraintsCodeGe
             resourceTypes(missionModelService, missionModelId));
   }
 
-  static Map<String, TypescriptCodeGenerationService.ActivityType> activityTypes(final MissionModelService missionModelService, final String modelId)
+  static Map<String, TypescriptCodeGenerationService.ActivityType> activityTypes(final MissionModelService missionModelService, final String missionModelId)
   throws MissionModelService.NoSuchMissionModelException
   {
     return missionModelService
-        .getActivityTypes(modelId)
+        .getActivityTypes(missionModelId)
         .entrySet()
         .stream()
         .map(entry -> Map.entry(

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/DevAppDriver.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/DevAppDriver.java
@@ -28,7 +28,7 @@ public final class DevAppDriver {
     final var missionModelController = new LocalMissionModelService(Path.of("/dev/null"), new InMemoryMissionModelRepository(), Instant.EPOCH);
     final var planController = new LocalPlanService(fixtures.planRepository);
 
-    final var typescriptCodeGenerationService = new TypescriptCodeGenerationServiceAdapter(missionModelController);
+    final var typescriptCodeGenerationService = new TypescriptCodeGenerationServiceAdapter(missionModelController, planController);
 
     final ConstraintsDSLCompilationService constraintsDSLCompilationService;
     try {

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindingsTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindingsTest.java
@@ -41,7 +41,7 @@ public final class MerlinBindingsTest {
     final var planApp = new StubPlanService();
     final var missionModelApp = new StubMissionModelService();
 
-    final var typescriptCodeGenerationService = new TypescriptCodeGenerationServiceAdapter(missionModelApp);
+    final var typescriptCodeGenerationService = new TypescriptCodeGenerationServiceAdapter(missionModelApp, planApp);
 
     final ConstraintsDSLCompilationService constraintsDSLCompilationService;
     try {

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.server.mocks;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityInstance;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
@@ -11,12 +12,14 @@ import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.services.PlanService;
 import gov.nasa.jpl.aerie.merlin.server.services.RevisionData;
+import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 public final class StubPlanService implements PlanService {
-  public static final String EXISTENT_PLAN_ID = "abc";
+  public static final PlanId EXISTENT_PLAN_ID = new PlanId(1L);
   public static final Plan EXISTENT_PLAN;
   public static final RevisionData REVISION_DATA =
       new RevisionData() {
@@ -40,6 +43,7 @@ public final class StubPlanService implements PlanService {
 
     EXISTENT_PLAN = new Plan();
     EXISTENT_PLAN.name = "existent";
+    EXISTENT_PLAN.missionModelId = "abc";
     EXISTENT_PLAN.activityInstances = Map.of(EXISTENT_ACTIVITY_ID, EXISTENT_ACTIVITY);
   }
 
@@ -72,6 +76,16 @@ public final class StubPlanService implements PlanService {
   throws NoSuchPlanException
   {
     return 0;
+  }
+
+  @Override
+  public List<Pair<Timestamp, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
+    return List.of();
+  }
+
+  @Override
+  public Map<String, ValueSchema> getExternalResourceSchemas(final PlanId planId) throws NoSuchPlanException {
+    return Map.of("external resource", ValueSchema.BOOLEAN);
   }
 
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.mocks;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
@@ -79,7 +80,7 @@ public final class StubPlanService implements PlanService {
   }
 
   @Override
-  public List<Pair<Timestamp, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
+  public List<Pair<Duration, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
     return List.of();
   }
 

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -6,6 +6,7 @@ import gov.nasa.jpl.aerie.constraints.tree.*;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.mocks.StubMissionModelService;
+import gov.nasa.jpl.aerie.merlin.server.mocks.StubPlanService;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,13 +22,14 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ConstraintsDSLCompilationServiceTests {
+  private static final String MISSION_MODEL_ID = "abc";
   private static final PlanId PLAN_ID = new PlanId(1L);
   ConstraintsDSLCompilationService constraintsDSLCompilationService;
 
   @BeforeAll
   void setUp() throws IOException {
     constraintsDSLCompilationService = new ConstraintsDSLCompilationService(
-        new TypescriptCodeGenerationServiceAdapter(new StubMissionModelService())
+        new TypescriptCodeGenerationServiceAdapter(new StubMissionModelService(), new StubPlanService())
     );
   }
 
@@ -38,7 +41,7 @@ class ConstraintsDSLCompilationServiceTests {
   private <T> void checkSuccessfulCompilation(String constraint, Expression<T> expected)
   {
     final ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult result;
-    result = assertDoesNotThrow(() -> constraintsDSLCompilationService.compileConstraintsDSL("abc", constraint));
+    result = assertDoesNotThrow(() -> constraintsDSLCompilationService.compileConstraintsDSL(MISSION_MODEL_ID, Optional.of(PLAN_ID), constraint));
     if (result instanceof ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Success r) {
       assertEquals(expected, r.constraintExpression());
     } else if (result instanceof ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Error r) {
@@ -49,7 +52,7 @@ class ConstraintsDSLCompilationServiceTests {
   private void checkFailedCompilation(String constraint, String error) {
     final ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Error actualErrors;
     actualErrors = (ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Error) assertDoesNotThrow(() -> constraintsDSLCompilationService.compileConstraintsDSL(
-        "abc", constraint
+        MISSION_MODEL_ID, Optional.of(PLAN_ID), constraint
     ));
     if (actualErrors.errors()
                     .stream()

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
@@ -3,9 +3,11 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.mocks.StubMissionModelService;
 import gov.nasa.jpl.aerie.merlin.server.mocks.StubPlanService;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TypescriptCodeGenerationServiceTest {
@@ -27,8 +29,9 @@ class TypescriptCodeGenerationServiceTest {
              "mode": ( | "Option1" | "Option2"),
              "state of charge": {initial: number, rate: number, },
              "an integer": number,
+             "external resource": boolean,
            };
-           export type ResourceName = "mode" | "state of charge" | "an integer";
+           export type ResourceName = "mode" | "state of charge" | "an integer" | "external resource";
            export type RealResourceName = "state of charge" | "an integer";
            export const ActivityTypeParameterMap = {
              [ActivityType.activity2]: (alias: string) => ({

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
@@ -1,15 +1,18 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.mocks.StubMissionModelService;
+import gov.nasa.jpl.aerie.merlin.server.mocks.StubPlanService;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TypescriptCodeGenerationServiceTest {
 
   @Test
-  void testCodeGen() throws MissionModelService.NoSuchMissionModelException {
-    final var codeGenService = new TypescriptCodeGenerationServiceAdapter(new StubMissionModelService());
+  void testCodeGen() throws MissionModelService.NoSuchMissionModelException, NoSuchPlanException {
+    final var codeGenService = new TypescriptCodeGenerationServiceAdapter(new StubMissionModelService(), new StubPlanService());
 
     assertEquals(
         """
@@ -58,7 +61,7 @@ class TypescriptCodeGenerationServiceTest {
              ActivityType
            });
            /** End Codegen */""",
-        codeGenService.generateTypescriptTypesFromMissionModel("abc")
+        codeGenService.generateTypescriptTypes("abc", Optional.of(new PlanId(1L)))
     );
   }
 }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/TimeRangeExpression.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/TimeRangeExpression.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.scheduler.constraints;
 
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Segment;
@@ -70,7 +71,7 @@ public class TimeRangeExpression {
 
     for (var expr : stateExpr) {
       final var domainOfInter = Interval.between(inter.minTrueTimePoint().get().getKey(), inter.maxTrueTimePoint().get().getKey());
-      Windows windowsState = expr.evaluate(simulationResults, domainOfInter, Map.of());
+      Windows windowsState = expr.evaluate(simulationResults, domainOfInter, new EvaluationEnvironment());
       inter = inter.and(windowsState);
       if(inter.stream().noneMatch(Segment::value)) return inter;
     }

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/filters/FilterEverViolated.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/filters/FilterEverViolated.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.scheduler.constraints.filters;
 
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
@@ -21,6 +22,6 @@ public class FilterEverViolated extends FilterFunctional {
 
   @Override
   public boolean shouldKeep(final SimulationResults simulationResults, final Plan plan, final Interval range) {
-    return !(expr.evaluate(simulationResults, range, Map.of()).equals(new Windows(range, true)));
+    return !(expr.evaluate(simulationResults, range, new EvaluationEnvironment()).equals(new Windows(range, true)));
   }
 }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1961
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR exposes external profiles to constraints. For dev environments, I suggest fully nuking every build product and volume you can find after this is merged.

The two bigger pieces of the change are:
1. Including resource names and schemas in typescript codegen. This is operational when constraints evaluation is triggered, but not operational yet when the UI requests the DSL for the editor.
    - This is because there is now plan-specific data that needs to be known for constraints codegen. The graphql query has changed from `constraintsDslTypescript(missionModelId: ID!)` to `constraintsDslTypescript(missionModelId: ID!, planId: Int)`. The `planId` argument is optional, and if not specified the code will not include external profiles.
2. Allow the constraints AST to access external profiles.

## Verification
I added tests for converting the external profile format to the expected format, and for querying external profiles from the evaluation environment.

For a full manual test, I added the following external profile and constraint (on a plan from day 273-274), and a violation appeared between hour 1 and hour 2.

```graphql
mutation addProfile($profileSet: ProfileSet!) {
  addExternalDataset(planId:1, datasetStart:"2022-273T00:00:00", profileSet: $profileSet) {
    datasetId
  }
}
```
```json
{
  "profileSet": {
    "/my_boolean": {
      "type": "discrete",
      "schema": {
        "type": "boolean"
      },
      "segments": [
        {"duration": 3600000000, "dynamics": false},
        {"duration": 3600000000, "dynamics": true}
      ]
    }
  }
}
```
```ts
export default (): Constraint => {
  return Discrete.Resource("/my_boolean").equal(false)
}
```

Currently the UI thinks that `Discrete.Resource("/my_boolean")` is not a valid name, but it is.

## Documentation
I haven't checked if we have any docs for uploading profiles. I'll add that if needed before merge.

## Future work
Small UI change to make external profiles visible in editor. ([opened PR here](https://github.com/NASA-AMMOS/aerie-ui/pull/166))

We still can't upload profiles that have gaps, or store them in the database.