### PR TITLE
Update to Java 19

### DIFF
--- a/constraints/build.gradle
+++ b/constraints/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 }
 

--- a/contrib/build.gradle
+++ b/contrib/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 
   withJavadocJar()

--- a/db-tests/build.gradle
+++ b/db-tests/build.gradle
@@ -8,6 +8,10 @@ java {
   }
 }
 
+test {
+  useJUnitPlatform()
+}
+
 task e2eTest(type: Test) {
   useJUnitPlatform()
 }

--- a/db-tests/build.gradle
+++ b/db-tests/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 }
 

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/DatabaseTestHelper.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/DatabaseTestHelper.java
@@ -44,7 +44,9 @@ public class DatabaseTestHelper {
 
       // Handle the case where we cannot connect to postgres by skipping the tests
       final var errors = new String(proc.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
-      Assumptions.assumeFalse(errors.contains("Connection refused"));
+      Assumptions.assumeFalse(
+          (  errors.contains("Connection refused")
+          || errors.contains("role \"postgres\" does not exist")));
       proc.waitFor();
       proc.destroy();
     }

--- a/examples/banananation/build.gradle
+++ b/examples/banananation/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 }
 

--- a/examples/config-with-defaults/build.gradle
+++ b/examples/config-with-defaults/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 }
 

--- a/examples/config-without-defaults/build.gradle
+++ b/examples/config-without-defaults/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 }
 

--- a/examples/foo-missionmodel/build.gradle
+++ b/examples/foo-missionmodel/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 }
 

--- a/merlin-driver/build.gradle
+++ b/merlin-driver/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 
   withJavadocJar()

--- a/merlin-framework-junit/build.gradle
+++ b/merlin-framework-junit/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 
   withJavadocJar()

--- a/merlin-framework-processor/build.gradle
+++ b/merlin-framework-processor/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 }
 

--- a/merlin-framework/build.gradle
+++ b/merlin-framework/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 
   withJavadocJar()

--- a/merlin-sdk/build.gradle
+++ b/merlin-sdk/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 
   withJavadocJar()

