### PR TITLE
[HOTFIX] Canonicalize activity template arguments

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -147,6 +147,7 @@ public record SynchronousSchedulerAgent(
             .type("GLOBAL_SCHEDULING_CONDITIONS_FAILED")
             .message("Global scheduling condition%s failed".formatted(failedGlobalSchedulingConditions.size() > 1 ? "s" : ""))
             .data(ResponseSerializers.serializeFailedGlobalSchedulingConditions(failedGlobalSchedulingConditions)));
+        return;
       }
 
       compiledGlobalSchedulingConditions.forEach(problem::add);

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -1215,4 +1215,34 @@ public class SchedulingIntegrationTests {
     }
   }
 
+  /**
+   * Make sure that although typescript does not differentiate between Int and Double, the SerializedValue
+   * should correspond to the type declared by the activity type.
+   */
+  @Test
+  void testIntDoubleDeserialization() {
+    final var goalDefinition = """
+        export default function myGoal() {
+          return Goal.ActivityRecurrenceGoal({
+            activityTemplate: ActivityTemplates.BakeBananaBread({
+              glutenFree: true,
+              tbSugar: 1,
+              temperature: 325.0
+            }),
+            interval: Temporal.Duration.from({days: 1})
+          })
+        }
+        """;
+    final var planningHorizon = new PlanningHorizon(TimeUtility.fromDOY("2021-001T00:00:00"),
+                                                    TimeUtility.fromDOY("2021-003T01:00:00"));
+    final var results = runScheduler(
+        BANANANATION,
+        List.of(),
+        List.of(new SchedulingGoal(new GoalId(0L), goalDefinition, true)),
+        planningHorizon);
+
+    assertEquals(
+        new SerializedValue.RealValue(325.0),
+        results.updatedPlan().stream().findFirst().get().args().get("temperature"));
+  }
 }


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This was a regression reported by @camargo, where the Recurrence goal would fail to recognize existing activities in the plan and go ahead and place more activities.

The root cause was traced to `.equals` returning `false` when comparing `SerializedValue.IntValue(325)` with `SerializedValue.RealValue(325.0)`. This existing issue was exacerbated #301, where we now call `getEffectiveArguments` on every activity in the plan to fill in its full argument set.

This PR augments `makeActivityTemplate` to call `getEffectiveArguments`. Looking forward to Activity Expressions (which are allowed to have missing arguments), this implementation catches `IllegalArgumentException` and ignores missing arguments.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I added a test to make sure that `325.0` results in a SerializedValue.RealValue rather than an IntValue.

Unfortunately, I wasn't able to directly write a test that reproduces the issue at the integration test level, since the effective arguments is called as part of the PlanService, which is mocked out. We can add an e2e test for this if we think it would be valuable.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
This is a bugfix, shouldn't need any docs updates.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
I wonder if comparing the serialized values is the move long term, or if we should be comparing values at the types defined in the model.