### PR TITLE
[FIX] Use property for publishing version string

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,14 +49,15 @@ configure(subprojects.findAll { it.projectDir.toPath().resolve('sql').toFile().e
   archiveDeployment.dependsOn distributeSql
 }
 
-project.ext.versionForPublishing = {
+// Set publishing version property globally for this project
+setProperty('publishing.version', {
   if (findProperty("version.isRelease").toBoolean()) {
     return "${findProperty("version.number")}"
   } else {
     def hash = 'git rev-parse --short HEAD'.execute().text.trim()
     return "${findProperty("version.number")}-SNAPSHOT-$hash"
   }
-}()
+}())
 
 subprojects {
   apply plugin: 'com.github.ben-manes.versions'

--- a/contrib/build.gradle
+++ b/contrib/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
-      version = rootProject.ext.versionForPublishing
+      version = findProperty('publishing.version')
       from components.java
     }
   }

--- a/examples/banananation/build.gradle
+++ b/examples/banananation/build.gradle
@@ -42,7 +42,7 @@ javadoc.options.tags = [ "contact", "subsystem" ]
 publishing {
   publications {
     library(MavenPublication) {
-      version = rootProject.ext.versionForPublishing
+      version = findProperty('publishing.version')
       from components.java
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,14 @@ publishing.url=https://maven.pkg.github.com/nasa-ammos/aerie
 publishing.usernameEnvironmentVariable=GITHUB_ACTOR
 publishing.passwordEnvironmentVariable=GITHUB_TOKEN
 
+# Left empty, is lazily set when building
+publishing.version=
+
 # Override for releases
 
 # Change the version number here
 version.number=0.13.2
+
 # If you are publishing a release *manually* (i.e. not through github actions),
 # override this on the command line with `./gradlew publish -Pversion.isRelease=true`.
-version.isRelease=false // override this on the command line
+version.isRelease=false

--- a/merlin-driver/build.gradle
+++ b/merlin-driver/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
-      version = rootProject.ext.versionForPublishing
+      version = findProperty('publishing.version')
       from components.java
     }
   }

--- a/merlin-framework-junit/build.gradle
+++ b/merlin-framework-junit/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
-      version = rootProject.ext.versionForPublishing
+      version = findProperty('publishing.version')
       from components.java
     }
   }

--- a/merlin-framework-processor/build.gradle
+++ b/merlin-framework-processor/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
-      version = rootProject.ext.versionForPublishing
+      version = findProperty('publishing.version')
       from components.java
     }
   }

--- a/merlin-framework/build.gradle
+++ b/merlin-framework/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
-      version = rootProject.ext.versionForPublishing
+      version = findProperty('publishing.version')
       from components.java
     }
   }

--- a/merlin-sdk/build.gradle
+++ b/merlin-sdk/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
-      version = rootProject.ext.versionForPublishing
+      version = findProperty('publishing.version')
       from components.java
     }
   }

--- a/parsing-utilities/build.gradle
+++ b/parsing-utilities/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 publishing {
   publications {
     library(MavenPublication) {
-      version = rootProject.ext.versionForPublishing
+      version = findProperty('publishing.version')
       from components.java
     }
   }


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

The previous solution using `rootProject.ext.versionForPublishing` failed when building Aerie locally from a separate Gradle project, likely due to `rootProject` taking on a different value/meaning in that context.

Using a global property here we're able to specify the publishing version in the top-level build and guarantee that any uses of it are localized to subprojects of our top-level build.

## Verification
- Aerie is compiling and passing tests.
- Running `gradle assemble -PuseLocalAerie=true -PlocalAeriePath=../../aerie` from a cloned `aerie-simple-mission-model` compiles the mission model without issues.

## Documentation
None.

## Future work

We'll want to apply this patch to the https://github.jpl.nasa.gov/Aerie/aerie-simple-mission-model repo.:
```diff
diff --git a/build.gradle b/build.gradle
index f47411b..3695094 100644
--- a/build.gradle
+++ b/build.gradle
@@ -27,19 +27,19 @@ jar {
 }

 dependencies {
-//  if (useLocalAerie == "true") {
-//    compileOnly project(':contrib')
-//    compileOnly project(':merlin-framework')
-//    implementation project(':parsing-utilities')
-//    annotationProcessor project(':merlin-framework-processor')
-//
-//    testImplementation project(':contrib')
-//    testImplementation project(':merlin-framework')
-//    testImplementation project(':merlin-sdk')
-//    testImplementation project(':merlin-driver')
-//    testImplementation project(':merlin-framework-junit')
-//  }
-//  else {
+  if (useLocalAerie == "true") {
+    compileOnly project(':contrib')
+    compileOnly project(':merlin-framework')
+    implementation project(':parsing-utilities')
+    annotationProcessor project(':merlin-framework-processor')
+
+    testImplementation project(':contrib')
+    testImplementation project(':merlin-framework')
+    testImplementation project(':merlin-sdk')
+    testImplementation project(':merlin-driver')
+    testImplementation project(':merlin-framework-junit')
+  }
+  else {
     implementation 'gov.nasa.jpl.aerie:contrib:0.13.0-SNAPSHOT-bad4548'
     implementation 'gov.nasa.jpl.aerie:merlin-framework:0.13.0-SNAPSHOT-bad4548'
     implementation 'gov.nasa.jpl.aerie:parsing-utilities:0.13.0-SNAPSHOT-bad4548'
@@ -50,8 +50,7 @@ dependencies {
     testImplementation 'gov.nasa.jpl.aerie:merlin-framework-junit:0.13.0-SNAPSHOT-bad4548'

     implementation 'gov.nasa.jpl.aerie:merlin-sdk:0.13.0-SNAPSHOT-bad4548'
-
-//  }
+  }
```