--- a/merlin-server/Dockerfile
+++ b/merlin-server/Dockerfile
@@ -4,7 +4,7 @@ COPY build/distributions/*.tar /usr/src/app/server.tar
 RUN mkdir /usr/src/app/extracted
 RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 
-FROM eclipse-temurin:18-focal
+FROM eclipse-temurin:19-jre-jammy
 
 ENV NODE_VERSION=16.14.0
 ENV NVM_DIR=/usr/src/.nvm

--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -78,7 +78,7 @@ dependencies {
   implementation project(':constraints')
 
   implementation 'org.apache.commons:commons-lang3:3.12.0'
-  implementation 'io.javalin:javalin:4.6.0'
+  implementation 'io.javalin:javalin:5.0.1'
   implementation 'org.slf4j:slf4j-simple:1.7.26'
   implementation 'org.glassfish:javax.json:1.1.4'
   implementation 'org.apache.bcel:bcel:6.5.0'

--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
@@ -96,12 +96,12 @@ public final class AerieAppDriver {
     server.setConnectors(new Connector[]{connector});
     final var javalin = Javalin.create(config -> {
       config.showJavalinBanner = false;
-      if (configuration.enableJavalinDevLogging()) config.enableDevLogging();
-      config.enableCorsForAllOrigins();
-      config.registerPlugin(merlinBindings);
-      config.registerPlugin(new LocalAppExceptionBindings());
-      config.registerPlugin(new MissionModelRepositoryExceptionBindings());
-      config.server(() -> server);
+      if (configuration.enableJavalinDevLogging()) config.plugins.enableDevLogging();
+      config.plugins.enableCors(cors -> cors.add(it -> it.anyHost()));
+      config.plugins.register(merlinBindings);
+      config.plugins.register(new LocalAppExceptionBindings());
+      config.plugins.register(new MissionModelRepositoryExceptionBindings());
+      config.jetty.server(() -> server);
     });
 
     // Start the HTTP server.

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/LocalAppExceptionBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/LocalAppExceptionBindings.java
@@ -2,7 +2,7 @@ package gov.nasa.jpl.aerie.merlin.server.http;
 
 import gov.nasa.jpl.aerie.merlin.server.services.LocalMissionModelService;
 import io.javalin.Javalin;
-import io.javalin.core.plugin.Plugin;
+import io.javalin.plugin.Plugin;
 
 public final class LocalAppExceptionBindings implements Plugin {
     @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -10,8 +10,8 @@ import gov.nasa.jpl.aerie.merlin.server.services.GetSimulationResultsAction;
 import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService;
 import gov.nasa.jpl.aerie.merlin.server.services.PlanService;
 import io.javalin.Javalin;
-import io.javalin.core.plugin.Plugin;
 import io.javalin.http.Context;
+import io.javalin.plugin.Plugin;
 
 import javax.json.Json;
 import javax.json.stream.JsonParsingException;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MissionModelRepositoryExceptionBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MissionModelRepositoryExceptionBindings.java
@@ -2,7 +2,7 @@ package gov.nasa.jpl.aerie.merlin.server.http;
 
 import gov.nasa.jpl.aerie.merlin.server.remotes.MissionModelAccessException;
 import io.javalin.Javalin;
-import io.javalin.core.plugin.Plugin;
+import io.javalin.plugin.Plugin;
 
 public final class MissionModelRepositoryExceptionBindings implements Plugin {
     @Override

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/DevAppDriver.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/DevAppDriver.java
@@ -50,11 +50,11 @@ public final class DevAppDriver {
 
     // Configure an HTTP server.
     final Javalin javalin = Javalin.create(config -> {
-        config.enableDevLogging();
-        config.enableCorsForAllOrigins();
-        config.registerPlugin(new MerlinBindings(missionModelController, planController, simulationAction, generateConstraintsLibAction));
-        config.registerPlugin(new LocalAppExceptionBindings());
-        config.registerPlugin(new MissionModelRepositoryExceptionBindings());
+      config.plugins.enableDevLogging();
+      config.plugins.enableCors(cors -> cors.add(it -> it.anyHost()));
+      config.plugins.register(new MerlinBindings(missionModelController, planController, simulationAction, generateConstraintsLibAction));
+      config.plugins.register(new LocalAppExceptionBindings());
+      config.plugins.register(new MissionModelRepositoryExceptionBindings());
     });
 
     // Start the HTTP server.

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindingsTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindingsTest.java
@@ -63,8 +63,8 @@ public final class MerlinBindingsTest {
 
     SERVER = Javalin.create(config -> {
       config.showJavalinBanner = false;
-      config.enableCorsForAllOrigins();
-      config.registerPlugin(new MerlinBindings(missionModelApp, planApp, simulationAction, generateConstraintsLibAction));
+      config.plugins.enableCors(cors -> cors.add(it -> it.anyHost()));
+      config.plugins.register(new MerlinBindings(missionModelApp, planApp, simulationAction, generateConstraintsLibAction));
     });
 
     SERVER.start(54321); // Use likely unused port to avoid clash with any currently hosted port 80 services

--- a/merlin-worker/Dockerfile
+++ b/merlin-worker/Dockerfile
@@ -4,7 +4,7 @@ COPY build/distributions/*.tar /usr/src/app/server.tar
 RUN mkdir /usr/src/app/extracted
 RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 
-FROM eclipse-temurin:18-focal
+FROM eclipse-temurin:19-jre-alpine
 
 COPY --from=extractor /usr/src/app/extracted /usr/src/app
 

--- a/merlin-worker/build.gradle
+++ b/merlin-worker/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   implementation project(':constraints')
 
   implementation 'org.apache.commons:commons-lang3:3.12.0'
-  implementation 'io.javalin:javalin:4.6.0'
+  implementation 'io.javalin:javalin:5.0.1'
   implementation 'org.slf4j:slf4j-simple:1.7.26'
   implementation 'org.eclipse:yasson:1.0.5'
   implementation 'org.apache.bcel:bcel:6.5.0'

--- a/merlin-worker/build.gradle
+++ b/merlin-worker/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 
   withJavadocJar()

--- a/parsing-utilities/build.gradle
+++ b/parsing-utilities/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 }
 

--- a/scheduler-server/Dockerfile
+++ b/scheduler-server/Dockerfile
@@ -4,7 +4,7 @@ COPY build/distributions/*.tar /usr/src/app/server.tar
 RUN mkdir /usr/src/app/extracted
 RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 
-FROM eclipse-temurin:18-focal
+FROM eclipse-temurin:19-jre-jammy
 
 ENV NODE_VERSION=16.14.0
 ENV NVM_DIR=/usr/src/.nvm

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -96,7 +96,7 @@ dependencies {
   implementation project(':scheduler')
 
   implementation 'org.apache.commons:commons-lang3:3.12.0'
-  implementation 'io.javalin:javalin:4.6.0'
+  implementation 'io.javalin:javalin:5.0.1'
   implementation 'org.eclipse:yasson:1.0.5'
   implementation 'org.apache.bcel:bcel:6.5.0'
 

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
@@ -101,10 +101,10 @@ public final class SchedulerAppDriver {
     //configure the http server (the consumer lambda overlays additional config on the input javalinConfig)
     final var javalin = Javalin.create(javalinConfig -> {
       javalinConfig.showJavalinBanner = false;
-      if (config.enableJavalinDevLogging()) javalinConfig.enableDevLogging();
-      javalinConfig.enableCorsForAllOrigins(); //TODO: probably don't want literally any cross-origin request...
-      javalinConfig.registerPlugin(bindings);
-      javalinConfig.server(() -> server);
+      if (config.enableJavalinDevLogging()) javalinConfig.plugins.enableDevLogging();
+      javalinConfig.plugins.enableCors(cors -> cors.add(it -> it.anyHost())); //TODO: probably don't want literally any cross-origin request...
+      javalinConfig.plugins.register(bindings);
+      javalinConfig.jetty.server(() -> server);
       //TODO: exception handling (shxould elevate/reuse from MerlinApp for consistency?)
     });
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
@@ -6,8 +6,8 @@ import gov.nasa.jpl.aerie.scheduler.server.services.GenerateSchedulingLibAction;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleAction;
 import gov.nasa.jpl.aerie.scheduler.server.services.SchedulerService;
 import io.javalin.Javalin;
-import io.javalin.core.plugin.Plugin;
 import io.javalin.http.Context;
+import io.javalin.plugin.Plugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,9 +25,9 @@ import static gov.nasa.jpl.aerie.scheduler.server.http.ResponseSerializers.seria
 import static gov.nasa.jpl.aerie.scheduler.server.http.SchedulerParsers.hasuraMissionModelIdActionP;
 import static gov.nasa.jpl.aerie.scheduler.server.http.SchedulerParsers.hasuraSpecificationActionP;
 import static io.javalin.apibuilder.ApiBuilder.before;
+import static io.javalin.apibuilder.ApiBuilder.get;
 import static io.javalin.apibuilder.ApiBuilder.path;
 import static io.javalin.apibuilder.ApiBuilder.post;
-import static io.javalin.apibuilder.ApiBuilder.get;
 
 /**
  * set up mapping between scheduler http endpoints and java method calls

--- a/scheduler/build.gradle
+++ b/scheduler/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(18)
+    languageVersion = JavaLanguageVersion.of(19)
   }
 }
 


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR updates our Gradle scripts and and Dockerfiles to use Java 19, which was released on September 20th, 2022. At this point, [Eclipse's Adoptium](https://adoptium.net/temurin/releases?version=19) has released its Temurin distribution of OpenJDK 19, including Docker base images.

The [features in Java 19](https://openjdk.org/projects/jdk/19/) are mostly at the preview and incubator stage, but this will allow us and our users to begin experimenting early with Loom's virtual threads, which we have been eagerly anticipating for possible performance gains and architectural simplifications (re: threaded tasks in simulation).

(For those for whom "what about LTS" comes to mind, please see Ron Pressler's thoughts on this: [[1]](https://news.ycombinator.com/item?id=33028988), [[2]](https://news.ycombinator.com/item?id=33046148). Ron is the technical lead on OpenJDK's Project Loom, and has been beating this particular drum for *years*.)

## Verification
Build, test, and assembly all complete successfully. We'll see if the GitHub Actions deployment behaves as well.

## Documentation
- [x] Mission modelers will need to install a Java 19 JDK in order to use builds of the Merlin libraries after this change, but existing built mission models should continue to work. Customer deployments which take our Docker images should continue to do so; no additional effort should be required.

## Future work
* Experiment with Loom!