### PR TITLE
Wrap simulation results writing in TransactionContext

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -614,8 +614,10 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
 
     @Override
     public void succeedWith(final SimulationResults results) {
-      try (final var connection = dataSource.getConnection()) {
+      try (final var connection = dataSource.getConnection();
+           final var transactionContext = new TransactionContext(connection)) {
         postSimulationResults(connection, datasetId, results);
+        transactionContext.commit();
       } catch (final SQLException ex) {
         throw new DatabaseException("Failed to store simulation results", ex);
       } catch (final NoSuchSimulationDatasetException ex) {


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

The default setting of a connection is with auto-commit enabled. This implicitly wraps every statement in a transaction, which induces a fair amount of overhead. By using a TransactionContext, we delay committing until we have finished our bulk insert.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

I modified Foo mission model in the following ways:
- Added a configuration parameter called "samplePeriod" of type Duration
- Modified the spawn at the end of the Mission model constructor to produce a lot of profile segments

```diff
spawn(() -> { // Register a never-ending daemon task
  while (true) {
-    ModelActions.delay(Duration.SECOND);
+    ModelActions.delay(config.samplePeriod);
+    this.simpleData.a.activate();
+    ModelActions.delay(config.samplePeriod);
+    this.simpleData.a.deactivate();
  }
});
```

I also added a timer around `writer.succeedWith` in the SynchronousSimulationAgent:

```diff
+final var startTime = System.nanoTime();
writer.succeedWith(results);
+System.out.println("Writing results to database took " + ((System.nanoTime() - startTime) / 1000000000.0) + " seconds.");
```

I uploaded the modified foo mission model to aerie, and ran the merlin worker with just the above `println` change.

#### With a week long plan, and a sample rate of 30 seconds (resulting in 60K total profile segments):

> Writing results to database took 32.3762787 seconds.

I then modified the merlin worker to include the change in this PR (with the `TransactionContext`), and re-ran the same simulation:

> Writing results to database took 17.213512793 seconds.

#### With a week long plan, and a sample rate of 15 seconds (resulting in 120K total profile segments):

Before:

> Writing results to database took 65.673432815 seconds.

After:

> Writing results to database took 31.675715796 seconds.

So there seems to be a fairly consistent speedup of a factor of 2.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

No user-facing documentation is affected by this change.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Proper performance testing, parallel database writes, TimescaleDB plugin
