### PR TITLE
[HOTFIX] Constraints Any semantics should preserve false

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/All.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/All.java
@@ -23,11 +23,11 @@ public final class All implements Expression<Windows> {
 
   @Override
   public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    Windows windows = new Windows(bounds, true);
+    Windows windows = new Windows(true);
     for (final var expression : this.expressions) {
       windows = windows.and(expression.evaluate(results, bounds, environment));
     }
-    return windows;
+    return windows.select(bounds);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Any.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Any.java
@@ -23,13 +23,13 @@ public final class Any implements Expression<Windows> {
 
   @Override
   public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    Windows windows = new Windows();
+    Windows windows = new Windows(false);
     for (final var expression : this.expressions) {
       windows = windows.or(
           expression.evaluate(results, bounds, environment)
       );
     }
-    return windows.and(new Windows(bounds, true));
+    return windows.select(bounds);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ViolationsOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ViolationsOf.java
@@ -19,9 +19,8 @@ public final class ViolationsOf implements Expression<List<Violation>> {
 
   @Override
   public List<Violation> evaluate(SimulationResults results, final Interval bounds, EvaluationEnvironment environment) {
-    final var boundsW = new Windows(bounds, true);
     final var satisfiedWindows = this.expression.evaluate(results, bounds, environment);
-    return List.of(new Violation(satisfiedWindows.not().and(boundsW)));
+    return List.of(new Violation(satisfiedWindows.not().select(bounds)));
   }
 
   @Override

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -1,19 +1,18 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
 import gov.nasa.jpl.aerie.constraints.InputMismatchException;
-import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
-import gov.nasa.jpl.aerie.constraints.time.UnsplittableSpanException;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfilePiece;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.model.Violation;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Segment;
-import gov.nasa.jpl.aerie.constraints.time.IntervalContainer;
 import gov.nasa.jpl.aerie.constraints.time.Spans;
+import gov.nasa.jpl.aerie.constraints.time.UnsplittableSpanException;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
@@ -270,7 +269,7 @@ public class ASTTests {
   @Test
   public void testOr() {
     final var simResults = new SimulationResults(
-        Interval.between(0, 20, SECONDS),
+        Interval.between(0, 26, SECONDS),
         List.of(),
         Map.of(),
         Map.of()
@@ -281,13 +280,15 @@ public class ASTTests {
         .set(Interval.between(6, Inclusive, 7, Inclusive, SECONDS), true)
         .set(Interval.between(8, Exclusive, 9, Exclusive, SECONDS), true)
         .set(Interval.between(10, Exclusive, 15, Exclusive, SECONDS), true)
-        .set(Interval.at(20, SECONDS), true);
+        .set(Interval.at(20, SECONDS), true)
+        .set(Interval.between(25, Inclusive, 26, Exclusive, SECONDS), false);
 
     final var right = new Windows()
         .set(Interval.between(0, Inclusive, 5, Inclusive, SECONDS), true)
         .set(Interval.between(7, Inclusive, 8, Exclusive, SECONDS), true)
         .set(Interval.between(10, Inclusive, 12, Inclusive, SECONDS), true)
-        .set(Interval.between(15, Inclusive, 20, Exclusive, SECONDS), true);
+        .set(Interval.between(15, Inclusive, 20, Exclusive, SECONDS), true)
+        .set(Interval.between(25, Inclusive, 26, Exclusive, SECONDS), false);
 
     final var result = new Any(Supplier.of(left), Supplier.of(right)).evaluate(simResults, new EvaluationEnvironment());
 
@@ -295,7 +296,8 @@ public class ASTTests {
         .set(Interval.between(  0, Inclusive,   5, Inclusive, SECONDS), true)
         .set(Interval.between(  6, Inclusive,   8, Exclusive, SECONDS), true)
         .set(Interval.between(  8, Exclusive,   9, Exclusive, SECONDS), true)
-        .set(Interval.between( 10, Inclusive,  20, Inclusive, SECONDS), true);
+        .set(Interval.between( 10, Inclusive,  20, Inclusive, SECONDS), true)
+        .set(Interval.between(25, Inclusive, 26, Exclusive, SECONDS), false);
 
     assertEquivalent(expected, result);
   }

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -612,11 +612,12 @@ public class ASTTests {
 
     final var windows = new Windows()
         .set(Interval.between(1, 4, SECONDS), true)
+        .set(Interval.between(5, 6, SECONDS), false)
         .set(Interval.between(7,20, SECONDS), true);
 
     final var result = new ViolationsOf(new Supplier<>(windows)).evaluate(simResults, new EvaluationEnvironment());
 
-    final var expected = List.of(new Violation(windows.not().and(new Windows(simResults.bounds, true))));
+    final var expected = List.of(new Violation(windows.not().select(simResults.bounds)));
 
     assertEquivalent(expected, result);
   }


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

This case was discovered by @camargo in preparation for a demo. A constraint similar to the following was never returning violations:

```typescript
export default (): Constraint => {
  return Constraint.ForEachActivity(ActivityType.grandchild, 
    instance => Discrete.Resource("/flag").equal("B").if(instance.window()));
}
```

As a reminder, the `x.if(y)` is syntactic sugar for `Any(not y, x)`.

I stepped through the debugger and found that the `Any` node was converting `false` into `null` in the following case:

(Assume that `/flag` is never equal to "B")

1. Instance.window produces three intervals: `(Duration.MIN, start time, FALSE)`, `(start time, end time, TRUE)`, and `(end time, Duration.MAX, FALSE)` (I'm being imprecise with my 'clusivity because it's irrelevant to my point)
2. The `Invert` correctly swaps `TRUE` with `FALSE` and vice versa above, resulting in `(Duration.MIN, start time, TRUE)`, `(start time, end time, FALSE)`, and `(end time, Duration.MAX, TRUE)`
3. We get up to the `Any` node, and we immediately OR these three intervals with the empty `Windows` object (which is `null` everywhere). This drops the `FALSE` interval, losing the crucial information we needed to check this constraint.
4. We emerge from `Any` with `(Duration.MIN, start time, TRUE)`, `(end time, Duration.MAX, TRUE)` and we say that there are no violations, since there are no FALSE intervals.

The change I'm proposing is that the `Any` node should start with the interval `FOREVER, FALSE` (the identity value for "OR"). This seems reasonable to me, but I'd like feedback from people who have spent more time thinking about this @JoelCourtney @Twisol .

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I updated `testOr` to check that a false interval in both `left` and `right` should be preserved by `Any(left, right)`. This test fails until the next commit, after which it passes.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Do we have documentation for how nullable windows behave?

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None
