### PR TITLE
[Aerie 2146] Include eDSL API docs on website

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -6,6 +6,8 @@ on:
       - develop
     paths:
       - "docs/**"
+      - "merlin-server/constraints-dsl-compiler/src/**"
+      - "scheduler-server/scheduling-dsl-compiler/src/**"
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -29,10 +31,17 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.7
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "19"
       - name: Set up env
         run: make -C docs setupenv
       - name: Build docs
-        run: make -C docs multiversion
+        working-directory: ./docs
+        shell: bash
+        run: make multiversion-ext
       - name: Build redirects
         run: make -C docs redirects
       - name: Upload artifacts

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -8,6 +8,8 @@ on:
       - develop
     paths:
       - "docs/**"
+      - "merlin-server/constraints-dsl-compiler/src/**"
+      - "scheduler-server/scheduling-dsl-compiler/src/**"
 
 jobs:
   build:
@@ -22,7 +24,14 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.7
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "19"
       - name: Set up env
         run: make -C docs setupenv
       - name: Build docs
-        run: make -C docs test
+        working-directory: ./docs
+        shell: bash
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,7 @@ test-report.html
 # Ignore docs-related build files
 docs/_build
 docs/**/__pycache__
+docs/source/constraints-edsl-api/
+docs/source/scheduling-edsl-api/
 .doctrees
 *.log

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -88,7 +88,7 @@ multiversionpreview: multiversion
 
 # Test commands
 .PHONY: test
