### PR TITLE
[AERIE-2177] Serialize Temporal.Duration as integer in scheduling edsl

### DIFF
--- a/docs/source/activity-plans/scheduling-guide.rst
+++ b/docs/source/activity-plans/scheduling-guide.rst
@@ -104,7 +104,7 @@ activity template and an interval. Let's add those:
   export default (): Goal => {
       return Goal.ActivityRecurrenceGoal({
           activityTemplate: null,
-          interval: 24 * 60 * 60 * 1000 * 1000 // 24 hours in microseconds
+          interval: Temporal.Duration.from({ hours: 24 })
       })
   }
 
@@ -179,9 +179,9 @@ and it will place an instance of that activity there.
     return Goal.ActivityRecurrenceGoal({
       activityTemplate: ActivityTemplates.GrowBanana({
         quantity: 1,
-        growingDuration: 1 * 60 * 60 * 1000 * 1000, //1 hour in microseconds
+        growingDuration: Temporal.Duration.from({ hours: 1 })
       }),
-      interval: 2 * 60 * 60 * 1000 * 1000 // 2 hours in microseconds
+      interval: Temporal.Duration.from({ hours: 2 })
     })
   }
 
@@ -217,7 +217,7 @@ instance using the given ``activityTemplate`` and temporal constraints.
   export default () => Goal.CoexistenceGoal({
     forEach: ActivityExpression.ofType(ActivityTypes.GrowBanana),
     activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
-    startsAt: TimingConstraint.singleton(WindowProperty.END).plus(5 * 60 * 1000 * 1000)
+    startsAt: TimingConstraint.singleton(WindowProperty.END).plus(Temporal.Duration.from({ minutes: 5 }))
   })
 
 Behavior: for each activity A of type ``GrowBanana`` present in the plan when the goal is evaluated, place an activity
@@ -228,34 +228,20 @@ of type ``PeelBanana`` starting exactly at the end of A + 5 minutes.
   export default () => Goal.CoexistenceGoal({
     forEach: ActivityExpression.ofType(ActivityTypes.GrowBanana),
     activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
-    startsWithin: TimingConstraint.range(WindowProperty.END, Operator.PLUS, 5 * 60 * 1000 * 1000),
-    endsWithin: TimingConstraint.range(WindowProperty.END, Operator.PLUS, 6 * 60 * 1000 * 1000)
+    startsWithin: TimingConstraint.range(WindowProperty.END, Operator.PLUS, Temporal.Duration.from({ minutes: 5 })),
+    endsWithin: TimingConstraint.range(WindowProperty.END, Operator.PLUS, Temporal.Duration.from({ minutes: 6 }))
   })
 
 Behavior: for each activity A of type ``GrowBanana`` present in the plan when the goal is evaluated, place an activity
 of type ``PeelBanana`` starting in the interval [end of A, end of A + 5 minutes] and ending in the interval [end of A,
 end of A + 6 minutes].
 
-The following diagram shows an example of how the temporal constraints defined in this example affects the placement
-of a ``PeelBanana`` activity with respect to an existing ``GrowBanana`` activity.
-
-.. code-block::
-
-  gantt
-    dateFormat HH:mm
-    axisFormat %H:%M
-    GrowBanana : 17:45, 10min
-    Start interval for PeelBanana : 17:55, 5min
-    End interval for PeelBanana : 17:55, 8min
-    Possible instanciation of PeelBanana : 17:56, 2min
-    Other possible instanciation of PeelBanana : 17:59, 3min
-
 .. code-block:: typescript
 
   export default () => Goal.CoexistenceGoal({
     forEach: Real.Resource("/fruit").equal(4.0),
     activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
-    endsAt: TimingConstraint.singleton(WindowProperty.END).plus(5 * 60 * 1000 * 1000)
+    endsAt: TimingConstraint.singleton(WindowProperty.END).plus(Temporal.Duration.from({ minutes: 5 }))
   })
 
 Behavior: for each continuous period of time during which the ``/fruit`` resource is equal to 4, place an activity of
@@ -295,9 +281,9 @@ Setting a lower bound on the total duration:
       return Goal.CardinalityGoal({
           activityTemplate: ActivityTemplates.GrowBanana({
               quantity: 1,
-              growingDuration: 1000000,
+              growingDuration: Temporal.Duration.from({ seconds: 1 }),
           }),
-          specification: { duration: 10 * 1000000 }
+          specification: { duration: Temporal.Duration.from({ seconds: 10 }) }
       })
   }
 
@@ -309,7 +295,7 @@ Setting a lower bound on the number of occurrences:
       return Goal.CardinalityGoal({
           activityTemplate: ActivityTemplates.GrowBanana({
               quantity: 1,
-              growingDuration: 1000000,
+              growingDuration: Temporal.Duration.from({ seconds: 1 }),
           }),
           specification: { occurrence: 10 }
       })
@@ -323,9 +309,9 @@ Combining the two:
       return Goal.CardinalityGoal({
           activityTemplate: ActivityTemplates.GrowBanana({
               quantity: 1,
-              growingDuration: 1000000,
+              growingDuration: Temporal.Duration.from({ seconds: 1 }),
           }),
-          specification: { occurrence: 10, duration: 10 * 1000000 }
+          specification: { occurrence: 10, duration: Temporal.Duration.from({ seconds: 10 }) }
       })
   }
 
