### PR TITLE
[FEAT](AERIE-2146) Include EDSL API docs in docs

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "18"
+          java-version: "19"
       - name: Set up Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Set up Gradle

--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -6,6 +6,8 @@ on:
       - develop
     paths:
       - "docs/**"
+      - "merlin-server/constraints-dsl-compiler/src/**"
+      - "scheduler-server/scheduling-dsl-compiler/src/**"
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -35,10 +35,32 @@ jobs:
         run: make -C docs multiversion
       - name: Build redirects
         run: make -C docs redirects
+
+      # Generate EDSL documentation
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "18"
+      - name: Set up Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Build Docs
+        run: ./gradlew publishDocs
+      - name: Copy Docs To Publish Dir
+        run: cp -r docs/_build/dirhtml publish-docs-tmp; cp -r docs/edsl-api-docs/. publish-docs-tmp
+      # Upload to GitHub Pages
       - name: Upload artifacts
         uses: actions/upload-pages-artifact@v1
         with:
-          path: "./docs/_build/dirhtml/"
+          path: "./publish-docs-tmp"
+      - name: Cleanup
+        run: rm -rf publish-docs-tmp
       - name: Deploy docs to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -8,6 +8,8 @@ on:
       - develop
     paths:
       - "docs/**"
+      - "merlin-server/constraints-dsl-compiler/src/**"
+      - "scheduler-server/scheduling-dsl-compiler/src/**"
 
 jobs:
   build:

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "18"
+          java-version: "19"
       - name: Set up Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Set up Gradle

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -26,3 +26,18 @@ jobs:
         run: make -C docs setupenv
       - name: Build docs
         run: make -C docs test
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "18"
+      - name: Set up Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Build EDSL Docs
+        run: ./gradlew publishDocs

--- a/docs/poetry.lock
+++ b/docs/poetry.lock
@@ -7,7 +7,7 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "Babel"
+name = "babel"
 version = "2.10.3"
 description = "Internationalization utilities"
 category = "main"
@@ -49,7 +49,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -113,7 +113,7 @@ perf = ["ipython"]
 testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
 
 [[package]]
-name = "Jinja2"
+name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
 category = "main"