-test: setup
+test: build-ext
 	$(SPHINXBUILD) -b dirhtml $(TESTSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
@@ -96,3 +96,28 @@ test: setup
 .PHONY: linkcheck
 linkcheck: setup
 	$(SPHINXBUILD) -b linkcheck $(SOURCEDIR) $(BUILDDIR)/linkcheck
+
+# EDSL-Included commands
+.PHONY: multiversion-ext
+multiversion-ext: setup
+	$(POETRY) run sphinx-multiversion source $(BUILDDIR)/dirhtml --pre-build 'touch buildExternalDocs.bash' --pre-build 'bash buildExternalDocs.bash'
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+.PHONY: multiversionpreview-ext
+multiversionpreview-ext: multiversion-ext
+	$(POETRY) run python -m http.server 5500 --directory $(BUILDDIR)/dirhtml
+
+.PHONY: preview-ext
+preview-ext: build-ext
+	$(POETRY) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --port 5500
+
+.PHONY: dirhtml-ext
+dirhtml-ext: build-ext
+	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+.PHONY: build-ext
+build-ext: setup
+	bash buildExternalDocs.bash

--- a/docs/buildExternalDocs.bash
+++ b/docs/buildExternalDocs.bash
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# Build the EDSL documentation and insert it into the current build directory
+../gradlew publishDocs -p ../
+
+ls -1 ../merlin-server/constraints-dsl-compiler/build/
+pwd
+ls -1 ./source
+
+mkdir -p ./source/constraints-edsl-api
+cp -a ../merlin-server/constraints-dsl-compiler/build/docs/. ./source/constraints-edsl-api
+rm -f ./source/constraints-edsl-api/.nojekyll
+
+mkdir -p ./source/scheduling-edsl-api
+cp -a ../scheduler-server/scheduling-dsl-compiler/build/docs/. ./source/scheduling-edsl-api
+rm -f ./source/scheduling-edsl-api/.nojekyll
+rm -f ./source/scheduling-edsl-api/README.md
+rm -rf ./source/scheduling-edsl-api/*/Constraint_eDSL.*
+
+# Remove the extra navigation bar from the generated Constraints EDSL files
+tail -n +3 "./source/constraints-edsl-api/README.md" > "./source/constraints-edsl-api/README.tmp" && mv "./source/constraints-edsl-api/README.tmp" "./source/constraints-edsl-api/README.md"
+sed -i -e 's/README/index/g' ./source/constraints-edsl-api/README.md
+
+for file in ./source/constraints-edsl-api/classes/*.md
+do
+  [ -e "$file" ] || continue
+  tail -n +3 "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+  sed -i -e 's/README/index/g' $file #StreamEDitor -in-place 'backupExtension' 'Substitution/matchString/replaceString/Global'
+done
+for file in ./source/constraints-edsl-api/enums/*.md
+do
+  [ -e "$file" ] || continue
+  tail -n +3 "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+  sed -i -e 's/README/index/g' $file
+done
+
+# Remove the extra navigation bar from the generated Scheduling EDSL files
+tail -n +3 "./source/scheduling-edsl-api/modules/Scheduling_eDSL.md" > "./source/scheduling-edsl-api/Scheduling_eDSL.tmp" && mv "./source/scheduling-edsl-api/Scheduling_eDSL.tmp" "./source/scheduling-edsl-api/Scheduling_eDSL.md"
+sed -i -e 's/README/index/g' ./source/scheduling-edsl-api/Scheduling_eDSL.md
+sed -i -e 's/Scheduling_eDSL.md/index.md/g' ./source/scheduling-edsl-api/Scheduling_eDSL.md
+# Replace any references to the Constraints EDSL files
+ # These must be written to replace the calls to other folders first
+sed -i -e 's,../classes/Constraint_eDSL.,../../constraints-edsl-api/classes/,g' ./source/scheduling-edsl-api/Scheduling_eDSL.md
+sed -i -e 's,../enums/Constraint_eDSL.,../../constraints-edsl-api/enums/,g' ./source/scheduling-edsl-api/Scheduling_eDSL.md
+sed -i -e 's,../interfaces/Constraint_eDSL.,../../constraints-edsl-api/interfaces/,g' ./source/scheduling-edsl-api/Scheduling_eDSL.md
+sed -i -e 's,Constraint_eDSL.md,../../constraints-edsl-api/index.md,g' ./source/scheduling-edsl-api/Scheduling_eDSL.md
+# Update the references to the other Scheduling EDSL files
+sed -i -e 's,../classes,./classes,g' ./source/scheduling-edsl-api/Scheduling_eDSL.md
+sed -i -e 's,../enums,./enums,g' ./source/scheduling-edsl-api/Scheduling_eDSL.md
+sed -i -e 's,../interfaces,./interfaces,g' ./source/scheduling-edsl-api/Scheduling_eDSL.md
+# Remove the word 'Module' in front of the title
+sed -i -e 's/Module: //' ./source/scheduling-edsl-api/Scheduling_eDSL.md
+
+for file in ./source/scheduling-edsl-api/classes/*.md
+do
+  [ -e "$file" ] || continue
+  tail -n +3 "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+  sed -i -e 's/README/index/g' $file
+  sed -i -e 's,../modules/Scheduling_eDSL.md,../index.md,g' $file
+  sed -i -e 's,../enums/Constraint_eDSL.,../../constraints-edsl-api/enums/,g' $file
+  sed -i -e 's,../interfaces/Constraint_eDSL.,../../constraints-edsl-api/enums/,g' $file
+  sed -i -e 's,Constraint_eDSL.,../../constraints-edsl-api/classes/,g' $file
+done
+for file in ./source/scheduling-edsl-api/enums/*.md
+do
+  [ -e "$file" ] || continue
+  tail -n +3 "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+  sed -i -e 's/README/index/g' $file
+  sed -i -e 's,../modules/Scheduling_eDSL.md,../index.md,g' $file
+  sed -i -e 's,../classes/Constraint_eDSL.,../../constraints-edsl-api/classes/,g' $file
+  sed -i -e 's,../interfaces/Constraint_eDSL.,../../constraints-edsl-api/interfaces/,g' $file
+  sed -i -e 's,Constraint_eDSL.,../../constraints-edsl-api/enums/,g' $file
+done
+for file in ./source/scheduling-edsl-api/interfaces/*.md
+do
+  [ -e "$file" ] || continue
+  tail -n +3 "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+  sed -i -e 's/README/index/g' $file
+  sed -i -e 's,../modules/Scheduling_eDSL.md,../index.md,g' $file
+  sed -i -e 's,../classes/Constraint_eDSL.,../../constraints-edsl-api/classes/,g' $file
+  sed -i -e 's,../enums/Constraint_eDSL.,../../constraints-edsl-api/enums/,g' $file
+  sed -i -e 's,Constraint_eDSL.,../../constraints-edsl-api/interfaces/,g' $file
+done
+
+# Generate an index.md for constraints-dsl-api
+echo '
+```{eval-rst}
+.. toctree::
+   :hidden:
+   :glob:
+
+   classes/*
+   enums/*
+```' | cat ./source/constraints-edsl-api/README.md - > ./source/constraints-edsl-api/index.md
+
+# Generate an index.md for scheduling-dsl-api
+echo '
+```{eval-rst}
+.. toctree::
+   :hidden:
+   :glob:
+
+   classes/*
+   enums/*
+   interfaces/*
+```' | cat ./source/scheduling-edsl-api/Scheduling_eDSL.md - > ./source/scheduling-edsl-api/index.md
+
+# Remove unneeded files
+rm -f ./source/constraints-edsl-api/README.md
+rm -f ./source/scheduling-edsl-api/Scheduling_eDSL.md
+rm -rf ./source/scheduling-edsl-api/modules
+# These are only generated when run using BSD (the version of SED on Mac)
+rm -f ./source/constraints-edsl-api/**/*-e
+rm -f ./source/scheduling-edsl-api/**/*-e
+rm -f ./source/constraints-edsl-api/README.md-e
+rm -f ./source/scheduling-edsl-api/Scheduling_eDSL.md-e

--- a/docs/poetry.lock
+++ b/docs/poetry.lock
@@ -7,7 +7,7 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "babel"
+name = "Babel"
 version = "2.10.3"
 description = "Internationalization utilities"
 category = "main"
@@ -49,7 +49,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode-backport = ["unicodedata2"]
+unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -113,7 +113,7 @@ perf = ["ipython"]
 testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
 
 [[package]]
-name = "jinja2"
+name = "Jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
 category = "main"
@@ -152,7 +152,7 @@ typing_extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 benchmarking = ["psutil", "pytest", "pytest-benchmark (>=3.2,<4.0)"]
-code-style = ["pre-commit (==2.6)"]
+code_style = ["pre-commit (==2.6)"]
 compare = ["commonmark (>=0.9.1,<0.10.0)", "markdown (>=3.3.6,<3.4.0)", "mistletoe (>=0.8.1,<0.9.0)", "mistune (>=2.0.2,<2.1.0)", "panflute (>=2.1.3,<2.2.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
 plugins = ["mdit-py-plugins"]
@@ -161,7 +161,7 @@ rtd = ["attrs", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
-name = "markupsafe"
+name = "MarkupSafe"
 version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
@@ -180,7 +180,7 @@ python-versions = ">=3.7"
 markdown-it-py = ">=1.0.0,<3.0.0"
 
 [package.extras]
-code-style = ["pre-commit"]
+code_style = ["pre-commit"]
 rtd = ["attrs", "myst-parser (>=0.16.1,<0.17.0)", "sphinx-book-theme (>=0.1.0,<0.2.0)"]
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
@@ -210,7 +210,7 @@ sphinx = ">=4,<6"
 typing-extensions = "*"
 
 [package.extras]
-code-style = ["pre-commit (>=2.12,<3.0)"]
+code_style = ["pre-commit (>=2.12,<3.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
 rtd = ["ipython", "sphinx-book-theme", "sphinx-design", "sphinxcontrib.mermaid (>=0.7.1,<0.8.0)", "sphinxext-opengraph (>=0.6.3,<0.7.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)"]
 testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=6,<7)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions", "sphinx (<5.2)", "sphinx-pytest"]
@@ -227,7 +227,7 @@ python-versions = ">=3.6"
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
-name = "pygments"
+name = "Pygments"
 version = "2.11.2"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
@@ -254,7 +254,7 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "pyyaml"
+name = "PyYAML"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "main"
@@ -262,7 +262,7 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "redirects-cli"
+name = "redirects_cli"
 version = "0.1.0"
 description = "Generates static redirections from a YAML file."
 category = "main"
@@ -292,7 +292,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "setuptools"
@@ -332,7 +332,7 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "sphinx"
+name = "Sphinx"
 version = "4.3.2"
 description = "Python documentation generator"
 category = "main"
@@ -380,7 +380,7 @@ sphinx = "*"
 test = ["pytest", "pytest-cov"]
 
 [[package]]
-name = "sphinx-collapse"
+name = "sphinx_collapse"
 version = "0.1.2"
 description = "Collapse extension for Sphinx."
 category = "main"
@@ -406,7 +406,7 @@ python-versions = ">=3.6"
 sphinx = ">=1.8"
 
 [package.extras]
-code-style = ["pre-commit (==2.12.1)"]
+code_style = ["pre-commit (==2.12.1)"]
 rtd = ["ipython", "myst-nb", "sphinx", "sphinx-book-theme"]
 
 [[package]]
@@ -466,7 +466,7 @@ six = "*"
 sphinx = ">=1.2"
 
 [[package]]
-name = "sphinx-substitution-extensions"
+name = "Sphinx-Substitution-Extensions"
 version = "2022.2.16"
 description = "Extensions for Sphinx which allow for substitutions."
 category = "main"
@@ -495,7 +495,7 @@ pygments = "*"
 sphinx = ">=2,<5"
 
 [package.extras]
-code-style = ["pre-commit (==2.13.0)"]
+code_style = ["pre-commit (==2.13.0)"]
 testing = ["bs4", "coverage", "pygments", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions", "rinohtype", "sphinx-testing"]
 
 [[package]]
@@ -637,7 +637,7 @@ alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
 ]
-babel = [
+Babel = [
     {file = "Babel-2.10.3-py3-none-any.whl", hash = "sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb"},
     {file = "Babel-2.10.3.tar.gz", hash = "sha256:7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51"},
 ]
@@ -677,7 +677,7 @@ importlib-metadata = [
     {file = "importlib_metadata-5.0.0-py3-none-any.whl", hash = "sha256:ddb0e35065e8938f867ed4928d0ae5bf2a53b7773871bfe6bcc7e4fcdc7dea43"},
     {file = "importlib_metadata-5.0.0.tar.gz", hash = "sha256:da31db32b304314d044d3c12c79bd59e307889b287ad12ff387b3500835fc2ab"},
 ]
-jinja2 = [
+Jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
     {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
 ]
@@ -688,7 +688,7 @@ markdown-it-py = [
     {file = "markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},
     {file = "markdown_it_py-2.1.0-py3-none-any.whl", hash = "sha256:93de681e5c021a432c63147656fe21790bc01231e0cd2da73626f1aa3ac0fe27"},
 ]
-markupsafe = [
+MarkupSafe = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
     {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e"},
@@ -746,7 +746,7 @@ packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
-pygments = [
+Pygments = [
     {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
     {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
 ]
@@ -758,7 +758,7 @@ pytz = [
     {file = "pytz-2022.5-py2.py3-none-any.whl", hash = "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22"},
     {file = "pytz-2022.5.tar.gz", hash = "sha256:c4d88f472f54d615e9cd582a5004d1e5f624854a6a27a6211591c251f22a6914"},
 ]
-pyyaml = [
+PyYAML = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
@@ -800,7 +800,7 @@ pyyaml = [
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
-redirects-cli = [
+redirects_cli = [
     {file = "redirects_cli-0.1.0-py3-none-any.whl", hash = "sha256:6feff2b2183c7251cb238a97bdd172ad28b1ca59568fe187099fc823a2e22a15"},
     {file = "redirects_cli-0.1.0.tar.gz", hash = "sha256:30c86c4caee85f1a95f145dc633a0583f1ed6b16d85fc1dfa0fb5979a7346024"},
 ]
@@ -824,7 +824,7 @@ soupsieve = [
     {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},
     {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
 ]
-sphinx = [
+Sphinx = [
     {file = "Sphinx-4.3.2-py3-none-any.whl", hash = "sha256:6a11ea5dd0bdb197f9c2abc2e0ce73e01340464feaece525e64036546d24c851"},
     {file = "Sphinx-4.3.2.tar.gz", hash = "sha256:0a8836751a68306b3fe97ecbe44db786f8479c3bf4b80e3a7f5c838657b4698c"},
 ]
@@ -832,7 +832,7 @@ sphinx-autobuild = [
     {file = "sphinx-autobuild-2021.3.14.tar.gz", hash = "sha256:de1ca3b66e271d2b5b5140c35034c89e47f263f2cd5db302c9217065f7443f05"},
     {file = "sphinx_autobuild-2021.3.14-py3-none-any.whl", hash = "sha256:8fe8cbfdb75db04475232f05187c776f46f6e9e04cacf1e49ce81bdac649ccac"},
 ]
-sphinx-collapse = [
+sphinx_collapse = [
     {file = "sphinx_collapse-0.1.2-py3-none-any.whl", hash = "sha256:7a2082da3c779916cc4c4d44832db3522a3a8bfbd12598ef01fb9eb523a164d0"},
     {file = "sphinx_collapse-0.1.2.tar.gz", hash = "sha256:a186000bf3fdac8ac0e8a99979f720ae790de15a5efc1435d4816f79a3d377c2"},
 ]
@@ -855,7 +855,7 @@ sphinx-scylladb-theme = [
 sphinx-sitemap = [
     {file = "sphinx-sitemap-2.2.0.tar.gz", hash = "sha256:65adda39233cb17c0da10ba1cebaa2df73e271cdb6f8efd5cec8eef3b3cf7737"},
 ]
-sphinx-substitution-extensions = [
+Sphinx-Substitution-Extensions = [
     {file = "Sphinx Substitution Extensions-2022.2.16.tar.gz", hash = "sha256:ff7d05bd00e8b2d7eb8a403b9f317d70411d4e9b6812bf91534a50df22190c75"},
     {file = "Sphinx_Substitution_Extensions-2022.2.16-py3-none-any.whl", hash = "sha256:5a8ca34dac3984486344e95c36e3ed4766d402a71bdee7390d600f153db9795b"},
 ]

--- a/docs/source/activity-plans/scheduling-guide.rst
+++ b/docs/source/activity-plans/scheduling-guide.rst
@@ -126,7 +126,7 @@ a goal is enabled or disabled.
 
 Scheduling DSL Documentation
 ============================
-Here you will find the full set of features in the scheduling DSL.
+The full set of features can be found in the :doc:`Scheduling EDSL API Documentation <../scheduling-edsl-api/index>`
 
 
 .. warning::
@@ -450,7 +450,7 @@ have:
 
 When mapping out a temporal window to apply a goal over, keep in mind that the ending boundary of the goal is
 *exclusive*, i.e. if I want to apply a goal in the window of 10-12 seconds, it will apply only on seconds 10 and 11.
-This is in line with the `fencepost problem <https://icarus.cs.weber.edu/~dab/cs1410/textbook/3.Control/fencepost.html>`__.
+This is in line with the `fencepost problem <https://en.wikipedia.org/wiki/Off-by-one_error#Fencepost_error>`__.
 
 Global Scheduling Conditions
 ============================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,8 +31,8 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx_sitemap",
     "sphinx_scylladb_theme",
-    "sphinx_multiversion",  # optional
-    "myst_parser",  # for converting .md to .rst,
+    "sphinx_multiversion",
+    "myst_parser"  # for converting .md to .rst,
 ]
 
 # The suffix(es) of source filenames.

--- a/docs/source/contribute/contribute-docs.rst
+++ b/docs/source/contribute/contribute-docs.rst
@@ -7,8 +7,7 @@ If you are reading this guide because you have decided to contribute to Aerie's 
 The purpose of this handbook is to explain how to contribute new content to Aerie's documentation either as a new
 topic or by editing an existing topic.
 
-If you feel something is missing from this document, do not hesitate to let us know. You can use the Feedback
-button at the bottom to open an issue.
+If you feel something is missing from this document, use the Feedback button at the bottom to open an issue.
 
 About Aerie Docs
 -----------------
@@ -51,10 +50,9 @@ Also, if there is an issue with any guide and the issue does not exist, please c
 Guidelines for branch names
 ===========================
 
-Ask the Maintainer of the project if he/she has any preference for naming branches before you contribute to the repo
-to avoid any collisions or confusion.
-If you are providing both documentation and code, it is recommended to name all of your documentation branches
-with a `doc/` prefix.
+If you are providing documentation alongside new code, prefix the name of your branch with `feature/`.
+
+If you are only providing documentation, prefix the name of your branch with `docs/`.
 
 Write content
 =============
@@ -113,14 +111,13 @@ To preview your changes while you are working, run ``make preview`` from the com
 
 When you are finished making changes, run ``make clean`` and then ``make dirhtml`` to ensure that the site will deploy. Once the site builds successfully without warnings, you may proceed to the next step.
 
-To check for broken links, run ``make dirhtml`` and then ``make linkcheck``.
+To check for broken links, run ``make clean && make dirhtml-ext`` then ``make linkcheck``.
 
 Submit a pull request (PR)
 ==========================
 
 We expect that you are aware of how to submit a PR to GitHub. If you are not, please look at this `tutorial <https://docs.github.com/en/get-started/quickstart/hello-world>`_.
-Every repository handles PRs differently. Some require you to use a template for submissions and some do not.
-Make sure to speak with the project’s maintainer before submitting the PR to avoid any misunderstanding or issues.
+When creating a PR, fill out the provided template.
 
 If you are writing new content it is **highly recommended** to set your PR to a draft state.
 For Documentation PRs, the following guidelines should be applicable to all Aerie projects:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,6 +59,24 @@
   The client application and API guide.
 
 .. topic-box::
+	:title: Constraints EDSL APIs
+	:link: constraints-edsl-api
+	:icon: scylla-icon scylla-icon--about-team
+	:class: large-6
+	:anchor: Learn more
+
+	Constraints EDSL APIs for defining constraints on activity plans.
+
+.. topic-box::
+	:title: Scheduling EDSL APIs
+	:link: scheduling-edsl-api
+	:icon: scylla-icon scylla-icon--about-team
+	:class: large-6
+	:anchor: Learn more
+
+	Scheduling EDSL APIs for defining scheduling rules.
+
+.. topic-box::
   :title: Deployment
   :link: deployment
   :icon: scylla-icon scylla-icon--cloud
@@ -98,3 +116,5 @@
   mission-modeling/index
   upgrade-guides/index
   user-interface/index
+  constraints-edsl-api/index
+  scheduling-edsl-api/index

--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -42,6 +42,15 @@ task generateDocumentation(type: NpmTask) {
   inputs.dir('src')
 }
 
+task cleanDocsFromDocsDir(type: Delete) {
+  delete rootDir.toPath().resolve('docs/edsl-api-docs/constraints-edsl-api/develop')
+}
+
+task publishDocs {
+  dependsOn cleanDocsFromDocsDir
+  dependsOn generateDocumentation
+}
+
 assemble {
   dependsOn assembleConstraintsDSLCompiler
   dependsOn generateASTJsonSchema

--- a/merlin-server/constraints-dsl-compiler/package-lock.json
+++ b/merlin-server/constraints-dsl-compiler/package-lock.json
@@ -11,13 +11,14 @@
         "@nasa-jpl/aerie-ts-user-code-runner": "^0.3.2",
         "prettier": "^2.6.2",
         "source-map": "^0.7.3",
-        "typedoc": "^0.23.10",
         "typescript": "^4.5.5",
         "typescript-json-schema": "0.53.0"
       },
       "devDependencies": {
         "@tsconfig/node16-strictest-esm": "^1.0.2",
-        "@types/node": "^17.0.21"
+        "@types/node": "^17.0.21",
+        "typedoc": "^0.23.10",
+        "typedoc-plugin-markdown": "^3.13.6"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -269,6 +270,36 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -335,6 +366,21 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -478,6 +524,7 @@
       "version": "0.23.10",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
       "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
+      "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.0.18",
@@ -492,6 +539,18 @@
       },
       "peerDependencies": {
         "typescript": "4.6.x || 4.7.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.6.tgz",
+      "integrity": "sha512-ISSc9v3BK7HkokxSBuJPttXox4tJ6hP0N9wfSIk0fmLN67+eqtAxbk97gs2nDiuha+RTO5eW9gdeAb+RPP0mgg==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7"
+      },
+      "peerDependencies": {
+        "typedoc": ">=0.23.0"
       }
     },
     "node_modules/typescript": {
@@ -579,6 +638,19 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -593,6 +665,12 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
       "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -858,6 +936,27 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -909,6 +1008,18 @@
       "requires": {
         "brace-expansion": "^2.0.1"
       }
+    },
+    "minimist": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -1000,11 +1111,21 @@
       "version": "0.23.10",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
       "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
+      "dev": true,
       "requires": {
         "lunr": "^2.3.9",
         "marked": "^4.0.18",
         "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
+      }
+    },
+    "typedoc-plugin-markdown": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.6.tgz",
+      "integrity": "sha512-ISSc9v3BK7HkokxSBuJPttXox4tJ6hP0N9wfSIk0fmLN67+eqtAxbk97gs2nDiuha+RTO5eW9gdeAb+RPP0mgg==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.7"
       }
     },
     "typescript": {
@@ -1068,6 +1189,13 @@
         }
       }
     },
+    "uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true
+    },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -1082,6 +1210,12 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
       "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/merlin-server/constraints-dsl-compiler/package.json
+++ b/merlin-server/constraints-dsl-compiler/package.json
@@ -4,11 +4,11 @@
   "description": "Typescript compiler for the constraints DSL",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf build; tsc",
     "test": "npm run build && node build/main.js",
     "generate-ast-schema": "npx typescript-json-schema src/libs/constraints-ast.ts \"*\" --aliasRefs --out ./build/constraints.schema.json",
     "reformat": "npx prettier --config ./.prettierrc -w ./src",
-    "generate-doc": "npx typedoc src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Constraints eDSL documentation\""
+    "generate-doc": "rm -rf build/docs; npx typedoc --plugin typedoc-plugin-markdown src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Constraints eDSL Documentation\" --readme none --gitRevision develop"
   },
   "author": "",
   "dependencies": {
@@ -16,11 +16,12 @@
     "prettier": "^2.6.2",
     "source-map": "^0.7.3",
     "typescript": "^4.5.5",
-    "typescript-json-schema": "0.53.0",
-    "typedoc": "^0.23.10"
+    "typescript-json-schema": "0.53.0"
   },
   "devDependencies": {
     "@tsconfig/node16-strictest-esm": "^1.0.2",
-    "@types/node": "^17.0.21"
+    "@types/node": "^17.0.21",
+    "typedoc": "^0.23.10",
+    "typedoc-plugin-markdown": "^3.13.6"
   }
 }

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -23,6 +23,7 @@ task deleteConstraintsTypescript(type: Delete) {
 
 task copyConstraintsTypescript(type: Copy) {
   dependsOn deleteConstraintsTypescript
+  dependsOn ':merlin-server:assembleConstraintsDSLCompiler'
   from rootDir.toPath().resolve('merlin-server/constraints-dsl-compiler/src/libs')
   into project.projectDir.toPath().resolve('scheduling-dsl-compiler/src/libs/constraints')
 }
@@ -56,6 +57,15 @@ task generateDocumentation(type: NpmTask) {
   args = ['run', 'generate-doc']
   inputs.files('package.json', 'package-lock.json', 'tsconfig.json')
   inputs.dir('src')
+}
+
+task cleanDocsFromDocsDir(type: Delete) {
+  delete rootDir.toPath().resolve('docs/edsl-api-docs/scheduling-edsl-api/develop')
+}
+
+task publishDocs {
+  dependsOn cleanDocsFromDocsDir
+  dependsOn generateDocumentation
 }
 
 assemble {

--- a/scheduler-server/scheduling-dsl-compiler/package-lock.json
+++ b/scheduler-server/scheduling-dsl-compiler/package-lock.json
@@ -6,18 +6,18 @@
   "packages": {
     "": {
       "name": "scheduling-dsl-compiler",
-      "version": "1.0.0",
       "dependencies": {
         "@js-temporal/polyfill": "^0.4.0",
         "@nasa-jpl/aerie-ts-user-code-runner": "^0.3.2",
         "source-map": "^0.7.3",
-        "typedoc": "^0.23.10",
         "typescript": "^4.5.5",
         "typescript-json-schema": "0.53.0"
       },
       "devDependencies": {
         "@tsconfig/node16-strictest-esm": "^1.0.2",
-        "@types/node": "^17.0.21"
+        "@types/node": "^17.0.21",
+        "typedoc": "^0.23.10",
+        "typedoc-plugin-markdown": "^3.13.6"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -281,6 +281,36 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -352,6 +382,21 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -486,6 +531,7 @@
       "version": "0.23.10",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
       "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
+      "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.0.18",
@@ -500,6 +546,18 @@
       },
       "peerDependencies": {
         "typescript": "4.6.x || 4.7.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.6.tgz",
+      "integrity": "sha512-ISSc9v3BK7HkokxSBuJPttXox4tJ6hP0N9wfSIk0fmLN67+eqtAxbk97gs2nDiuha+RTO5eW9gdeAb+RPP0mgg==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7"
+      },
+      "peerDependencies": {
+        "typedoc": ">=0.23.0"
       }
     },
     "node_modules/typescript": {
@@ -587,6 +645,19 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -601,6 +672,12 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
       "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -875,6 +952,27 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -931,6 +1029,18 @@
       "requires": {
         "brace-expansion": "^2.0.1"
       }
+    },
+    "minimist": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -1022,11 +1132,21 @@
       "version": "0.23.10",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
       "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
+      "dev": true,
       "requires": {
         "lunr": "^2.3.9",
         "marked": "^4.0.18",
         "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
+      }
+    },
+    "typedoc-plugin-markdown": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.6.tgz",
+      "integrity": "sha512-ISSc9v3BK7HkokxSBuJPttXox4tJ6hP0N9wfSIk0fmLN67+eqtAxbk97gs2nDiuha+RTO5eW9gdeAb+RPP0mgg==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.7"
       }
     },
     "typescript": {
@@ -1090,6 +1210,13 @@
         }
       }
     },
+    "uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true
+    },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -1104,6 +1231,12 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
       "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/scheduler-server/scheduling-dsl-compiler/package.json
+++ b/scheduler-server/scheduling-dsl-compiler/package.json
@@ -1,13 +1,12 @@
 {
   "name": "scheduling-dsl-compiler",
-  "version": "1.0.0",
   "description": "Typescript compiler for the scheduling server DSL",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf build; tsc",
     "test": "npm run build && node build/main.js",
     "generate-ast-schema": "npx typescript-json-schema src/libs/scheduler-ast.ts \"*\" --aliasRefs --out ./build/scheduler.schema.json",
-    "generate-doc": "npx typedoc src/libs/scheduler-edsl-fluent-api.ts src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Scheduling eDSL documentation\""
+    "generate-doc": "rm -rf build/docs; npx typedoc --plugin typedoc-plugin-markdown src/libs/scheduler-edsl-fluent-api.ts src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Scheduling eDSL Documentation\" --readme none --gitRevision develop"
   },
   "author": "",
   "dependencies": {
@@ -15,11 +14,12 @@
     "@js-temporal/polyfill": "^0.4.0",
     "source-map": "^0.7.3",
     "typescript": "^4.5.5",
-    "typescript-json-schema": "0.53.0",
-    "typedoc": "^0.23.10"
+    "typescript-json-schema": "0.53.0"
   },
   "devDependencies": {
     "@tsconfig/node16-strictest-esm": "^1.0.2",
-    "@types/node": "^17.0.21"
+    "@types/node": "^17.0.21",
+    "typedoc": "^0.23.10",
+    "typedoc-plugin-markdown": "^3.13.6"
   }
 }

--- a/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
+++ b/scheduler-server/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
@@ -119,7 +119,7 @@ export class Goal {
    * Restricts the windows on which a goal is applied
    *
    *
-   * By default, a goal applies on the whole planning horizon. The Aerie scheduler provides support for restricting _when_ a goal applies with the `.applyWhen()` method in the `Goal` class. This node allows users to provide a set of windows (`Windows`, see [documentation](https://github.com/NASA-AMMOS/aerie/wiki/Constraints#windows)) which could be a time or a resource-based window.
+   * By default, a goal applies on the whole planning horizon. The Aerie scheduler provides support for restricting _when_ a goal applies with the `.applyWhen()` method in the `Goal` class. This node allows users to provide a set of windows (`Windows`, see [documentation](../../constraints-edsl-api/classes/Windows)) which could be a time or a resource-based window.
    *
    * The `.applyWhen()` method, takes one argument: the windows (in the form of an expression) that the goal should apply over. What follows is an example that applies a daily recurrence goal only when a given resource is greater than 2. If the resource is less than two, then the goal is no longer applied.
    *
@@ -149,7 +149,7 @@ export class Goal {
    * GOAL WINDOW:         [+++++--+++--]
    * RESULT:              [++-----++---] //(the second one is applied independently of the first!)
    * ```
-   * * When mapping out a temporal window to apply a goal over, keep in mind that the ending boundary of the goal is _exclusive_, i.e. if I want to apply a goal in the window of 10-12 seconds, it will apply only on seconds 10 and 11. This is in line with the [fencepost problem](https://icarus.cs.weber.edu/~dab/cs1410/textbook/3.Control/fencepost.html).
+   * * When mapping out a temporal window to apply a goal over, keep in mind that the ending boundary of the goal is _exclusive_, i.e. if I want to apply a goal in the window of 10-12 seconds, it will apply only on seconds 10 and 11. This is in line with the [fencepost problem](https://en.wikipedia.org/wiki/Off-by-one_error#Fencepost_error).
    *
    * @param windows the windows on which this goal applies
    * @returns a new goal applying on a restricted horizon
@@ -210,7 +210,7 @@ export class Goal {
    * The Coexistence Goal specifies that a certain activity should occur once **for each** occurrence of some condition.
    *
    * #### Inputs
-   * - **forEach**: a set of time windows (`Windows`, see [documentation](https://github.com/NASA-AMMOS/aerie/wiki/Constraints#windows) on how to produce such an expression) or a set of activities (`ActivityExpression`)
+   * - **forEach**: a set of time windows (`Windows`, see [documentation](../../constraints-edsl-api/classes/Windows) on how to produce such an expression) or a set of activities (`ActivityExpression`)
    * - **activityTemplate**: the description of the activity to insert after each activity identified by `forEach`
    * - **startsAt**: optionally specify a specific time when the activity should start relative to the window
    * - **startsWithin**: optionally specify a range when the activity should start relative to the window
@@ -257,7 +257,7 @@ export class Goal {
    *
    * KNOWN ISSUE: If the end is unconstrained while the activity has an uncontrollable duration, the scheduler may fail to place the activity. To work around this, add an `endsWithin` constraint that encompasses your expectation for the duration of the activity - this will help the scheduler narrow the search space.
    *
-   * @param opts an object containing the activity template, a set of windows, and optionnally temporal constraints.
+   * @param opts an object containing the activity template, a set of windows, and optionally temporal constraints.
    */
   public static CoexistenceGoal(opts: {
     activityTemplate: ActivityTemplate,


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2146
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR re-introduces building our eDSL docs as a part of our Sphinx deployment (see #391). As a side-effect, the generateDocs task now builds the docs into MarkDown.

Regarding CI:
If either of the eDSL docs changes structure, `buildExternalDocs.zsh` will need to be updated to reflect the new layout of the docs. This shouldn't lead to any backwards compatibility issues, however, as Sphinx runs the version of `buildExternalDocs.zsh` present on the branch/tag it has currently checked out.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Generated both single-version and multiversion of the docs and ensured that internal page links were present, especially with the Scheduling docs, which cross-references the Constraints docs.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
We can hopefully use similar techniques to include the JavaDocs on the website.