@@ -356,16 +342,16 @@ satisfied, the scheduler will not backtrack and will let the inserted activities
       return Goal.CardinalityGoal({
                activityTemplate: ActivityTemplates.GrowBanana({
                  quantity: 1,
-                 growingDuration: 1000 * 1000 * 60 * 60, //1 hour in microseconds
+                 growingDuration: Temporal.Duration.from({ hours: 1 }),
              }),
             specification: { occurrence : 10 }
             }).or(
              Goal.ActivityRecurrenceGoal({
               activityTemplate: ActivityTemplates.GrowBanana({
               quantity: 1,
-              growingDuration: 1 * 60 * 60 * 1000 * 1000, //1 hour in microseconds
+              growingDuration: Temporal.Duration.from({ hours: 1 }),
             }),
-            interval: 2 * 60 * 60 * 1000 * 1000 // 2 hours in microseconds
+            interval: Temporal.Duration.from({ hours: 2 })
           }))
   }
 
@@ -399,7 +385,7 @@ will appear satisfied. If one or several subgoals have not been satisfied, the A
       return Goal.CoexistenceGoal({
         forEach: Real.Resource("/fruit").equal(4.0),
         activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
-        endsAt: TimingConstraint.singleton(WindowProperty.END).plus(5 * 60 * 1000 * 1000)
+        endsAt: TimingConstraint.singleton(WindowProperty.END).plus(Temporal.Duration.from({ minutes: 5 }))
       }).and(
         Goal.CardinalityGoal({
               activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
@@ -432,9 +418,9 @@ If the resource is less than two, then the goal is no longer applied.
       return Goal.ActivityRecurrenceGoal({
               activityTemplate: ActivityTemplates.GrowBanana({
               quantity: 1,
-              growingDuration: 1 * 60 * 60 * 1000 * 1000, //1 hour in microseconds
+              growingDuration: Temporal.Duration.from({ hours: 1 }), //1 hour in microseconds
             }),
-            interval: 2 * 60 * 60 * 1000 * 1000 // 2 hours in microseconds
+            interval: Temporal.Duration.from({ hours: 2 }) // 2 hours in microseconds
           }).applyWhen(Real.Resource("/fruit").greaterThan(2))
   }
 

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/DurationParameterActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/DurationParameterActivity.java
@@ -1,0 +1,22 @@
+package gov.nasa.jpl.aerie.banananation.activities;
+
+import gov.nasa.jpl.aerie.banananation.Mission;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.AutoValueMapper;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+/**
+ * This activity type intentionally takes a duration as a parameter, but is not a ControllableDuration activity
+ */
+@ActivityType("DurationParameterActivity")
+public record DurationParameterActivity(Duration duration) {
+
+  @EffectModel
+  public ComputedAttributes run(Mission mission) {
+    return new ComputedAttributes(duration);
+  }
+
+  @AutoValueMapper.Record
+  public record ComputedAttributes(Duration duration) {}
+}

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
@@ -19,6 +19,7 @@
 @WithActivityType(DecomposingSpawnActivity.DecomposingSpawnChildActivity.class)
 @WithActivityType(BakeBananaBreadActivity.class)
 @WithActivityType(BananaNapActivity.class)
+@WithActivityType(DurationParameterActivity.class)
 
 package gov.nasa.jpl.aerie.banananation;
 
@@ -28,12 +29,12 @@ import gov.nasa.jpl.aerie.banananation.activities.BiteBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ChangeProducerActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DecomposingActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DecomposingSpawnActivity;
+import gov.nasa.jpl.aerie.banananation.activities.DurationParameterActivity;
 import gov.nasa.jpl.aerie.banananation.activities.GrowBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.LineCountBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ParameterTestActivity;
 import gov.nasa.jpl.aerie.banananation.activities.PeelBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.PickBananaActivity;
-import gov.nasa.jpl.aerie.banananation.activities.BananaNapActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ThrowBananaActivity;
 import gov.nasa.jpl.aerie.contrib.serialization.rulesets.BasicValueMappers;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.MissionModel;

--- a/scheduler-server/scheduling-dsl-compiler/src/main.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/main.ts
@@ -91,7 +91,15 @@ async function handleRequest(data: Buffer) {
       return;
     }
 
-    const stringified = JSON.stringify(result.unwrap().__astNode);
+    const stringified = JSON.stringify(
+        result.unwrap().__astNode,
+        function replacer(key, value) {
+          if (this[key] instanceof Temporal.Duration) {
+            return this[key].total({ unit: "microseconds" });
+          }
+          return value;
+        }
+    );
     if (stringified === undefined) {
       throw Error(JSON.stringify(result.unwrap().__astNode) + ' was not JSON serializable');
     }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/StrictSerializedValueJsonParser.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/StrictSerializedValueJsonParser.java
@@ -82,8 +82,9 @@ public final class StrictSerializedValueJsonParser implements JsonParser<Seriali
       case STRING -> SerializedValue.of(((JsonString) value).getString());
       case NUMBER -> {
         final var isInt = schema.asInt().isPresent();
+        final var isDuration = schema.asDuration().isPresent();
         final var num = (JsonNumber) value;
-        yield (isInt)
+        yield (isInt || isDuration)
             ? SerializedValue.of(num.longValue())
             : SerializedValue.of(num.doubleValue());
       }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/SchedulingDSL.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/SchedulingDSL.java
@@ -25,6 +25,7 @@ import static gov.nasa.jpl.aerie.json.BasicParsers.enumP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.intP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.listP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.literalP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.longP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.recursiveP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
@@ -33,9 +34,9 @@ import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
 public class SchedulingDSL {
 
   private static final JsonParser<Duration> durationP =
-      stringP
-      . map(iso8601String -> Duration.fromISO8601String(iso8601String),
-          duration -> java.time.Duration.ofMillis(duration.in(Duration.MILLISECOND)).toString());
+      longP.map(
+          microseconds -> Duration.of(microseconds, Duration.MICROSECONDS),
+          duration -> duration.in(Duration.MICROSECONDS));
 
   private static final JsonParser<ClosedOpenInterval> intervalP =
       productP

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
@@ -1,7 +1,7 @@
 package gov.nasa.jpl.aerie.scheduler.server.remotes.postgres;
 
-import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
@@ -21,6 +21,7 @@ import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
 import gov.nasa.jpl.aerie.scheduler.server.models.SchedulingDSL;
 import gov.nasa.jpl.aerie.scheduler.server.models.Timestamp;
 import gov.nasa.jpl.aerie.scheduler.server.services.UnexpectedSubtypeError;
+
 import java.util.function.Function;
 public class GoalBuilder {
   private GoalBuilder() {}
@@ -133,7 +134,8 @@ public class GoalBuilder {
     if(type.getDurationType() instanceof DurationType.Controllable durationType){
       //detect duration parameter
       if(activityTemplate.arguments().containsKey(durationType.parameterName())){
-        builder.duration(Duration.fromISO8601String(activityTemplate.arguments().get(durationType.parameterName()).asString().get()));
+        final var argument = activityTemplate.arguments().get(durationType.parameterName());
+        builder.duration(Duration.of(argument.asInt().get(), Duration.MICROSECONDS));
         activityTemplate.arguments().remove(durationType.parameterName());
       }
     }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SynchronousSchedulerAgent.java
@@ -146,6 +146,7 @@ public record SynchronousSchedulerAgent(
             .type("GLOBAL_SCHEDULING_CONDITIONS_FAILED")
             .message("Global scheduling condition%s failed".formatted(failedGlobalSchedulingConditions.size() > 1 ? "s" : ""))
             .data(ResponseSerializers.serializeFailedGlobalSchedulingConditions(failedGlobalSchedulingConditions)));
+        return;
       }
 
       compiledGlobalSchedulingConditions.forEach(problem::add);
@@ -177,6 +178,7 @@ public record SynchronousSchedulerAgent(
             .type("SCHEDULING_GOALS_FAILED")
             .message("Scheduling goal%s failed".formatted(failedGoals.size() > 1 ? "s" : ""))
             .data(ResponseSerializers.serializeFailedGoals(failedGoals)));
+        return;
       }
       for (final var compiledGoal : compiledGoals) {
         final var goal = GoalBuilder

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
@@ -22,6 +22,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.HOUR;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECOND;
 import static gov.nasa.jpl.aerie.scheduler.server.services.TypescriptCodeGenerationServiceTest.MISSION_MODEL_TYPES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -66,9 +69,9 @@ class SchedulingDSLCompilationServiceTests {
                     activityTemplate: ActivityTemplates.SampleActivity1({
                       variant: 'option2',
                       fancy: { subfield1: 'value1', subfield2: [{subsubfield1: 2}]},
-                      duration: Temporal.Duration.from({ milliseconds: 60 * 60 * 1000 })
+                      duration: Temporal.Duration.from({ hours: 1 })
                     }),
-                    interval: Temporal.Duration.from({ milliseconds: 60 * 60 * 1000 })
+                    interval: Temporal.Duration.from({ hours: 1 })
                   })
                 }
             """);
@@ -81,10 +84,10 @@ class SchedulingDSLCompilationServiceTests {
                     Map.entry("subfield1", SerializedValue.of("value1")),
                     Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                 )))),
-                Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
+                Map.entry("duration", SerializedValue.of(Duration.of(1, HOUR).in(MICROSECONDS)))
             )
         ),
-        Duration.HOUR
+        HOUR
     );
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success<SchedulingDSL.GoalSpecifier> r) {
       assertEquals(expectedGoalDefinition, r.value());
@@ -103,13 +106,13 @@ class SchedulingDSLCompilationServiceTests {
                   return myHelper(ActivityTemplates.SampleActivity1({
                     variant: 'option2',
                     fancy: { subfield1: 'value1', subfield2: [{subsubfield1: 2}]},
-                    duration: Temporal.Duration.from({ milliseconds: 60 * 60 * 1000 })
+                    duration: Temporal.Duration.from({ hours: 1 })
                   }))
                 }
                 function myHelper(activityTemplate) {
                   return Goal.ActivityRecurrenceGoal({
                     activityTemplate,
-                    interval: Temporal.Duration.from({ milliseconds: 60 * 60 * 1000 })
+                    interval: Temporal.Duration.from({ hours: 1 })
                   })
                 }
             """);
@@ -122,10 +125,10 @@ class SchedulingDSLCompilationServiceTests {
                     Map.entry("subfield1", SerializedValue.of("value1")),
                     Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                     )))),
