### PR TITLE
[Aerie-2118] Database Migration Script Prototype

### DIFF
--- a/db-migrations/aerie_db_migration
+++ b/db-migrations/aerie_db_migration
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+'Migrate an AERIE Databse'
+
+import os
+import argparse
+import sys
+import shutil
+
+HASURA_PATH = "./deployment/hasura/"
+MIGRATION_PATH = HASURA_PATH+"migrations/"
+
+# Create a cli parser
+my_parser = argparse.ArgumentParser(description=__doc__)
+
+# Add arguments
+my_parser.add_argument(
+    '-a', '--apply',
+    help="apply all migration steps to all databases if one isn't provided",
+    action='store_true')
+
+my_parser.add_argument(
+    '-r', '--revert',
+    help="revert all migration steps to all databases if one isn't provided",
+    action='store_true')
+
+my_parser.add_argument(
+    '-db', '--db-name',
+    help="name of a specific DB to apply or revert all migration steps",
+    type=str)
+
+
+# Generate arguments
+args = my_parser.parse_args()
+
+# pre-check to you have hasura cli installed
+if not shutil.which('hasura'):
+  sys.exit(f'Hasura CLI is not installed. Exiting...')
+else:
+  os.system('hasura version')
+
+# Verify you use the command line options correctly
+if not args.apply and not args.revert and args.db_name:
+  sys.exit(f'Error specify [-a, -r] when using --db-name')
+
+# internal class
+class DB_Migration:
+    steps = []
+    db_name = ''
+    def __init__(self, db_name):
+        self.db_name = db_name
+
+    def add_migration_step(self,_migration_step):
+      self.steps = sorted(_migration_step)
+
+
+# find all migration folders for each Aerie database
+migration_db = []
+
+for db in os.listdir(MIGRATION_PATH):
+  #ignore hidden folders
+  if db.startswith('.'):
+    continue
+  migration = DB_Migration(db)
+  for root,dirs,files in os.walk(MIGRATION_PATH+db):
+    if dirs:
+      migration.add_migration_step(dirs)
+  migration_db.append(migration)
+
+# navigate to the hasura directory
+os.chdir(HASURA_PATH)
+
+# no cli arguments provided enter manual mode
+if not args.apply and not args.revert:
+
+  while True:
+    print(f'\n#########################\nManual DB Migration Mode\n#########################')
+    print(f'\n0) \n\nQUIT MANUAL MODE...')
+    for migration_number in range(0,len(migration_db)):
+      print(f'\n{migration_number+1})')
+
+      if len(migration_db[migration_number].steps) > 0:
+        os.system(f'hasura migrate status --database-name {migration_db[migration_number].db_name}')
+      else:
+        print(f'\nDatabase: {migration_db[migration_number].db_name}\nNo migration steps')
+
+    value = -1
+    while(value < 0 or value > len(migration_db)):
+      value = int(input(f"\nWhich DB would you like to apply migrations to (0-{len(migration_db)}): "))
+      if value == 0:
+        sys.exit()
+
+    #apply each migration step for the database selected
+    migration = migration_db[value-1]
+    for step in migration.steps:
+
+      value = 'z'
+      while value != "a" and value != "r":
+        value = input(f'Apply/Revert {step} (a/r): ')
+
+      timestamp = step.split("_")[0]
+      if value == "a":
+        print('Applying...')
+        os.system(f'hasura migrate apply --version {timestamp} --type up --database-name {migration.db_name}')
+      else:
+        print('Reverting...')
+        os.system(f'hasura migrate apply --version {timestamp} --type down --database-name {migration.db_name}')
+
+    os.system('hasura metadata reload')
+else:
+  #find user specified database and remove the rest from the list
+  if args.db_name:
+    migration_db= list(filter(lambda migration: migration.db_name == args.db_name,migration_db))
+    if len(migration_db) != 1:
+      sys.exit(f'Database "{args.db_name}" not found, exiting...')
+
+  #migrate each database
+  for migration in migration_db:
+    print(f'\n#################\n{migration.db_name}\n#################\n')
+    if len(migration.steps) > 0:
+      for step in migration.steps:
+        timestamp = step.split("_")[0]
+
+        if args.apply:
+          print(f'\nApplying {step}...')
+          os.system(f'hasura migrate apply --version {timestamp} --type up --database-name {migration.db_name}')
+        else:
+          print(f'\nReverting {step}...')
+          os.system(f'hasura migrate apply --version {timestamp} --type down --database-name {migration.db_name}')
+
+      os.system('hasura metadata reload')
+    else:
+      print(f'No migration steps present...')
+
+  # show the result after the migration
+  print(f'\n\n###################\nDatabase Status\n###################\n')
+  for migration in migration_db:
+    if len(migration.steps) > 0:
+      os.system(f'hasura migrate status --database-name {migration.db_name}')
+    else:
+      print(f'\nDatabase: {migration.db_name}\nNo migration steps')
+
+print('\n')

