### PR TITLE
[AERIE-2155] Use version for publishing only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,15 @@ configure(subprojects.findAll { it.projectDir.toPath().resolve('sql').toFile().e
   archiveDeployment.dependsOn distributeSql
 }
 
+project.ext.versionForPublishing = {
+  if (findProperty("version.isRelease").toBoolean()) {
+    return "${findProperty("version.number")}"
+  } else {
+    def hash = 'git rev-parse --short HEAD'.execute().text.trim()
+    return "${findProperty("version.number")}-SNAPSHOT-$hash"
+  }
+}()
+
 subprojects {
   apply plugin: 'com.github.ben-manes.versions'
 
@@ -59,15 +68,6 @@ subprojects {
   }
 
   group = 'gov.nasa.jpl.aerie'
-
-  version = {
-    if (findProperty("version.isRelease").toBoolean()) {
-      return "${findProperty("version.number")}"
-    } else {
-      def hash = 'git rev-parse --short HEAD'.execute().text.trim()
-      return "${findProperty("version.number")}-SNAPSHOT-$hash"
-    }
-  }()
 
   tasks.withType(JavaCompile) {
     options.compilerArgs << '-Xlint:deprecation' << '-Xlint:unchecked'

--- a/contrib/build.gradle
+++ b/contrib/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
+      version = rootProject.ext.versionForPublishing
       from components.java
     }
   }

--- a/examples/banananation/build.gradle
+++ b/examples/banananation/build.gradle
@@ -42,6 +42,7 @@ javadoc.options.tags = [ "contact", "subsystem" ]
 publishing {
   publications {
     library(MavenPublication) {
+      version = rootProject.ext.versionForPublishing
       from components.java
     }
   }

--- a/merlin-driver/build.gradle
+++ b/merlin-driver/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
+      version = rootProject.ext.versionForPublishing
       from components.java
     }
   }

--- a/merlin-framework-junit/build.gradle
+++ b/merlin-framework-junit/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
+      version = rootProject.ext.versionForPublishing
       from components.java
     }
   }

--- a/merlin-framework-processor/build.gradle
+++ b/merlin-framework-processor/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
+      version = rootProject.ext.versionForPublishing
       from components.java
     }
   }

--- a/merlin-framework/build.gradle
+++ b/merlin-framework/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
+      version = rootProject.ext.versionForPublishing
       from components.java
     }
   }

--- a/merlin-sdk/build.gradle
+++ b/merlin-sdk/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
+      version = rootProject.ext.versionForPublishing
       from components.java
     }
   }

--- a/parsing-utilities/build.gradle
+++ b/parsing-utilities/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
+      version = rootProject.ext.versionForPublishing
       from components.java
     }
   }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2155
* **Review:** By file  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
### Background
When we merge into develop, we run a publish workflow to make our jar files and Docker images available. (Primarily for use when developing aerie-ui, as far as I know). An issue that we ran into (AERIE-1716) was that merges into develop did not necessarily change the version of the published artifacts, causing us to try to re-publish artifacts with the same version, which would fail. In #62 we started appending the git commit hash as a suffix to our published artifacts to avoid re-publishing artifacts with the same version. #84 limited that behavior to only append the hash to `develop` merges, and to use a `version.number` property for releases.

One problem introduced by #62 is that all of our application `.tar` files (e.g. `merlin-server/build/distributions/*.tar`) would now be produced with a commit suffix. This violated an assumption we made in our `Dockerfile`s - that there must be only one tar file in the distributions directory:

https://github.com/NASA-AMMOS/aerie/blob/d620b8e9886d69461f246808f7431bb3eb7d0c15/merlin-server/Dockerfile#L3

This proliferation of commit-suffixed tar files cause Docker to choose one of the tar files based on the alphabetic order of the commit hashes. (The `COPY` command above would copy all the tar files, but each would overwrite the previous one, so the last one alphabetically would win).

This meant that simply running `./gradlew assemble` followed by `docker-compose build` was not guaranteed to give you the latest version of your code. Our trust in our build system eroded, and it became standard practice to remove the build directory before running `./gradlew assemble`, which erases gradle's ability to do incremental builds, one of its [biggest selling points](https://gradle.org/features/#performance).

### Changes in this PR
This PR uses the `version` property of the `MavenPublication` to append the version suffix, instead of the `project.version` property. This means that the hash will be used for publication, but not for anything else.

I would appreciate confirmation from people more familiar with our publish workflow that this will indeed accomplish what we want.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

I ran ` ./gradlew :merlin-framework:generatePomFileForLibraryPublication` and examined `merlin-framework/build/publications/library/pom-default.xml` to see that the `SNAPSHOT-hash` suffix is still being added correctly:

<details>
<summary>pom.xml contents</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <!-- This module was also published with a richer model, Gradle metadata,  -->
  <!-- which should be used instead. Do not delete the following line which  -->
  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
  <!-- that they should prefer consuming it instead. -->
  <!-- do_not_remove: published-with-gradle-metadata -->
  <modelVersion>4.0.0</modelVersion>
  <groupId>gov.nasa.jpl.aerie</groupId>
  <artifactId>merlin-framework</artifactId>
  <version>0.13.2-SNAPSHOT-f9eee58a6</version>
  <dependencies>
    <dependency>
      <groupId>gov.nasa.jpl.aerie</groupId>
      <artifactId>merlin-sdk</artifactId>
      <version>0.13.2-SNAPSHOT-f9eee58a6</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.apache.commons</groupId>
      <artifactId>commons-lang3</artifactId>
      <version>3.12.0</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
</project>
```
</details>

I then ran `./gradlew :merlin-server:assemble` and checked that the `distributions` directory contains only an untagged `tar` file:

```
$ ls merlin-server/build/distributions      
merlin-server.tar merlin-server.zip
```

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No documentation was invalidated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
No future work.