### PR TITLE
[HOTFIX] Change the Merlin Worker Java image from alpine to jammy

### DIFF
--- a/merlin-worker/Dockerfile
+++ b/merlin-worker/Dockerfile
@@ -4,7 +4,7 @@ COPY build/distributions/*.tar /usr/src/app/server.tar
 RUN mkdir /usr/src/app/extracted
 RUN cd /usr/src/app && tar --strip-components 1 -xf server.tar -C extracted
 
-FROM eclipse-temurin:19-jre-alpine
+FROM eclipse-temurin:19-jre-jammy
 
 COPY --from=extractor /usr/src/app/extracted /usr/src/app
 


### PR DESCRIPTION
* **Tickets addressed:** AERIE-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
In #379, the Merlin Worker was changed to use the `eclipse-temurin:19-jre-apline` Java image. This image is Intel-only. This PR changes the Merlin Worker to use `eclipse-temurin:19-jre-jammy` instead, which supports AMD chips as well.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