--- a/deployment/hasura/config.yaml
+++ b/deployment/hasura/config.yaml
@@ -1,11 +1,9 @@
 # This file configures the Hasura CLI, a local development (and deployment) tool.
 # It is required to run the Hasura CLI (even if empty).
 
+version: 3
+endpoint: http://localhost:8080/
+metadata_directory: metadata
 actions:
-  handler_webhook_baseurl:
-  kind:
-endpoint:
-metadata_directory:
-migrations_directory:
-seeds_directory:
-version:
+  kind: synchronous
+  handler_webhook_baseurl: http://localhost:3000

--- a/deployment/hasura/migrations/AerieCommanding/1664478381304_rename_mission_column/down.sql
+++ b/deployment/hasura/migrations/AerieCommanding/1664478381304_rename_mission_column/down.sql
@@ -1,0 +1,12 @@
+----- NOTE: Test file, should not be used in real database migration
+
+--- Database Change
+
+--Verify column exists and rename column
+select missions from "public"."command_dictionary";
+alter table "public"."command_dictionary" rename column "missions" to "mission";
+
+--- Data migration logic
+
+--- Database Check
+select mission from "public"."command_dictionary";

--- a/deployment/hasura/migrations/AerieCommanding/1664478381304_rename_mission_column/up.sql
+++ b/deployment/hasura/migrations/AerieCommanding/1664478381304_rename_mission_column/up.sql
@@ -1,0 +1,12 @@
+----- NOTE: Test file, should not be used in real database migration
+
+--- Database Change
+
+--Verify column exists and rename column
+select mission from "public"."command_dictionary";
+alter table "public"."command_dictionary" rename column "mission" to "missions";
+
+--- Data migration logic
+
+--- Database Check
+select missions from "public"."command_dictionary";

--- a/deployment/hasura/migrations/AerieCommanding/1664478481307_add_column_expand_to/down.sql
+++ b/deployment/hasura/migrations/AerieCommanding/1664478481307_add_column_expand_to/down.sql
@@ -1,0 +1,8 @@
+----- NOTE: Test file, should not be used in real database migration
+
+--- Database Change
+alter table "public"."activity_instance_commands" drop column "expand_to" cascade;
+
+--- Data migration logic
+
+--- Database Check

