### PR TITLE
Add parent_plan and child_plans Hasura metadata relationships

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan.yaml
@@ -5,6 +5,15 @@ object_relationships:
 - name: mission_model
   using:
     foreign_key_constraint_on: model_id
+- name: parent_plan
+  using:
+    manual_configuration:
+      column_mapping:
+        parent_id: id
+      insertion_order: null
+      remote_table:
+        name: plan
+        schema: public
 array_relationships:
 - name: activity_directives
   using:
@@ -33,6 +42,15 @@ array_relationships:
       column: plan_id
       table:
         name: simulation
+        schema: public
+- name: child_plans
+  using:
+    manual_configuration:
+      column_mapping:
+        id: parent_id
+      insertion_order: null
+      remote_table:
+        name: plan
         schema: public
 remote_relationships:
 - name: scheduling_specifications


### PR DESCRIPTION
* **Tickets addressed:** [AERIE-2171](https://jira.jpl.nasa.gov/browse/AERIE-2171)
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adding parent_plan and child_plans relationships to Hasura to make client querying easier.

## Verification
Tested relationships work via API queries in the Hasura playground

## Documentation
N/A documented in GraphQL schema

## Future work
N/A