@@ -152,7 +152,7 @@ typing_extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 benchmarking = ["psutil", "pytest", "pytest-benchmark (>=3.2,<4.0)"]
-code_style = ["pre-commit (==2.6)"]
+code-style = ["pre-commit (==2.6)"]
 compare = ["commonmark (>=0.9.1,<0.10.0)", "markdown (>=3.3.6,<3.4.0)", "mistletoe (>=0.8.1,<0.9.0)", "mistune (>=2.0.2,<2.1.0)", "panflute (>=2.1.3,<2.2.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
 plugins = ["mdit-py-plugins"]
@@ -161,7 +161,7 @@ rtd = ["attrs", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
-name = "MarkupSafe"
+name = "markupsafe"
 version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
@@ -180,7 +180,7 @@ python-versions = ">=3.7"
 markdown-it-py = ">=1.0.0,<3.0.0"
 
 [package.extras]
-code_style = ["pre-commit"]
+code-style = ["pre-commit"]
 rtd = ["attrs", "myst-parser (>=0.16.1,<0.17.0)", "sphinx-book-theme (>=0.1.0,<0.2.0)"]
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
@@ -210,7 +210,7 @@ sphinx = ">=4,<6"
 typing-extensions = "*"
 
 [package.extras]
-code_style = ["pre-commit (>=2.12,<3.0)"]
+code-style = ["pre-commit (>=2.12,<3.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
 rtd = ["ipython", "sphinx-book-theme", "sphinx-design", "sphinxcontrib.mermaid (>=0.7.1,<0.8.0)", "sphinxext-opengraph (>=0.6.3,<0.7.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)"]
 testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=6,<7)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions", "sphinx (<5.2)", "sphinx-pytest"]
@@ -227,7 +227,7 @@ python-versions = ">=3.6"
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
-name = "Pygments"
+name = "pygments"
 version = "2.11.2"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
@@ -247,14 +247,14 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytz"
-version = "2022.4"
+version = "2022.5"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
 python-versions = "*"
 
 [[package]]
-name = "PyYAML"
+name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "main"
@@ -262,7 +262,7 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "redirects_cli"
+name = "redirects-cli"
 version = "0.1.0"
 description = "Generates static redirections from a YAML file."
 category = "main"
@@ -292,11 +292,11 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "setuptools"
-version = "65.4.1"
+version = "65.5.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
@@ -332,7 +332,7 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "Sphinx"
+name = "sphinx"
 version = "4.3.2"
 description = "Python documentation generator"
 category = "main"
@@ -380,7 +380,7 @@ sphinx = "*"
 test = ["pytest", "pytest-cov"]
 
 [[package]]
-name = "sphinx_collapse"
+name = "sphinx-collapse"
 version = "0.1.2"
 description = "Collapse extension for Sphinx."
 category = "main"
@@ -406,7 +406,7 @@ python-versions = ">=3.6"
 sphinx = ">=1.8"
 
 [package.extras]
-code_style = ["pre-commit (==2.12.1)"]
+code-style = ["pre-commit (==2.12.1)"]
 rtd = ["ipython", "myst-nb", "sphinx", "sphinx-book-theme"]
 
 [[package]]
@@ -466,7 +466,7 @@ six = "*"
 sphinx = ">=1.2"
 
 [[package]]
-name = "Sphinx-Substitution-Extensions"
+name = "sphinx-substitution-extensions"
 version = "2022.2.16"
 description = "Extensions for Sphinx which allow for substitutions."
 category = "main"
@@ -495,7 +495,7 @@ pygments = "*"
 sphinx = ">=2,<5"
 
 [package.extras]
-code_style = ["pre-commit (==2.13.0)"]
+code-style = ["pre-commit (==2.13.0)"]
 testing = ["bs4", "coverage", "pygments", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions", "rinohtype", "sphinx-testing"]
 
 [[package]]
@@ -596,7 +596,7 @@ test = ["black (>=22.3.0,<23.0.0)", "coverage (>=5.2,<6.0)", "isort (>=5.0.6,<6.
 
 [[package]]
 name = "typing-extensions"
-version = "4.3.0"
+version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -617,15 +617,15 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "zipp"
-version = "3.8.1"
+version = "3.9.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
@@ -637,7 +637,7 @@ alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
 ]
-Babel = [
+babel = [
     {file = "Babel-2.10.3-py3-none-any.whl", hash = "sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb"},
     {file = "Babel-2.10.3.tar.gz", hash = "sha256:7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51"},
 ]
@@ -677,7 +677,7 @@ importlib-metadata = [
     {file = "importlib_metadata-5.0.0-py3-none-any.whl", hash = "sha256:ddb0e35065e8938f867ed4928d0ae5bf2a53b7773871bfe6bcc7e4fcdc7dea43"},
     {file = "importlib_metadata-5.0.0.tar.gz", hash = "sha256:da31db32b304314d044d3c12c79bd59e307889b287ad12ff387b3500835fc2ab"},
 ]
-Jinja2 = [
+jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
     {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
 ]
@@ -688,7 +688,7 @@ markdown-it-py = [
     {file = "markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},
     {file = "markdown_it_py-2.1.0-py3-none-any.whl", hash = "sha256:93de681e5c021a432c63147656fe21790bc01231e0cd2da73626f1aa3ac0fe27"},
 ]
-MarkupSafe = [
+markupsafe = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
     {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e"},
@@ -746,7 +746,7 @@ packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
-Pygments = [
+pygments = [
     {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
     {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
 ]
@@ -755,10 +755,10 @@ pyparsing = [
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pytz = [
-    {file = "pytz-2022.4-py2.py3-none-any.whl", hash = "sha256:2c0784747071402c6e99f0bafdb7da0fa22645f06554c7ae06bf6358897e9c91"},
-    {file = "pytz-2022.4.tar.gz", hash = "sha256:48ce799d83b6f8aab2020e369b627446696619e79645419610b9facd909b3174"},
+    {file = "pytz-2022.5-py2.py3-none-any.whl", hash = "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22"},
+    {file = "pytz-2022.5.tar.gz", hash = "sha256:c4d88f472f54d615e9cd582a5004d1e5f624854a6a27a6211591c251f22a6914"},
 ]
-PyYAML = [
+pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
@@ -800,7 +800,7 @@ PyYAML = [
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
-redirects_cli = [
+redirects-cli = [
     {file = "redirects_cli-0.1.0-py3-none-any.whl", hash = "sha256:6feff2b2183c7251cb238a97bdd172ad28b1ca59568fe187099fc823a2e22a15"},
     {file = "redirects_cli-0.1.0.tar.gz", hash = "sha256:30c86c4caee85f1a95f145dc633a0583f1ed6b16d85fc1dfa0fb5979a7346024"},
 ]
@@ -809,8 +809,8 @@ requests = [
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
 setuptools = [
-    {file = "setuptools-65.4.1-py3-none-any.whl", hash = "sha256:1b6bdc6161661409c5f21508763dc63ab20a9ac2f8ba20029aaaa7fdb9118012"},
-    {file = "setuptools-65.4.1.tar.gz", hash = "sha256:3050e338e5871e70c72983072fe34f6032ae1cdeeeb67338199c2f74e083a80e"},
+    {file = "setuptools-65.5.0-py3-none-any.whl", hash = "sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356"},
+    {file = "setuptools-65.5.0.tar.gz", hash = "sha256:512e5536220e38146176efb833d4a62aa726b7bbff82cfbc8ba9eaa3996e0b17"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -824,7 +824,7 @@ soupsieve = [
     {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},
     {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
 ]
-Sphinx = [
+sphinx = [
     {file = "Sphinx-4.3.2-py3-none-any.whl", hash = "sha256:6a11ea5dd0bdb197f9c2abc2e0ce73e01340464feaece525e64036546d24c851"},
     {file = "Sphinx-4.3.2.tar.gz", hash = "sha256:0a8836751a68306b3fe97ecbe44db786f8479c3bf4b80e3a7f5c838657b4698c"},
 ]
@@ -832,7 +832,7 @@ sphinx-autobuild = [
     {file = "sphinx-autobuild-2021.3.14.tar.gz", hash = "sha256:de1ca3b66e271d2b5b5140c35034c89e47f263f2cd5db302c9217065f7443f05"},
     {file = "sphinx_autobuild-2021.3.14-py3-none-any.whl", hash = "sha256:8fe8cbfdb75db04475232f05187c776f46f6e9e04cacf1e49ce81bdac649ccac"},
 ]
-sphinx_collapse = [
+sphinx-collapse = [
     {file = "sphinx_collapse-0.1.2-py3-none-any.whl", hash = "sha256:7a2082da3c779916cc4c4d44832db3522a3a8bfbd12598ef01fb9eb523a164d0"},
     {file = "sphinx_collapse-0.1.2.tar.gz", hash = "sha256:a186000bf3fdac8ac0e8a99979f720ae790de15a5efc1435d4816f79a3d377c2"},
 ]
@@ -855,7 +855,7 @@ sphinx-scylladb-theme = [
 sphinx-sitemap = [
     {file = "sphinx-sitemap-2.2.0.tar.gz", hash = "sha256:65adda39233cb17c0da10ba1cebaa2df73e271cdb6f8efd5cec8eef3b3cf7737"},
 ]
-Sphinx-Substitution-Extensions = [
+sphinx-substitution-extensions = [
     {file = "Sphinx Substitution Extensions-2022.2.16.tar.gz", hash = "sha256:ff7d05bd00e8b2d7eb8a403b9f317d70411d4e9b6812bf91534a50df22190c75"},
     {file = "Sphinx_Substitution_Extensions-2022.2.16-py3-none-any.whl", hash = "sha256:5a8ca34dac3984486344e95c36e3ed4766d402a71bdee7390d600f153db9795b"},
 ]
@@ -905,14 +905,14 @@ typer = [
     {file = "typer-0.6.1.tar.gz", hash = "sha256:2d5720a5e63f73eaf31edaa15f6ab87f35f0690f8ca233017d7d23d743a91d73"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
-    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
     {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
 ]
 zipp = [
-    {file = "zipp-3.8.1-py3-none-any.whl", hash = "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"},
-    {file = "zipp-3.8.1.tar.gz", hash = "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2"},
+    {file = "zipp-3.9.0-py3-none-any.whl", hash = "sha256:972cfa31bc2fedd3fa838a51e9bc7e64b7fb725a8c00e7431554311f180e9980"},
+    {file = "zipp-3.9.0.tar.gz", hash = "sha256:3a7af91c3db40ec72dd9d154ae18e008c69efe8ca88dde4f9a731bb82fe2f9eb"},
 ]

--- a/docs/source/_ext/rst_jinja.py
+++ b/docs/source/_ext/rst_jinja.py
@@ -1,0 +1,24 @@
+import os
+
+def rstjinja(app, docname, source):
+		"""
+		Render our pages as a jinja template for fancy templating goodness.
+		"""
+		# Make sure we're outputting HTML
+		if app.builder.format != 'html':
+				return
+		src = source[0]
+
+		additional_context = {
+		 'current_version': os.environ.get('SPHINX_MULTIVERSION_NAME'),
+		}
+
+		rendered = app.builder.templates.render_string(
+				src, {**app.config.html_context,  **additional_context}
+		)
+		source[0] = rendered
+
+def setup(app):
+		app.setup_extension('sphinx_multiversion')
+		app.connect("source-read", rstjinja)
+

--- a/docs/source/activity-plans/scheduling-guide.rst
+++ b/docs/source/activity-plans/scheduling-guide.rst
@@ -126,7 +126,7 @@ a goal is enabled or disabled.
 
 Scheduling DSL Documentation
 ============================
-Here you will find the full set of features in the scheduling DSL.
+Here you will find the full set of features in the `Scheduling EDSL API Documentation <../../scheduling-edsl-api/{{current_version}}/index.html>`__.
 
 
 .. warning::

--- a/docs/source/activity-plans/scheduling-guide.rst
+++ b/docs/source/activity-plans/scheduling-guide.rst
@@ -126,7 +126,7 @@ a goal is enabled or disabled.
 
 Scheduling DSL Documentation
 ============================
-Here you will find the full set of features in the `Scheduling EDSL API Documentation <../../scheduling-edsl-api/{{current_version}}/index.html>`__.
+The full set of features can be found in the `Scheduling EDSL API Documentation <../../scheduling-edsl-api/{{current_version}}/index.html>`__.
 
 
 .. warning::

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,6 +7,7 @@ from datetime import date
 from sphinx_scylladb_theme.utils import multiversion_regex_builder
 
 sys.path.insert(0, os.path.abspath(".."))
+sys.path.append(os.path.abspath("./_ext"))
 
 # -- Global variables
 
@@ -33,6 +34,7 @@ extensions = [
     "sphinx_scylladb_theme",
     "sphinx_multiversion",  # optional
     "myst_parser",  # for converting .md to .rst,
+    "rst_jinja"
 ]
 
 # The suffix(es) of source filenames.

--- a/docs/source/constraints/overview.md
+++ b/docs/source/constraints/overview.md
@@ -126,7 +126,7 @@ A constraint is violated from 2 to 4 and also from 5 to 8. No activities are inv
 
 ## Constraints API
 
-Below we list all classes, constructors, and methods in the Constraints API, along with their arguments and return types. But before we do that, keep in mind that the entire API is a facade and does _none_ of the constraint evaluation itself. So for example, when we say that `.lessThan(...)` returns a "set of windows", this is merely a helpful lie.
+Below we list all classes, constructors, and methods in the <a href="../../constraints-edsl-api/{{current_version}}/index.html" target="_blank">Constraint EDSL API</a>, along with their arguments and return types. But before we do that, keep in mind that the entire API is a facade and does _none_ of the constraint evaluation itself. So for example, when we say that `.lessThan(...)` returns a "set of windows", this is merely a helpful lie.
 
 In reality, it returns a node of an Abstract Syntax Tree (AST) which represents the `LessThan` operation, which is serialized and sent to Merlin's Java backend to be evaluated there. Before the constraints API was released, constraint authors had to write a highly verbose JSON AST representing these operations. The API builds that same AST. Due to this architecture, it is not possible to use the constraint to actually _observe_ the "set of windows" represented by `.lessThan(...)`, or the "discrete profile" represented by `Discrete.Resource(...)`, or any other value or object "returned" by the API.
 

--- a/docs/source/edsl-api-documentation/index.rst
+++ b/docs/source/edsl-api-documentation/index.rst
@@ -1,0 +1,11 @@
+============================
+Aerie EDSL API Documentation
+============================
+
+Aerie uses a number of Embedded Domain Specific Languages (EDSLs) to enable automated scheduling and constraint checking. These are embedded in `Typescript <https://www.typescriptlang.org/>`__ to enable a full range of programmatic constructs and solid typechecking and code-completion.
+
+- `Constraint EDSL API Documentation <../../constraints-edsl-api/{{current_version}}/index.html>`__
+
+- `Scheduling EDSL API Documentation <../../scheduling-edsl-api/{{current_version}}/index.html>`__
+
+.. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -76,6 +76,15 @@
 
   Get setup for development as a contributor to the Aerie project.
 
+.. topic-box::
+  :title: EDSL API Documentation
+  :link: edsl-api-documentation
+  :icon: scylla-icon scylla-icon--about-team
+  :class: large-8
+  :anchor: Learn more
+
+  Detailed API documentation for Aerie Constraint and Scheduling EDSLs.
+
 .. raw:: html
 
   </div></div>
@@ -98,3 +107,4 @@
   mission-modeling/index
   upgrade-guides/index
   user-interface/index
+  edsl-api-documentation/index

--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -42,6 +42,21 @@ task generateDocumentation(type: NpmTask) {
   inputs.dir('src')
 }
 
+task cleanDocsFromDocsDir(type: Delete) {
+  delete rootDir.toPath().resolve('docs/edsl-api-docs/constraints-edsl-api/develop')
+}
+
+task copyDocsToDocsDirectory(type: Copy) {
+  from rootDir.toPath().resolve('merlin-server/constraints-dsl-compiler/build/docs')
+  into rootDir.toPath().resolve('docs/edsl-api-docs/constraints-edsl-api/develop')
+}
+
+task publishDocs {
+  dependsOn cleanDocsFromDocsDir
+  dependsOn generateDocumentation
+  dependsOn copyDocsToDocsDirectory
+}
+
 assemble {
   dependsOn assembleConstraintsDSLCompiler
   dependsOn generateASTJsonSchema

--- a/merlin-server/constraints-dsl-compiler/package-lock.json
+++ b/merlin-server/constraints-dsl-compiler/package-lock.json
@@ -12,6 +12,7 @@
         "prettier": "^2.6.2",
         "source-map": "^0.7.3",
         "typedoc": "^0.23.10",
+        "typedoc-plugin-extras": "^2.3.0",
         "typescript": "^4.5.5",
         "typescript-json-schema": "0.53.0"
       },
@@ -492,6 +493,14 @@
       },
       "peerDependencies": {
         "typescript": "4.6.x || 4.7.x"
+      }
+    },
+    "node_modules/typedoc-plugin-extras": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-extras/-/typedoc-plugin-extras-2.3.0.tgz",
+      "integrity": "sha512-XjzutqICAkSpl1vhyloYfd35mn0U6WwOQ7BttRkwGhmBQs/qFLz2K+AU0/lj2Cx4WY6AqVr4c/PzFbqI4fACqw==",
+      "peerDependencies": {
+        "typedoc": "0.23.x"
       }
     },
     "node_modules/typescript": {
@@ -1006,6 +1015,12 @@
         "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
       }
+    },
+    "typedoc-plugin-extras": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-extras/-/typedoc-plugin-extras-2.3.0.tgz",
+      "integrity": "sha512-XjzutqICAkSpl1vhyloYfd35mn0U6WwOQ7BttRkwGhmBQs/qFLz2K+AU0/lj2Cx4WY6AqVr4c/PzFbqI4fACqw==",
+      "requires": {}
     },
     "typescript": {
       "version": "4.7.4",

--- a/merlin-server/constraints-dsl-compiler/package.json
+++ b/merlin-server/constraints-dsl-compiler/package.json
@@ -4,11 +4,11 @@
   "description": "Typescript compiler for the constraints DSL",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf build; tsc",
     "test": "npm run build && node build/main.js",
     "generate-ast-schema": "npx typescript-json-schema src/libs/constraints-ast.ts \"*\" --aliasRefs --out ./build/constraints.schema.json",
     "reformat": "npx prettier --config ./.prettierrc -w ./src",
-    "generate-doc": "npx typedoc src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Constraints eDSL documentation\""
+    "generate-doc": "rm -rf build/docs; npx typedoc --plugin typedoc-plugin-extras --customTitle \"AERIE DOCUMENTATION\" --customTitleLink ../index.html src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Constraints eDSL documentation\""
   },
   "author": "",
   "dependencies": {
@@ -17,7 +17,8 @@
     "source-map": "^0.7.3",
     "typescript": "^4.5.5",
     "typescript-json-schema": "0.53.0",
-    "typedoc": "^0.23.10"
+    "typedoc": "^0.23.10",
+    "typedoc-plugin-extras": "^2.3.0"
   },
   "devDependencies": {
     "@tsconfig/node16-strictest-esm": "^1.0.2",

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -23,6 +23,7 @@ task deleteConstraintsTypescript(type: Delete) {
 
 task copyConstraintsTypescript(type: Copy) {
   dependsOn deleteConstraintsTypescript
+  dependsOn ':merlin-server:assembleConstraintsDSLCompiler'
   from rootDir.toPath().resolve('merlin-server/constraints-dsl-compiler/src/libs')
   into project.projectDir.toPath().resolve('scheduling-dsl-compiler/src/libs/constraints')
 }

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -58,6 +58,21 @@ task generateDocumentation(type: NpmTask) {
   inputs.dir('src')
 }
 
+task cleanDocsFromDocsDir(type: Delete) {
+  delete rootDir.toPath().resolve('docs/edsl-api-docs/scheduling-edsl-api/develop')
+}
+
+task copyDocsToDocsDirectory(type: Copy) {
+  from rootDir.toPath().resolve('scheduler-server/scheduling-dsl-compiler/build/docs')
+  into rootDir.toPath().resolve('docs/edsl-api-docs/scheduling-edsl-api/develop')
+}
+
+task publishDocs {
+  dependsOn cleanDocsFromDocsDir
+  dependsOn generateDocumentation
+  dependsOn copyDocsToDocsDirectory
+}
+
 assemble {
   dependsOn assembleSchedulingDSLCompiler
   dependsOn generateASTJsonSchema

--- a/scheduler-server/scheduling-dsl-compiler/package-lock.json
+++ b/scheduler-server/scheduling-dsl-compiler/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "scheduling-dsl-compiler",
-      "version": "1.0.0",
       "dependencies": {
         "@js-temporal/polyfill": "^0.4.0",
         "@nasa-jpl/aerie-ts-user-code-runner": "^0.3.2",
         "source-map": "^0.7.3",
         "typedoc": "^0.23.10",
+        "typedoc-plugin-extras": "^2.3.0",
         "typescript": "^4.5.5",
         "typescript-json-schema": "0.53.0"
       },
@@ -500,6 +500,14 @@
       },
       "peerDependencies": {
         "typescript": "4.6.x || 4.7.x"
+      }
+    },
+    "node_modules/typedoc-plugin-extras": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-extras/-/typedoc-plugin-extras-2.3.0.tgz",
+      "integrity": "sha512-XjzutqICAkSpl1vhyloYfd35mn0U6WwOQ7BttRkwGhmBQs/qFLz2K+AU0/lj2Cx4WY6AqVr4c/PzFbqI4fACqw==",
+      "peerDependencies": {
+        "typedoc": "0.23.x"
       }
     },
     "node_modules/typescript": {
@@ -1028,6 +1036,12 @@
         "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
       }
+    },
+    "typedoc-plugin-extras": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-extras/-/typedoc-plugin-extras-2.3.0.tgz",
+      "integrity": "sha512-XjzutqICAkSpl1vhyloYfd35mn0U6WwOQ7BttRkwGhmBQs/qFLz2K+AU0/lj2Cx4WY6AqVr4c/PzFbqI4fACqw==",
+      "requires": {}
     },
     "typescript": {
       "version": "4.7.4",

--- a/scheduler-server/scheduling-dsl-compiler/package.json
+++ b/scheduler-server/scheduling-dsl-compiler/package.json
@@ -1,13 +1,12 @@
 {
   "name": "scheduling-dsl-compiler",
-  "version": "1.0.0",
   "description": "Typescript compiler for the scheduling server DSL",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf build; tsc",
     "test": "npm run build && node build/main.js",
     "generate-ast-schema": "npx typescript-json-schema src/libs/scheduler-ast.ts \"*\" --aliasRefs --out ./build/scheduler.schema.json",
-    "generate-doc": "npx typedoc src/libs/scheduler-edsl-fluent-api.ts src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Scheduling eDSL documentation\""
+    "generate-doc": "rm -rf build/docs; npx typedoc --plugin typedoc-plugin-extras --customTitle \"AERIE DOCUMENTATION\" --customTitleLink ../index.html typedoc-plugin-extras src/libs/scheduler-edsl-fluent-api.ts src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Scheduling eDSL documentation\""
   },
   "author": "",
   "dependencies": {
@@ -16,7 +15,8 @@
     "source-map": "^0.7.3",
     "typescript": "^4.5.5",
     "typescript-json-schema": "0.53.0",
-    "typedoc": "^0.23.10"
+    "typedoc": "^0.23.10",
+    "typedoc-plugin-extras": "^2.3.0"
   },
   "devDependencies": {
     "@tsconfig/node16-strictest-esm": "^1.0.2",

--- a/scheduler-server/scheduling-dsl-compiler/tsconfig.json
+++ b/scheduler-server/scheduling-dsl-compiler/tsconfig.json
@@ -6,5 +6,6 @@
 
     "noUnusedParameters": false,
     "noUnusedLocals": false
-  }
+  },
+  "exclude": ["node_modules", "build", "scripts"]
 }


### PR DESCRIPTION
Includes the autogenerated EDSL API documentation in our documentation site

* **Tickets addressed:** AERIE-2146
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

Makes EDSL documentation part of the docsite generation and includes them in the docsite outputs. Includes some links to them in the existing docsite files.

Release procedure:

Ensure the current docs for EDSLs are in `docs/edsl-api-docs/<constraints|schedling>-edsl-api/develop` (can run `./gradlew publishDocs` to generate it there) and copy it to a versioned directory (ie `docs/edsl-api-docs/<constraints|schedling>-edsl-api/v0.13.2`). Note that this versioned directory MUST have the same name as the release tag for it to properly be linked in the site docs.

This new versioned directory needs to be committed to git so we maintain the older versions of edsl docs.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Generated them locally and was able to link locally - will have to build + deploy to see if it works in CI

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

None

## Future work
<!-- What next steps can we anticipate from here, if any? -->