-                Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
+                Map.entry("duration", SerializedValue.of(HOUR.in(MICROSECONDS)))
             )
         ),
-        Duration.HOUR);
+        HOUR);
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
       assertEquals(expectedGoalDefinition, r.value());
     } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
@@ -144,7 +147,7 @@ class SchedulingDSLCompilationServiceTests {
                   return myHelper(ActivityTemplates.SampleActivity1({
                     variant: 'option2',
                     fancy: { subfield1: 'value1', subfield2: [{subsubfield1: 2}]},
-                    duration: Temporal.Duration.from({ milliseconds: 60 * 60 * 1000 })
+                    duration: Temporal.Duration.from({ hours: 1 })
                   }))
                 }
                 function myHelper(activityTemplate) {
@@ -192,10 +195,10 @@ class SchedulingDSLCompilationServiceTests {
                                 "subsubfield1",
                                 SerializedValue.of(2.0)))))
                         )))),
-                    Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
+                    Map.entry("duration", SerializedValue.of(HOUR.in(MICROSECONDS)))
                 )
             ),
-            Duration.HOUR
+            HOUR
         ),
         new GreaterThan(
             new RealResource("/sample/resource/1"),
@@ -228,7 +231,7 @@ class SchedulingDSLCompilationServiceTests {
 
   @Test
   void testSchedulingDSL_temporal() {
-    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult result;
+    final SchedulingDSLCompilationService.SchedulingDSLCompilationResult<?> result;
     result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
         missionModelService,
         PLAN_ID,
@@ -237,7 +240,7 @@ class SchedulingDSLCompilationServiceTests {
                       activityTemplate: ActivityTemplates.SampleActivity1({
                         variant: 'option2',
                         fancy: { subfield1: 'value1', subfield2: [{subsubfield1: 2}]},
-                        duration: Temporal.Duration.from({ milliseconds: 60 * 60 * 1000 })
+                        duration: Temporal.Duration.from({ hours: 1 })
                       }),
                       interval:  Temporal.Duration.from({days: 1})
                     })
@@ -251,7 +254,7 @@ class SchedulingDSLCompilationServiceTests {
                     Map.entry("subfield1", SerializedValue.of("value1")),
                     Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                     )))),
