### PR TITLE
[FIX] Load scheduling DSL TypeScript libraries in `scheduler-server`

### DIFF
--- a/e2e-tests/src/tests/scheduler.test.ts
+++ b/e2e-tests/src/tests/scheduler.test.ts
@@ -32,6 +32,11 @@ test.describe('Scheduling', () => {
     await delay(2000);
   });
 
+  test('Get scheduling DSL TypeScript', async ({ request }) => {
+    const schedulingDslTypes = await req.getSchedulingDslTypeScript(request, mission_model_id);
+    expect(schedulingDslTypes.typescriptFiles.length).toEqual(7);
+  });
+
   test('Create Plan', async ({ request }) => {
     const plan_input : CreatePlanInput = {
       model_id : mission_model_id,

--- a/e2e-tests/src/types/scheduling-goal.d.ts
+++ b/e2e-tests/src/types/scheduling-goal.d.ts
@@ -1,8 +1,13 @@
 type SchedulingDslTypesResponse = {
   reason: string;
   status: 'failure' | 'success';
-  typescript: string;
+  typescriptFiles: TypescriptFile[];
 };
+
+type TypescriptFile = {
+  filePath: string;
+  content: string;
+}
 
 type SchedulingGoal = {
   analyses: SchedulingGoalAnalysis[];

--- a/e2e-tests/src/utilities/gql.ts
+++ b/e2e-tests/src/utilities/gql.ts
@@ -102,6 +102,19 @@ const gql = {
     }
   `,
 
+  GET_SCHEDULING_DSL_TYPESCRIPT: `#graphql
+    query GetSchedulingDslTypeScript($missionModelId: Int!) {
+      schedulingDslTypescript(missionModelId: $missionModelId) {
+        reason
+        status
+        typescriptFiles {
+          filePath
+          content
+        }
+      }
+    }
+  `,
+
   DELETE_PLAN: `#graphql
     mutation DeletePlan($id: Int!) {
       deletePlan: delete_plan_by_pk(id: $id) {

--- a/e2e-tests/src/utilities/requests.ts
+++ b/e2e-tests/src/utilities/requests.ts
@@ -172,6 +172,12 @@ const req = {
     return specification_id;
   },
 
+  async getSchedulingDslTypeScript(request: APIRequestContext, missionModelId: number): Promise<SchedulingDslTypesResponse> {
+    const data = await req.hasura(request, gql.GET_SCHEDULING_DSL_TYPESCRIPT, { missionModelId: missionModelId });
+    const { schedulingDslTypescript } = data;
+    return schedulingDslTypescript;
+  },
+
   async deletePlan(request: APIRequestContext, id: number){
     const data = await req.hasura(request, gql.DELETE_PLAN, { id: id })
     const { deletePlan } = data;

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -1,8 +1,9 @@
+import java.nio.file.Path
+
 plugins {
   id 'java'
   id 'java-test-fixtures'
   id 'application'
-  id 'com.github.node-gradle.node' version '3.5.0'
 }
 
 java {
@@ -40,6 +41,11 @@ dependencies {
   testImplementation 'org.glassfish:javax.json:1.1.4'
 
   testFixturesImplementation project(':merlin-driver')
+}
+
+processResources {
+  // Copy in scheduling DSL compiler static libraries when processing resources
+  from project(':scheduler-worker').projectDir.toPath().resolve(Path.of('scheduling-dsl-compiler', 'src', 'libs'))
 }
 
 test {

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/GenerateSchedulingLibActionTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/GenerateSchedulingLibActionTest.java
@@ -1,0 +1,22 @@
+package gov.nasa.jpl.aerie.scheduler.server.services;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class GenerateSchedulingLibActionTest {
+
+  @Test
+  void testTypescriptResourcesLoaded() {
+    assertTypescriptResourceLoaded("scheduler-edsl-fluent-api.ts");
+    assertTypescriptResourceLoaded("scheduler-ast.ts");
+    assertTypescriptResourceLoaded("constraints-edsl-fluent-api.ts");
+    assertTypescriptResourceLoaded("constraints-ast.ts");
+    assertTypescriptResourceLoaded("TemporalPolyfillTypes.ts");
+  }
+
+  private static void assertTypescriptResourceLoaded(final String basename) {
+    final var res = GenerateSchedulingLibAction.getTypescriptResource(basename);
+    assertThat(res.basename()).isEqualTo(basename);
+    assertThat(res.source()).isNotEmpty();
+  }
+}


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Since splitting `scheduler-server` into `scheduler-worker` – and thereby relocating the scheduling DSL Node project – the scheduler server has not had access to static DSL libraries. This PR loads scheduling DSL TypeScript libraries from the scheduler server JAR instead of requiring Docker to be configured to copy in the directory and set an environment variable.

## Verification
- [x] Unit test added to test loading `.ts` files from the `scheduler-server` JAR.
- [x] Manually tested end-to-end.
- [x] Automated end-to-end tests.

## Documentation
None.

## Future work
None.