### PR TITLE
[AERIE-2183] Revert name changes to boolean operations

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
@@ -261,30 +261,30 @@ public final class ConstraintParsers {
               untuple((kind, left, right) -> new GreaterThanOrEqual(left, right)),
               $ -> tuple(Unit.UNIT, $.left, $.right));
 
-  static JsonParser<All> allF(final JsonParser<Expression<Windows>> windowsExpressionP) {
+  static JsonParser<And> andF(final JsonParser<Expression<Windows>> windowsExpressionP) {
     return productP
-        .field("kind", literalP("WindowsExpressionAll"))
+        .field("kind", literalP("WindowsExpressionAnd"))
         .field("expressions", listP(windowsExpressionP))
         .map(
-            untuple((kind, expressions) -> new All(expressions)),
+            untuple((kind, expressions) -> new And(expressions)),
             $ -> tuple(Unit.UNIT, $.expressions));
   }
 
-  static JsonParser<Any> anyF(final JsonParser<Expression<Windows>> windowsExpressionP) {
+  static JsonParser<Or> orF(final JsonParser<Expression<Windows>> windowsExpressionP) {
     return productP
-        .field("kind", literalP("WindowsExpressionAny"))
+        .field("kind", literalP("WindowsExpressionOr"))
         .field("expressions", listP(windowsExpressionP))
         .map(
-            untuple((kind, expressions) -> new Any(expressions)),
+            untuple((kind, expressions) -> new Or(expressions)),
             $ -> tuple(Unit.UNIT, $.expressions));
   }
 
-  static JsonParser<Invert> invertF(final JsonParser<Expression<Windows>> windowsExpressionP) {
+  static JsonParser<Not> notF(final JsonParser<Expression<Windows>> windowsExpressionP) {
     return productP
-        .field("kind", literalP("WindowsExpressionInvert"))
+        .field("kind", literalP("WindowsExpressionNot"))
         .field("expression", windowsExpressionP)
         .map(
-            untuple((kind, expr) -> new Invert(expr)),
+            untuple((kind, expr) -> new Not(expr)),
             $ -> tuple(Unit.UNIT, $.expression));
   }
 
@@ -365,9 +365,9 @@ public final class ConstraintParsers {
         equalF(discreteProfileExprP),
         notEqualF(linearProfileExprP),
         notEqualF(discreteProfileExprP),
-        allF(selfP),
-        anyF(selfP),
-        invertF(selfP),
+        andF(selfP),
+        orF(selfP),
+        notF(selfP),
         shiftByF(selfP),
         startsF(selfP),
         endsF(selfP),

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/And.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/And.java
@@ -9,15 +9,15 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-public final class All implements Expression<Windows> {
+public final class And implements Expression<Windows> {
   public final List<Expression<Windows>> expressions;
 
-  public All(final List<Expression<Windows>> expressions) {
+  public And(final List<Expression<Windows>> expressions) {
     this.expressions = expressions;
   }
 
   @SafeVarargs
-  public All(final Expression<Windows>... expressions) {
+  public And(final Expression<Windows>... expressions) {
     this(List.of(expressions));
   }
 
@@ -54,8 +54,8 @@ public final class All implements Expression<Windows> {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof All)) return false;
-    final var o = (All)obj;
+    if (!(obj instanceof And)) return false;
+    final var o = (And)obj;
 
     return Objects.equals(this.expressions, o.expressions);
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Not.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Not.java
@@ -8,10 +8,10 @@ import gov.nasa.jpl.aerie.constraints.time.Windows;
 import java.util.Objects;
 import java.util.Set;
 
-public final class Invert implements Expression<Windows> {
+public final class Not implements Expression<Windows> {
   public final Expression<Windows> expression;
 
-  public Invert(final Expression<Windows> expression) {
+  public Not(final Expression<Windows> expression) {
     this.expression = expression;
   }
 
@@ -36,8 +36,8 @@ public final class Invert implements Expression<Windows> {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof Invert)) return false;
-    final var o = (Invert)obj;
+    if (!(obj instanceof Not)) return false;
+    final var o = (Not)obj;
 
     return Objects.equals(this.expression, o.expression);
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Or.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Or.java
@@ -9,15 +9,15 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-public final class Any implements Expression<Windows> {
+public final class Or implements Expression<Windows> {
   public final List<Expression<Windows>> expressions;
 
-  public Any(final List<Expression<Windows>> expressions) {
+  public Or(final List<Expression<Windows>> expressions) {
     this.expressions = expressions;
   }
 
   @SafeVarargs
-  public Any(final Expression<Windows>... expressions) {
+  public Or(final Expression<Windows>... expressions) {
     this(List.of(expressions));
   }
 
@@ -56,8 +56,8 @@ public final class Any implements Expression<Windows> {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof Any)) return false;
-    Any o = (Any)obj;
+    if (!(obj instanceof Or)) return false;
+    Or o = (Or)obj;
 
     return Objects.equals(this.expressions, o.expressions);
   }

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsersTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsersTest.java
@@ -1,7 +1,7 @@
 package gov.nasa.jpl.aerie.constraints.json;
 
 import gov.nasa.jpl.aerie.constraints.time.Interval;
-import gov.nasa.jpl.aerie.constraints.tree.All;
+import gov.nasa.jpl.aerie.constraints.tree.And;
 import gov.nasa.jpl.aerie.constraints.tree.Changes;
 import gov.nasa.jpl.aerie.constraints.tree.DiscreteParameter;
 import gov.nasa.jpl.aerie.constraints.tree.DiscreteResource;
@@ -15,9 +15,9 @@ import gov.nasa.jpl.aerie.constraints.tree.GreaterThan;
 import gov.nasa.jpl.aerie.constraints.tree.GreaterThanOrEqual;
 import gov.nasa.jpl.aerie.constraints.tree.LessThan;
 import gov.nasa.jpl.aerie.constraints.tree.LessThanOrEqual;
-import gov.nasa.jpl.aerie.constraints.tree.Invert;
+import gov.nasa.jpl.aerie.constraints.tree.Not;
 import gov.nasa.jpl.aerie.constraints.tree.NotEqual;
-import gov.nasa.jpl.aerie.constraints.tree.Any;
+import gov.nasa.jpl.aerie.constraints.tree.Or;
 import gov.nasa.jpl.aerie.constraints.tree.Plus;
 import gov.nasa.jpl.aerie.constraints.tree.ProfileExpression;
 import gov.nasa.jpl.aerie.constraints.tree.Rate;
@@ -423,10 +423,10 @@ public final class ConstraintParsersTest {
   }
 
   @Test
-  public void testParseAll() {
+  public void testParseAnd() {
     final var json = Json
         .createObjectBuilder()
-        .add("kind", "WindowsExpressionAll")
+        .add("kind", "WindowsExpressionAnd")
         .add("expressions", Json
             .createArrayBuilder()
             .add(Json
@@ -442,7 +442,7 @@ public final class ConstraintParsersTest {
     final var result = windowsExpressionP.parse(json).getSuccessOrThrow();
 
     final var expected =
-        new All(
+        new And(
             new ActivityWindow("A"),
             new ActivityWindow("B"));
 
@@ -450,10 +450,10 @@ public final class ConstraintParsersTest {
   }
 
   @Test
-  public void testParseAny() {
+  public void testParseOr() {
     final var json = Json
         .createObjectBuilder()
-        .add("kind", "WindowsExpressionAny")
+        .add("kind", "WindowsExpressionOr")
         .add("expressions", Json
             .createArrayBuilder()
             .add(Json
@@ -469,7 +469,7 @@ public final class ConstraintParsersTest {
     final var result = windowsExpressionP.parse(json).getSuccessOrThrow();
 
     final var expected =
-        new Any(
+        new Or(
             new ActivityWindow("A"),
             new ActivityWindow("B"));
 
@@ -477,10 +477,10 @@ public final class ConstraintParsersTest {
   }
 
   @Test
-  public void testParseInvert() {
+  public void testParseNot() {
     final var json = Json
         .createObjectBuilder()
-        .add("kind", "WindowsExpressionInvert")
+        .add("kind", "WindowsExpressionNot")
         .add("expression", Json
             .createObjectBuilder()
             .add("kind", "WindowsExpressionActivityWindow")
@@ -490,7 +490,7 @@ public final class ConstraintParsersTest {
     final var result = windowsExpressionP.parse(json).getSuccessOrThrow();
 
     final var expected =
-        new Invert(
+        new Not(
             new ActivityWindow("A"));
 
     assertEquivalent(expected, result);
@@ -633,17 +633,17 @@ public final class ConstraintParsersTest {
             .add("alias", "B")
             .add("expression", Json
                 .createObjectBuilder()
-                .add("kind", "WindowsExpressionAny")
+                .add("kind", "WindowsExpressionOr")
                 .add("expressions", Json
                     .createArrayBuilder()
                     .add(Json
                              .createObjectBuilder()
-                             .add("kind", "WindowsExpressionAny")
+                             .add("kind", "WindowsExpressionOr")
                              .add("expressions", Json
                                  .createArrayBuilder()
                                  .add(Json
                                           .createObjectBuilder()
-                                          .add("kind", "WindowsExpressionInvert")
+                                          .add("kind", "WindowsExpressionNot")
                                           .add("expression", Json
                                               .createObjectBuilder()
                                               .add("kind", "RealProfileLessThan")
@@ -674,14 +674,14 @@ public final class ConstraintParsersTest {
                                               .add("name", "b")))))
                     .add(Json
                              .createObjectBuilder()
-                             .add("kind", "WindowsExpressionInvert")
+                             .add("kind", "WindowsExpressionNot")
                              .add("expression", Json
                                  .createObjectBuilder()
                                  .add("kind", "WindowsExpressionActivityWindow")
                                  .add("alias", "A")))
                     .add(Json
                              .createObjectBuilder()
-                             .add("kind", "WindowsExpressionInvert")
+                             .add("kind", "WindowsExpressionNot")
                              .add("expression", Json
                                  .createObjectBuilder()
                                  .add("kind", "WindowsExpressionActivityWindow")
@@ -696,9 +696,9 @@ public final class ConstraintParsersTest {
             "TypeB",
             "B",
             new ViolationsOf(
-                new Any(
-                    new Any(
-                        new Invert(
+                new Or(
+                    new Or(
+                        new Not(
                             new LessThan(
                                 new Times(
                                     new RealResource("ResC"),
@@ -707,8 +707,8 @@ public final class ConstraintParsersTest {
                         new Equal<>(
                             new DiscreteValue(SerializedValue.of(false)),
                             new DiscreteParameter("B", "b"))),
-                    new Invert(new ActivityWindow("A")),
-                    new Invert(new ActivityWindow("B"))))));
+                    new Not(new ActivityWindow("A")),
+                    new Not(new ActivityWindow("B"))))));
 
     assertEquivalent(expected, result);
   }

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -50,7 +50,7 @@ public class ASTTests {
         .set(Interval.between(10, Exclusive, 15, Exclusive, SECONDS), false)
         .set(Interval.at(20, SECONDS), true);
 
-    final var result = new Invert(Supplier.of(windows)).evaluate(simResults, new EvaluationEnvironment());
+    final var result = new Not(Supplier.of(windows)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between(0, Inclusive, 5, Exclusive, SECONDS), false)
@@ -256,7 +256,7 @@ public class ASTTests {
         .set(Interval.between(10, Inclusive, 12, Inclusive, SECONDS), true)
         .set(Interval.between(15, Inclusive, 20, Exclusive, SECONDS), true);
 
-    final var result = new All(Supplier.of(left), Supplier.of(right)).evaluate(simResults, new EvaluationEnvironment());
+    final var result = new And(Supplier.of(left), Supplier.of(right)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between( 0, Inclusive,  5, Exclusive, SECONDS), true)
@@ -290,7 +290,7 @@ public class ASTTests {
         .set(Interval.between(15, Inclusive, 20, Exclusive, SECONDS), true)
         .set(Interval.between(25, Inclusive, 26, Exclusive, SECONDS), false);
 
-    final var result = new Any(Supplier.of(left), Supplier.of(right)).evaluate(simResults, new EvaluationEnvironment());
+    final var result = new Or(Supplier.of(left), Supplier.of(right)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between(  0, Inclusive,   5, Inclusive, SECONDS), true)

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -26,9 +26,9 @@ export enum NodeKind {
   RealProfileLessThanOrEqual = 'RealProfileLessThanOrEqual',
   RealProfileGreaterThan = 'RealProfileGreaterThan',
   RealProfileGreaterThanOrEqual = 'RealProfileGreaterThanOrEqual',
-  WindowsExpressionAll = 'WindowsExpressionAll',
-  WindowsExpressionAny = 'WindowsExpressionAny',
-  WindowsExpressionInvert = 'WindowsExpressionInvert',
+  WindowsExpressionAnd = 'WindowsExpressionAnd',
+  WindowsExpressionOr = 'WindowsExpressionOr',
+  WindowsExpressionNot = 'WindowsExpressionNot',
   IntervalsExpressionStarts = 'IntervalsExpressionStarts',
   IntervalsExpressionEnds = 'IntervalsExpressionEnds',
   ForEachActivity = 'ForEachActivity',
@@ -64,11 +64,11 @@ export type WindowsExpression =
   | ExpressionEqual<DiscreteProfileExpression>
   | ExpressionNotEqual<RealProfileExpression>
   | ExpressionNotEqual<DiscreteProfileExpression>
-  | WindowsExpressionAll
-  | WindowsExpressionAny
+  | WindowsExpressionAnd
+  | WindowsExpressionOr
   | WindowsExpressionLongerThan
   | WindowsExpressionShorterThan
-  | WindowsExpressionInvert
+  | WindowsExpressionNot
   | WindowsExpressionShiftBy
   | WindowsExpressionFromSpans
   | IntervalsExpressionStarts
@@ -89,8 +89,8 @@ export interface ProfileChanges {
   expression: ProfileExpression;
 }
 
-export interface WindowsExpressionInvert {
-  kind: NodeKind.WindowsExpressionInvert;
+export interface WindowsExpressionNot {
+  kind: NodeKind.WindowsExpressionNot;
   expression: WindowsExpression;
 }
 
@@ -103,13 +103,13 @@ export interface WindowsExpressionShiftBy {
   fromEnd: Duration,
 }
 
-export interface WindowsExpressionAny {
-  kind: NodeKind.WindowsExpressionAny;
+export interface WindowsExpressionOr {
+  kind: NodeKind.WindowsExpressionOr;
   expressions: WindowsExpression[];
 }
 
-export interface WindowsExpressionAll {
-  kind: NodeKind.WindowsExpressionAll;
+export interface WindowsExpressionAnd {
+  kind: NodeKind.WindowsExpressionAnd;
   expressions: WindowsExpression[];
 }
 

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -36,7 +36,7 @@ export class Constraint {
         activityType1,
         activity1 => Constraint.ForEachActivity(
             activityType2,
-            activity2 => Windows.All(activity1.window(), activity2.window()).invert()
+            activity2 => Windows.And(activity1.window(), activity2.window()).not()
         )
     )
   }
@@ -80,9 +80,9 @@ export class Windows {
    *
    * @param windows any number of windows expressions
    */
-  public static All(...windows: Windows[]): Windows {
+  public static And(...windows: Windows[]): Windows {
     return new Windows({
-      kind: AST.NodeKind.WindowsExpressionAll,
+      kind: AST.NodeKind.WindowsExpressionAnd,
       expressions: [...windows.map(other => other.__astNode)],
     });
   }
@@ -94,9 +94,9 @@ export class Windows {
    *
    * @param windows one or more windows expressions
    */
-  public static Any(...windows: Windows[]): Windows {
+  public static Or(...windows: Windows[]): Windows {
     return new Windows({
-      kind: AST.NodeKind.WindowsExpressionAny,
+      kind: AST.NodeKind.WindowsExpressionOr,
       expressions: [...windows.map(other => other.__astNode)],
     });
   }
@@ -108,10 +108,10 @@ export class Windows {
    */
   public if(condition: Windows): Windows {
     return new Windows({
-      kind: AST.NodeKind.WindowsExpressionAny,
+      kind: AST.NodeKind.WindowsExpressionOr,
       expressions: [
         {
-          kind: AST.NodeKind.WindowsExpressionInvert,
+          kind: AST.NodeKind.WindowsExpressionNot,
           expression: condition.__astNode,
         },
         this.__astNode,
@@ -122,9 +122,9 @@ export class Windows {
   /**
    * Invert all the windows produced this.
    */
-  public invert(): Windows {
+  public not(): Windows {
     return new Windows({
-      kind: AST.NodeKind.WindowsExpressionInvert,
+      kind: AST.NodeKind.WindowsExpressionNot,
       expression: this.__astNode,
     });
   }
@@ -676,7 +676,7 @@ declare global {
      *
      * @param windows any number of windows expressions
      */
-    public static All(...windows: Windows[]): Windows;
+    public static And(...windows: Windows[]): Windows;
 
     /**
      * Produce a window when any argument produces a window.
@@ -685,7 +685,7 @@ declare global {
      *
      * @param windows one or more windows expressions
      */
-    public static Any(...windows: Windows[]): Windows;
+    public static Or(...windows: Windows[]): Windows;
 
     /**
      * Only check this expression of the condition argument produces a window.
@@ -697,7 +697,7 @@ declare global {
     /**
      * Invert all the windows produced this.
      */
-    public invert(): Windows;
+    public not(): Windows;
 
     /**
      * Produce a constraint violation whenever this does NOT produce a window.

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -122,6 +122,14 @@ export class Windows {
   /**
    * Invert all the windows produced this.
    */
+  public and(...windows: Windows[]): Windows {
+    return Windows.And(this, ...windows);
+  }
+
+  public or(...windows: Windows[]): Windows {
+    return Windows.Or(this, ...windows);
+  }
+   */
   public not(): Windows {
     return new Windows({
       kind: AST.NodeKind.WindowsExpressionNot,
@@ -697,6 +705,10 @@ declare global {
     /**
      * Invert all the windows produced this.
      */
+    public and(...windows: Windows[]): Windows;
+
+    public or(...windows: Windows[]): Windows;
+
     public not(): Windows;
 
     /**

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -1,7 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.constraints.time.Interval;
-import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.constraints.tree.*;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
@@ -490,8 +489,8 @@ class ConstraintsDSLCompilationServiceTests {
           }
         """,
         new ViolationsOf(
-            new Any(
-                new Invert(new Changes<>(
+            new Or(
+                new Not(new Changes<>(
                     new ProfileExpression<>(new DiscreteResource("mode"))
                 )),
                 new LessThan(new RealResource("state of charge"), new RealValue(2.0))
@@ -501,11 +500,11 @@ class ConstraintsDSLCompilationServiceTests {
   }
 
   @Test
-  void testAll() {
+  void testAnd() {
     checkSuccessfulCompilation(
         """
           export default () => {
-            return Windows.All(
+            return Windows.And(
               Real.Resource("state of charge").lessThan(2),
               Discrete.Value("hello there").notEqual(Discrete.Value("hello there")),
               Real.Value(5).changes()
@@ -513,7 +512,7 @@ class ConstraintsDSLCompilationServiceTests {
           }
         """,
         new ViolationsOf(
-            new All(
+            new And(
                 java.util.List.of(
                     new LessThan(new RealResource("state of charge"), new RealValue(2.0)),
                     new NotEqual<>(new DiscreteValue(SerializedValue.of("hello there")), new DiscreteValue(SerializedValue.of("hello there"))),
@@ -525,11 +524,11 @@ class ConstraintsDSLCompilationServiceTests {
   }
 
   @Test
-  void testAny() {
+  void testOr() {
     checkSuccessfulCompilation(
         """
           export default () => {
-            return Windows.Any(
+            return Windows.Or(
               Real.Resource("state of charge").lessThan(2),
               Discrete.Value("hello there").notEqual(Discrete.Value("hello there")),
               Real.Value(5).changes()
@@ -537,7 +536,7 @@ class ConstraintsDSLCompilationServiceTests {
           }
         """,
         new ViolationsOf(
-            new Any(
+            new Or(
                 java.util.List.of(
                     new LessThan(new RealResource("state of charge"), new RealValue(2.0)),
                     new NotEqual<>(new DiscreteValue(SerializedValue.of("hello there")), new DiscreteValue(SerializedValue.of("hello there"))),
@@ -549,15 +548,15 @@ class ConstraintsDSLCompilationServiceTests {
   }
 
   @Test
-  void testInvert() {
+  void testNot() {
     checkSuccessfulCompilation(
         """
           export default () => {
-            return Discrete.Resource("mode").changes().invert()
+            return Discrete.Resource("mode").changes().not()
           }
         """,
         new ViolationsOf(
-            new Invert(
+            new Not(
                 new Changes<>(new ProfileExpression<>(new DiscreteResource("mode")))
             )
         )
@@ -770,7 +769,7 @@ class ConstraintsDSLCompilationServiceTests {
             new ForEachActivity(
                 "activity",
                 "activity alias 1",
-                new ViolationsOf(new Invert(new All(new ActivityWindow("activity alias 0"), new ActivityWindow("activity alias 1"))))
+                new ViolationsOf(new Not(new And(new ActivityWindow("activity alias 0"), new ActivityWindow("activity alias 1"))))
             )
         )
     );
@@ -817,13 +816,13 @@ class ConstraintsDSLCompilationServiceTests {
             ActivityType.activity,
             (alias1) => Constraint.ForEachActivity(
               ActivityType.activity,
-              (alias2) => Windows.All(alias1.window(), alias2.window())
+              (alias2) => Windows.And(alias1.window(), alias2.window())
             )
           )
         }
         """,
         new ForEachActivity("activity", "activity alias 0", new ForEachActivity("activity", "activity alias 1", new ViolationsOf(
-            new All(new ActivityWindow("activity alias 0"), new ActivityWindow("activity alias 1"))
+            new And(new ActivityWindow("activity alias 0"), new ActivityWindow("activity alias 1"))
         )))
     );
   }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -501,6 +501,16 @@ class ConstraintsDSLCompilationServiceTests {
 
   @Test
   void testAnd() {
+    final var expected = new ViolationsOf(
+        new And(
+            java.util.List.of(
+                new LessThan(new RealResource("state of charge"), new RealValue(2.0)),
+                new NotEqual<>(new DiscreteValue(SerializedValue.of("hello there")), new DiscreteValue(SerializedValue.of("hello there"))),
+                new Changes<>(new ProfileExpression<>(new RealValue(5.0)))
+            )
+        )
+    );
+
     checkSuccessfulCompilation(
         """
           export default () => {
@@ -511,20 +521,35 @@ class ConstraintsDSLCompilationServiceTests {
             );
           }
         """,
-        new ViolationsOf(
-            new And(
-                java.util.List.of(
-                    new LessThan(new RealResource("state of charge"), new RealValue(2.0)),
-                    new NotEqual<>(new DiscreteValue(SerializedValue.of("hello there")), new DiscreteValue(SerializedValue.of("hello there"))),
-                    new Changes<>(new ProfileExpression<>(new RealValue(5.0)))
-                )
-            )
-        )
+        expected
+    );
+
+    checkSuccessfulCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(2)
+              .and(
+                Discrete.Value("hello there").notEqual(Discrete.Value("hello there")),
+                Real.Value(5).changes()
+              );
+          }
+        """,
+        expected
     );
   }
 
   @Test
   void testOr() {
+    final var expected = new ViolationsOf(
+        new Or(
+            java.util.List.of(
+                new LessThan(new RealResource("state of charge"), new RealValue(2.0)),
+                new NotEqual<>(new DiscreteValue(SerializedValue.of("hello there")), new DiscreteValue(SerializedValue.of("hello there"))),
+                new Changes<>(new ProfileExpression<>(new RealValue(5.0)))
+            )
+        )
+    );
+
     checkSuccessfulCompilation(
         """
           export default () => {
@@ -535,15 +560,20 @@ class ConstraintsDSLCompilationServiceTests {
             );
           }
         """,
-        new ViolationsOf(
-            new Or(
-                java.util.List.of(
-                    new LessThan(new RealResource("state of charge"), new RealValue(2.0)),
-                    new NotEqual<>(new DiscreteValue(SerializedValue.of("hello there")), new DiscreteValue(SerializedValue.of("hello there"))),
-                    new Changes<>(new ProfileExpression<>(new RealValue(5.0)))
-                )
-            )
-        )
+        expected
+    );
+
+    checkSuccessfulCompilation(
+        """
+          export default () => {
+            return Real.Resource("state of charge").lessThan(2)
+              .or(
+                Discrete.Value("hello there").notEqual(Discrete.Value("hello there")),
+                Real.Value(5).changes()
+              );
+          }
+        """,
+        expected
     );
   }
 

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulingIntegrationTests.java
@@ -436,7 +436,7 @@ public class SchedulingIntegrationTests {
          export default (): Goal => {
           return Goal.CoexistenceGoal({
             activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
-            forEach: Windows.All(
+            forEach: Windows.And(
               Real.Resource("/fruit").lessThan(4.0),
               Real.Resource("/fruit").greaterThan(2.0)
             ),
@@ -471,7 +471,7 @@ public class SchedulingIntegrationTests {
                 export default (): Goal => {
                  return Goal.CoexistenceGoal({
                    activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromTip"}),
-                   forEach: Windows.All(
+                   forEach: Windows.And(
                      Real.Resource("/fruit").greaterThan(5.0),
                      Real.Resource("/fruit").lessThan(6.0),
                    ),
@@ -611,7 +611,7 @@ public class SchedulingIntegrationTests {
   }
 
   @Test
-  void testBetweenInTermsOfAll() {
+  void testBetweenInTermsOfAnd() {
     // Initial plant count is 200 in default configuration
     // PickBanana removes 100
     // GrowBanana adds 100
@@ -634,7 +634,7 @@ public class SchedulingIntegrationTests {
                 export default (): Goal => {
                  return Goal.CoexistenceGoal({
                    activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
-                   forEach: Windows.All(
+                   forEach: Windows.And(
                      Real.Resource("/plant").greaterThan(50.0),
                      Real.Resource("/plant").lessThan(150.0),
                    ),
@@ -655,7 +655,7 @@ public class SchedulingIntegrationTests {
   }
 
   @Test
-  void testWindowsAny() {
+  void testWindowsOr() {
     // Initial plant count is 200 in default configuration
     // PickBanana removes 100
     // GrowBanana adds 100
@@ -678,7 +678,7 @@ public class SchedulingIntegrationTests {
                 export default (): Goal => {
                  return Goal.CoexistenceGoal({
                    activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
-                   forEach: Windows.Any(
+                   forEach: Windows.Or(
                      Real.Resource("/plant").equal(999.0),
                      Real.Resource("/plant").equal(100.0),
                    ),

--- a/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Goal.java
+++ b/scheduler/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Goal.java
@@ -3,7 +3,7 @@ package gov.nasa.jpl.aerie.scheduler.goals;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
-import gov.nasa.jpl.aerie.constraints.tree.All;
+import gov.nasa.jpl.aerie.constraints.tree.And;
 import gov.nasa.jpl.aerie.constraints.tree.Expression;
 import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -173,7 +173,7 @@ public class Goal {
       goal.resourceConstraints = null;
       if (this.resourceConstraints.size() > 0) {
         if (this.resourceConstraints.size() > 1) {
-          goal.resourceConstraints = new All(resourceConstraints);
+          goal.resourceConstraints = new And(resourceConstraints);
         } else {
           goal.resourceConstraints = resourceConstraints.get(0);
         }

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/AerieLanderRules.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/AerieLanderRules.java
@@ -2,12 +2,12 @@ package gov.nasa.jpl.aerie.scheduler;
 
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
-import gov.nasa.jpl.aerie.constraints.tree.All;
+import gov.nasa.jpl.aerie.constraints.tree.And;
 import gov.nasa.jpl.aerie.constraints.tree.DiscreteResource;
 import gov.nasa.jpl.aerie.constraints.tree.DiscreteValue;
 import gov.nasa.jpl.aerie.constraints.tree.Equal;
 import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
-import gov.nasa.jpl.aerie.constraints.tree.Any;
+import gov.nasa.jpl.aerie.constraints.tree.Or;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -554,14 +554,14 @@ public class AerieLanderRules extends Problem {
 
     //the dsn visibility activities from generateDSNVisibilityAllocationGoal are required for the following goals
 
-    var sc1 = new All(new Equal<>(new DiscreteResource("/dsn/visible/Canberra"),new DiscreteValue(SerializedValue.of("InView"))),
+    var sc1 = new And(new Equal<>(new DiscreteResource("/dsn/visible/Canberra"), new DiscreteValue(SerializedValue.of("InView"))),
                       new Equal<>(new DiscreteResource("/dsn/allocated/Canberra"),new DiscreteValue(SerializedValue.of("Allocated"))));
-    var sc2 = new All(new Equal<>(new DiscreteResource("/dsn/visible/Madrid"),new DiscreteValue(SerializedValue.of("InView"))),
+    var sc2 = new And(new Equal<>(new DiscreteResource("/dsn/visible/Madrid"), new DiscreteValue(SerializedValue.of("InView"))),
                       new Equal<>(new DiscreteResource("/dsn/allocated/Madrid"),new DiscreteValue(SerializedValue.of("Allocated"))));
-    var sc3 = new All(new Equal<>(new DiscreteResource("/dsn/visible/Goldstone"),new DiscreteValue(SerializedValue.of("InView"))),
+    var sc3 = new And(new Equal<>(new DiscreteResource("/dsn/visible/Goldstone"), new DiscreteValue(SerializedValue.of("InView"))),
                       new Equal<>(new DiscreteResource("/dsn/allocated/Goldstone"),new DiscreteValue(SerializedValue.of("Allocated"))));
 
-    var disj = new Any(sc1, sc2, sc3);
+    var disj = new Or(sc1, sc2, sc3);
 
     TimeRangeExpression expr = new TimeRangeExpression.Builder()
         .from(disj)

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
@@ -3,7 +3,7 @@ package gov.nasa.jpl.aerie.scheduler;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Segment;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
-import gov.nasa.jpl.aerie.constraints.tree.All;
+import gov.nasa.jpl.aerie.constraints.tree.And;
 import gov.nasa.jpl.aerie.constraints.tree.DiscreteResource;
 import gov.nasa.jpl.aerie.constraints.tree.Equal;
 import gov.nasa.jpl.aerie.constraints.tree.GreaterThan;
@@ -32,7 +32,6 @@ import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
 import gov.nasa.jpl.aerie.scheduler.model.Problem;
 import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
 import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -222,7 +221,7 @@ public class SimulationFacadeTest {
   public void whenValueBetweenDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
-    var actual = new All(new GreaterThanOrEqual(getFruitRes(), new RealValue(3.0)), new LessThanOrEqual(getFruitRes(), new RealValue(3.99))).evaluate(facade.getLatestConstraintSimulationResults());
+    var actual = new And(new GreaterThanOrEqual(getFruitRes(), new RealValue(3.0)), new LessThanOrEqual(getFruitRes(), new RealValue(3.99))).evaluate(facade.getLatestConstraintSimulationResults());
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 1, Exclusive, SECONDS), false),
         Segment.of(interval(1, Inclusive, 2, Exclusive, SECONDS), true),
@@ -270,7 +269,7 @@ public class SimulationFacadeTest {
      * fruit:|4.0-------|3.0-------|2.9------->
      * </pre>
      **/
-    final var constraint = new All(
+    final var constraint = new And(
         new LessThanOrEqual(new RealResource("/peel"), new RealValue(3.0)),
         new LessThanOrEqual(new RealResource("/fruit"), new RealValue(2.9))
     );
@@ -299,7 +298,7 @@ public class SimulationFacadeTest {
   public void testProceduralGoalWithResourceConstraint() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
 
-    final var constraint = new All(
+    final var constraint = new And(
         new LessThanOrEqual(new RealResource("/peel"), new RealValue(3.0)),
         new LessThanOrEqual(new RealResource("/fruit"), new RealValue(2.9))
     );
@@ -339,7 +338,7 @@ public class SimulationFacadeTest {
   public void testActivityTypeWithResourceConstraint() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
 
-    final var constraint = new All(
+    final var constraint = new And(
         new LessThanOrEqual(new RealResource("/peel"), new RealValue(3.0)),
         new LessThanOrEqual(new RealResource("/fruit"), new RealValue(2.9))
     );

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
@@ -2,7 +2,7 @@ package gov.nasa.jpl.aerie.scheduler;
 
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
-import gov.nasa.jpl.aerie.constraints.tree.All;
+import gov.nasa.jpl.aerie.constraints.tree.And;
 import gov.nasa.jpl.aerie.constraints.tree.Expression;
 import gov.nasa.jpl.aerie.constraints.tree.GreaterThanOrEqual;
 import gov.nasa.jpl.aerie.constraints.tree.RealResource;
@@ -1266,7 +1266,7 @@ public class TestApplyWhen {
 
 
     // "Make an expression that depends on a resource (the resource here is mission.activitiesExecuted).
-    Expression<Windows> gte = new All(
+    Expression<Windows> gte = new And(
         new LinkedList<>(Arrays.asList(
             new GreaterThanOrEqual(
                 new RealResource("/activitiesExecuted"),

--- a/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestFilters.java
+++ b/scheduler/src/test/java/gov/nasa/jpl/aerie/scheduler/TestFilters.java
@@ -5,7 +5,7 @@ import gov.nasa.jpl.aerie.constraints.model.DiscreteProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
-import gov.nasa.jpl.aerie.constraints.tree.All;
+import gov.nasa.jpl.aerie.constraints.tree.And;
 import gov.nasa.jpl.aerie.constraints.tree.DiscreteResource;
 import gov.nasa.jpl.aerie.constraints.tree.DiscreteValue;
 import gov.nasa.jpl.aerie.constraints.tree.Equal;
@@ -18,7 +18,6 @@ import gov.nasa.jpl.aerie.scheduler.constraints.filters.Filters;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -45,7 +44,7 @@ public class TestFilters {
     );
 
     final var ste = new Equal<>(new DiscreteResource("smallState1"), new DiscreteValue(SerializedValue.of(true)));
-    final var ste2 = new All(
+    final var ste2 = new And(
         new Equal<>(new DiscreteResource("smallState1"), new DiscreteValue(SerializedValue.of(true))),
         new Equal<>(new DiscreteResource("smallState2"), new DiscreteValue(SerializedValue.of(true)))
     );


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2183
* **Review:** By file  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

**Changelog entry:** Rename `Windows.Any` to `Windows.Or`, `Windows.All` to `Windows.And`, and `windows.invert` to `windows.not` in Constraints eDSL

## Description
- The main change is to revert my change to the constraints eDSL 4 months ago: renaming All -> And, Any -> Or, Invert -> Not. This is because with the introduction of gaps, I think the most helpful mental model is that of a boolean profile. So we should have boolean suggestive names. (I forget who disagreed with me four months ago, but you were right :).
- I also created new methods in the DSL that delegate to the static And/Or functions. i.e. `left.and(right) -> Windows.And(left, right)`

## Verification
The new methods have a test in the CompilationServiceTests.

## Documentation
I brought all of the DSL doc-comments up to date, and added a few extra.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
