### PR TITLE
[FIX][AERIE-2132] Incremental simulation incorrectly updated its timeline 

### DIFF
--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationDriver.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationDriver.java
@@ -106,6 +106,14 @@ public class IncrementalSimulationDriver<Model> {
   }
 
 
+  /**
+   * Simulate an activity
+   * @param activity the activity to simulate
+   * @param startTime the start time of the activity
+   * @param activityId the activity id for the activity to simulate
+   * @throws TaskSpecType.UnconstructableTaskSpecException
+   * @throws InvalidArgumentsException
+   */
   public void simulateActivity(SerializedActivity activity, Duration startTime, ActivityInstanceId activityId)
   throws TaskSpecType.UnconstructableTaskSpecException, InvalidArgumentsException
   {
@@ -130,11 +138,11 @@ public class IncrementalSimulationDriver<Model> {
 
   /**
    * Get the simulation results from the Duration.ZERO to the current simulation time point
-   * @param startTime the epoch start time for these results
+   * @param startTimestamp the timestamp for the start of the planning horizon. Used as epoch for computing SimulationResults.
    * @return the simulation results
    */
-  public SimulationResults getSimulationResults(Instant startTime){
-    return getSimulationResultsUpTo(curTime, startTime);
+  public SimulationResults getSimulationResults(Instant startTimestamp){
+    return getSimulationResultsUpTo(startTimestamp, curTime);
   }
 
   public Duration getCurrentSimulationEndTime(){
@@ -144,20 +152,20 @@ public class IncrementalSimulationDriver<Model> {
   /**
    * Get the simulation results from the Duration.ZERO to a specified end time point.
    * The provided simulation results might cover more than the required time period.
-   * @param endTime the duration onto which these results are computed
-   * @param startTime the epoch start time for these results
+   * @param startTimestamp the timestamp for the start of the planning horizon. Used as epoch for computing SimulationResults.
+   * @param endTime the end timepoint. The simulation results will be computed up to this point.
    * @return the simulation results
    */
-  public SimulationResults getSimulationResultsUpTo(Duration endTime, Instant startTime){
+  public SimulationResults getSimulationResultsUpTo(Instant startTimestamp, Duration endTime){
     //if previous results cover a bigger period, we return do not regenerate
     if(endTime.longerThan(curTime)){
       simulateUntil(endTime);
     }
 
-    if(lastSimResults == null || endTime.longerThan(lastSimResultsEnd)) {
+    if(lastSimResults == null || endTime.longerThan(lastSimResultsEnd) || startTimestamp.compareTo(lastSimResults.startTime) != 0) {
       lastSimResults = SimulationEngine.computeResults(
           engine,
-          startTime,
+          startTimestamp,
           endTime,
           activityTopic,
           timeline,

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationDriver.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationDriver.java
@@ -52,7 +52,6 @@ public class IncrementalSimulationDriver<Model> {
     this.missionModel = missionModel;
     plannedDirectiveToTask = new HashMap<>();
     initSimulation();
-    simulateUntil(Duration.ZERO);
   }
 
   /*package-private*/ void initSimulation(){
@@ -95,8 +94,8 @@ public class IncrementalSimulationDriver<Model> {
       if(batch.offsetFromStart().longerThan(endTime) || endTime.isEqualTo(Duration.MAX_VALUE)){
         break;
       }
-      curTime = batch.offsetFromStart();
       final var delta = batch.offsetFromStart().minus(curTime);
+      curTime = batch.offsetFromStart();
       timeline.add(delta);
       // Run the jobs in this batch.
       final var commit = engine.performJobs(batch.jobs(), cells, curTime, Duration.MAX_VALUE, missionModel);

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationResultsConverter.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationResultsConverter.java
@@ -1,0 +1,106 @@
+package gov.nasa.jpl.aerie.scheduler.simulation;
+
+import com.google.common.collect.Maps;
+import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
+import gov.nasa.jpl.aerie.constraints.model.DiscreteProfilePiece;
+import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
+import gov.nasa.jpl.aerie.constraints.model.LinearProfilePiece;
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.merlin.driver.SimulatedActivity;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
+
+public class SimulationResultsConverter {
+
+  /**
+   * convert a simulation driver SimulationResult to a constraint evaluation engine SimulationResult
+   *
+   * @param driverResults the recorded results of a simulation run from the simulation driver
+   * @param planDuration the duration of the plan
+   * @return the same results rearranged to be suitable for use by the constraint evaluation engine
+   */
+  public static gov.nasa.jpl.aerie.constraints.model.SimulationResults convertToConstraintModelResults(
+      SimulationResults driverResults, Duration planDuration){
+    final var activities =  driverResults.simulatedActivities.entrySet().stream()
+                                                             .map(e -> convertToConstraintModelActivityInstance(e.getKey().id(), e.getValue(), driverResults.startTime))
+                                                             .collect(Collectors.toList());
+    return new gov.nasa.jpl.aerie.constraints.model.SimulationResults(
+        Interval.between(Duration.ZERO, planDuration),
+        activities,
+        Maps.transformValues(driverResults.realProfiles, SimulationResultsConverter::convertToConstraintModelLinearProfile),
+        Maps.transformValues(driverResults.discreteProfiles, SimulationResultsConverter::convertToConstraintModelDiscreteProfile)
+    );
+  }
+
+  /**
+   * convert an activity entry output by the simulation driver to one suitable for the constraint evaluation engine
+   *
+   * @param id the name of the activity instance
+   * @param driverActivity the completed activity instance details from a driver SimulationResult
+   * @return an activity instance suitable for a constraint model SimulationResult
+   */
+  public static gov.nasa.jpl.aerie.constraints.model.ActivityInstance convertToConstraintModelActivityInstance(
+      long id, SimulatedActivity driverActivity, final Instant startTime)
+  {
+    final var startT = Duration.of(startTime.until(driverActivity.start(), ChronoUnit.MICROS), MICROSECONDS);
+    final var endT = startT.plus(driverActivity.duration());
+    final var activityInterval = startT.isEqualTo(endT)
+        ? Interval.between(startT, endT)
+        : Interval.betweenClosedOpen(startT, endT);
+    return new gov.nasa.jpl.aerie.constraints.model.ActivityInstance(
+        id, driverActivity.type(), driverActivity.arguments(),
+        activityInterval);
+  }
+
+  /**
+   * convert a linear profile output from the simulation driver to one suitable for the constraint evaluation engine
+   *
+   * @param driverProfile the as-simulated real profile from a driver SimulationResult
+   * @return a real profile suitable for a constraint model SimulationResult, starting from the zero duration
+   */
+  public static LinearProfile convertToConstraintModelLinearProfile(
+      Pair<ValueSchema, List<Pair<Duration, RealDynamics>>> driverProfile)
+  {
+    final var pieces = new ArrayList<LinearProfilePiece>(driverProfile.getRight().size());
+    var elapsed = Duration.ZERO;
+    for (final var piece : driverProfile.getRight()) {
+      final var extent = piece.getLeft();
+      final var value = piece.getRight();
+      pieces.add(new LinearProfilePiece(Interval.betweenClosedOpen(elapsed, elapsed.plus(extent)), value.initial, value.rate));
+      elapsed = elapsed.plus(extent);
+    }
+    return new LinearProfile(pieces);
+  }
+
+  /**
+   * convert a discrete profile output from the simulation driver to one suitable for the constraint evaluation engine
+   *
+   * @param driverProfile the as-simulated discrete profile from a driver SimulationResult
+   * @return a discrete profile suitable for a constraint model SimulationResult, starting from the zero duration
+   */
+  public static DiscreteProfile convertToConstraintModelDiscreteProfile(
+      Pair<ValueSchema, List<Pair<Duration, SerializedValue>>> driverProfile)
+  {
+    final var pieces = new ArrayList<DiscreteProfilePiece>(driverProfile.getRight().size());
+    var elapsed = Duration.ZERO;
+    for (final var piece : driverProfile.getRight()) {
+      final var extent = piece.getLeft();
+      final var value = piece.getRight();
+      pieces.add(new DiscreteProfilePiece(Interval.betweenClosedOpen(elapsed, elapsed.plus(extent)), value));
+      elapsed = elapsed.plus(extent);
+    }
+    return new DiscreteProfile(pieces);
+  }
+}

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/LongDurationPlanTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/LongDurationPlanTest.java
@@ -1,0 +1,101 @@
+package gov.nasa.jpl.aerie.scheduler;
+
+import com.google.common.truth.Correspondence;
+import com.google.common.truth.Truth;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.scheduler.goals.ProceduralCreationGoal;
+import gov.nasa.jpl.aerie.scheduler.model.ActivityInstance;
+import gov.nasa.jpl.aerie.scheduler.model.PlanInMemory;
+import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
+import gov.nasa.jpl.aerie.scheduler.model.Problem;
+import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
+import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.truth.Truth8.assertThat;
+
+public class LongDurationPlanTest {
+
+  private static PrioritySolver makeProblemSolver(Problem problem) {
+    return new PrioritySolver(problem);
+  }
+
+  //test mission with two primitive activity types
+  private static Problem makeTestMissionAB() {
+    final var banananationMissionModel = SimulationUtility.getBananaMissionModel();
+    return new Problem(banananationMissionModel, h, new SimulationFacade(h, banananationMissionModel), SimulationUtility.getBananaSchedulerModel());
+  }
+
+  private final static PlanningHorizon h = new PlanningHorizon(TimeUtility.fromDOY("2025-001T01:01:01.001"), TimeUtility.fromDOY("2030-005T01:01:01.001"));
+  private final static Duration t0 = h.getStartAerie();
+  private final static Duration d1year = Duration.of(1, Duration.SECONDS).times(3600).times(24).times(365);
+  private final static Duration d1min = Duration.of(1, Duration.MINUTES);
+
+  private final static Duration t1year = t0.plus(d1year);
+  private final static Duration t2year = t1year.plus(d1year);
+
+  private final static Duration t3year = t2year.plus(d1year);
+
+  private static PlanInMemory makePlanA012(Problem problem) {
+    final var plan = new PlanInMemory();
+    final var actTypeA = problem.getActivityType("GrowBanana");
+    plan.add(new ActivityInstance(actTypeA, t0, d1min));
+    plan.add(new ActivityInstance(actTypeA, t1year, d1min));
+    plan.add(new ActivityInstance(actTypeA, t2year, d1min));
+    plan.add(new ActivityInstance(actTypeA, t3year, d1min));
+    return plan;
+  }
+
+  /** used to compare plan activities but ignore generated details like name **/
+  private static boolean equalsExceptInName(ActivityInstance a, ActivityInstance b) {
+    //REVIEW: maybe unify within ActivityInstance closer to data
+    return Objects.equals(a.getType(), b.getType())
+           && Objects.equals(a.getStartTime(), b.getStartTime())
+           && Objects.equals(a.getEndTime(), b.getEndTime())
+           && Objects.equals(a.getDuration(), b.getDuration())
+           && Objects.equals(a.getArguments(), b.getArguments());
+  }
+
+  /** matches activities if they agree in everything except the (possibly auto-generated) names **/
+  private static final Correspondence<ActivityInstance, ActivityInstance> equalExceptInName = Correspondence.from(
+      LongDurationPlanTest::equalsExceptInName, "matches");
+
+  @Test
+  public void getNextSolution_initialPlanInOutput() {
+    final var problem = makeTestMissionAB();
+    final var expectedPlan = makePlanA012(problem);
+    problem.setInitialPlan(makePlanA012(problem));
+    final var solver = makeProblemSolver(problem);
+
+    final var plan = solver.getNextSolution();
+
+    assertThat(plan).isPresent();
+    Truth.assertThat(plan.get().getActivitiesByTime())
+         .comparingElementsUsing(equalExceptInName)
+         .containsExactlyElementsIn(expectedPlan.getActivitiesByTime());
+  }
+
+  @Test
+  public void getNextSolution_proceduralGoalCreatesActivities() {
+    final var problem = makeTestMissionAB();
+    final var expectedPlan = makePlanA012(problem);
+    final var goal = new ProceduralCreationGoal.Builder()
+        .named("g0")
+        .generateWith((plan) -> expectedPlan.getActivitiesByTime())
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(h.getHor(), true)))
+        .build();
+    problem.setGoals(List.of(goal));
+    final var solver = makeProblemSolver(problem);
+
+    final var plan = solver.getNextSolution().orElseThrow();
+
+    Truth.assertThat(plan.getActivitiesByTime())
+         .comparingElementsUsing(equalExceptInName)
+         .containsExactlyElementsIn(expectedPlan.getActivitiesByTime());
+  }
+}

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
@@ -70,7 +70,7 @@ public class PrioritySolverTest {
     return new Problem(fooMissionModel, h, new SimulationFacade(h, fooMissionModel), SimulationUtility.getFooSchedulerModel());
   }
 
-  private final static PlanningHorizon h = new PlanningHorizon(TimeUtility.fromDOY("2025-001T01:01:01.001"), TimeUtility.fromDOY("2030-001T01:01:01.001"));
+  private final static PlanningHorizon h = new PlanningHorizon(TimeUtility.fromDOY("2025-001T01:01:01.001"), TimeUtility.fromDOY("2025-005T01:01:01.001"));
   private final static Duration t0 = h.getStartAerie();
   private final static Duration d1min = Duration.of(1, Duration.MINUTE);
   private final static Duration d1hr = Duration.of(1, Duration.HOUR);


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2132
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

When evaluating the anchor expression (a simple `GreaterThan` or `LessThan`) of a `CoexistenceGoal`, the expression returned no intervals instead of 2 as expected.

When looking at the `SimulationResults` produced, the value of the resource was never changing during the planning horizon (which is incorrect, the value is actually changing) and thus never moved to regions where the expression would evaluate to `True`. 

There are two methods for making the simulation go forward in `IncrementalSimulationDriver` : 
- `simulateSchedule` taking a list of activities as argument and simulating them until the end of the last one
- `simulateUntil` taking only an end time as argument and simulating until this time 

In absence of activities, `simulateUntil` was used. And this method was incorrectly updating the timeline with a delta always equal to 0. And thus values were never updated. This is the bug. It is fixed in the first commit. 

The second commit is not related to the bug. It moves methods about conversion of `SimulationResults` out of the `SimulationFacade` to make the latter more readable and maintainable. It also correctly sets the start timestamp of results with the start of the planning horizon. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Simulation results coming from the `SimulationDriver` and `IncrementalSimulationDriver` were compared on a 0.13.0 clipper-specific mission model containing resources that evolve with time. 
Can't add this test because it depends on this specific mission model. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Nothing

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None