### PR TITLE
[FIX] Consistently serialize invalid arguments exception

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -166,8 +166,7 @@ public final class MerlinBindings implements Plugin {
     } catch (final InvalidEntityException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
     } catch (final InvalidArgumentsException ex) {
-      ctx.status(400)
-          .result(ResponseSerializers.serializeFailures(List.of(ex.getMessage())).toString());
+      ctx.status(400).result(ResponseSerializers.serializeInvalidArgumentsException(ex).toString());
     } catch (final NoSuchPlanException ex) {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchPlanException(ex).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
@@ -257,8 +256,7 @@ public final class MerlinBindings implements Plugin {
 
       ctx.result(ResponseSerializers.serializeValidationNotices(notices).toString());
     } catch (final InvalidArgumentsException ex) {
-      ctx.status(400)
-         .result(ResponseSerializers.serializeFailures(List.of(ex.getMessage())).toString());
+      ctx.status(400).result(ResponseSerializers.serializeInvalidArgumentsException(ex).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
     } catch (final InvalidJsonException ex) {
@@ -280,8 +278,7 @@ public final class MerlinBindings implements Plugin {
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
     } catch (final InvalidArgumentsException ex) {
-      ctx.status(400)
-         .result(ResponseSerializers.serializeFailures(List.of(ex.getMessage())).toString());
+      ctx.status(400).result(ResponseSerializers.serializeInvalidArgumentsException(ex).toString());
     } catch (final InvalidJsonException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     } catch (final InvalidEntityException ex) {


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

A while back (#258) `InvalidArgumentsException` exceptions were serialized when caught within `MerlinBindings`. There were a few validation endpoints that were not changed to use this serialization and instead turned the exception into a raw string. This PR correctly and consistently serializes all `InvalidArgumentException`s.

@camargo @duranb With these changes the Merlin endpoints `validateActivityArguments` and `validateModelArguments` will return an errors like so when the arguments are invalid (invalid in the sense that they are incorrectly-typed, not in the sense that they fail `@Validation`):
```
"errors": {
                "extraneousArguments": [],
                "missingArguments": [
                  "glutenFree"
                ],
                "unconstructableArguments": [
                  {
                    "failure": "Expected boolean, got StringValue[value=true]",
                    "name": "glutenFree"
                  }
                ]
              },
```
Previously this was reported as a JSON array:
```
"errors": [
    "some long java exception turned into a string"
]
```

## Verification

When validating `BakeBananaBread` with a `glutenFree` value of `"true"` (note, incorrectly typed as it should be a bool instead of a string) we now have a properly serialized `InvalidArgumentsException` instead of the exception turned into a raw string:
```json
"response": {
            "body": {
              "arguments": {
                "tbSugar": 34,
                "temperature": 99
              },
              "errors": {
                "extraneousArguments": [],
                "missingArguments": [
                  "glutenFree"
                ],
                "unconstructableArguments": [
                  {
                    "failure": "Expected boolean, got StringValue[value=true]",
                    "name": "glutenFree"
                  }
                ]
              },
              "success": false
            },
```

## Documentation
None.

## Future work
None.
