### PR TITLE
build: upgrade Hasura to v2.12.0

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -128,7 +128,7 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: warn
       HASURA_GRAPHQL_METADATA_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_hasura"
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: "hasura/graphql-engine:v2.8.4.cli-migrations-v3"
+    image: "hasura/graphql-engine:v2.12.0.cli-migrations-v3"
     ports: ["8080:8080"]
     restart: always
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,7 +173,7 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: info
       HASURA_GRAPHQL_METADATA_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_hasura"
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: "hasura/graphql-engine:v2.8.4.cli-migrations-v3"
+    image: "hasura/graphql-engine:v2.12.0.cli-migrations-v3"
     ports: ["8080:8080"]
     restart: always
     volumes:

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -174,7 +174,7 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: info
       HASURA_GRAPHQL_METADATA_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_hasura'
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: 'hasura/graphql-engine:v2.8.4.cli-migrations-v3'
+    image: 'hasura/graphql-engine:v2.12.0.cli-migrations-v3'
     ports: ['8080:8080']
     restart: always
     volumes:


### PR DESCRIPTION
## Description

* Upgrade to [Hasura to v2.12.0](https://github.com/hasura/graphql-engine/releases/tag/v2.12.0)
* Mainly so we can use streaming subscriptions out of the box

Make sure you remove your old local Hasura `v2.8.4` Docker image.
