### PR TITLE
[AERIE-2153] Remove `refreshActivityValidations` event trigger

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
@@ -33,18 +33,3 @@ remote_relationships:
         name: scheduling_goal
       field_mapping:
         source_scheduling_goal_id: id
-event_triggers:
-- definition:
-    enable_manual: false
-    insert:
-      columns:
-      - arguments
-    update:
-      columns:
-      - arguments
-  name: refreshActivityValidations
-  retry_conf:
-    interval_sec: 10
-    num_retries: 0
-    timeout_sec: 60
-  webhook: http://aerie_merlin:27183/refreshActivityValidations


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2153 (partially)
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Functionally reverts #330. Removes the `refreshActivityValidations` event trigger as an interim solution while batching of activity validations (or another solution) is worked out.

## Verification
- This is a fairly straightforward removal of functionality with no dependent tests.
- The UI (`aerie-ui`) has yet to make use of `activity_directive_validations` so this is safe to remove.

## Documentation
None.

## Future work
Batching of activity validations (or another solution).