### PR TITLE
build: update gradle wrapper version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: "temurin"
-        java-version: "18"
+        java-version: "19"
     - run: |
         ./gradlew testClasses
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "18"
+          java-version: "19"
       - uses: gradle/wrapper-validation-action@v1
       - uses: gradle/gradle-build-action@v2
       - name: Build Classes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "18"
+          java-version: "19"
       - name: Setup Postgres Client (psql)
         run: |
           sudo apt-get update

--- a/docs/source/deployment/building.md
+++ b/docs/source/deployment/building.md
@@ -6,8 +6,8 @@
 
 | Name    | Version          | Notes        | Download             |
 | ------- | ---------------- | ------------ | -------------------- |
-| OpenJDK | Temurin 17 (LTS) | HotSpot JVM  | https://adoptium.net |
-| Gradle  | 7.4              | Build system | https://gradle.org   |
+| OpenJDK | Temurin 19 (LTS) | HotSpot JVM  | https://adoptium.net |
+| Gradle  | 7.6              | Build system | https://gradle.org   |
 
 ### Testing
 
@@ -39,6 +39,7 @@ process. This is evidenced by the `build:` directive in the `merlin`
 section in docker-compose.yml.
 
 Prior to building docker-compose.yml, it is necessary to create a .env file using the template found in .env.template in the Aerie root directory.
+
 ### Docker Compose Build
 
 `docker compose build`

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.6-20221017231502+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description

- Use Gradle 7.6 snapshot so we can use Java 19 to build Aerie locally
- Follow up to https://github.com/NASA-AMMOS/aerie/pull/379
- See: https://github.com/gradle/gradle/issues/20372
- See: https://services.gradle.org/distributions-snapshots/
- See: https://services.gradle.org/distributions/ (Will return to pulling from here when Gradle 7.6 is released)

## Future

When Gradle 7.6 is officially released we can switch to use it here