### PR TITLE
[HOTFIX] Use the constraints DSL from the constraints folder

### DIFF
--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 }
 
 processResources {
+  dependsOn ":scheduler-worker:copyConstraintsTypescript"
   // Copy in scheduling DSL compiler static libraries when processing resources
   from project(':scheduler-worker').projectDir.toPath().resolve(Path.of('scheduling-dsl-compiler', 'src', 'libs'))
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GenerateSchedulingLibAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GenerateSchedulingLibAction.java
@@ -34,8 +34,8 @@ public record GenerateSchedulingLibAction(
     try {
       final var schedulingDsl         = getTypescriptResource("scheduler-edsl-fluent-api.ts");
       final var schedulerAst          = getTypescriptResource("scheduler-ast.ts");
-      final var windowsDsl            = getTypescriptResource("constraints-edsl-fluent-api.ts");
-      final var windowsAst            = getTypescriptResource("constraints-ast.ts");
+      final var windowsDsl            = getTypescriptResource("constraints/constraints-edsl-fluent-api.ts");
+      final var windowsAst            = getTypescriptResource("constraints/constraints-ast.ts");
       final var temporalPolyfillTypes = getTypescriptResource("TemporalPolyfillTypes.ts");
 
       final var missionModelTypes = missionModelService.getMissionModelTypes(missionModelId);


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Problem: The scheduling goal editor in the UI does not have the constraints language loaded correctly:
<img width="477" alt="Screen Shot 2022-11-08 at 6 28 00 AM" src="https://user-images.githubusercontent.com/1189602/200590802-407cb3b5-1a38-4444-a528-373cb28942a0.png">

The files in the libs/constraints folder are copied from the constraints-edsl-compiler. The similarly named files at the top level are stubs to make the typescript compiler happy during development.

In #424 we added a `processResources` step to the scheduler-server that brings in the scheduling edsl libs files. This PR fills in two gaps there:
- Refer to the files in the `constraints` folder: `constraints/constraints-edsl-fluent-api.ts` and `constraints/constraints-ast.ts` rather than their top-level stubs
- Add a dependency on the scheduler-worker's `copyConstraintsTypescript` task to make sure we're getting the correct files.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I ran `./gradlew :scheduler-server:processResources` and manually inspected the build directory. I also brought up a local aerie deployment and made sure that I got suggestions for `equalTo` and other profile operations.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
This is a bugfix - the existing documentation assumes this bug doesn't exist 😅 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
No future work