### PR TITLE
[AERIE-2119] Structure `failWith()` reasons

### DIFF
--- a/e2e-tests/src/tests/scheduler.test.ts
+++ b/e2e-tests/src/tests/scheduler.test.ts
@@ -189,7 +189,7 @@ test.describe('Scheduling', () => {
     const max_it = 10;
     let it = 0;
     let reason_local: string;
-    while (it++ <  max_it && status == "incomplete"){
+    while (it++ < max_it && status == "incomplete") {
       const { reason, status, analysisId } = await req.schedule(request, specification_id);
       status_local = status;
       reason_local = reason;
@@ -197,7 +197,7 @@ test.describe('Scheduling', () => {
       expect(status).toBeDefined();
       await delay(1000);
     }
-    if (status_local == "failed"){
+    if (status_local == "failed") {
       throw new Error(reason_local);
     }
     expect(status_local).toEqual("complete")

--- a/e2e-tests/src/types/scheduling-goal.d.ts
+++ b/e2e-tests/src/types/scheduling-goal.d.ts
@@ -32,7 +32,7 @@ type SchedulingGoalInsertInput = Omit<
 type SchedulingResponseStatus = 'complete' | 'failed' | 'incomplete';
 
 type SchedulingResponse = {
-  reason: string;
+  reason: any;
   status: SchedulingResponseStatus;
   analysisId: number;
 };

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationFailure.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationFailure.java
@@ -1,0 +1,45 @@
+package gov.nasa.jpl.aerie.merlin.driver;
+
+import javax.json.JsonValue;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public record SimulationFailure(
+    String type,
+    String message,
+    JsonValue data,
+    String trace
+) {
+  public static final class Builder {
+    private String type = "";
+    private String message = "";
+    private String trace = "";
+    private JsonValue data = JsonValue.EMPTY_JSON_OBJECT;
+
+    public Builder type(final String type) {
+      this.type = type;
+      return this;
+    }
+
+    public Builder message(final String message) {
+      this.message = message;
+      return this;
+    }
+
+    public Builder trace(final Throwable throwable) {
+      final var sw = new StringWriter();
+      throwable.printStackTrace(new PrintWriter(sw));
+      this.trace = sw.toString();
+      return this;
+    }
+
+    public Builder data(final JsonValue data) {
+      this.data = data;
+      return this;
+    }
+
+    public SimulationFailure build() {
+      return new SimulationFailure(type, message, data, trace);
+    }
+  }
+}

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationFailure.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationFailure.java
@@ -3,12 +3,14 @@ package gov.nasa.jpl.aerie.merlin.driver;
 import javax.json.JsonValue;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.Instant;
 
 public record SimulationFailure(
     String type,
     String message,
     JsonValue data,
-    String trace
+    String trace,
+    Instant timestamp
 ) {
   public static final class Builder {
     private String type = "";
@@ -39,7 +41,7 @@ public record SimulationFailure(
     }
 
     public SimulationFailure build() {
-      return new SimulationFailure(type, message, data, trace);
+      return new SimulationFailure(type, message, data, trace, Instant.now());
     }
   }
 }

--- a/merlin-server/sql/merlin/tables/simulation_dataset.sql
+++ b/merlin-server/sql/merlin/tables/simulation_dataset.sql
@@ -18,7 +18,7 @@ create table simulation_dataset (
 
   -- Simulation state
   status status_t not null default 'pending',
-  reason text null,
+  reason jsonb null,
   canceled boolean not null default false,
 
   constraint simulation_dataset_synthetic_key

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import static gov.nasa.jpl.aerie.json.BasicParsers.*;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
 import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
+import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.pgTimestampP;
 
 public abstract class MerlinParsers {
   private MerlinParsers() {}
@@ -76,8 +77,9 @@ public abstract class MerlinParsers {
       .field("message", stringP)
       .field("data", anyP)
       .optionalField("trace", stringP)
+      .field("timestamp", pgTimestampP)
       .map(
-          untuple((type, message, data, trace) -> new SimulationFailure(type, message, data, trace.orElse(""))),
-          failure -> tuple(failure.type(), failure.message(), failure.data(), Optional.ofNullable(failure.trace()))
+          untuple((type, message, data, trace, timestamp) -> new SimulationFailure(type, message, data, trace.orElse(""), timestamp.toInstant())),
+          failure -> tuple(failure.type(), failure.message(), failure.data(), Optional.ofNullable(failure.trace()), new Timestamp(failure.timestamp()))
       );
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.json.JsonParseResult;
 import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.json.SchemaCache;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityInstanceId;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationFailure;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
@@ -13,9 +14,10 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonValue;
 import java.time.format.DateTimeParseException;
-
-import static gov.nasa.jpl.aerie.json.BasicParsers.longP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
+import java.util.Optional;
+import static gov.nasa.jpl.aerie.json.BasicParsers.*;
+import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
+import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
 
 public abstract class MerlinParsers {
   private MerlinParsers() {}
@@ -68,4 +70,14 @@ public abstract class MerlinParsers {
       . map(
           PlanId::new,
           PlanId::id);
+
+  public static final JsonParser<SimulationFailure> simulationFailureP = productP
+      .field("type", stringP)
+      .field("message", stringP)
+      .field("data", anyP)
+      .optionalField("trace", stringP)
+      .map(
+          untuple((type, message, data, trace) -> new SimulationFailure(type, message, data, trace.orElse(""))),
+          failure -> tuple(failure.type(), failure.message(), failure.data(), Optional.ofNullable(failure.trace()))
+      );
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -246,7 +246,7 @@ public final class ResponseSerializers {
           .createObjectBuilder()
           .add("status", "failed")
           .add("simulationDatasetId", r.simulationDatasetId())
-          .add("reason", r.reason())
+          .add("reason", MerlinParsers.simulationFailureP.unparse(r.reason()))
           .build();
     } else if (response instanceof GetSimulationResultsAction.Response.Complete r) {
       return Json
@@ -387,17 +387,24 @@ public final class ResponseSerializers {
   }
 
   public static JsonValue serializeNoSuchPlanException(final NoSuchPlanException ex) {
-    // TODO: Improve diagnostic information
     return Json.createObjectBuilder()
         .add("message", "no such plan")
+        .add("plan_id", ex.id.id())
         .build();
   }
 
   public static JsonValue serializeNoSuchMissionModelException(final MissionModelService.NoSuchMissionModelException ex) {
-    // TODO: Improve diagnostic information
     return Json.createObjectBuilder()
-               .add("message", "no such mission model")
-               .build();
+        .add("message", "no such mission model")
+        .add("mission_model_id", ex.missionModelId)
+        .build();
+  }
+
+  public static JsonValue serializeNoSuchActivityTypeException(final MissionModelService.NoSuchActivityTypeException ex) {
+    return Json.createObjectBuilder()
+        .add("message", "no such activity type")
+        .add("activity_type", ex.activityTypeId)
+        .build();
   }
 
   private static final class ValueSchemaSerializer implements ValueSchema.Visitor<JsonValue> {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -185,14 +185,19 @@ public final class ResponseSerializers {
                 Collectors.toMap(e -> Long.toString(e.getKey().id()), Map.Entry::getValue)));
   }
 
-  private static JsonValue serializeUnconstructableActivityFailure(final String reason) {
-    return Json
-        .createObjectBuilder()
-        .add("reason", reason)
-        .build();
+  private static JsonValue serializeUnconstructableActivityFailure(final MissionModelService.ActivityInstantiationFailure reason) {
+    // TODO use pattern-matching switch expression here when available with LTS
+    final var builder = Json.createObjectBuilder();
+    if (reason instanceof final MissionModelService.ActivityInstantiationFailure.InvalidArguments r) {
+      return builder.add("reason", serializeInvalidArgumentsException(r.ex())).build();
+    }
+    else if (reason instanceof final MissionModelService.ActivityInstantiationFailure.NoSuchActivityType r) {
+      return builder.add("reason", serializeNoSuchActivityTypeException(r.ex())).build();
+    }
+    throw new UnexpectedSubtypeError(MissionModelService.ActivityInstantiationFailure.class, reason);
   }
 
-  public static JsonValue serializeUnconstructableActivityFailures(final Map<ActivityInstanceId, String> failures) {
+  public static JsonValue serializeUnconstructableActivityFailures(final Map<ActivityInstanceId, MissionModelService.ActivityInstantiationFailure> failures) {
     if (failures.isEmpty()) {
       return Json.createObjectBuilder()
         .add("success", JsonValue.TRUE)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes;
 
+import gov.nasa.jpl.aerie.merlin.driver.SimulationFailure;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
@@ -114,7 +115,7 @@ public final class InMemoryResultsCellRepository implements ResultsCellRepositor
     }
 
     @Override
-    public void failWith(final String reason) {
+    public void failWith(final SimulationFailure reason) {
       if (!(this.state instanceof ResultsProtocol.State.Incomplete)) {
         throw new IllegalStateException("Cannot transition to failed state from state %s".formatted(
             this.state.getClass().getCanonicalName()));

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ClaimSimulationAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ClaimSimulationAction.java
@@ -10,8 +10,7 @@ import java.sql.SQLException;
   private static final @Language("SQL") String sql = """
     update simulation_dataset
       set
-        status = 'incomplete',
-	    reason = ''
+        status = 'incomplete'
       where (dataset_id = ? and status = 'pending');
   """;
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateSimulationDatasetAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateSimulationDatasetAction.java
@@ -54,13 +54,9 @@ import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
       }
 
       final var datasetId = results.getLong(1);
-      final var reason = results.getString(3);
-
-      final var state = new SimulationStateRecord(
-          status,
-          reason);
+      final var reason = PreparedStatements.getFailureReason(results, 3);
+      final var state = new SimulationStateRecord(status, reason);
       final var canceled = results.getBoolean(4);
-
       final var simulationDatasetId = results.getLong(5);
 
       return new SimulationDatasetRecord(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationDatasetAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationDatasetAction.java
@@ -46,13 +46,11 @@ import java.util.Optional;
       }
 
       final var simulationId = results.getLong(1);
-      final var reason = results.getString(3);
+      final var reason = PreparedStatements.getFailureReason(results, 3);
       final var canceled = results.getBoolean(4);
       final var offsetFromPlanStart = PostgresParsers.parseOffset(results, 5, planStart);
       final var simulationDatasetId = results.getLong(6);
-      final var state = new SimulationStateRecord(
-          status,
-          reason);
+      final var state = new SimulationStateRecord(status, reason);
 
       return Optional.of(
           new SimulationDatasetRecord(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/LookupSimulationDatasetAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/LookupSimulationDatasetAction.java
@@ -73,13 +73,11 @@ import java.util.Optional;
       }
 
       final var datasetId = results.getLong(1);
-      final var reason = results.getString(3);
+      final var reason = PreparedStatements.getFailureReason(results, 3);
       final var canceled = results.getBoolean(4);
       final var offsetFromPlanStart = PostgresParsers.parseOffset(results, 5, planStart);
       final var simulationDatasetId = results.getLong(6);
-      final var state = new SimulationStateRecord(
-          status,
-          reason);
+      final var state = new SimulationStateRecord(status, reason);
 
       return Optional.of(
           new SimulationDatasetRecord(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
@@ -25,14 +25,9 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.util.Map;
+import java.util.Optional;
 
-import static gov.nasa.jpl.aerie.json.BasicParsers.chooseP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.intP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.literalP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.longP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.mapP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.*;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
 import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
 import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.serializedValueP;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
@@ -25,7 +25,6 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.util.Map;
-import java.util.Optional;
 
 import static gov.nasa.jpl.aerie.json.BasicParsers.*;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
@@ -53,14 +52,14 @@ public final class PostgresParsers {
     @Override
     public JsonParseResult<Timestamp> parse(final JsonValue json) {
       final var result = stringP.parse(json);
-      if (result instanceof JsonParseResult.Success<String> s) {
+      if (result instanceof final JsonParseResult.Success<String> s) {
         try {
           final var instant = LocalDateTime.parse(s.result(), format).atZone(ZoneOffset.UTC);
           return JsonParseResult.success(new Timestamp(instant));
-        } catch (DateTimeParseException e) {
+        } catch (final DateTimeParseException e) {
           return JsonParseResult.failure("invalid timestamp format "+e);
         }
-      } else if (result instanceof JsonParseResult.Failure<?> f) {
+      } else if (result instanceof final JsonParseResult.Failure<?> f) {
         return f.cast();
       } else {
         throw new UnexpectedSubtypeError(JsonParseResult.class, result);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SetSimulationStateAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SetSimulationStateAction.java
@@ -11,7 +11,7 @@ import java.sql.SQLException;
         update simulation_dataset
           set
             status = ?,
-            reason = ?
+            reason = ?::json
           where dataset_id = ?
         """;
 
@@ -25,7 +25,7 @@ import java.sql.SQLException;
   throws SQLException, NoSuchSimulationDatasetException
   {
     this.statement.setString(1, state.status().label);
-    this.statement.setString(2, state.reason());
+    PreparedStatements.setFailureReason(this.statement, 2, state.reason().orElse(null));
     this.statement.setLong(3, datasetId);
 
     final var count = this.statement.executeUpdate();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulationStateRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulationStateRecord.java
@@ -1,20 +1,23 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
-public record SimulationStateRecord(Status status, String reason) {
+import java.util.Optional;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationFailure;
+
+public record SimulationStateRecord(Status status, Optional<SimulationFailure> reason) {
   public static SimulationStateRecord pending() {
-    return new SimulationStateRecord(Status.PENDING, "");
+    return new SimulationStateRecord(Status.PENDING, Optional.empty());
   }
 
   public static SimulationStateRecord incomplete() {
-    return new SimulationStateRecord(Status.INCOMPLETE, "");
+    return new SimulationStateRecord(Status.INCOMPLETE, Optional.empty());
   }
 
-  public static SimulationStateRecord failed(final String reason) {
-    return new SimulationStateRecord(Status.FAILED, reason);
+  public static SimulationStateRecord failed(final SimulationFailure reason) {
+    return new SimulationStateRecord(Status.FAILED, Optional.of(reason));
   }
 
   public static SimulationStateRecord success() {
-    return new SimulationStateRecord(Status.SUCCESS, "");
+    return new SimulationStateRecord(Status.SUCCESS, Optional.empty());
   }
 
   public enum Status {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -10,6 +10,7 @@ import gov.nasa.jpl.aerie.constraints.model.LinearProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.Violation;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.tree.Expression;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationFailure;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
@@ -32,7 +33,7 @@ public final class GetSimulationResultsAction {
   public sealed interface Response {
     record Pending(long simulationDatasetId) implements Response {}
     record Incomplete(long simulationDatasetId) implements Response {}
-    record Failed(long simulationDatasetId, String reason) implements Response {}
+    record Failed(long simulationDatasetId, SimulationFailure reason) implements Response {}
     record Complete(long simulationDatasetId) implements Response {}
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -141,18 +141,20 @@ public final class LocalMissionModelService implements MissionModelService {
    * @return A map of validation errors mapping activity instance ID to failure message. If validation succeeds the map is empty.
    */
   @Override
-  public Map<ActivityInstanceId, String> validateActivityInstantiations(final String missionModelId, final Map<ActivityInstanceId, SerializedActivity> activities)
+  public Map<ActivityInstanceId, ActivityInstantiationFailure> validateActivityInstantiations(final String missionModelId, final Map<ActivityInstanceId, SerializedActivity> activities)
   throws NoSuchMissionModelException, MissionModelLoadException
   {
-    final var failures = new HashMap<ActivityInstanceId, String>();
+    final var failures = new HashMap<ActivityInstanceId, ActivityInstantiationFailure>();
 
     for (final var entry : activities.entrySet()) {
       final var id = entry.getKey();
       final var act = entry.getValue();
       try {
         this.getActivityEffectiveArguments(missionModelId, act); // The return value is intentionally ignored - we are only interested in failures
-      } catch (final MissionModelService.NoSuchActivityTypeException | InvalidArgumentsException e) {
-        failures.put(id, e.toString());
+      } catch (final MissionModelService.NoSuchActivityTypeException e) {
+        failures.put(id, new ActivityInstantiationFailure.NoSuchActivityType(e));
+      } catch (final InvalidArgumentsException e) {
+        failures.put(id, new ActivityInstantiationFailure.InvalidArguments(e));
       }
     }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -10,7 +10,6 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirective;
-import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelJar;
@@ -40,8 +39,11 @@ public interface MissionModelService {
   List<ValidationNotice> validateActivityArguments(String missionModelId, SerializedActivity activity)
   throws NoSuchMissionModelException, InvalidArgumentsException;
 
-  Map<ActivityInstanceId, String> validateActivityInstantiations(String missionModelId, Map<ActivityInstanceId, SerializedActivity> activities)
-  throws NoSuchMissionModelException, LocalMissionModelService.MissionModelLoadException;
+  Map<ActivityInstanceId, ActivityInstantiationFailure> validateActivityInstantiations(
+      String missionModelId,
+      Map<ActivityInstanceId,
+      SerializedActivity> activities
+  ) throws NoSuchMissionModelException, LocalMissionModelService.MissionModelLoadException;
 
   Map<String, SerializedValue> getActivityEffectiveArguments(String missionModelId, SerializedActivity activity)
   throws NoSuchMissionModelException,
@@ -68,6 +70,11 @@ public interface MissionModelService {
   void refreshActivityTypes(String missionModelId) throws NoSuchMissionModelException;
   void refreshActivityValidations(String missionModelId, ActivityDirective directive)
   throws NoSuchMissionModelException, InvalidArgumentsException;
+
+  sealed interface ActivityInstantiationFailure {
+    record NoSuchActivityType(NoSuchActivityTypeException ex) implements ActivityInstantiationFailure { }
+    record InvalidArguments(InvalidArgumentsException ex) implements ActivityInstantiationFailure { }
+  }
 
   final class NoSuchMissionModelException extends Exception {
     public final String missionModelId;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ThreadedSimulationAgent.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ThreadedSimulationAgent.java
@@ -66,7 +66,10 @@ public final class ThreadedSimulationAgent implements SimulationAgent {
               this.simulationAgent.simulate(req.planId(), req.revisionData(), req.writer());
             } catch (final Throwable ex) {
               ex.printStackTrace(System.err);
-              req.writer().failWith(ex);
+              req.writer().failWith(b -> b
+                  .type("UNEXPECTED_SIMULATION_EXCEPTION")
+                  .message("Something went wrong while simulating")
+                  .trace(ex));
             }
             // continue
           } else if (request instanceof SimulationRequest.Terminate) {

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -158,7 +158,7 @@ public final class StubMissionModelService implements MissionModelService {
   }
 
   @Override
-  public Map<ActivityInstanceId, String> validateActivityInstantiations(
+  public Map<ActivityInstanceId, ActivityInstantiationFailure> validateActivityInstantiations(
       final String missionModelId,
       final Map<ActivityInstanceId, SerializedActivity> activities)
   throws LocalMissionModelService.MissionModelLoadException

--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
@@ -83,7 +83,10 @@ public final class MerlinWorkerAppDriver {
         simulationAgent.simulate(planId, revisionData, writer);
       } catch (final Throwable ex) {
         ex.printStackTrace(System.err);
-        writer.failWith(ex);
+        writer.failWith(b -> b
+            .type("UNEXPECTED_SIMULATION_EXCEPTION")
+            .message("Something went wrong while simulating")
+            .trace(ex));
       }
     }
   }

--- a/scheduler-server/sql/scheduler/tables/scheduling_request.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_request.sql
@@ -5,7 +5,7 @@ create table scheduling_request (
   analysis_id integer not null,
 
   status status_t not null default 'incomplete',
-  failure_reason jsonb null,
+  reason jsonb null,
   canceled boolean not null default false,
 
   specification_revision integer not null,
@@ -34,7 +34,7 @@ comment on column scheduling_request.analysis_id is e''
   'The ID associated with the analysis of this scheduling run.';
 comment on column scheduling_request.status is e''
   'The state of the the scheduling request.';
-comment on column scheduling_request.failure_reason is e''
+comment on column scheduling_request.reason is e''
   'The reason for failure when a scheduling request fails.';
 comment on column scheduling_request.specification_revision is e''
   'The revision of the scheduling_specification associated with this request.';

--- a/scheduler-server/sql/scheduler/tables/scheduling_request.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_request.sql
@@ -1,11 +1,11 @@
 create type status_t as enum('incomplete', 'failed', 'success');
 
 create table scheduling_request (
-  specification_id     integer not null,
+  specification_id integer not null,
   analysis_id integer not null,
 
   status status_t not null default 'incomplete',
-  failure_reason text null,
+  failure_reason jsonb null,
   canceled boolean not null default false,
 
   specification_revision integer not null,

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/ResultsProtocol.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/ResultsProtocol.java
@@ -1,9 +1,8 @@
 package gov.nasa.jpl.aerie.scheduler.server;
 
+import java.util.function.Consumer;
+import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleFailure;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleResults;
-
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 /**
  * interfaces used to coordinate parties interested in the scheduling results
@@ -43,7 +42,7 @@ public final class ResultsProtocol {
      *
      * @param reason description of why the scheduling operation failed
      */
-    record Failed(String reason, long analysisId) implements State {}
+    record Failed(ScheduleFailure reason, long analysisId) implements State {}
   }
 
   /**
@@ -96,17 +95,12 @@ public final class ResultsProtocol {
      *
      * @param reason the reason that the scheduling run failed
      */
-    void failWith(String reason);
+    void failWith(ScheduleFailure reason);
 
-    /**
-     * convenience method for reporting an unhandled exception
-     *
-     * @param throwable the exception that caused the scheduling run to fail
-     */
-    default void failWith(final Throwable throwable) {
-      final var stringWriter = new StringWriter();
-      throwable.printStackTrace(new PrintWriter(stringWriter));
-      this.failWith(stringWriter.toString());
+    default void failWith(final Consumer<ScheduleFailure.Builder> builderConsumer) {
+      final var builder = new ScheduleFailure.Builder();
+      builderConsumer.accept(builder);
+      failWith(builder.build());
     }
   }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/exceptions/NoSuchSpecificationException.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/exceptions/NoSuchSpecificationException.java
@@ -3,7 +3,10 @@ package gov.nasa.jpl.aerie.scheduler.server.exceptions;
 import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
 
 public final class NoSuchSpecificationException extends Exception {
+  public final SpecificationId specificationId;
+
   public NoSuchSpecificationException(final SpecificationId specificationId) {
     super("No scheduling specification exists with id `" + specificationId.id() + "`");
+    this.specificationId = specificationId;
   }
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
@@ -4,20 +4,19 @@ import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.scheduler.server.models.HasuraAction;
 import gov.nasa.jpl.aerie.scheduler.server.models.MissionModelId;
 import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
+import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleFailure;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Optional;
 
-import static gov.nasa.jpl.aerie.json.BasicParsers.longP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.*;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
 import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
 
 /**
  * json parsers for data objects used in the scheduler service endpoints
  */
-public class SchedulerParsers {
+public final class SchedulerParsers {
   private SchedulerParsers() {}
 
   //TODO: unify common private parsers between services (eg hasura details copied from MerlinParsers)
@@ -33,6 +32,16 @@ public class SchedulerParsers {
       . map(
           MissionModelId::new,
           MissionModelId::id);
+
+  public static final JsonParser<ScheduleFailure> scheduleFailureP = productP
+      .field("type", stringP)
+      .field("message", stringP)
+      .field("data", anyP)
+      .optionalField("trace", stringP)
+      .map(
+          untuple((type, message, data, trace) -> new ScheduleFailure(type, message, data, trace.orElse(""))),
+          failure -> tuple(failure.type(), failure.message(), failure.data(), Optional.ofNullable(failure.trace()))
+      );
 
   /**
    * parser for hasura session details

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.scheduler.server.models.HasuraAction;
 import gov.nasa.jpl.aerie.scheduler.server.models.MissionModelId;
 import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
+import gov.nasa.jpl.aerie.scheduler.server.models.Timestamp;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleFailure;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -12,6 +13,7 @@ import java.util.Optional;
 import static gov.nasa.jpl.aerie.json.BasicParsers.*;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
 import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
+import static gov.nasa.jpl.aerie.scheduler.server.remotes.postgres.PostgresParsers.pgTimestampP;
 
 /**
  * json parsers for data objects used in the scheduler service endpoints
@@ -38,9 +40,10 @@ public final class SchedulerParsers {
       .field("message", stringP)
       .field("data", anyP)
       .optionalField("trace", stringP)
+      .field("timestamp", pgTimestampP)
       .map(
-          untuple((type, message, data, trace) -> new ScheduleFailure(type, message, data, trace.orElse(""))),
-          failure -> tuple(failure.type(), failure.message(), failure.data(), Optional.ofNullable(failure.trace()))
+          untuple((type, message, data, trace, timestamp) -> new ScheduleFailure(type, message, data, trace.orElse(""), timestamp.toInstant())),
+          failure -> tuple(failure.type(), failure.message(), failure.data(), Optional.ofNullable(failure.trace()), new Timestamp(failure.timestamp()))
       );
 
   /**

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/CreateRequestAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/CreateRequestAction.java
@@ -1,10 +1,12 @@
 package gov.nasa.jpl.aerie.scheduler.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleFailure;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Optional;
 
 /*package-local*/ final class CreateRequestAction implements AutoCloseable {
   private final @Language("SQL") String sql = """
@@ -38,7 +40,7 @@ import java.sql.SQLException;
     }
 
     final var analysis_id = result.getLong("analysis_id");
-    final var failureReason = result.getString("failure_reason");
+    final var failureReason$ = PreparedStatements.getFailureReason(result, "failure_reason");
     final var canceled = result.getBoolean("canceled");
 
     return new RequestRecord(
@@ -46,7 +48,7 @@ import java.sql.SQLException;
         analysis_id,
         specification.revision(),
         status,
-        failureReason,
+        failureReason$,
         canceled
     );
   }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/CreateRequestAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/CreateRequestAction.java
@@ -15,7 +15,7 @@ import java.util.Optional;
       returning
         analysis_id,
         status,
-        failure_reason,
+        reason,
         canceled
     """;
 
@@ -40,7 +40,7 @@ import java.util.Optional;
     }
 
     final var analysis_id = result.getLong("analysis_id");
-    final var failureReason$ = PreparedStatements.getFailureReason(result, "failure_reason");
+    final var failureReason$ = PreparedStatements.getFailureReason(result, "reason");
     final var canceled = result.getBoolean("canceled");
 
     return new RequestRecord(

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetRequestAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetRequestAction.java
@@ -1,7 +1,12 @@
 package gov.nasa.jpl.aerie.scheduler.server.remotes.postgres;
 
+import javax.json.Json;
+import gov.nasa.jpl.aerie.scheduler.server.http.SchedulerParsers;
+import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleFailure;
 import org.intellij.lang.annotations.Language;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -49,7 +54,7 @@ import java.util.Optional;
     }
 
     final var analysisId = resultSet.getLong("analysis_id");
-    final var failureReason = resultSet.getString("failure_reason");
+    final var failureReason$ = PreparedStatements.getFailureReason(resultSet, "failure_reason");
     final var canceled = resultSet.getBoolean("canceled");
 
     return Optional.of(new RequestRecord(
@@ -57,7 +62,7 @@ import java.util.Optional;
         analysisId,
         specificationRevision,
         status,
-        failureReason,
+        failureReason$,
         canceled));
   }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetRequestAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetRequestAction.java
@@ -17,7 +17,7 @@ import java.util.Optional;
     select
       r.analysis_id,
       r.status,
-      r.failure_reason,
+      r.reason,
       r.canceled
     from scheduling_request as r
     where
@@ -54,7 +54,7 @@ import java.util.Optional;
     }
 
     final var analysisId = resultSet.getLong("analysis_id");
-    final var failureReason$ = PreparedStatements.getFailureReason(resultSet, "failure_reason");
+    final var failureReason$ = PreparedStatements.getFailureReason(resultSet, "reason");
     final var canceled = resultSet.getBoolean("canceled");
 
     return Optional.of(new RequestRecord(

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresParsers.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresParsers.java
@@ -1,13 +1,67 @@
 package gov.nasa.jpl.aerie.scheduler.server.remotes.postgres;
 
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+import gov.nasa.jpl.aerie.json.JsonParseResult;
 import gov.nasa.jpl.aerie.json.JsonParser;
+import gov.nasa.jpl.aerie.json.SchemaCache;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.scheduler.server.models.Timestamp;
+import gov.nasa.jpl.aerie.scheduler.server.services.UnexpectedSubtypeError;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
 import java.util.Map;
 
 import static gov.nasa.jpl.aerie.json.BasicParsers.mapP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
 import static gov.nasa.jpl.aerie.scheduler.server.http.SerializedValueJsonParser.serializedValueP;
 
 public final class PostgresParsers {
+
+  public static final JsonParser<Timestamp> pgTimestampP = new JsonParser<>() {
+    private static final DateTimeFormatter format =
+        new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+            .toFormatter();
+
+    @Override
+    public JsonObject getSchema(final SchemaCache anchors) {
+      return Json
+          .createObjectBuilder(stringP.getSchema())
+          .add("format", "date-time")
+          .build();
+    }
+
+    @Override
+    public JsonParseResult<Timestamp> parse(final JsonValue json) {
+      final var result = stringP.parse(json);
+      if (result instanceof final JsonParseResult.Success<String> s) {
+        try {
+          final var instant = LocalDateTime.parse(s.result(), format).atZone(ZoneOffset.UTC);
+          return JsonParseResult.success(new Timestamp(instant));
+        } catch (final DateTimeParseException e) {
+          return JsonParseResult.failure("invalid timestamp format "+e);
+        }
+      } else if (result instanceof final JsonParseResult.Failure<?> f) {
+        return f.cast();
+      } else {
+        throw new UnexpectedSubtypeError(JsonParseResult.class, result);
+      }
+    }
+
+    @Override
+    public JsonValue unparse(final Timestamp value) {
+      final var s = format.format(value.toInstant().atZone(ZoneOffset.UTC));
+      return stringP.unparse(s);
+    }
+  };
+
   public static final JsonParser<Map<String, SerializedValue>> simulationArgumentsP = mapP(serializedValueP);
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -239,7 +239,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
         return switch(request.status()) {
           case INCOMPLETE -> new ResultsProtocol.State.Incomplete(this.analysisId);
           case FAILED -> new ResultsProtocol.State.Failed(
-              request.failureReason()
+              request.reason()
                   .orElseThrow(() -> new Error("Unexpected state: %s request state has no failure message".formatted(request.status()))),
               this.analysisId);
           case SUCCESS -> new ResultsProtocol.State.Success(getResults(connection, request.analysisId()), this.analysisId);

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PreparedStatements.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PreparedStatements.java
@@ -1,0 +1,39 @@
+package gov.nasa.jpl.aerie.scheduler.server.remotes.postgres;
+
+import javax.json.Json;
+import gov.nasa.jpl.aerie.scheduler.server.http.SchedulerParsers;
+import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleFailure;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+
+public final class PreparedStatements {
+  private PreparedStatements() {}
+
+  public static void setFailureReason(final PreparedStatement statement, final int parameter, final ScheduleFailure reason)
+  throws SQLException
+  {
+    statement.setString(parameter, reason == null ?
+        null :
+        SchedulerParsers.scheduleFailureP.unparse(reason).toString());
+  }
+
+  public static Optional<ScheduleFailure> getFailureReason(final ResultSet results, final String columnLabel)
+  throws SQLException
+  {
+    final var failureJson = results.getString(columnLabel);
+    return failureJson == null || failureJson.isBlank() ?
+        Optional.empty() :
+        Optional.of(PreparedStatements.deserializeScheduleFailure(results.getString(columnLabel)));
+  }
+
+  private static ScheduleFailure deserializeScheduleFailure(final String failureJson) {
+    try (final var reader = Json.createReader(new ByteArrayInputStream(failureJson.getBytes(StandardCharsets.UTF_8)))) {
+      return SchedulerParsers.scheduleFailureP.parse(reader.readValue()).getSuccessOrThrow();
+    }
+  }
+}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/RequestRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/RequestRecord.java
@@ -1,11 +1,14 @@
 package gov.nasa.jpl.aerie.scheduler.server.remotes.postgres;
 
+import java.util.Optional;
+import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleFailure;
+
 public record RequestRecord(
     long specificationId,
     long analysisId,
     long specificationRevision,
     Status status,
-    String failureReason,
+    Optional<ScheduleFailure> failureReason,
     boolean canceled
 ) {
   public enum Status {

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/RequestRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/RequestRecord.java
@@ -8,7 +8,7 @@ public record RequestRecord(
     long analysisId,
     long specificationRevision,
     Status status,
-    Optional<ScheduleFailure> failureReason,
+    Optional<ScheduleFailure> reason,
     boolean canceled
 ) {
   public enum Status {

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/SetRequestStateAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/SetRequestStateAction.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.scheduler.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleFailure;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
@@ -11,7 +12,7 @@ import java.sql.SQLException;
     update scheduling_request
       set
         status = ?,
-        failure_reason = ?
+        failure_reason = ?::json
       where
         specification_id = ? and
         specification_revision = ?
@@ -24,14 +25,14 @@ import java.sql.SQLException;
   }
 
   public void apply(
-      final long specificationid,
+      final long specificationId,
       final long specificationRevision,
       final RequestRecord.Status status,
-      final String failureReason
+      final ScheduleFailure failureReason
   ) throws SQLException {
     this.statement.setString(1, status.label);
-    this.statement.setString(2, failureReason);
-    this.statement.setLong(3, specificationid);
+    PreparedStatements.setFailureReason(this.statement, 2, failureReason);
+    this.statement.setLong(3, specificationId);
     this.statement.setLong(4, specificationRevision);
 
     final var count = this.statement.executeUpdate();

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/SetRequestStateAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/SetRequestStateAction.java
@@ -12,7 +12,7 @@ import java.sql.SQLException;
     update scheduling_request
       set
         status = ?,
-        failure_reason = ?::json
+        reason = ?::json
       where
         specification_id = ? and
         specification_revision = ?

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleAction.java
@@ -37,7 +37,7 @@ public record ScheduleAction(SpecificationService specificationService, Schedule
     /**
      * scheduler completed unsuccessfully, eg in an error or canceled
      */
-    record Failed(String reason, long analysisId) implements Response {}
+    record Failed(ScheduleFailure reason, long analysisId) implements Response {}
 
     /**
      * scheduler completed successfully; contains the requested results

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleFailure.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleFailure.java
@@ -1,0 +1,45 @@
+package gov.nasa.jpl.aerie.scheduler.server.services;
+
+import javax.json.JsonValue;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public record ScheduleFailure(
+    String type,
+    String message,
+    JsonValue data,
+    String trace
+) {
+  public static final class Builder {
+    private String type = "";
+    private String message = "";
+    private String trace = "";
+    private JsonValue data = JsonValue.EMPTY_JSON_OBJECT;
+
+    public Builder type(final String type) {
+      this.type = type;
+      return this;
+    }
+
+    public Builder message(final String message) {
+      this.message = message;
+      return this;
+    }
+
+    public Builder trace(final Throwable throwable) {
+      final var sw = new StringWriter();
+      throwable.printStackTrace(new PrintWriter(sw));
+      this.trace = sw.toString();
+      return this;
+    }
+
+    public Builder data(final JsonValue data) {
+      this.data = data;
+      return this;
+    }
+
+    public ScheduleFailure build() {
+      return new ScheduleFailure(type, message, data, trace);
+    }
+  }
+}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleFailure.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleFailure.java
@@ -3,12 +3,14 @@ package gov.nasa.jpl.aerie.scheduler.server.services;
 import javax.json.JsonValue;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.Instant;
 
 public record ScheduleFailure(
     String type,
     String message,
     JsonValue data,
-    String trace
+    String trace,
+    Instant timestamp
 ) {
   public static final class Builder {
     private String type = "";
@@ -39,7 +41,7 @@ public record ScheduleFailure(
     }
 
     public ScheduleFailure build() {
-      return new ScheduleFailure(type, message, data, trace);
+      return new ScheduleFailure(type, message, data, trace, Instant.now());
     }
   }
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ThreadedSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ThreadedSchedulerAgent.java
@@ -64,7 +64,10 @@ public final class ThreadedSchedulerAgent implements SchedulerAgent {
               this.schedulerAgent.schedule(req.request(), req.writer());
             } catch (final Throwable ex) {
               ex.printStackTrace(System.err);
-              req.writer().failWith(ex);
+              req.writer().failWith(b -> b
+                  .type("UNEXPECTED_SCHEDULER_EXCEPTION")
+                  .message("Something went wrong while scheduling")
+                  .trace(ex));
             }
             // continue
           } else if (request instanceof SchedulingRequest.Terminate) {

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockResultsProtocolWriter.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/MockResultsProtocolWriter.java
@@ -14,7 +14,7 @@ class MockResultsProtocolWriter implements ResultsProtocol.WriterRole {
   sealed interface Result {
     record Success(ScheduleResults results) implements Result {}
 
-    record Failure(String reason) implements Result {}
+    record Failure(ScheduleFailure reason) implements Result {}
   }
 
   @Override
@@ -28,7 +28,7 @@ class MockResultsProtocolWriter implements ResultsProtocol.WriterRole {
   }
 
   @Override
-  public void failWith(final String reason) {
+  public void failWith(final ScheduleFailure reason) {
     this.results.add(new Result.Failure(reason));
   }
 }

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -9,6 +9,7 @@ import gov.nasa.jpl.aerie.scheduler.TimeUtility;
 import gov.nasa.jpl.aerie.scheduler.model.ActivityTypeList;
 import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
 import gov.nasa.jpl.aerie.scheduler.server.config.PlanOutputMode;
+import gov.nasa.jpl.aerie.scheduler.server.http.SchedulerParsers;
 import gov.nasa.jpl.aerie.scheduler.server.models.GlobalSchedulingConditionRecord;
 import gov.nasa.jpl.aerie.scheduler.server.models.GlobalSchedulingConditionSource;
 import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
@@ -956,8 +957,9 @@ public class SchedulingIntegrationTests {
     assertEquals(1, writer.results.size());
     final var result = writer.results.get(0);
     if (result instanceof MockResultsProtocolWriter.Result.Failure e) {
-      System.err.println(e.reason());
-      fail(e.reason());
+      final var serializedReason = SchedulerParsers.scheduleFailureP.unparse(e.reason()).toString();
+      System.err.println(serializedReason);
+      fail(serializedReason);
     }
     return new SchedulingRunResults(((MockResultsProtocolWriter.Result.Success) result).results(), mockMerlinService.updatedPlan);
   }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2119
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

Motivated by [discussion](https://jpl.slack.com/archives/GJ07FGRPH/p1664308622371219) with @camargo and @duranb. The UI and API clients would like to have some structure within our `simulation_dataset.reason` and `scheduling_request.failure_reason` columns.

This PR introduces a serialization of these `reason`s with `ScheduleFailure` and `SimulationFailure`. Notably, there's now a `message` field to act as a human-readable summary of the failure.

This PR also renames `scheduling_request.failure_reason` -> `scheduling_request.reason`.

## Verification

- End-to-end tests passing
- Manual inspecting `simulation_dataset.reason` and `scheduler_request.failure_reason` columns after end-to-end tests.

After simulating with an activity (`BiteBanana`) with extraneous arguments `simulation_dataset.reason` contains:
```json
{
    "type": "PLAN_CONTAINS_UNCONSTRUCTABLE_ACTIVITIES",
    "message": "Plan contains unconstructable activities",
    "data": {
        "success": false,
        "errors": {
            "2": {
                "reason": {
                    "success": false,
                    "errors": {
                        "extraneousArguments": [
                            "bad_three",
                            "bad_one",
                            "bad_two"
                        ],
                        "unconstructableArguments": [],
                        "missingArguments": []
                    },
                    "arguments": {
                        "biteSize": 1.0
                    }
                }
            }
        }
    },
    "trace": "",
    "timestamp": "2022-10-10T18:05:27.5648916Z.564891"
}

```

@camargo / @duranb: Note that the inner `data.errors` in this case is now the exact same structure that's reported from `getActivityEffectiveArguments`/`getModelEffectiveArguments`. This should hopefully make ingesting this data easier.

## Documentation

TODO: will update this section once this PR has general/informal approval.

## Future work
- Find other services/areas where our error reporting could be more human-friendly.