### PR TITLE
[HOTFIX] Fix json<->SerializedValue int/double ambiguity when parsing

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/ActivityTemplateJsonParser.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/ActivityTemplateJsonParser.java
@@ -1,0 +1,71 @@
+package gov.nasa.jpl.aerie.scheduler.server.http;
+
+import gov.nasa.jpl.aerie.json.Breadcrumb;
+import gov.nasa.jpl.aerie.json.JsonParseResult;
+import gov.nasa.jpl.aerie.json.JsonParser;
+import gov.nasa.jpl.aerie.json.SchemaCache;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.scheduler.server.models.SchedulingDSL;
+import gov.nasa.jpl.aerie.scheduler.server.services.MissionModelService;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ActivityTemplateJsonParser implements JsonParser<SchedulingDSL.ActivityTemplate> {
+
+  private final Map<String, MissionModelService.ActivityType> activityTypesByName = new HashMap<>();
+
+  public ActivityTemplateJsonParser(MissionModelService.MissionModelTypes activityTypes){
+    activityTypes.activityTypes().forEach((actType)-> activityTypesByName.put(actType.name(), actType));
+  }
+
+  @Override
+  public JsonObject getSchema(final SchemaCache anchors) {
+    return Json
+        .createObjectBuilder()
+        .add("type", "object")
+        .build();
+  }
+
+  @Override
+  public JsonParseResult<SchedulingDSL.ActivityTemplate> parse(final JsonValue json) {
+    if (!(json instanceof JsonObject)) return JsonParseResult.failure("expected object");
+    final var asObject = json.asJsonObject();
+    if(!asObject.containsKey("activityType") || !asObject.containsKey("args")) return JsonParseResult.failure("expected fields activityType and args");
+    final var activityType = asObject.getString("activityType");
+    final var args = asObject.getJsonObject("args");
+    final var map = new HashMap<String, SerializedValue>(json.asJsonObject().size());
+    for (final var field : args.entrySet()) {
+      final var parsedValue = new StrictSerializedValueJsonParser(this.activityTypesByName.get(activityType).parameters().get(field.getKey())).parse(field.getValue());
+      if (parsedValue instanceof JsonParseResult.Failure<SerializedValue> failure){
+        failure.prependBreadcrumb(Breadcrumb.ofString(field.getKey()));
+        return failure.cast();
+      }
+      map.put(field.getKey(), parsedValue.getSuccessOrThrow());
+    }
+    return JsonParseResult.success(new SchedulingDSL.ActivityTemplate(activityType,map));
+  }
+
+
+  @Override
+  public JsonValue unparse(final SchedulingDSL.ActivityTemplate activityTemplate) {
+    final var builder = Json.createObjectBuilder();
+    builder.add("activityType", activityTemplate.activityType());
+    final var argumentsBuilder = Json.createObjectBuilder();
+    for (final var entry : activityTemplate.arguments().entrySet()) {
+      argumentsBuilder.add(
+          entry.getKey(),
+          new StrictSerializedValueJsonParser(
+              this.activityTypesByName
+                  .get(activityTemplate.activityType())
+                  .parameters()
+                  .get(entry.getKey()))
+              .unparse(entry.getValue()));
+    }
+    builder.add("args", argumentsBuilder.build());
+    return builder.build();
+  }
+}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/StrictSerializedValueJsonParser.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/StrictSerializedValueJsonParser.java
@@ -1,0 +1,150 @@
+package gov.nasa.jpl.aerie.scheduler.server.http;
+
+import gov.nasa.jpl.aerie.json.JsonParseResult;
+import gov.nasa.jpl.aerie.json.JsonParser;
+import gov.nasa.jpl.aerie.json.SchemaCache;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+
+import javax.json.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class StrictSerializedValueJsonParser implements JsonParser<SerializedValue> {
+  private final ValueSchema valueSchema;
+
+  public StrictSerializedValueJsonParser(ValueSchema valueSchema){
+    this.valueSchema = valueSchema;
+  }
+
+  @Override
+  public JsonObject getSchema(final SchemaCache anchors) {
+    return Json.createObjectBuilder().add("type", valueSchema.match(new ValueSchema.Visitor<String>() {
+      @Override
+      public String onReal() {
+        return "number";
+      }
+
+      @Override
+      public String onInt() {
+        return "number";
+      }
+
+      @Override
+      public String onBoolean() {
+        return "boolean";
+      }
+
+      @Override
+      public String onString() {
+        return "string";
+      }
+
+      @Override
+      public String onDuration() {
+        return "string";
+      }
+
+      @Override
+      public String onPath() {
+        return "string";
+      }
+
+      @Override
+      public String onSeries(final ValueSchema value) {
+        return "array";
+      }
+
+      @Override
+      public String onStruct(final Map<String, ValueSchema> value) {
+        return "object";
+      }
+
+      @Override
+      public String onVariant(final List<ValueSchema.Variant> variants) {
+        return "object";
+      }
+    })).build();
+  }
+
+  @Override
+  public JsonParseResult<SerializedValue> parse(final JsonValue json) {
+    return JsonParseResult.success(this.parseInfallible(json, this.valueSchema));
+  }
+
+  private SerializedValue parseInfallible(final JsonValue value, ValueSchema schema) {
+    return switch (value.getValueType()) {
+      case NULL -> SerializedValue.NULL;
+      case TRUE -> SerializedValue.of(true);
+      case FALSE -> SerializedValue.of(false);
+      case STRING -> SerializedValue.of(((JsonString) value).getString());
+      case NUMBER -> {
+        final var isInt = schema.asInt().isPresent();
+        final var num = (JsonNumber) value;
+        yield (isInt)
+            ? SerializedValue.of(num.longValue())
+            : SerializedValue.of(num.doubleValue());
+      }
+      case ARRAY -> {
+        final var arr = (JsonArray) value;
+        final var list = new ArrayList<SerializedValue>(arr.size());
+        for (final var element : arr) list.add(this.parseInfallible(element, schema.asSeries().get()));
+        yield SerializedValue.of(list);
+      }
+      case OBJECT -> {
+        final var obj = (JsonObject) value;
+        final var map = new HashMap<String, SerializedValue>(obj.size());
+        for (final var entry : obj.entrySet()) map.put(entry.getKey(), this.parseInfallible(entry.getValue(), schema.asStruct().get().get(entry.getKey())));
+        yield SerializedValue.of(map);
+      }
+    };
+  }
+
+  @Override
+  public JsonValue unparse(final SerializedValue value) {
+    return value.match(new SerializedValue.Visitor<>() {
+      @Override
+      public JsonValue onNull() {
+        return JsonValue.NULL;
+      }
+
+      @Override
+      public JsonValue onBoolean(final boolean value) {
+        return (value) ? JsonValue.TRUE : JsonValue.FALSE;
+      }
+
+      @Override
+      public JsonValue onReal(final double value) {
+        return Json.createValue(value);
+      }
+
+      @Override
+      public JsonValue onInt(final long value) {
+        return Json.createValue(value);
+      }
+
+      @Override
+      public JsonValue onString(final String value) {
+        return Json.createValue(value);
+      }
+
+      @Override
+      public JsonValue onList(final List<SerializedValue> elements) {
+        final var builder = Json.createArrayBuilder();
+        for (final var element : elements) builder.add(element.match(this));
+
+        return builder.build();
+      }
+
+      @Override
+      public JsonValue onMap(final Map<String, SerializedValue> fields) {
+        final var builder = Json.createObjectBuilder();
+        for (final var entry : fields.entrySet()) builder.add(entry.getKey(), entry.getValue().match(this));
+
+        return builder.build();
+      }
+    });
+  }
+}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresParsers.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresParsers.java
@@ -63,5 +63,6 @@ public final class PostgresParsers {
     }
   };
 
