### PR TITLE
Javadocs for merlin.protocol

### DIFF
--- a/contrib/build.gradle
+++ b/contrib/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
   api 'JNISpice:JNISpice:1.0-20190517.205223-2'
   api 'org.apache.commons:commons-math3:3.6.1'
+  api 'org.apache.commons:commons-lang3:3.12.0'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
   testImplementation project(':merlin-framework-junit')

--- a/examples/config-with-defaults/build.gradle
+++ b/examples/config-with-defaults/build.gradle
@@ -11,6 +11,8 @@ java {
 jar {
   from {
     configurations.runtimeClasspath.filter{ it.exists() }.collect{ it.isDirectory() ? it : zipTree(it) }
+  } {
+    exclude 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt'
   }
 }
 

--- a/examples/config-without-defaults/build.gradle
+++ b/examples/config-without-defaults/build.gradle
@@ -11,6 +11,8 @@ java {
 jar {
   from {
     configurations.runtimeClasspath.filter{ it.exists() }.collect{ it.isDirectory() ? it : zipTree(it) }
+  } {
+    exclude 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt'
   }
 }
 

--- a/examples/foo-missionmodel/build.gradle
+++ b/examples/foo-missionmodel/build.gradle
@@ -11,6 +11,8 @@ java {
 jar {
   from {
     configurations.runtimeClasspath.filter{ it.exists() }.collect{ it.isDirectory() ? it : zipTree(it) }
+  } {
+    exclude 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt'
   }
 }
 

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelBuilder.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelBuilder.java
@@ -13,8 +13,6 @@ import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.model.CellType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.OutputType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Resource;
-import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
-import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -58,7 +56,7 @@ public final class MissionModelBuilder implements Initializer {
   }
 
   @Override
-  public <Return> void daemon(final TaskFactory<Return> task) {
+  public void daemon(final TaskFactory<?> task) {
     this.state.daemon(task);
   }
 
@@ -132,7 +130,7 @@ public final class MissionModelBuilder implements Initializer {
     }
 
     @Override
-    public <Return> void daemon(final TaskFactory<Return> task) {
+    public void daemon(final TaskFactory<?> task) {
       this.daemons.add(task);
     }
 
@@ -187,7 +185,7 @@ public final class MissionModelBuilder implements Initializer {
     }
 
     @Override
-    public <Return> void daemon(final TaskFactory<Return> task) {
+    public void daemon(final TaskFactory<?> task) {
       throw new IllegalStateException("Daemons cannot be added after the schema is built");
     }
 

--- a/merlin-framework/build.gradle
+++ b/merlin-framework/build.gradle
@@ -26,6 +26,7 @@ javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 
 dependencies {
   compileOnlyApi project(':merlin-sdk')
+  implementation 'org.apache.commons:commons-lang3:3.12.0'
 
   testImplementation project(':merlin-sdk')
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
@@ -32,7 +32,7 @@ public interface Context {
 
   interface TaskFactory<Return> { Task<Return> create(ExecutorService executor); }
 
-  <Return> void spawn(TaskFactory<Return> task);
+  void spawn(TaskFactory<?> task);
   <Return> void call(TaskFactory<Return> task);
 
   void delay(Duration duration);

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
@@ -54,8 +54,14 @@ public final class InitializationContext implements Context {
   }
 
   @Override
-  public <Return> void spawn(final TaskFactory<Return> task) {
-    this.builder.daemon(() -> task.create(InitializationContext.this.executor));
+  public void spawn(final TaskFactory<?> task) {
+    this.builder.daemon(wrap(task));
+  }
+
+  // It looks stupid, but this method is actually necessary to bind the type parameter T.
+  // Inlining this method at its call site induces a compiler error.
+  private <T> Initializer.TaskFactory<T> wrap(final TaskFactory<T> task) {
+    return () -> task.create(this.executor);
   }
 
   @Override

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/QueryContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/QueryContext.java
@@ -42,7 +42,7 @@ public final class QueryContext implements Context {
   }
 
   @Override
-  public <Return> void spawn(final TaskFactory<Return> task) {
+  public void spawn(final TaskFactory<?> task) {
     throw new IllegalStateException("Cannot schedule tasks in a query-only context");
   }
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
@@ -67,7 +67,7 @@ final class ReplayingReactionContext implements Context {
   }
 
   @Override
-  public <T> void spawn(final TaskFactory<T> task) {
+  public void spawn(final TaskFactory<?> task) {
     this.memory.doOnce(() -> {
       this.scheduler.spawn(task.create(this.executor));
     });

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
@@ -56,7 +56,7 @@ final class ThreadedReactionContext implements Context {
   }
 
   @Override
-  public <T> void spawn(final TaskFactory<T> task) {
+  public void spawn(final TaskFactory<?> task) {
     this.scheduler.spawn(task.create(this.executor));
   }
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/resources/package-info.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/resources/package-info.java
@@ -16,7 +16,7 @@
  * <p>
  *   Pragmatically, a dynamics at one time may not be a reasonable approximation at a later time.
  *   As a resource is derived from zero or more backing states, we may take the minimum over calls
- *   to {@link gov.nasa.jpl.aerie.merlin.protocol.model.Applicator#getExpiry(java.lang.Object)} as the amount of time
+ *   to {@link gov.nasa.jpl.aerie.merlin.protocol.model.CellType#getExpiry(java.lang.Object)} as the amount of time
  *   for which a resource's current dynamics is legal.
  * </p>
  *

--- a/merlin-framework/src/test/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTaskTest.java
+++ b/merlin-framework/src/test/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTaskTest.java
@@ -28,7 +28,7 @@ public final class ThreadedTaskTest {
       }
 
       @Override
-      public <Output> void spawn(final Task<Output> task) {
+      public void spawn(final Task<?> task) {
         throw new UnsupportedOperationException();
       }
     };

--- a/merlin-sdk/build.gradle
+++ b/merlin-sdk/build.gradle
@@ -19,23 +19,10 @@ test {
 
 jacocoTestReport.dependsOn test
 
-// Link references to standard Java classes to the official Java 11 documentation.
-javadoc.options.links 'https://docs.oracle.com/en/java/javase/11/docs/api/'
-javadoc.options.links 'https://commons.apache.org/proper/commons-lang/javadocs/api-3.9/'
 javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 
 dependencies {
-  api 'org.apache.commons:commons-lang3:3.12.0'
-
-  implementation 'org.apache.commons:commons-collections4:4.4'
-  implementation 'org.apache.commons:commons-math3:3.6.1'
-  implementation 'org.pcollections:pcollections:3.1.4'
-  implementation 'com.squareup:javapoet:1.13.0'
-  implementation 'com.fasterxml.jackson.core:jackson-core:2.13.0'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
-
-  testImplementation 'org.assertj:assertj-core:3.23.1'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 }
 
 publishing {

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Initializer.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Initializer.java
@@ -4,15 +4,75 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.CellType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.OutputType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Resource;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
-import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
-import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
 import java.util.function.Function;
 
+/**
+ * An interface to the driver during model instantiation.
+ *
+ * <p> An {@code Initializer} allows models to {@linkplain #allocate(Object, CellType, Function, Topic) allocate}
+ * storage for simulation-aware state, which is the only mutable state that can safely be shared among
+ * stateful cells that can be read and updated from {@link Task}s. The model must not interact with an {@code Initializer}
+ * beyond the scope in which it was received. </p>
+ *
+ * <p> Models can also export resources (time-varying values) and topics (streams of discrete events) via this interface.
+ * These observable outputs of the model provide feedback to users, displaying the effect on the model of the input
+ * directives and configuration. Observing the behavior of resources and topics is very nearly the whole point of
+ * simulating a model, so it is essential to register these outputs for clients to make use of. </p>
+ *
+ * <p> In a future revision of this API, exportation of resources and topics may be moved to the {@link gov.nasa.jpl.aerie.merlin.protocol.model.ModelType}
+ * interface, so that the existence and shape of these outputs cannot vary with model configuration. </p>
+ */
 public interface Initializer {
+  /**
+   * Gets the current state of the cell with the given ID.
+   *
+   * <p> Since cells cannot be mutated during initialization, this method always returns the initial state provided to
+   * {@link #allocate(Object, CellType, Function, Topic)} for the given cell ID. </p>
+   *
+   * @param <State>
+   *   The type of state held by the cell.
+   * @param cellId
+   *   The ID of the cell to query.
+   * @return
+   *   The current state of the cell.
+   */
   <State>
   State getInitialState(CellId<State> cellId);
 
+  /**
+   * Allocates a stateful cell with the given initial state, which may evolve over time and under effects. The cell is
+   * automatically subscribed to the provided topic, whose events are interpreted as effects by the given function.
+   *
+   * <p> All mutable state referenced by a model must be allocated via this method. In turn, this method returns
+   * {@link gov.nasa.jpl.aerie.merlin.protocol.driver.CellId}s, which identify the cell to the driver in future
+   * read/write interactions. This makes it possible to give each concurrent task a transactional view of the model
+   * state, to resolve any concurrent effects on state in a coherent way, and to identify which resources need to be
+   * recomputed based on when the cells they are computed from are updated. </p>
+   *
+   * <p> The given {@link CellType} describes how concurrent effects resolve into coherent updates to the cell's state,
+   * and how time causes the state to evolve autonomously. The given {@link Topic} and associated interpretation
+   * function describe how a particular class of events influences this cell. In the future, it may become possible to
+   * subscribe a cell to zero or multiple topics, in which case this method will likely factor into separate actions
+   * for allocation and subscription. </p>
+   *
+   * @param <Event>
+   *   The type of event streamed over the given topic.
+   * @param <Effect>
+   *   The type of effect accepted by the given cell type.
+   * @param <State>
+   *   The type of state managed by the given cell type.
+   * @param initialState
+   *   The initial state of the cell.
+   * @param cellType
+   *   A specification of the cell's behavior over time and under effects.
+   * @param interpretation
+   *   An interpretation of events as effects on this particular cell.
+   * @param topic
+   *   A stream of events to subscribe this cell to.
+   * @return
+   *   A unique token identifying the allocated cell.
+   */
   <Event, Effect, State>
   CellId<State> allocate(
       State initialState,
@@ -20,18 +80,58 @@ public interface Initializer {
       Function<Event, Effect> interpretation,
       Topic<Event> topic);
 
+  /**
+   * Registers a specification for a top-level "daemon" task to be spawned at the beginning of simulation.
+   *
+   * <p> Daemon tasks are so-named in analogy to the <a href="https://en.wikipedia.org/wiki/Daemon_(computing)">"daemon"
+   * processes</a> of UNIX, which are background processes that monitor system state and take action on some condition
+   * or periodic schedule. Merlin's daemon tasks are much the same: tasks that exist on the model's behalf, rather than
+   * as reactions to environmental stimuli, which may model some system upkeep behavior on some condition or periodic
+   * schedule. </p>
+   *
+   * <p> The return value from a daemon task is discarded and ignored. </p>
+   *
+   * @param factory
+   *   A factory for constructing instances of the daemon task.
+   */
   void daemon(TaskFactory<?> factory);
 
+  /**
+   * Registers a model resource whose value over time is observable by the environment.
+   *
+   * @param name
+   *   The name of the resource, unique amongst all resources.
+   * @param resource
+   *   The method to use to observe the value of the resource.
+   */
   void resource(
       String name,
       Resource<?> resource);
 
+  /**
+   * Registers a stream of events (a "topic") observable by the environment.
+   *
+   * @param name
+   *   The name of the topic, unique amongst all topics.
+   * @param topic
+   *   The identifier associated to each event on the topic.
+   * @param outputType
+   *   A description of the type of data carried by events on the topic.
+   * @param <Event>
+   *   The type of data carried by events on the topic.
+   */
   <Event>
   void topic(
       String name,
       Topic<Event> topic,
       OutputType<Event> outputType);
 
+  /**
+   * A factory for creating fresh copies of a task. All tasks created by a factory must be observationally equivalent.
+   *
+   * @param <Return>
+   *   The type of data returned by a task created by this factory.
+   */
   interface TaskFactory<Return> {
     Task<Return> create();
   }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Initializer.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Initializer.java
@@ -20,8 +20,7 @@ public interface Initializer {
       Function<Event, Effect> interpretation,
       Topic<Event> topic);
 
-  <Return>
-  void daemon(TaskFactory<Return> factory);
+  void daemon(TaskFactory<?> factory);
 
   void resource(
       String name,

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Scheduler.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Scheduler.java
@@ -7,5 +7,5 @@ public interface Scheduler {
 
   <Event> void emit(Event event, Topic<Event> topic);
 
-  <Output> void spawn(Task<Output> task);
+  void spawn(Task<?> task);
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Topic.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Topic.java
@@ -1,10 +1,13 @@
 package gov.nasa.jpl.aerie.merlin.protocol.driver;
 
+import gov.nasa.jpl.aerie.merlin.protocol.Capability;
+
 /**
- * An unforgeable token identifying a particular family of events.
+ * An unforgeable token identifying a particular stream of events.
  *
  * Every {@code Topic} instance identifies a unique topic, even if two topics share the same {@code EventType}.
  */
+@Capability
 public final class Topic<EventType> {
   @Override
   public String toString() {

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/package-info.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/package-info.java
@@ -1,0 +1,47 @@
+/**
+ * Interfaces implemented by the external environment of a mission model.
+ *
+ * <p> Since a model provides methods to be invoked by a driver, typically the only way for the model to communicate
+ * back to the driver is via the values returned from its methods. However, it is often necessary for the model to
+ * communicate with the driver without returning immediately. The interfaces in this package are provided as arguments
+ * to a model at one time or another, allowing the model to call <i>back</i> to the driver. </p>
+ *
+ * <p> The exception (which proves the rule) is the {@link gov.nasa.jpl.aerie.merlin.protocol.driver.CellId} type, which
+ * has no methods of its own. Instead, it acts as a typed identifier that the model can use to ask the driver for
+ * the current state of an allocated cell. (It "proves the rule" because it is used precisely when calling the driver
+ * back.) </p>
+ *
+ * <p> The model can only interact with the driver during three contexts: <i>initialization</i>, <i>execution</i>,
+ * and <i>inquisition</i>. </p>
+ *
+ * <ul>
+ *   <li>
+ *     <p> During <i>initialization</i>, a model can allocate cells to hold its internal state, spawn top-level "daemon"
+ *     tasks, and export resources (time-varying values) and topics (streams of discrete events). It can also query the
+ *     current state of its cells, even though they cannot be changed from their initial values during this phase. The
+ *     {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer} interface grants access to these actions, and is
+ *     typically provided to the {@link gov.nasa.jpl.aerie.merlin.protocol.model.ModelType#instantiate(java.time.Instant, java.lang.Object, gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer)}
+ *     method. </p>
+ *
+ *     <p> In the future, resource and topic exportation may be moved to the {@link gov.nasa.jpl.aerie.merlin.protocol.model.ModelType}
+ *     class instead, so that the input and output interface of a model can be known independent of a particular choice
+ *     of configuration. </p>
+ *   </li>
+ *
+ *   <li>
+ *     <p> During <i>execution</i>, a model can get the current value of a cell, emit events (to influence cells or to be
+ *     logged on an exported topic), and spawn additional tasks. The {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler}
+ *     interface grants access to these actions, and is typically provided to the {@link gov.nasa.jpl.aerie.merlin.protocol.model.Task#step(gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler)}
+ *     method.</p>
+ *
+ *     <p> In the future, models may also be able to allocate state during execution, to facilitate sharing temporary
+ *     state between subtasks. </p>
+ *   </li>
+ *
+ *   <li> During <i>inquisition</i>, a model can only get the current value of a cell. The {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Querier}
+ *   interface provides this read-only access to the model's state, and is typically provided to the {@link gov.nasa.jpl.aerie.merlin.protocol.model.Resource#getDynamics(gov.nasa.jpl.aerie.merlin.protocol.driver.Querier)}
+ *   and {@link gov.nasa.jpl.aerie.merlin.protocol.model.Condition#nextSatisfied(gov.nasa.jpl.aerie.merlin.protocol.driver.Querier, gov.nasa.jpl.aerie.merlin.protocol.types.Duration)}
+ *   methods. </li>
+ * </ul>
+ */
+package gov.nasa.jpl.aerie.merlin.protocol.driver;

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/DirectiveType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/DirectiveType.java
@@ -7,7 +7,12 @@ import java.util.Map;
 
 public interface DirectiveType<Model, Arguments, Result> {
   InputType<Arguments> getInputType();
+
+  // TODO: Remove this, since anything that currently depends on this
+  //   ought to instead depend on the topics exported by a model on which
+  //   the output data is emitted.
   OutputType<Result> getOutputType();
+
   Task<Result> createTask(Model model, Arguments arguments);
 
   /**

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/DirectiveType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/DirectiveType.java
@@ -5,21 +5,68 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.util.Map;
 
+/**
+ * A type of directive that can be issued to a Merlin model.
+ *
+ * <p> A <i>directive</i> is a means by which a model's environment can influence the model's behavior. For instance, a
+ * space relay system might normally take no autonomous actions of its own; instead, it waits until it receives a
+ * request to store and forward a given payload to another node in the system. </p>
+ *
+ * <p> A directive can be instantiated using its associated {@link InputType}, and its associated behavior can be
+ * extracted using the {@link #createTask(Model, Arguments)} method. When the directive's behavior is finished, its
+ * result value can be manipulated using its associated {@link OutputType}. </p>
+ *
+ * <p> As a reflective interface, {@code DirectiveType} is analogous to {@link java.lang.reflect.Method}. It represents
+ * an executable method on a {@code Model} receiver with an {@code Arguments} input and a {@code Result} output. </p>
+ *
+ * @param <Model>
+ *   The model that can be influenced by this directive.
+ * @param <Arguments>
+ *   The type of the arguments to the directive.
+ * @param <Result>
+ *   The result of performing the directive to completion.
+ */
 public interface DirectiveType<Model, Arguments, Result> {
+  /** Gets the type of input accepted by this directive. */
   InputType<Arguments> getInputType();
 
+  /** Gets the type of output produced by this directive. */
   // TODO: Remove this, since anything that currently depends on this
   //   ought to instead depend on the topics exported by a model on which
   //   the output data is emitted.
   OutputType<Result> getOutputType();
 
+  /**
+   * Initializes a {@link Task} operating on the given model given a directive instance.
+   *
+   * <p> This method and the returned {@code Task} must never cause the given {@code Model} or {@code Arguments} to be
+   * mutated. It may only read/write cells allocated to the model via any {@link gov.nasa.jpl.aerie.merlin.protocol.driver.CellId}
+   * references the model holds, or update the private state of the {@code Task} itself. This is because multiple {@code Task}s
+   * may reference the {@code Model} or {@code Arguments} concurrently, and updates by one {@code Task} may interfere
+   * with the transactional isolation afforded to others. </p>
+   */
   Task<Result> createTask(Model model, Arguments arguments);
 
   /**
-   * This method must behave as though implemented as:
+   * Initializes a {@link Task} given a set of arguments determining the directive instance.
+   *
+   * <p> This method is a convenience method, allowing callers to avoid binding the generic type {@code T}. This method
+   * must behave as though implemented as: </p>
+   *
    * {@snippet :
    * return this.createTask(model, this.getInputType().instantiate(arguments));
    * }
+   *
+   * @param model
+   *   The model to perform the directive.
+   * @param arguments
+   *   Arguments uniquely determining the directive to perform.
+   * @return
+   *   An executable task operating on the model's state, terminating with a {@code Result} value.
+   * @throws InvalidArgumentsException
+   *   When the given arguments do not uniquely determine a directive instance.
+   * @see InputType#instantiate(Map)
+   * @see #createTask(Model, Arguments)
    */
   default Task<Result> createTask(final Model model, final Map<String, SerializedValue> arguments)
   throws InstantiationException

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/InputType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/InputType.java
@@ -7,27 +7,192 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * A type of data accepted as input by a Merlin model.
+ *
+ * <p> An implementation of this interface provides reflective, at-a-distance access to an abstract type {@code T}
+ * accepted by a Merlin model as input. Instances may be constructed from serialized arguments using
+ * {@link #instantiate(Map)}, and arguments can be recovered from an instance using {@link #getArguments(T)}. </p>
+ *
+ * <p> This interface "embeds" the abstract type {@code T} in the domain of {@link SerializedValue}s, in that
+ * every instance of {@code T} has a corresponding set of arguments that uniquely determines it. Put differently,
+ * calling {@link #instantiate(Map)} on the result of {@link #getArguments(T)} method gives a value equivalent to the
+ * original {@link T}. </p>
+ *
+ * <p> Most uses of this interface, however, will attempt to instantiate a value of type {@link T} from
+ * manually-constructed sets of arguments, for the simple reason that clients cannot use {@link #getArguments(T)}
+ * without already having a value of type {@link T}. This interface provides several facilities to assist clients in
+ * finding instantiable sets of arguments. </p>
+ *
+ * <ul>
+ *   <li> The {@link #getParameters()} method names all (and only) the arguments accepted by {@link #instantiate(Map)}. </li>
+ *
+ *   <li> The {@link #getParameters()} method provides a rough schema for each argument. An argument that does not meet
+ *   this schema is guaranteed to be rejected; an argument that does meet this schema may still be rejected due to
+ *   semantic invalidity. (It is hard, for instance, to capture requirements like "sorted list" or "legally-formatted
+ *   email address" schematically, and a constructor of a domain type may fail for any similar reason.) </li>
+ *
+ *   <li> The {@link #getRequiredParameters()} method indicates each parameter for which an argument must be provided.
+ *   A required parameter left unspecified is guaranteed to fail instantiation; but a set of arguments that provides all
+ *   required parameters may still fail. For instance, if at least one of parameters "x" and "y" must be provided, then
+ *   there exist instantiable argument sets where either one is not present, so neither is "required" in all cases. </li>
+ *
+ *   <li> The {@link #instantiate(Map)} method will throw an {@link IllegalArgumentException} if the argument set is
+ *   not instantiable, and will include actionable information about what to do to bring the argument set closer to
+ *   validity. Where the other methods speak about all possible values for type {@code T}, this method is concerned with
+ *   the values that the given argument set could possible indicate. Errors typically fall into two classes:
+ *   under-specification, where more arguments are needed, and over-specification, where conflicts among the arguments
+ *   mean that no possible value of type {@code T} observes those arguments. </li>
+ * </ul>
+ *
+ * <p> The {@link #getParameters()} and {@link #getRequiredParameters()} provide primarily schematic information to
+ * support user interface customization for editing and displaying the arguments for this type. In turn,
+ * {@link #instantiate(Map)} is the final source of truth on what sets of arguments are actually instantiable; the
+ * schematic information only sets a low bar to constrain inputs to those that have a chance of being reasonable. </p>
+ *
+ * <p> The {@link #getValidationFailures(T)} method provides <i>post-instantiation</i> notices, providing additional
+ * feedback on values which may be legal yet unadvisable for some reason. These may be thought of as "warnings" (or
+ * even weaker, depending on their contents), where failures to instantiate constitute "errors". </p>
+ *
+ * @param <T>
+ *   The abstract type of input described by this object.
+ */
 public interface InputType<T> {
+  /**
+   * Gets the ordered family of named parameters defining this type.
+   *
+   * <p> Each parameter describes the name and schematic approximation of an argument accepted by
+   * {@link #instantiate(Map)}. </p>
+   *
+   * <p> The order of parameters is meaningful: models may list their parameters in an order recommended for human
+   * operators to specify them in. For instance, required parameters <i>may</i> be sorted toward the front, and
+   * rarely-used parameters <i>may</i> be sorted toward the back. Alternatively, order may be used to group semantically
+   * related parameters. </p>
+   *
+   * <p> Clients should preserve the order of this list whenever it might be displayed for a human
+   * operator. </p>
+   *
+   * <p> Conversely, this order only matters for parameters; {@link #instantiate(Map)} accepts an unordered {@code Map},
+   * so the order of specified arguments is irrelevant. </p>
+   *
+   * @return
+   *   An ordered family of named parameters describing the arguments for {@link #instantiate(Map)}.
+   */
   List<Parameter> getParameters();
 
+  /**
+   * Names a subset of parameters returned by {@link #getParameters()} whose absence on instantiation would
+   * certainly result in an {@link InvalidArgumentsException}.
+   *
+   * <p> Providing a schematically-valid argument for every "required" parameter does not guarantee success in
+   * instantiating a value of type {@code T}. For example, two parameters may be inter-derivable: if only one is not
+   * given, the other could be inferred from it. Neither parameter is "required", because some instantiation could
+   * succeed even with that parameter unspecified. </p>
+   *
+   * <p> The best way to see if a set of arguments describes a valid input value is to attempt to instantiate it with
+   * {@link #instantiate(Map)}. </p>
+   *
+   * @return
+   *   A set of parameters whose absence will cause {{@link #instantiate(Map)}} to fail.
+   */
   List<String> getRequiredParameters();
 
+  /**
+   * Instantiates a value of type {@code T} from arguments.
+   *
+   * <p> The arguments provided must correspond to the parameters returned by {@link #getParameters()}, and must
+   * at a minimum include an argument for each parameter indicated by {@link #getRequiredParameters()}. </p>
+   *
+   * <p> On the other hand, not every parameter must be supplied an argument. If an argument is left unspecified, it can
+   * sometimes be automatically filled in, whether by deriving it from its relationship with other arguments or by
+   * automatically inferring a default value. </p>
+   *
+   * <p> Instantiation may fail for one of two reasons: </p>
+   *
+   * <ul>
+   *   <li> <i>Under-specification</i>: Multiple possible values of type {@code T} match the specified arguments. More
+   *   arguments need to be specified in order to pin down a single value of type {@code T} uniquely. </li>
+   *
+   *   <li> <i>Over-specification</i>: No value of type {@code T} matches the specified arguments. Some of the specified
+   *   arguments need to be changed (or removed, if there is no parameter by a specified name). </li>
+   * </ul>
+   *
+   * @param arguments
+   *   The arguments determining a value of type {@code T}.
+   * @return
+   *   The instance of type {@code T} corresponding to the given arguments.
+   * @throws InvalidArgumentsException
+   *   When the given arguments do not uniquely (or at all) determine a value of type {@code T}.
+   */
+  // TODO: Define distinct exceptions for under-specification and over-specification failures,
+  //   and provide actionable information specific to each kind of failure.
+  //  * Under-specification: We can usually tell what arguments remain to be specified.
+  //  * Over-specification: We can usually tell which specified arguments are in error.
   T instantiate(Map<String, SerializedValue> arguments)
       throws InstantiationException;
 
+  /**
+   * Extracts the complete set of arguments for a given value of type {@code T}.
+   *
+   * <p> The arguments returned by this method are "complete" in the sense that every parameter described by
+   * {@link #getParameters()} has a corresponding argument returned by this method. The representation of each argument
+   * <i>may</i> be different from that originally provided to {@link #instantiate(Map)}. However, it is guaranteed
+   * that invoking {@link #instantiate(Map)} on the arguments returned by this method will produce an equivalent value
+   * of type {@code T}. </p>
+   *
+   * @param value
+   *   The value to extract arguments from.
+   * @return
+   *   The complete set of arguments determining the provided value.
+   */
   Map<String, SerializedValue> getArguments(T value);
 
+  /**
+   * Provides validation information about a value of type {@code T}.
+   *
+   * <p> Not all values of {@code T} may be recommended for use with the model. This method provides information
+   * for a human operator about the given value, such as recommendations to change arguments to meet higher standards
+   * of validity. </p>
+   *
+   * <p> For instance, supposing {@code T} has two integer arguments, it may be best in most cases for those two
+   * arguments to differ by at most 5. Values where the difference is greater may still be used, and their effects on
+   * the model observed, but the human operator may need to be cognizant of that deviation earlier. </p>
+   *
+   * <p> The order of the list of validation notices is meaningful; later messages may build on the information
+   * conveyed by earlier messages. Clients should preserve the order of this list whenever it might be displayed for a
+   * human operator. </p>
+   *
+   * @param value
+   *   The value to validate.
+   * @return
+   *   An ordered list of informational notices for a human operator.
+   */
   List<ValidationNotice> getValidationFailures(T value);
 
+  /** A named parameter to an {@link InputType} */
   record Parameter(String name, ValueSchema schema) {}
 
+  /** A human-readable advisory concerning a subset of the arguments for an instance of an {@link InputType}. */
   record ValidationNotice(List<String> subjects, String message) { }
 
   /**
-   * This method must behave as though implemented as:
+   * Provides validation information about the value of type {@code T} determined by a set of arguments.
+   *
+   * <p> This method is a convenience method, allowing callers to avoid binding the generic type {@code T}. This method
+   * must behave as though implemented as: </p>
+   *
    * {@snippet :
    * return this.getValidationFailures(this.instantiate(arguments));
    * }
+   *
+   * @param arguments
+   *   The arguments determining a value of type {@code T}.
+   * @return
+   *   An ordered list of informational notices for a human operator.
+   * @throws InvalidArgumentsException
+   *   When the given arguments do not uniquely (or at all) determine a value of type {@code T}.
+   * @see #instantiate(Map)
+   * @see #getValidationFailures(T)
    */
   default List<ValidationNotice> validateArguments(final Map<String, SerializedValue> arguments)
   throws InstantiationException
@@ -36,10 +201,23 @@ public interface InputType<T> {
   }
 
   /**
-   * This method must behave as though implemented as:
+   * Completes a set of arguments from the value of type {@code T} it determines.
+   *
+   * <p> This method is a convenience method, allowing callers to avoid binding the generic type {@code T}. This method
+   * must behave as though implemented as: </p>
+   *
    * {@snippet :
    * return this.getArguments(this.instantiate(arguments));
    * }
+   *
+   * @param arguments
+   *   The arguments determining a value of type {@code T}.
+   * @return
+   *   The completed set of arguments determining the same unique value as the given arguments.
+   * @throws InvalidArgumentsException
+   *   When the given arguments do not uniquely (or at all) determine a value of type {@code T}.
+   * @see #instantiate(Map)
+   * @see #getArguments(T)
    */
   default Map<String, SerializedValue> getEffectiveArguments(final Map<String, SerializedValue> arguments)
   throws InstantiationException

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/MerlinPlugin.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/MerlinPlugin.java
@@ -1,6 +1,24 @@
 package gov.nasa.jpl.aerie.merlin.protocol.model;
 
-/** A service interface suitable for use with {@link java.util.ServiceLoader}. */
+/**
+ * A reflection-friendly service for interacting with a simulation model.
+ *
+ * <p> Since the {@link ModelType} type has generic type parameters, it cannot be instantiated reflectively
+ * without using raw types, which puts the onus on the client to decide what type arguments it should take. However,
+ * each implementation of {@link ModelType} is only defined for *one* set of type arguments, which are
+ * simply unknown to the client. Instead, the {@code MerlinPlugin} interface provides an extra layer of indirection,
+ * providing a method that returns a non-raw type with wildcard type arguments, so that the {@code MerlinPlugin} itself
+ * is safe to instantiate reflectively. </p>
+ *
+ * <p> Implementations should register with the {@link java.util.ServiceLoader} service registry; see that class
+ * for details. </p>
+ */
 public interface MerlinPlugin {
+  /**
+   * Gets the model type for the mission model associated with this plugin.
+   *
+   * @return
+   *   The model type associated with this plugin.
+   */
   ModelType<?, ?> getModelType();
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/ModelType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/ModelType.java
@@ -5,10 +5,75 @@ import gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer;
 import java.time.Instant;
 import java.util.Map;
 
+/**
+ * A Merlin simulation model.
+ *
+ * <p> A Merlin model describes an <a href="https://en.wikipedia.org/wiki/Open_system_%28systems_theory%29">open
+ * system</a>: a stateful system that evolves over time, with defined modes of interaction with its environment.
+ * The inputs to the system are known as "directives"; outputs are "resources"; and the state of the system is captured
+ * in "cells". The system's environment -- typically a simulation host like Aerie -- may construct and issue directives
+ * by using the {@link DirectiveType}s exposed by a model; resources can be queried with the {@link Resource}s exposed
+ * by a model; and cells can be managed and advanced through time using the exposed {@link CellType}s. </p>
+ *
+ * <p> In Java, each of these interfaces, as well as {@code ModelType} itself, provides reflective, at-a-distance access
+ * to an abstract domain type relevant to the model. See {@linkplain gov.nasa.jpl.aerie.merlin.protocol the package
+ * documentation} for an overview. </p>
+ *
+ * <p> A {@code ModelType} actually defines a family of related models, in that different models can be
+ * {@linkplain #instantiate(Instant, Config, Initializer) instantiated} with different configuration. In order to work
+ * consistently with any instance of the model, <i>all</i> models of the given type must have a consistent set of
+ * directive types and resource types. That is, while the behavior of any particular directive or resource may vary with
+ * configuration, their mere existence and structural characteristics must be fixed. (The same requirement is not levied
+ * on cells, as the concrete state of the model is not observable directly by the environment.) </p>
+ *
+ * @param <Config>
+ *   The type of configuration accepted by this model.
+ * @param <Model>
+ *   The type of instances of this model.
+ */
 public interface ModelType<Config, Model> {
+  /**
+   * Gets the directive types supported by this model.
+   *
+   * @return
+   *   The family of named types of directive supported by this model.
+   */
   Map<String, ? extends DirectiveType<Model, ?, ?>> getDirectiveTypes();
 
+  /**
+   * Gets the configuration type accepted by this model.
+   *
+   * @return
+   *   The configuration type accepted by this model.
+   */
   InputType<Config> getConfigurationType();
 
+  /**
+   * Constructs a model instance with the given configuration, allocating cells from the given initializer.
+   *
+   * <p> <b>The returned model instance must be immutable.</b> All mutable state must be allocated via the provided
+   * initializer. In turn, the initializer returns {@link gov.nasa.jpl.aerie.merlin.protocol.driver.CellId}s, which do
+   * not contain the cell state, but rather identify the cell to the driver in future read/write interactions. This
+   * makes it possible to give each concurrent task a transactional view of the model state, to resolve any concurrent
+   * effects on state in a coherent way, and to identify which resources need to be recomputed based on when the cells
+   * they are computed from are updated. </p>
+   *
+   * <p> The state of the resulting model instance can be evolved by either instantiating directives and running their
+   * associated tasks, or by progressing time on the simulation-aware state allocated by the model instance. </p>
+   *
+   * <p> The model also exports resources and topics via the initializer. Notably, the exported resources and topics
+   * must not vary with the configuration. The {@code ModelType} API may be changed in the future to enforce this. </p>
+   *
+   * @param planStart
+   *   The real-time instant against which the behavior of this model will be compared to other temporal data.
+   * @param configuration
+   *   A configuration to instantiate this model with.
+   * @param builder
+   *   An allocator to allocate cells with.
+   * @return
+   *   An instance of this model.
+   */
+  // TODO: Every model instance should export the same resources and topics, independent of any provided configuration.
+  //   Extract resource and topic registration from the `Initializer` to the top-level `ModelType`.
   Model instantiate(Instant planStart, Config configuration, Initializer builder);
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/OutputType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/OutputType.java
@@ -3,8 +3,25 @@ package gov.nasa.jpl.aerie.merlin.protocol.model;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
+/**
+ * A type of data produced as output by a Merlin model.
+ *
+ * <p> An implementation of this interface provides reflective, at-a-distance access to an abstract type {@code T}
+ * produced by a Merlin model as output. Values of type {@code T} can be {@linkplain #serialize(T) extracted} into
+ * a model-agnostic format with a consistent {@linkplain #getSchema() schema} conformed to by all such values. </p>
+ *
+ * <p> Although it might seem unnecessary for the model to return a value of an opaque type when our only capability
+ * is to serialize it to another form, it is particularly useful for a simulation system to be able to separate
+ * production of output and serialization. Data transformation can be costly, and offloading serialization to a separate
+ * thread or stage of the processing pipeline can allow simulation to proceed at a faster rate. </p>
+ *
+ * @param <T>
+ *   The abstract type of output described by this object.
+ */
 public interface OutputType<T> {
+  /** Gets the schema describing all values produced by {@link #serialize(T)}. */
   ValueSchema getSchema();
 
+  /** Extracts a value conforming to this type's {@linkplain #getSchema() schema} from an opaque value of type {@code T}. */
   SerializedValue serialize(T value);
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/Resource.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/Resource.java
@@ -5,8 +5,15 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
 public interface Resource<Dynamics> {
+  String getType();
+
   OutputType<Dynamics> getOutputType();
 
-  String getType();
+  /**
+   * Get the current value of this resource.
+   *
+   * <p> The result of this method must vary only dependent on the cells allocated by the model instance that registered
+   * this resource. In other words, it cannot depend on any hidden state. </p>
+   */
   Dynamics getDynamics(Querier querier);
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/package-info.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/package-info.java
@@ -1,0 +1,50 @@
+/**
+ * Interfaces implemented by a mission model.
+ *
+ * <p> In analogy to regular Java, it can be helpful to think of the model as a kind of class, whose mutator methods are
+ * described by directive types, whose getter methods are described by resources, whose constructor parameters are
+ * described by a configuration type, and whose internal state is described by simulation cells. In this metaphor,
+ * the interfaces implemented by the model (in the {@link gov.nasa.jpl.aerie.merlin.protocol.model} package) provide
+ * <i><a href="https://en.wikipedia.org/wiki/Mirror_(programming)">reflective access</a></i> to the mission model and
+ * these features thereof. While a multi-mission driver cannot know about the types used by a model concretely,
+ * it can work with them generically and at a distance by way of these interfaces. </p>
+ *
+ * <p> The {@link gov.nasa.jpl.aerie.merlin.protocol.model.ModelType} interface describes the mission
+ * model as a whole, and is the starting point for any interaction with a model. See its documentation for details. </p>
+ *
+ * <p> Here are some of the most important reflective interfaces: </p>
+ *
+ * <ul>
+ *    <li> The {@link gov.nasa.jpl.aerie.merlin.protocol.model.ModelType} interface describes the mission
+ *    model as a whole, and is the starting point for any interaction with a model. As a reflective interface, it is
+ *    analogous to {@link java.lang.Class}. It provides access to its directive types and configuration type, as well
+ *    as the ability to instantiate the underlying model type. </li>
+ *
+ *    <li> The {@link gov.nasa.jpl.aerie.merlin.protocol.model.InputType} interface describes a type of data that can
+ *    be accepted by the model. It provides facilities for constructing and validating input values. As a reflective
+ *    interface, it is roughly analogous to the {@link java.lang.Class}es provided by
+ *    {@link java.lang.reflect.Method#getParameterTypes()}. The model itself accepts input as configuration, and its
+ *    directive types accept input to modulate the behavior of the resulting directives. </li>
+ *
+ *    <li> The {@link gov.nasa.jpl.aerie.merlin.protocol.model.OutputType} interface describes a type of data that can
+ *    be produced by the model. It provides facilities for interrogating the type's schematic structure and serializing
+ *    individual values of the type. As a reflective interface, it is roughly analogous to the {@link java.lang.Class}
+ *    returned by {@link java.lang.reflect.Method#getReturnType()}. The model produces such output from directives
+ *    and resources. </li>
+ *
+ *    <li> The {@link gov.nasa.jpl.aerie.merlin.protocol.model.DirectiveType} interface describes a directive type,
+ *    a family of behaviors that the model can perform. As a reflective interface, it is roughly analogous to
+ *    {@link java.lang.reflect.Method}. It includes an input type, an output type, and a facility for constructing an
+ *    executable {@link gov.nasa.jpl.aerie.merlin.protocol.model.Task} against a model instance.  </li>
+ *
+ *    <li> The {@link gov.nasa.jpl.aerie.merlin.protocol.model.Resource} interface describes a resource, an observable
+ *    value computed based on the model's internal state.  As a reflective interface, it is roughly analogous to
+ *    {@link java.lang.reflect.Method}. It includes an output type and a facility for querying a value of that type
+ *    from a model instance. </li>
+ *
+ *    <li> The {@link gov.nasa.jpl.aerie.merlin.protocol.model.CellType} interface describes the internal state of a
+ *    model. It provides facilities for applying events to a cell and stepping it forward over time. As a reflective
+ *    interface, it is roughly analogous to {@link java.lang.reflect.Field}. </li>
+ * </ul>
+ */
+package gov.nasa.jpl.aerie.merlin.protocol.model;

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/package-info.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/package-info.java
@@ -1,0 +1,112 @@
+/**
+ * The interfaces and data types describing the interactions between a mission model and its external environment.
+ *
+ * <p> This package tree defines the foundational interfaces and data types for interactions between a mission model
+ * and the system interacting with it (generically referred to as a "driver"). A particular driver can leverage these
+ * interactions for various scenarios, including simulation; but these packages have little to say about how simulation
+ * is actually performed. Only, when a simulator needs to ask the model what its effect on the simulation is, it will
+ * use the interfaces defined here to make that request. </p>
+ *
+ * <p> In addition, the {@link gov.nasa.jpl.aerie.merlin.protocol.model.MerlinPlugin} interface provides a
+ * {@link java.util.ServiceLoader}-friendly service interface, as it hides the generic type parameters of an underlying
+ * {@link gov.nasa.jpl.aerie.merlin.protocol.model.ModelType}. Implementors of the latter should typically also
+ * provide the former, for interoperability with plugin-based multi-mission systems such as an Aerie deployment. </p>
+ *
+ * <p> A typical exchange for simulation will look something like the following. </p>
+ *
+ * <ul>
+ *   <li> Driver obtains a {@link gov.nasa.jpl.aerie.merlin.protocol.model.MerlinPlugin} (e.g. by reflection from a
+ *   JAR). </li>
+ *
+ *   <li> Driver calls {@link gov.nasa.jpl.aerie.merlin.protocol.model.MerlinPlugin#getModelType()} to obtain
+ *   the top-level {@link gov.nasa.jpl.aerie.merlin.protocol.model.ModelType}. </li>
+ *
+ *   <li> Driver calls {@link gov.nasa.jpl.aerie.merlin.protocol.model.ModelType#getConfigurationType()} to obtain
+ *   the {@link gov.nasa.jpl.aerie.merlin.protocol.model.InputType} describing the model's configuration type. </li>
+ *
+ *   <li> Driver calls {@link gov.nasa.jpl.aerie.merlin.protocol.model.InputType#instantiate(java.util.Map)} to
+ *   construct a configuration input. </li>
+ *
+ *   <li>
+ *     Driver calls {@link gov.nasa.jpl.aerie.merlin.protocol.model.ModelType#instantiate(java.time.Instant, java.lang.Object, gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer)}
+ *     to construct a model instance, providing a {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer}.
+ *
+ *     <ul>
+ *       <li> Model calls {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer#allocate(java.lang.Object, gov.nasa.jpl.aerie.merlin.protocol.model.CellType, java.util.function.Function, gov.nasa.jpl.aerie.merlin.protocol.driver.Topic)}
+ *       any number of times to allocate mutable internal state described by a {@link gov.nasa.jpl.aerie.merlin.protocol.model.CellType}
+ *       and subscribe it to an internal stream of events. </li>
+ *
+ *       <li> Model calls {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer#daemon(gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer.TaskFactory)}
+ *       any number of times to spawn internal {@link gov.nasa.jpl.aerie.merlin.protocol.model.Task}s independent of any external directive. </li>
+ *
+ *       <li> Model calls {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer#resource(java.lang.String, gov.nasa.jpl.aerie.merlin.protocol.model.Resource)}
+ *       any number of times to register an observable {@link gov.nasa.jpl.aerie.merlin.protocol.model.Resource}. </li>
+ *
+ *       <li> Model calls {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer#topic(java.lang.String, gov.nasa.jpl.aerie.merlin.protocol.driver.Topic, gov.nasa.jpl.aerie.merlin.protocol.model.OutputType)}
+ *       any number of times to register an observable {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Topic}. </li>
+ *
+ *       <li> Model returns a model instance. </li>
+ *     </ul>
+ *   </li>
+ *
+ *   <li> Driver calls {@link gov.nasa.jpl.aerie.merlin.protocol.model.ModelType#getDirectiveTypes()} to obtain the
+ *   {@link gov.nasa.jpl.aerie.merlin.protocol.model.DirectiveType}s the model can react to. </li>
+ *
+ *   <li> For each scheduled directive to simulate, Driver calls {@link gov.nasa.jpl.aerie.merlin.protocol.model.DirectiveType#getInputType()}
+ *   and then {@link gov.nasa.jpl.aerie.merlin.protocol.model.DirectiveType#createTask(java.lang.Object, java.util.Map)} to instantiate
+ *   a {@link gov.nasa.jpl.aerie.merlin.protocol.model.Task} modeling the model's reaction to the directive. </li>
+ *
+ *   <li>
+ *     Whenever a task needs to be advanced, Driver calls {@link gov.nasa.jpl.aerie.merlin.protocol.model.Task#step(gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler)},
+ *     providing a {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler}.
+ *
+ *     <ul>
+ *       <li> Model calls {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler#emit(java.lang.Object, gov.nasa.jpl.aerie.merlin.protocol.driver.Topic)}
+ *       any number of times to record an event on some topic. </li>
+ *
+ *       <li>
+ *         Model calls {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler#get(gov.nasa.jpl.aerie.merlin.protocol.driver.CellId)}
+ *         any number of times to get the current value for an allocated stateful cell.
+ *
+ *         <ul>
+ *           <li> Driver converts all events not yet consumed by the cell to per-cell effects by using the topic and projection
+ *           registered with the cell. </li>
+ *
+ *           <li> Driver calls {@link gov.nasa.jpl.aerie.merlin.protocol.model.CellType#getEffectType()} and uses the
+ *           returned {@link gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait} to combine concurrent effects. </li>
+ *
+ *           <li> Driver calls {@link gov.nasa.jpl.aerie.merlin.protocol.model.CellType#step(java.lang.Object, gov.nasa.jpl.aerie.merlin.protocol.types.Duration)}
+ *           and {@link gov.nasa.jpl.aerie.merlin.protocol.model.CellType#apply(java.lang.Object, java.lang.Object)}
+ *           to bring the cell's state up to the time at the Model's request. </li>
+ *
+ *           <li> Driver returns the current state of the cell. </li>
+ *         </ul>
+ *       </li>
+ *
+ *       <li> Model calls {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler#spawn(gov.nasa.jpl.aerie.merlin.protocol.model.Task)}
+ *       any number of times to spawn additional concurrent {@link gov.nasa.jpl.aerie.merlin.protocol.model.Task}s. </li>
+ *
+ *       <li> Model returns a {@link gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus} describing the conditions
+ *       under which to resume the task, or produces a terminal output if the task is complete. </li>
+ *     </ul>
+ *   </li>
+ *
+ *   <li>
+ *     Whenever the Driver wants to observe the current value of a {@link gov.nasa.jpl.aerie.merlin.protocol.model.Resource},
+ *     Driver calls {@link gov.nasa.jpl.aerie.merlin.protocol.model.Resource#getDynamics(gov.nasa.jpl.aerie.merlin.protocol.driver.Querier)},
+ *     providing a {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Querier}.
+ *
+ *     <ul>
+ *       <li> Model calls {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Querier#getState(gov.nasa.jpl.aerie.merlin.protocol.driver.CellId)}
+ *       any number of times to get the current value for an allocated stateful cell. (The Driver responds as in the
+ *       analogous case when a {@link gov.nasa.jpl.aerie.merlin.protocol.model.Task} queries a cell.) </li>
+ *
+ *       <li> Model returns the current observable value of the resource. </li>
+ *     </ul>
+ *   </li>
+ * </ul>
+ *
+ * @see gov.nasa.jpl.aerie.merlin.protocol.driver
+ * @see gov.nasa.jpl.aerie.merlin.protocol.model
+ */
+package gov.nasa.jpl.aerie.merlin.protocol;

--- a/scheduler/build.gradle
+++ b/scheduler/build.gradle
@@ -17,6 +17,7 @@ dependencies {
   compileOnly project(':merlin-driver')
   compileOnly project(':constraints')
 
+  implementation 'org.apache.commons:commons-lang3:3.12.0'
   implementation 'org.apache.commons:commons-math3:3.6.1'
   implementation 'com.google.guava:guava:31.0.1-jre'
   implementation 'org.jfree:jfreechart:1.5.3'


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR contains a bunch of actual Javadocs for the `merlin.protocol` package. It's still in progress, but this is the kind of thing that can be done incrementally!

Also, a fair amount of "documentation" came in #318, which reorganized and renamed many of the entities in `merlin.protocol` to give a better baseline of self-documenting code. That isn't to say that prose documentation isn't needed (heavens, no!) -- only that readers of the prose documentation herein will greatly benefit from the much tighter naming and organization prepared in #318.

As usual, this PR also comes with a (small) prefix of refactors that came up during the main work. (Really, #318 was the prefix for this work, but it was separated out because of how much there was to it -- and the bug it ultimately fixed.) Here, I've cleaned up some Gradle dependencies in `merlin-sdk` and removed a type parameter that no longer matters.

## Verification
It all compiles and runs; the changes made in this PR are either documentation-only or do not impinge on business logic. (For instance, the type parameter removal is the kind of thing where, if it's wrong, the system should simply not compile. Type checking is a form of testing!)

## Documentation
Lots of javadocs were added, but nothing existing needs to change.

## Future work
Document all the things!

![image](https://user-images.githubusercontent.com/61392/196052523-1242665d-30f6-4d0d-b32b-c490b200495d.png)