### PR TITLE
[REFACTOR] Avoid computing samples eagerly in SimulationResults

### DIFF
--- a/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/Main.java
+++ b/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/Main.java
@@ -1,7 +1,6 @@
 package gov.nasa.jpl.aerie.banananation;
 
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
-import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -39,6 +38,7 @@ public final class Main {
 
     final var simulationResults = SimulationUtility.simulate(schedule, simulationDuration);
 
-    System.out.println(SimulationResults.resourceSamples(simulationResults));
+    System.out.println(simulationResults.discreteProfiles);
+    System.out.println(simulationResults.realProfiles);
   }
 }

--- a/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/Main.java
+++ b/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/Main.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.banananation;
 
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -38,6 +39,6 @@ public final class Main {
 
     final var simulationResults = SimulationUtility.simulate(schedule, simulationDuration);
 
-    System.out.println(simulationResults.resourceSamples);
+    System.out.println(SimulationResults.resourceSamples(simulationResults));
   }
 }

--- a/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/SimulateMapSchedule.java
+++ b/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/SimulateMapSchedule.java
@@ -7,7 +7,6 @@ import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationDriver;
-import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.driver.json.JsonEncoding;
 import gov.nasa.jpl.aerie.merlin.framework.RootModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -51,9 +50,14 @@ public class SimulateMapSchedule {
           startTime,
           simulationDuration);
 