+  //TODO: serializedValueP is NOT safe to use here because used for parsing: subject to int/double typing confusion
   public static final JsonParser<Map<String, SerializedValue>> simulationArgumentsP = mapP(serializedValueP);
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -443,6 +443,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements PlanService.
   {
     final var arguments = Json.createObjectBuilder();
     for (final var arg : activity.arguments().entrySet()) {
+      //serializedValueP is safe to use here because only unparsing. otherwise subject to int/double typing confusion
       arguments.add(arg.getKey(), serializedValueP.unparse(arg.getValue()));
     }
     final var query = """
@@ -577,6 +578,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements PlanService.
       }
 
       for (final var arg : act.getArguments().entrySet()) {
+        //serializedValueP is safe to use here because only unparsing. otherwise subject to int/double typing confusion
         insertionObjectArguments.add(arg.getKey(), serializedValueP.unparse(arg.getValue()));
       }
       insertionObject.add("arguments", insertionObjectArguments.build());

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
@@ -79,7 +79,7 @@ class SchedulingDSLCompilationServiceTests {
                 Map.entry("variant", SerializedValue.of("option2")),
                 Map.entry("fancy", SerializedValue.of(Map.ofEntries(
                     Map.entry("subfield1", SerializedValue.of("value1")),
-                    Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2)))))
+                    Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                 )))),
                 Map.entry("duration", SerializedValue.of("PT3600S"))
             )
@@ -120,7 +120,7 @@ class SchedulingDSLCompilationServiceTests {
                 Map.entry("variant", SerializedValue.of("option2")),
                 Map.entry("fancy", SerializedValue.of(Map.ofEntries(
                     Map.entry("subfield1", SerializedValue.of("value1")),
-                    Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2)))))
+                    Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                     )))),
                 Map.entry("duration", SerializedValue.of("PT3600S"))
             )
@@ -190,7 +190,7 @@ class SchedulingDSLCompilationServiceTests {
                             "subfield2",
                             SerializedValue.of(List.of(SerializedValue.of(Map.of(
                                 "subsubfield1",
-                                SerializedValue.of(2)))))
+                                SerializedValue.of(2.0)))))
                         )))),
                     Map.entry("duration", SerializedValue.of("PT1H"))
                 )
@@ -249,7 +249,7 @@ class SchedulingDSLCompilationServiceTests {
                 Map.entry("variant", SerializedValue.of("option2")),
                 Map.entry("fancy", SerializedValue.of(Map.ofEntries(
                     Map.entry("subfield1", SerializedValue.of("value1")),
-                    Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2)))))
+                    Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                     )))),
                 Map.entry("duration", SerializedValue.of("PT3600S"))
             )
@@ -288,7 +288,7 @@ class SchedulingDSLCompilationServiceTests {
                 Map.entry("variant", SerializedValue.of("option2")),
                 Map.entry("fancy", SerializedValue.of(Map.ofEntries(
                     Map.entry("subfield1", SerializedValue.of("value1")),
-                    Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2)))))
+                    Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                     )))),
                 Map.entry("duration", SerializedValue.of("PT3600S"))
             )
@@ -328,7 +328,7 @@ class SchedulingDSLCompilationServiceTests {
                                                      Map.entry("variant", SerializedValue.of("option2")),
                                                      Map.entry("fancy", SerializedValue.of(Map.ofEntries(
                                                          Map.entry("subfield1", SerializedValue.of("value1")),
-                                                         Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2)))))
+                                                         Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                                                          )))),
                                                      Map.entry("duration", SerializedValue.of("PT1H"))
                                                  )
@@ -494,7 +494,7 @@ class SchedulingDSLCompilationServiceTests {
                                                      Map.entry("variant", SerializedValue.of("option2")),
                                                      Map.entry("fancy", SerializedValue.of(Map.ofEntries(
                                                          Map.entry("subfield1", SerializedValue.of("value1")),
-                                                         Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2)))))
+                                                         Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                                                          )))),
                                                      Map.entry("duration", SerializedValue.of("PT3600S"))
                                                  )


### PR DESCRIPTION
* **Tickets addressed:** HOTFIX
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Problem: when parsing the arguments of a `ActivityTemplate` to transform them into SerializedValue, a json number will be parsed in the following block (from `SerializedValueJsonParser`): 
```
case NUMBER -> {
        final var num = (JsonNumber) value;
        yield (num.isIntegral())
            ? SerializedValue.of(num.longValue())
            : SerializedValue.of(num.doubleValue());
      }
```
If `300.0` is parsed, it will result into a `IntValue` even though the mission model specifies that this argument should be a `RealValue`. And then collide with effective arguments (that are correctly typed) later. 

Approach: create a "strict" `SerializedValueJsonParser` taking a `ValueSchema` as argument to treat this real/int ambiguity. To pass the correct `ValueSchema` to this strict parser when deserializing, I also created a specific parser for `ActivityTemplate` that goes and picks the right `ValueSchema` for each of the argument. 

Then I annotated the safe and unsafe used of `SerializedValueJsonParser` in the scheduler. Safe is when deserializing, unsafe is when serializing. 

Finally, I have updated the tests. Even though it was transparent because of the use of `SerializedValue.of()`, the bug was actually present there also as the argument with the name `subsubfield1` has type `Real` but was always returned as an `Integer`. 

https://github.com/NASA-AMMOS/aerie/pull/369 by @mattdailis is trying to fix the same bug. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Tests are passing.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None, this is a bug. 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
I believe this bug exists everywhere arguments are parsed. It may not be visible if the arguments are then going through effective arguments as the effective arguments will "come back" with the correct type. 