-                Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
+                Map.entry("duration", SerializedValue.of(HOUR.in(MICROSECONDS)))
             )
         ),
         Duration.HOURS.times(24)
@@ -275,9 +278,9 @@ class SchedulingDSLCompilationServiceTests {
                     activityTemplate: ActivityTemplates.SampleActivity1({
                       variant: 'option2',
                       fancy: { subfield1: 'value1', subfield2: [{subsubfield1: 2}]},
-                      duration: Temporal.Duration.from({ milliseconds: 60 * 60 * 1000 })
+                      duration: Temporal.Duration.from({ hours: 1 })
                     }),
-                    interval: Temporal.Duration.from({ milliseconds: 60 * 60 * 1000 })
+                    interval: Temporal.Duration.from({ hours: 1 })
                   })
                 }
             """ + " ".repeat(9001));
@@ -290,10 +293,10 @@ class SchedulingDSLCompilationServiceTests {
                     Map.entry("subfield1", SerializedValue.of("value1")),
                     Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                     )))),
-                Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
+                Map.entry("duration", SerializedValue.of(HOUR.in(MICROSECONDS)))
             )
         ),
-        Duration.HOUR
+        HOUR
     );
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
       assertEquals(expectedGoalDefinition, r.value());
@@ -330,11 +333,11 @@ class SchedulingDSLCompilationServiceTests {
                                                          Map.entry("subfield1", SerializedValue.of("value1")),
                                                          Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                                                          )))),
-                                                     Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
+                                                     Map.entry("duration", SerializedValue.of(HOUR.in(MICROSECONDS)))
                                                  )
               ),
               new SchedulingDSL.ConstraintExpression.ActivityExpression("SampleActivity2"),
-              Optional.of(new SchedulingDSL.ActivityTimingConstraint(TimeAnchor.START, TimeUtility.Operator.PLUS, Duration.of(1, Duration.SECONDS), true)),
+              Optional.of(new SchedulingDSL.ActivityTimingConstraint(TimeAnchor.START, TimeUtility.Operator.PLUS, SECOND, true)),
               Optional.empty()
           ),
           r.value()
@@ -372,7 +375,7 @@ class SchedulingDSLCompilationServiceTests {
         """);
 
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
-      assertEquals(r.errors().size(), 1);
+      assertEquals(1, r.errors().size());
       assertEquals(
           "TypeError: TS2741 Incorrect return type. Expected: 'Goal', Actual: 'FakeGoal'.",
           r.errors().get(0).message()
@@ -391,7 +394,7 @@ class SchedulingDSLCompilationServiceTests {
               activityTemplate: ActivityTemplates.SampleActivity1({
                 variant: 'option2',
                 fancy: { subfield1: 'value1', subfield2: [{subsubfield1: 2}]},
-                duration: Temporal.Duration.from({ milliseconds: 60 * 60 * 1000 })
+                duration: Temporal.Duration.from({ hours: 1 })
               }),
               forEach: Discrete.Resource(Resources["/sample/resource/1"]).transition("Chiquita", "Dole"),
               startsAt: TimingConstraint.singleton(WindowProperty.END)
@@ -426,7 +429,7 @@ class SchedulingDSLCompilationServiceTests {
             "SampleActivityEmpty",
             Map.of()
         ),
-        Duration.HOUR
+        HOUR
     );
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
       assertEquals(expectedGoalDefinition, r.value());
@@ -448,13 +451,6 @@ class SchedulingDSLCompilationServiceTests {
                   })
                 }
             """);
-    final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
-        new SchedulingDSL.ActivityTemplate(
-            "SampleActivityEmpty",
-            Map.of()
-        ),
-        Duration.HOUR
-    );
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
       assertEquals(1, r.errors().size());
       assertEquals(
@@ -478,7 +474,7 @@ class SchedulingDSLCompilationServiceTests {
               activityTemplate: ActivityTemplates.SampleActivity1({
                 variant: 'option2',
                 fancy: { subfield1: 'value1', subfield2: [{subsubfield1: 2}]},
-                duration: Temporal.Duration.from({ milliseconds: 60 * 60 * 1000 })
+                duration: Temporal.Duration.from({ hours: 1 })
               }),
               forEach: Real.Resource(Resources["/sample/resource/1"]).greaterThan(50.0).longerThan(10),
               startsAt: TimingConstraint.singleton(WindowProperty.END)
@@ -496,7 +492,7 @@ class SchedulingDSLCompilationServiceTests {
                                                          Map.entry("subfield1", SerializedValue.of("value1")),
                                                          Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                                                          )))),
-                                                     Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
+                                                     Map.entry("duration", SerializedValue.of(HOUR.in(MICROSECONDS)))
                                                  )
               ),
               new SchedulingDSL.ConstraintExpression.WindowsExpression(new LongerThan(new GreaterThan(new RealResource("/sample/resource/1"), new RealValue(50.0)), Duration.of(10, Duration.MICROSECOND))),
@@ -550,13 +546,13 @@ class SchedulingDSLCompilationServiceTests {
               "SampleActivityEmpty",
               Map.of()
           ),
-          Duration.HOUR
+          HOUR
     ), new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
             new SchedulingDSL.ActivityTemplate(
                 "SampleActivityEmpty",
                 Map.of()
             ),
-            Duration.HOUR.times(2)
+            HOUR.times(2)
         )));
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
       assertEquals(
@@ -591,13 +587,13 @@ class SchedulingDSLCompilationServiceTests {
                 "SampleActivityEmpty",
                 Map.of()
             ),
-            Duration.HOUR
+            HOUR
         ), new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
             new SchedulingDSL.ActivityTemplate(
                 "SampleActivityEmpty",
                 Map.of()
             ),
-            Duration.HOUR.times(2)
+            HOUR.times(2)
         )));
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success<SchedulingDSL.GoalSpecifier> r) {
       assertEquals(

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingDSLCompilationServiceTests.java
@@ -81,7 +81,7 @@ class SchedulingDSLCompilationServiceTests {
                     Map.entry("subfield1", SerializedValue.of("value1")),
                     Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                 )))),
-                Map.entry("duration", SerializedValue.of("PT3600S"))
+                Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
             )
         ),
         Duration.HOUR
@@ -122,7 +122,7 @@ class SchedulingDSLCompilationServiceTests {
                     Map.entry("subfield1", SerializedValue.of("value1")),
                     Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                     )))),
-                Map.entry("duration", SerializedValue.of("PT3600S"))
+                Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
             )
         ),
         Duration.HOUR);
@@ -192,7 +192,7 @@ class SchedulingDSLCompilationServiceTests {
                                 "subsubfield1",
                                 SerializedValue.of(2.0)))))
                         )))),
-                    Map.entry("duration", SerializedValue.of("PT1H"))
+                    Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
                 )
             ),
             Duration.HOUR
@@ -251,7 +251,7 @@ class SchedulingDSLCompilationServiceTests {
                     Map.entry("subfield1", SerializedValue.of("value1")),
                     Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                     )))),
-                Map.entry("duration", SerializedValue.of("PT3600S"))
+                Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
             )
         ),
         Duration.HOURS.times(24)
@@ -290,7 +290,7 @@ class SchedulingDSLCompilationServiceTests {
                     Map.entry("subfield1", SerializedValue.of("value1")),
                     Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                     )))),
-                Map.entry("duration", SerializedValue.of("PT3600S"))
+                Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
             )
         ),
         Duration.HOUR
@@ -330,7 +330,7 @@ class SchedulingDSLCompilationServiceTests {
                                                          Map.entry("subfield1", SerializedValue.of("value1")),
                                                          Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                                                          )))),
-                                                     Map.entry("duration", SerializedValue.of("PT1H"))
+                                                     Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
                                                  )
               ),
               new SchedulingDSL.ConstraintExpression.ActivityExpression("SampleActivity2"),
@@ -496,7 +496,7 @@ class SchedulingDSLCompilationServiceTests {
                                                          Map.entry("subfield1", SerializedValue.of("value1")),
                                                          Map.entry("subfield2", SerializedValue.of(List.of(SerializedValue.of(Map.of("subsubfield1", SerializedValue.of(2.0)))))
                                                          )))),
-                                                     Map.entry("duration", SerializedValue.of("PT3600S"))
+                                                     Map.entry("duration", SerializedValue.of(60 * 60 * 1000 * 1000.0))
                                                  )
               ),
               new SchedulingDSL.ConstraintExpression.WindowsExpression(new LongerThan(new GreaterThan(new RealResource("/sample/resource/1"), new RealValue(50.0)), Duration.of(10, Duration.MICROSECOND))),

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -38,6 +38,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.HOURS;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECOND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -351,11 +353,11 @@ public class SchedulingIntegrationTests {
             Map.of(
                 "quantity", SerializedValue.of(100),
                 "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
-            Duration.of(2, Duration.HOURS)),
+            Duration.of(2, HOURS)),
         new MockMerlinService.PlannedActivityInstance(
             "PickBanana",
             Map.of("quantity", SerializedValue.of(100)),
-            Duration.of(4, Duration.HOURS))), List.of(new SchedulingGoal(new GoalId(0L), """
+            Duration.of(4, HOURS))), List.of(new SchedulingGoal(new GoalId(0L), """
          export default (): Goal => {
           return Goal.CoexistenceGoal({
             activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
@@ -388,13 +390,13 @@ public class SchedulingIntegrationTests {
             new MockMerlinService.PlannedActivityInstance(
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(100)),
-                Duration.of(2, Duration.HOURS)),
+                Duration.of(2, HOURS)),
             new MockMerlinService.PlannedActivityInstance(
                     "GrowBanana",
                     Map.of(
                         "quantity", SerializedValue.of(100),
                         "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
-                    Duration.of(4, Duration.HOURS))),
+                    Duration.of(4, HOURS))),
         List.of(new SchedulingGoal(new GoalId(0L), """
                 export default (): Goal => {
                  return Goal.CoexistenceGoal({
@@ -425,11 +427,11 @@ public class SchedulingIntegrationTests {
         new MockMerlinService.PlannedActivityInstance(
             "BiteBanana",
             Map.of("biteSize", SerializedValue.of(1.0)),
-            Duration.of(2, Duration.HOURS)),
+            Duration.of(2, HOURS)),
         new MockMerlinService.PlannedActivityInstance(
             "BiteBanana",
             Map.of("biteSize", SerializedValue.of(1.0)),
-            Duration.of(4, Duration.HOURS))
+            Duration.of(4, HOURS))
     ), List.of(new SchedulingGoal(new GoalId(0L), """
          export default (): Goal => {
           return Goal.CoexistenceGoal({
@@ -446,8 +448,8 @@ public class SchedulingIntegrationTests {
     assertEquals(3, results.updatedPlan().size());
     final var planByActivityType = partitionByActivityType(results.updatedPlan());
     final var peelBanana = planByActivityType.get("PeelBanana").iterator().next();
-    assertTrue(peelBanana.startTime().noShorterThan(Duration.of(2, Duration.HOURS)), "PeelBanana was placed at %s which is before the start/end of BiteBanana at %s".formatted(peelBanana.startTime(), Duration.of(2, Duration.HOURS)));
-    assertTrue(peelBanana.startTime().noLongerThan(Duration.of(4, Duration.HOURS)), "PeelBanana was placed at %s which is before the start/end of BiteBanana at %s".formatted(peelBanana.startTime(), Duration.of(4, Duration.HOURS)));
+    assertTrue(peelBanana.startTime().noShorterThan(Duration.of(2, HOURS)), "PeelBanana was placed at %s which is before the start/end of BiteBanana at %s".formatted(peelBanana.startTime(), Duration.of(2, HOURS)));
+    assertTrue(peelBanana.startTime().noLongerThan(Duration.of(4, HOURS)), "PeelBanana was placed at %s which is before the start/end of BiteBanana at %s".formatted(peelBanana.startTime(), Duration.of(4, HOURS)));
     assertEquals(Map.of("peelDirection", SerializedValue.of("fromStem")), peelBanana.args());
   }
 
@@ -462,8 +464,8 @@ public class SchedulingIntegrationTests {
             new MockMerlinService.PlannedActivityInstance(
                 "GrowBanana",
                 Map.of("quantity", SerializedValue.of(3.0),
-                       "growingDuration", SerializedValue.of(Duration.of(3, Duration.HOURS).in(Duration.MICROSECONDS))),
-                Duration.of(1, Duration.HOURS))),
+                       "growingDuration", SerializedValue.of(Duration.of(3, HOURS).in(Duration.MICROSECONDS))),
+                Duration.of(1, HOURS))),
 
         List.of(new SchedulingGoal(new GoalId(0L), """
                 export default (): Goal => {
@@ -482,8 +484,8 @@ public class SchedulingIntegrationTests {
     assertEquals(2, results.updatedPlan().size());
     final var planByActivityType = partitionByActivityType(results.updatedPlan());
     final var peelBanana = planByActivityType.get("PeelBanana").iterator().next();
-    assertTrue(peelBanana.startTime().noShorterThan(Duration.of(2, Duration.HOURS)), "PeelBanana was placed at %s which is before the start/end of GrowBanana at %s".formatted(peelBanana.startTime(), Duration.of(2, Duration.HOURS)));
-    assertTrue(peelBanana.startTime().noLongerThan(Duration.of(3, Duration.HOURS)), "PeelBanana was placed at %s which is before the start/end of GrowBanana at %s".formatted(peelBanana.startTime(), Duration.of(3, Duration.HOURS)));
+    assertTrue(peelBanana.startTime().noShorterThan(Duration.of(2, HOURS)), "PeelBanana was placed at %s which is before the start/end of GrowBanana at %s".formatted(peelBanana.startTime(), Duration.of(2, HOURS)));
+    assertTrue(peelBanana.startTime().noLongerThan(Duration.of(3, HOURS)), "PeelBanana was placed at %s which is before the start/end of GrowBanana at %s".formatted(peelBanana.startTime(), Duration.of(3, HOURS)));
     assertEquals(Map.of("peelDirection", SerializedValue.of("fromTip")), peelBanana.args());
   }
 
@@ -500,13 +502,13 @@ public class SchedulingIntegrationTests {
             new MockMerlinService.PlannedActivityInstance(
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(100)),
-                Duration.of(2, Duration.HOURS)),
+                Duration.of(2, HOURS)),
             new MockMerlinService.PlannedActivityInstance(
                 "GrowBanana",
                 Map.of(
                     "quantity", SerializedValue.of(100),
                     "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
-                Duration.of(4, Duration.HOURS))),
+                Duration.of(4, HOURS))),
         List.of(new SchedulingGoal(new GoalId(0L), """
                 export default (): Goal => {
                  return Goal.CoexistenceGoal({
@@ -541,13 +543,13 @@ public class SchedulingIntegrationTests {
             new MockMerlinService.PlannedActivityInstance(
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(99)),
-                Duration.of(2, Duration.HOURS)),
+                Duration.of(2, HOURS)),
             new MockMerlinService.PlannedActivityInstance(
                 "GrowBanana",
                 Map.of(
                     "quantity", SerializedValue.of(100),
                     "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
-                Duration.of(4, Duration.HOURS))),
+                Duration.of(4, HOURS))),
         List.of(new SchedulingGoal(new GoalId(0L), """
                 export default (): Goal => {
                  return Goal.CoexistenceGoal({
@@ -563,8 +565,8 @@ public class SchedulingIntegrationTests {
     final var planByActivityType = partitionByActivityType(results.updatedPlan());
     final var pickBanana = planByActivityType.get("PickBanana").iterator().next();
     final var growBanana = planByActivityType.get("GrowBanana").iterator().next();
-    assertEquals(Duration.of(2, Duration.HOURS), pickBanana.startTime());
-    assertEquals(Duration.of(4, Duration.HOURS), growBanana.startTime());
+    assertEquals(Duration.of(2, HOURS), pickBanana.startTime());
+    assertEquals(Duration.of(4, HOURS), growBanana.startTime());
   }
 
   @Test
@@ -580,13 +582,13 @@ public class SchedulingIntegrationTests {
             new MockMerlinService.PlannedActivityInstance(
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(100)),
-                Duration.of(2, Duration.HOURS)),
+                Duration.of(2, HOURS)),
             new MockMerlinService.PlannedActivityInstance(
                 "GrowBanana",
                 Map.of(
                     "quantity", SerializedValue.of(100),
                     "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
-                Duration.of(4, Duration.HOURS))),
+                Duration.of(4, HOURS))),
         List.of(new SchedulingGoal(new GoalId(0L), """
                 export default (): Goal => {
                  return Goal.CoexistenceGoal({
@@ -621,13 +623,13 @@ public class SchedulingIntegrationTests {
             new MockMerlinService.PlannedActivityInstance(
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(100)),
-                Duration.of(2, Duration.HOURS)),
+                Duration.of(2, HOURS)),
             new MockMerlinService.PlannedActivityInstance(
                 "GrowBanana",
                 Map.of(
                     "quantity", SerializedValue.of(100),
                     "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
-                Duration.of(4, Duration.HOURS))),
+                Duration.of(4, HOURS))),
         List.of(new SchedulingGoal(new GoalId(0L), """
                 export default (): Goal => {
                  return Goal.CoexistenceGoal({
@@ -665,13 +667,13 @@ public class SchedulingIntegrationTests {
             new MockMerlinService.PlannedActivityInstance(
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(100)),
-                Duration.of(2, Duration.HOURS)),
+                Duration.of(2, HOURS)),
             new MockMerlinService.PlannedActivityInstance(
                 "GrowBanana",
                 Map.of(
                     "quantity", SerializedValue.of(100),
                     "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
-                Duration.of(4, Duration.HOURS))),
+                Duration.of(4, HOURS))),
         List.of(new SchedulingGoal(new GoalId(0L), """
                 export default (): Goal => {
                  return Goal.CoexistenceGoal({
@@ -705,7 +707,7 @@ public class SchedulingIntegrationTests {
         new MockMerlinService.PlannedActivityInstance(
             "ChangeProducer",
             Map.of(),
-            Duration.of(2, Duration.HOURS))), List.of(new SchedulingGoal(new GoalId(0L), """
+            Duration.of(2, HOURS))), List.of(new SchedulingGoal(new GoalId(0L), """
          export default (): Goal => {
           return Goal.CoexistenceGoal({
             activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
@@ -732,7 +734,7 @@ public class SchedulingIntegrationTests {
         new MockMerlinService.PlannedActivityInstance(
             "ChangeProducer",
             Map.of("producer", SerializedValue.of("Fyffes")),
-            Duration.of(2, Duration.HOURS))), List.of(new SchedulingGoal(new GoalId(0L), """
+            Duration.of(2, HOURS))), List.of(new SchedulingGoal(new GoalId(0L), """
          export default (): Goal => {
           return Goal.CoexistenceGoal({
             activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
@@ -778,7 +780,7 @@ public class SchedulingIntegrationTests {
                 Map.of(
                     "quantity", SerializedValue.of(100000)
                 ),
-                Duration.of(48, Duration.HOURS))
+                Duration.of(48, HOURS))
         ),
         List.of(new SchedulingGoal(new GoalId(0L), """
                   export default () => Goal.ActivityRecurrenceGoal({
@@ -855,7 +857,7 @@ public class SchedulingIntegrationTests {
             new MockMerlinService.PlannedActivityInstance(
                 "BiteBanana",
                 Map.of("biteSize", SerializedValue.of(1)),
-                Duration.of(24L * 60 * 60 * 1000 * 1000 - 1, Duration.MICROSECONDS))
+                Duration.of(24, HOURS).minus(MICROSECOND))
         ),
         List.of(new SchedulingGoal(new GoalId(0L), """
           export default () => Goal.ActivityRecurrenceGoal({
@@ -1112,13 +1114,13 @@ public class SchedulingIntegrationTests {
             new MockMerlinService.PlannedActivityInstance(
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(99)),
-                Duration.of(2, Duration.HOURS)),
+                Duration.of(2, HOURS)),
             new MockMerlinService.PlannedActivityInstance(
                 "GrowBanana",
                 Map.of(
                     "quantity", SerializedValue.of(100),
                     "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
-                Duration.of(4, Duration.HOURS))),
+                Duration.of(4, HOURS))),
         List.of(new SchedulingGoal(new GoalId(0L), """
                 export default (): Goal => {
                  return Goal.CoexistenceGoal({
@@ -1143,9 +1145,9 @@ public class SchedulingIntegrationTests {
     final var pickBanana = planByActivityType.get("PickBanana").iterator().next();
     final var growBanana = planByActivityType.get("GrowBanana").iterator().next();
     final var peelBanana = planByActivityType.get("PeelBanana").iterator().next();
-    assertEquals(Duration.of(2, Duration.HOURS), pickBanana.startTime());
-    assertEquals(Duration.of(4, Duration.HOURS), peelBanana.startTime());
-    assertEquals(Duration.of(4, Duration.HOURS), growBanana.startTime());
+    assertEquals(Duration.of(2, HOURS), pickBanana.startTime());
+    assertEquals(Duration.of(4, HOURS), peelBanana.startTime());
+    assertEquals(Duration.of(4, HOURS), growBanana.startTime());
   }
 
   @Test
@@ -1168,7 +1170,7 @@ public class SchedulingIntegrationTests {
                      new MockMerlinService.PlannedActivityInstance(
                          "parent",
                          Map.of(),
-                         Duration.of(1, Duration.HOURS))),
+                         Duration.of(1, HOURS))),
                  List.of(new SchedulingGoal(new GoalId(0L), goalDefinition, true)),
                  planningHorizon);
     final var planByActivityType = partitionByActivityType(results.updatedPlan());
@@ -1201,7 +1203,7 @@ public class SchedulingIntegrationTests {
                                          new MockMerlinService.PlannedActivityInstance(
                                              "parent",
                                              Map.of(),
-                                             Duration.of(1, Duration.HOURS))),
+                                             Duration.of(1, HOURS))),
                                      List.of(new SchedulingGoal(new GoalId(0L), goalDefinition, true)),
                                      planningHorizon);
     final var planByActivityType = partitionByActivityType(results.updatedPlan());

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -1216,4 +1216,22 @@ public class SchedulingIntegrationTests {
     }
   }
 
+  @Test
+  void testDurationParameter() {
+    final var results = runScheduler(
+        BANANANATION,
+        List.of(),
+        List.of(new SchedulingGoal(new GoalId(0L), """
+        export default function myGoal() {
+          return Goal.ActivityRecurrenceGoal({
+            activityTemplate: ActivityTemplates.DurationParameterActivity({
+              duration: Temporal.Duration.from({seconds: 1}),
+            }),
+            interval: Temporal.Duration.from({hours: 1})
+          })
+        }
+          """, true)),
+        PLANNING_HORIZON);
+    assertEquals(96, results.updatedPlan().size());
+  }
 }


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
~~This PR walks #187 back slightly. That PR changed all Durations in the scheduling EDSL to use Temporal.Duration - but this breaks for ActivityTemplate, because the parameters passed to ActivityTemplate are passed unchanged to the activity mapper's `instantiate` method.~~

~~This PR continues to use Temporal.Duration for scheduler-defined values, but goes back to integer microseconds for Activity Parameter values.~~

~~This is a stepping stone to avoid introducing regressions to 0.13.2. We're looking into serializing the Temporal.Duration to microseconds on the Javascript side.~~

UPDATE: After some iteration, this PR instead uses the JSON.stringify `replacer` function to define the serialization of Temporal.Duration.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I've added a test to catch the regression - there is now a `DurationParameterActivity` in Banananation.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
~~The examples in the [Scheduling Guide](https://nasa-ammos.github.io/aerie/stable/activity-plans/scheduling-guide.html) continue to show controllable duration activity parameters as integers, so I think we're good on that front for now.~~

- [x] The above examples need to be updated prior to release.

~~I've updated the type alias from `Duration` to `IntegerMicroseconds` to hopefully serve as additional documentation while we still have this way of expressing durations.~~

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- [x] We toyed around with how to serialize Temporal.Duration to microseconds in javascript - @dyst5422 I forget if this is something we had explored previously.