-      SimulationResults.resourceSamples(simulationResults).forEach((name, samples) -> {
+      simulationResults.realProfiles.forEach((name, samples) -> {
         System.out.println(name + ":");
-        samples.forEach(point -> System.out.format("\t%s\t%s\n", point.getKey(), point.getValue()));
+        samples.getRight().forEach(point -> System.out.format("\t%s\t%s\n", point.getKey(), point.getValue()));
+      });
+
+      simulationResults.discreteProfiles.forEach((name, samples) -> {
+        System.out.println(name + ":");
+        samples.getRight().forEach(point -> System.out.format("\t%s\t%s\n", point.getKey(), point.getValue()));
       });
 
       simulationResults.simulatedActivities.forEach((name, activity) -> {

--- a/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/SimulateMapSchedule.java
+++ b/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/SimulateMapSchedule.java
@@ -7,6 +7,7 @@ import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationDriver;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.driver.json.JsonEncoding;
 import gov.nasa.jpl.aerie.merlin.framework.RootModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -50,7 +51,7 @@ public class SimulateMapSchedule {
           startTime,
           simulationDuration);
 
-      simulationResults.resourceSamples.forEach((name, samples) -> {
+      SimulationResults.resourceSamples(simulationResults).forEach((name, samples) -> {
         System.out.println(name + ":");
         samples.forEach(point -> System.out.format("\t%s\t%s\n", point.getKey(), point.getValue()));
       });

--- a/examples/foo-missionmodel/src/test/resources/gov/nasa/jpl/aerie/foomissionmodel/plan.json
+++ b/examples/foo-missionmodel/src/test/resources/gov/nasa/jpl/aerie/foomissionmodel/plan.json
@@ -2,24 +2,29 @@
     "type": "foo",
     "arguments":
       { "x": 1,
-        "y": "test_1" } },
+        "y": "test_1",
+        "z": 4 } },
   { "defer": 50000,
     "type": "foo",
     "arguments":
       { "x": 2,
-        "y": "spawn" } },
+        "y": "spawn",
+        "z": 4 } },
   { "defer": 50000,
     "type": "foo",
     "arguments":
       { "x": 2,
-        "y": "test" } },
+        "y": "test",
+        "z": 4 } },
   { "defer": 100000,
     "type": "foo",
     "arguments":
       { "x": 2,
-        "y": "test_2" } },
+        "y": "test_2",
+        "z": 4 } },
   { "defer": 150000,
     "type": "foo",
     "arguments":
       { "x": 3,
-        "y": "test_3" } } ]
+        "y": "test_3",
+        "z": 4 } } ]

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationResults.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationResults.java
@@ -19,7 +19,6 @@ public final class SimulationResults {
   public final Instant startTime;
   public final Map<String, Pair<ValueSchema, List<Pair<Duration, RealDynamics>>>> realProfiles;
   public final Map<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>> discreteProfiles;
-  public final Map<String, List<Pair<Duration, SerializedValue>>> resourceSamples;
   public final Map<ActivityInstanceId, SimulatedActivity> simulatedActivities;
   public final Map<ActivityInstanceId, UnfinishedActivity> unfinishedActivities;
   public final List<Triple<Integer, String, ValueSchema>> topics;
@@ -38,10 +37,13 @@ public final class SimulationResults {
     this.realProfiles = realProfiles;
     this.discreteProfiles = discreteProfiles;
     this.topics = topics;
-    this.resourceSamples = takeSamples(realProfiles, discreteProfiles);
     this.simulatedActivities = simulatedActivities;
     this.unfinishedActivities = unfinishedActivities;
     this.events = events;
+  }
+
+  public static Map<String, List<Pair<Duration, SerializedValue>>> resourceSamples(final SimulationResults results) {
+      return takeSamples(results.realProfiles, results.discreteProfiles);
   }
 
   private static Map<String, List<Pair<Duration, SerializedValue>>>

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationResults.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationResults.java
@@ -9,8 +9,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -40,55 +38,6 @@ public final class SimulationResults {
     this.simulatedActivities = simulatedActivities;
     this.unfinishedActivities = unfinishedActivities;
     this.events = events;
-  }
-
-  public static Map<String, List<Pair<Duration, SerializedValue>>> resourceSamples(final SimulationResults results) {
-      return takeSamples(results.realProfiles, results.discreteProfiles);
-  }
-
-  private static Map<String, List<Pair<Duration, SerializedValue>>>
-  takeSamples(
-      final Map<String, Pair<ValueSchema, List<Pair<Duration, RealDynamics>>>> realProfiles,
-      final Map<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>> discreteProfiles)
-  {
-    final var samples = new HashMap<String, List<Pair<Duration, SerializedValue>>>();
-
-    realProfiles.forEach((name, p) -> {
-      var elapsed = Duration.ZERO;
-      var profile = p.getRight();
-
-      final var timeline = new ArrayList<Pair<Duration, SerializedValue>>();
-      for (final var piece : profile) {
-        final var extent = piece.getLeft();
-        final var dynamics = piece.getRight();
-
-        timeline.add(Pair.of(elapsed, SerializedValue.of(
-            dynamics.initial)));
-        elapsed = elapsed.plus(extent);
-        timeline.add(Pair.of(elapsed, SerializedValue.of(
-            dynamics.initial + dynamics.rate * extent.ratioOver(Duration.SECONDS))));
-      }
-
-      samples.put(name, timeline);
-    });
-    discreteProfiles.forEach((name, p) -> {
-      var elapsed = Duration.ZERO;
-      var profile = p.getRight();
-
-      final var timeline = new ArrayList<Pair<Duration, SerializedValue>>();
-      for (final var piece : profile) {
-        final var extent = piece.getLeft();
-        final var value = piece.getRight();
-
-        timeline.add(Pair.of(elapsed, value));
-        elapsed = elapsed.plus(extent);
-        timeline.add(Pair.of(elapsed, value));
-      }
-
-      samples.put(name, timeline);
-    });
-
-    return samples;
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -3,14 +3,13 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 import gov.nasa.jpl.aerie.constraints.InputMismatchException;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
-import gov.nasa.jpl.aerie.constraints.model.DiscreteProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
-import gov.nasa.jpl.aerie.constraints.model.LinearProfilePiece;
 import gov.nasa.jpl.aerie.constraints.model.Violation;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.tree.Expression;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationFailure;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
@@ -78,7 +77,7 @@ public final class GetSimulationResultsAction {
     final var revisionData = this.planService.getPlanRevisionData(planId);
     return this.simulationService
         .get(planId, revisionData)
-        .map(r -> r.resourceSamples)
+        .map(SimulationResults::resourceSamples)
         .orElseGet(Collections::emptyMap);
   }
 


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR removes `resourceSamples` as a field on `SimulationResults`. Prior to this PR, this field was derived from `realProfiles` and `discreteProfiles` via the `takeSamples` method - upon calling the `SimulationResults` constructor, `takeSamples` would be called eagerly.

In typical usage, `resourceSamples` is unused - the simulation results are written to the database using the `realProfiles` and `discreteProfiles` directly. The only time it is used (outside of testing) is via the explicit `resourceSamples` hasura action.

This PR moves computation of resource samples out of the `SimulationResults` constructor, so that they can be computed when requested, but not by default.

I have not done any performance measurements to see whether or not this change is significant - nevertheless, I believe avoiding needless computations is generally a good thing.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I spun up a local Aerie deployment and checked that running simulations and viewing their results worked, and I also called the `resourceSamples` endpoint directly.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No functional behavior has changed, so no documentation needs to be updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
No future work