### PR TITLE
[AERIE-1930] Include awaiting execution state activity tasks in results

### DIFF
--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/DecomposingSpawnActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/DecomposingSpawnActivity.java
@@ -1,0 +1,43 @@
+package gov.nasa.jpl.aerie.banananation.activities;
+
+import gov.nasa.jpl.aerie.banananation.Mission;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Parameter;
+
+import static gov.nasa.jpl.aerie.banananation.generated.ActivityActions.spawn;
+import static gov.nasa.jpl.aerie.banananation.generated.ActivityActions.call;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.*;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECOND;
+
+public final class DecomposingSpawnActivity {
+  @ActivityType("DecomposingSpawnParent")
+  public static final class DecomposingSpawnParentActivity {
+    @Parameter
+    public String label = "unlabeled";
+
+    @EffectModel
+    public void run(final Mission mission) {
+      spawn(new DecomposingSpawnChildActivity(1));
+      delay(1, SECOND);
+      spawn(new DecomposingSpawnChildActivity(2));
+    }
+  }
+
+  @ActivityType("DecomposingSpawnChild")
+  public static final class DecomposingSpawnChildActivity {
+    @Parameter
+    public int counter = 0;
+
+    public DecomposingSpawnChildActivity() {}
+
+    public DecomposingSpawnChildActivity(final int counter) {
+      this.counter = counter;
+    }
+
+    @EffectModel
+    public void run(final Mission mission) {
+      delay(2, SECOND);
+    }
+  }
+}

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
@@ -15,6 +15,8 @@
 @WithActivityType(DecomposingActivity.ParentActivity.class)
 @WithActivityType(DecomposingActivity.ChildActivity.class)
 @WithActivityType(DecomposingActivity.GrandchildActivity.class)
+@WithActivityType(DecomposingSpawnActivity.DecomposingSpawnParentActivity.class)
+@WithActivityType(DecomposingSpawnActivity.DecomposingSpawnChildActivity.class)
 @WithActivityType(BakeBananaBreadActivity.class)
 @WithActivityType(BananaNapActivity.class)
 
@@ -25,6 +27,7 @@ import gov.nasa.jpl.aerie.banananation.activities.BananaNapActivity;
 import gov.nasa.jpl.aerie.banananation.activities.BiteBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ChangeProducerActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DecomposingActivity;
+import gov.nasa.jpl.aerie.banananation.activities.DecomposingSpawnActivity;
 import gov.nasa.jpl.aerie.banananation.activities.GrowBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.LineCountBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ParameterTestActivity;

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -531,6 +531,18 @@ public final class SimulationEngine implements AutoCloseable {
             activityChildren.getOrDefault(activityId, Collections.emptyList()),
             (activityParents.containsKey(activityId)) ? Optional.empty() : Optional.of(activityId)
         ));
+      } else if (state instanceof ExecutionState.AwaitingChildren<?> e){
+        final var inputAttributes = taskInfo.input().get(task.id());
+        unfinishedActivities.put(activityId, new UnfinishedActivity(
+            inputAttributes.getTypeName(),
+            inputAttributes.getArguments(),
+            startTime.plus(e.startOffset().in(Duration.MICROSECONDS), ChronoUnit.MICROS),
+            activityParents.get(activityId),
+            activityChildren.getOrDefault(activityId, Collections.emptyList()),
+            (activityParents.containsKey(activityId)) ? Optional.empty() : Optional.of(activityId)
+        ));
+      } else {
+        throw new Error("Unexpected subtype of %s: %s".formatted(ExecutionState.class, state.getClass()));
       }
     });
 


### PR DESCRIPTION
* **Tickets addressed:** AERIE-1930
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
ComputeResults incorrectly assumes that tasks are either in the Terminated or InProgress state. There is a third state,  AwaitingChildren, which is like "Unfinished" in that it doesn't have an end time, but it's like "Finished" in that it has computed attributes. The check for Task state is extended to catch this third state so that all activities are included in simulation results.

## Verification
Added a test which simulates a small plan which has been constructed such that there will always be a parent activity awaiting a child. A new activity type, which decomposes using spawn, is added to Banananation for this purpose.

## Documentation
No changes or additions needed

## Future work
None
