### PR TITLE
[AERIE-2158] Refactor activity validation check

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -141,7 +141,9 @@ public final class LocalMissionModelService implements MissionModelService {
    * @return A map of validation errors mapping activity instance ID to failure message. If validation succeeds the map is empty.
    */
   @Override
-  public Map<ActivityInstanceId, ActivityInstantiationFailure> validateActivityInstantiations(final String missionModelId, final Map<ActivityInstanceId, SerializedActivity> activities)
+  public Map<ActivityInstanceId, ActivityInstantiationFailure>
+  validateActivityInstantiations(final String missionModelId,
+                                 final Map<ActivityInstanceId, SerializedActivity> activities)
   throws NoSuchMissionModelException, MissionModelLoadException
   {
     final var factory = this.loadMissionModelFactory(missionModelId);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -144,17 +144,24 @@ public final class LocalMissionModelService implements MissionModelService {
   public Map<ActivityInstanceId, ActivityInstantiationFailure> validateActivityInstantiations(final String missionModelId, final Map<ActivityInstanceId, SerializedActivity> activities)
   throws NoSuchMissionModelException, MissionModelLoadException
   {
+    final var factory = this.loadMissionModelFactory(missionModelId);
+    final var registry = DirectiveTypeRegistry.extract(factory);
+
     final var failures = new HashMap<ActivityInstanceId, ActivityInstantiationFailure>();
 
     for (final var entry : activities.entrySet()) {
       final var id = entry.getKey();
       final var act = entry.getValue();
       try {
-        this.getActivityEffectiveArguments(missionModelId, act); // The return value is intentionally ignored - we are only interested in failures
-      } catch (final MissionModelService.NoSuchActivityTypeException e) {
-        failures.put(id, new ActivityInstantiationFailure.NoSuchActivityType(e));
-      } catch (final InvalidArgumentsException e) {
-        failures.put(id, new ActivityInstantiationFailure.InvalidArguments(e));
+        // The return value is intentionally ignored - we are only interested in failures
+        final var specType = Optional
+        .ofNullable(registry.taskSpecTypes().get(act.getTypeName()))
+        .orElseThrow(() -> new MissionModelService.NoSuchActivityTypeException(act.getTypeName()));
+        specType.getEffectiveArguments(act.getArguments());
+      } catch (final NoSuchActivityTypeException ex) {
+        failures.put(id, new ActivityInstantiationFailure.NoSuchActivityType(ex));
+      } catch (final InvalidArgumentsException ex) {
+        failures.put(id, new ActivityInstantiationFailure.InvalidArguments(ex));
       }
     }
 


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2158
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The function `LocalMissionModelService#validateActivityInstantiations` validates each activity in the provided map. Problematically, it was loading the mission model for each activity validated. This refactor simply changes it to load the mission model once. This should significantly reduce the latency in requesting simulation results.

## Verification
Ran the e2e tests.

## Documentation
None needed, no changes to system behavior.

## Future work
None