--- a/deployment/hasura/migrations/AerieCommanding/1664478481307_add_column_expand_to/up.sql
+++ b/deployment/hasura/migrations/AerieCommanding/1664478481307_add_column_expand_to/up.sql
@@ -1,0 +1,12 @@
+----- NOTE: Test file, should not be used in real database migration
+
+--- Database Change
+alter table "public"."activity_instance_commands" add column "expand_to" int4;
+comment on column "public"."activity_instance_commands"."expand_to" is E'how many commands that were expanded to';
+alter table "public"."activity_instance_commands" alter column "expand_to" set default 0;
+alter table "public"."activity_instance_commands" alter column "expand_to" drop not null;
+
+--- Data migration logic
+
+--- Database Check
+select expand_to from "public"."activity_instance_commands";


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2118
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
I prototyped a migration strategy from our GitHub discussion on [Database migration](https://github.com/NASA-AMMOS/aerie/discussions/346).

The PR has examples of database changes, `up.sql` are migrations, and `down.sql` are DB reverts. The idea is that each up/down.sql will have 3 sections:

* Database changes - alteration to the database such as creation or deletion of tables, columns, etc.
* Data Migration - any data that needs to be migrated to a new table should go here 
* Database Check - Any checks you can do with the database after the alteration is made. This is the first line of defense in preventing a corrupted database.

The migration script is a python CLI tool 

```
./aerie_db_migration -h                      
usage: aerie_db_migration [-h] [-a] [-r] [-db DB_NAME]

Migrate an AERIE Database

optional arguments:
  -h, --help            show this help message and exit
  -a, --apply           apply all migration steps to all databases if one isn't provided
  -r, --revert          revert all migration steps to all databases if one isn't provided
  -db DB_NAME, --db-name DB_NAME
                        name of a specific DB to apply or revert all migration steps
```

If you want to run a manual mode you should run the script without any arguments:
`Not Present` means you haven't applied the migration to the database yet


```
./aerie_db_migration
#########################
Manual DB Migration Mode
#########################

0) 

QUIT MANUAL MODE...

1)

Database: AerieScheduler
No migration steps

2)

Database: AerieMerlin
No migration steps

3)

Database: AerieCommanding
VERSION        NAME                   SOURCE STATUS  DATABASE STATUS
1664478381304  rename_mission_column  Present        Not Present
1664478481307  add_column_expand_to   Present        Not Present

4)

Database: AerieUI
No migration steps

Which DB would you like to apply migrations to (0-4):        
```


To apply all migration steps automatically per database run the command:
```
./aerie_db_migration -a
```

To revert all migration steps automatically per database run the command:
```
./aerie_db_migration -r
```

To target a specific database to apply all the migration steps automatically run the command:
```
./aerie_db_migration -a -db AerieCommanding
```


## Verification
Here is the full output from the script when applying the migration across all databases:

```

rrgoetz@MT-306238 aerie % ./aerie_db_migration -a
INFO hasura cli                                    version=v2.12.0

#################
AerieScheduler
#################

No migration steps present...

#################
AerieMerlin
#################

No migration steps present...

#################
AerieCommanding
#################


Applying 1664478381304_rename_mission_column...
INFO migrations applied                                                                                                                       

Applying 1664478481307_add_column_expand_to...
INFO migrations applied                                                                                                                       
INFO Metadata reloaded                            
INFO Metadata is consistent                       

#################
AerieUI
#################

No migration steps present...


###################
Database Status
###################


Database: AerieScheduler
No migration steps

Database: AerieMerlin
No migration steps

Database: AerieCommanding
VERSION        NAME                   SOURCE STATUS  DATABASE STATUS
1664478381304  rename_mission_column  Present        Present
1664478481307  add_column_expand_to   Present        Present

Database: AerieUI
No migration steps
```

One migration step was to rename column `mission` to `missions` with no loss of data
<img width="602" alt="Screen Shot 2022-10-06 at 7 21 11 AM" src="https://user-images.githubusercontent.com/70245883/194378255-71bd2017-8c93-4d05-94fa-f4cb02431ca0.png">

Applying the revert changed the name back to `mission` without loss of data
<img width="609" alt="Screen Shot 2022-10-06 at 7 22 39 AM" src="https://user-images.githubusercontent.com/70245883/194378527-a0ecbd62-4dbc-48db-b935-41a3af3722c1.png">

The second migration step was to add a new column 'expand_to'

<img width="320" alt="Screen Shot 2022-10-06 at 7 24 07 AM" src="https://user-images.githubusercontent.com/70245883/194378785-22abf3bc-52a7-4470-84a1-4bc72cae10a8.png">


## Documentation
We should probably capture this PR as a way to document a migration

## Future work
Apply this strategy to CD and AWS
