### PR TITLE
[AERIE-2205] Rename condition table to "constraint"

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_constraint.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_constraint.yaml
@@ -1,3 +1,3 @@
 table:
-  name: condition
+  name: constraint
   schema: public

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_mission_model.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_mission_model.yaml
@@ -20,12 +20,12 @@ array_relationships:
       table:
         name: activity_type
         schema: public
-- name: conditions
+- name: constraints
   using:
     foreign_key_constraint_on:
       column: model_id
       table:
-        name: condition
+        name: constraint
         schema: public
 - name: plans
   using:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan.yaml
@@ -22,12 +22,12 @@ array_relationships:
       table:
         name: activity_directive
         schema: public
-- name: conditions
+- name: constraints
   using:
     foreign_key_constraint_on:
       column: plan_id
       table:
-        name: condition
+        name: constraint
         schema: public
 - name: datasets
   using:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
@@ -2,7 +2,7 @@
 - "!include public_activity_directive_validations.yaml"
 - "!include public_activity_type.yaml"
 - "!include public_activity_directive_metadata_schema.yaml"
-- "!include public_condition.yaml"
+- "!include public_constraint.yaml"
 - "!include public_dataset.yaml"
 - "!include public_mission_model.yaml"
 - "!include public_mission_model_parameters.yaml"

--- a/e2e-tests/src/utilities/gql.ts
+++ b/e2e-tests/src/utilities/gql.ts
@@ -142,7 +142,7 @@ const gql = {
           startOffset: start_offset
           type
         }
-        constraints: conditions {
+        constraints {
           definition
           description
           id
@@ -158,7 +158,7 @@ const gql = {
             name
             parameters
           }
-          constraints: conditions {
+          constraints {
             definition
             description
             id

--- a/merlin-server/sql/merlin/init.sql
+++ b/merlin-server/sql/merlin/init.sql
@@ -30,7 +30,7 @@ begin;
   \ir tables/event.sql
 
   -- Analysis intents
-  \ir tables/condition.sql
+  \ir tables/constraint.sql
   \ir tables/profile_request.sql
 
   \ir tables/mission_model_parameters.sql

--- a/merlin-server/sql/merlin/tables/constraint.sql
+++ b/merlin-server/sql/merlin/tables/constraint.sql
@@ -1,4 +1,4 @@
-create table condition (
+create table "constraint" (
   id integer generated always as identity,
 
   name text not null,
@@ -9,19 +9,19 @@ create table condition (
   plan_id integer null,
   model_id integer null,
 
-  constraint condition_synthetic_key
+  constraint constraint_synthetic_key
     primary key (id),
-  constraint condition_scoped_to_plan
+  constraint constraint_scoped_to_plan
     foreign key (plan_id)
     references plan
     on update cascade
     on delete cascade,
-  constraint condition_scoped_to_model
+  constraint constraint_scoped_to_model
     foreign key (model_id)
     references mission_model
     on update cascade
     on delete cascade,
-  constraint condition_has_one_scope
+  constraint constraint_has_one_scope
     check (
       -- Model-scoped
       (plan_id is null     and model_id is not null) or
@@ -30,20 +30,20 @@ create table condition (
     )
 );
 
-comment on table condition is e''
+comment on table "constraint" is e''
   'A constraint associated with an individual plan.';
 
-comment on column condition.id is e''
+comment on column "constraint".id is e''
   'The synthetic identifier for this constraint.';
-comment on column condition.name is e''
+comment on column "constraint".name is e''
   'A human-meaningful name.';
-comment on column condition.summary is e''
+comment on column "constraint".summary is e''
   'A short summary suitable for use in a tooltip or compact list.';
-comment on column condition.description is e''
+comment on column "constraint".description is e''
   'A detailed description suitable for long-form documentation.';
-comment on column condition.definition is e''
+comment on column "constraint".definition is e''
   'An executable expression in the Merlin constraint language.';
-comment on column condition.plan_id is e''
+comment on column "constraint".plan_id is e''
   'The ID of the plan owning this constraint, if plan-scoped.';
-comment on column condition.model_id is e''
+comment on column "constraint".model_id is e''
   'The ID of the mission model owning this constraint, if model-scoped.';

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetModelConstraintsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetModelConstraintsAction.java
@@ -17,7 +17,7 @@ import java.util.Optional;
   private static final @Language("SQL") String sql = """
     select c.id, c.name, c.summary, c.description, c.definition
     from mission_model AS m
-    left join condition AS c
+    left join "constraint" AS c
       on m.id = c.model_id
     where m.id = ?
     """;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanConstraintsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanConstraintsAction.java
@@ -17,7 +17,7 @@ import java.util.Optional;
   private static final @Language("SQL") String sql = """
     select c.id, c.name, c.summary, c.description, c.definition
     from plan AS p
-    left join condition AS c
+    left join "constraint" AS c
       on p.id = c.plan_id
     where p.id = ?
     """;


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2205
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

**Changelog entry:** Rename condition table to constraint. GraphQL queries that interact with the `condition` table will need to be refactored.

## Description
The constraints in the database are still stored in a table named `condition`, which is a relic name from the ancient past (probably like the cretaceous, I donno). Now with scheduling conditions, this is extra confusing. So I changed the table name to `"constraint"`. Unfortunately `constraint` is a keyword, so we have to put quotes around it, but other than that this is much less confusing.

## Verification
I manually created and ran a constraint in the UI just for sanity.

## Documentation
This allows the graphql documentation to call constraints by what they actually are :)

## Future work
I'm opening a sister PR in the UI ([here](https://github.com/NASA-AMMOS/aerie-ui/pull/212))
