### PR TITLE
[AERIE-2198] Assign Gaps

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
@@ -17,6 +17,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import java.util.List;
 
 import static gov.nasa.jpl.aerie.constraints.json.SerializedValueJsonParser.serializedValueP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.boolP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.chooseP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.doubleP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.enumP;
@@ -188,6 +189,15 @@ public final class ConstraintParsers {
           . map(
               microseconds -> Duration.of(microseconds, Duration.MICROSECONDS),
               duration -> duration.in(Duration.MICROSECONDS));
+
+  static final JsonParser<WindowsValue> windowsValueP =
+      productP
+          .field("kind", literalP("WindowsValueExpression"))
+          .field("value", boolP)
+          .map(
+              untuple((kind, value) -> new WindowsValue(value)),
+              $ -> tuple(Unit.UNIT, $.value())
+          );
 
   static JsonParser<ShiftBy> shiftByF(JsonParser<Expression<Windows>> windowsExpressionP) {
     return productP
@@ -383,6 +393,7 @@ public final class ConstraintParsers {
 
   private static JsonParser<Expression<Windows>> windowsExpressionF(JsonParser<Expression<Spans>> spansP) {
     return recursiveP(selfP -> chooseP(
+        windowsValueP,
         startOfP,
         endOfP,
         changesP,

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
@@ -192,7 +192,7 @@ public final class ConstraintParsers {
 
   static final JsonParser<WindowsValue> windowsValueP =
       productP
-          .field("kind", literalP("WindowsValueExpression"))
+          .field("kind", literalP("WindowsExpressionValue"))
           .field("value", boolP)
           .map(
               untuple((kind, value) -> new WindowsValue(value)),

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfile.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfile.java
@@ -106,6 +106,17 @@ public final class DiscreteProfile implements Profile<DiscreteProfile>, Iterable
     return new Windows(result.build());
   }
 
+  /** Assigns a default value to all gaps in the profile. */
+  @Override
+  public DiscreteProfile assignGaps(final DiscreteProfile def) {
+    return new DiscreteProfile(
+        IntervalMap.map2(
+            this.profilePieces, def.profilePieces,
+            (original, defaultSegment) -> original.isPresent() ? original : defaultSegment
+        )
+    );
+  }
+
   public static DiscreteProfile fromSimulatedProfile(final List<Pair<Duration, SerializedValue>> simulatedProfile) {
     return fromProfileHelper(Duration.ZERO, simulatedProfile, Optional::of);
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/LinearProfile.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/LinearProfile.java
@@ -128,6 +128,17 @@ public final class LinearProfile implements Profile<LinearProfile>, Iterable<Seg
       return new Windows(result.build());
     }
 
+  /** Assigns a default value to all gaps in the profile. */
+  @Override
+  public LinearProfile assignGaps(final LinearProfile def) {
+    return new LinearProfile(
+        IntervalMap.map2(
+            this.profilePieces, def.profilePieces,
+            (original, defaultSegment) -> original.isPresent() ? original : defaultSegment
+        )
+    );
+  }
+
   public static LinearProfile fromSimulatedProfile(final List<Pair<Duration, RealDynamics>> simulatedProfile) {
     return fromProfileHelper(Duration.ZERO, simulatedProfile, Optional::of);
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/Profile.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/Profile.java
@@ -1,10 +1,11 @@
 package gov.nasa.jpl.aerie.constraints.model;
 
-import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 
 public interface Profile<P extends Profile<P>> {
   Windows equalTo(P other);
   Windows notEqualTo(P other);
   Windows changePoints();
+
+  P assignGaps(P def);
 }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
@@ -487,6 +487,17 @@ public final class Windows implements Iterable<Segment<Boolean>>, IntervalContai
         .toList());
   }
 
+  /** Assigns a default value to all gaps in the profile. */
+  @Override
+  public Windows assignGaps(final Windows def) {
+    return new Windows(
+        IntervalMap.map2(
+            this.segments, def.segments,
+            (original, defaultSegment) -> original.isPresent() ? original : defaultSegment
+        )
+    );
+  }
+
   @Override
   public Windows equalTo(final Windows other) {
     return new Windows(

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/AssignGaps.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/AssignGaps.java
@@ -1,0 +1,38 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
+import gov.nasa.jpl.aerie.constraints.model.Profile;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+
+import java.util.Objects;
+import java.util.Set;
+
+public record AssignGaps<P extends Profile<P>>(
+    Expression<P> originalProfile,
+    Expression<P> defaultProfile) implements Expression<P> {
+
+  @Override
+  public P evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+    final var originalProfile = this.originalProfile.evaluate(results, bounds, environment);
+    final var defaultProfile = this.defaultProfile.evaluate(results, bounds, environment);
+
+    return originalProfile.assignGaps(defaultProfile);
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {
+    this.originalProfile.extractResources(names);
+    this.defaultProfile.extractResources(names);
+  }
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return String.format(
+        "\n%s(assignGaps %s %s)",
+        prefix,
+        this.originalProfile.prettyPrint(prefix + "  "),
+        this.defaultProfile.prettyPrint(prefix + "  ")
+    );
+  }
+}

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsValue.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsValue.java
@@ -1,0 +1,29 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+
+import java.util.Objects;
+import java.util.Set;
+
+public record WindowsValue(boolean value) implements Expression<Windows> {
+
+  @Override
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+    return new Windows(bounds, value);
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {}
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return String.format(
+        "\n%s(value %s)",
+        prefix,
+        this.value
+    );
+  }
+}

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -37,6 +37,51 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ASTTests {
 
   @Test
+  public void testAssignGaps() {
+    final var simResults = new SimulationResults(
+        Interval.between(0, 20, SECONDS),
+        List.of(),
+        Map.of(),
+        Map.of()
+    );
+
+    final var originalWindows = new Windows()
+        .set(Interval.between(-2, -1, SECONDS), true)
+        .set(Interval.between(1, 2, SECONDS), false);
+
+    final var defaultWindows = new Windows(false)
+        .set(Interval.between(Duration.ZERO, Duration.MAX_VALUE), true);
+
+    final var result = new AssignGaps<>(
+        Supplier.of(originalWindows),
+        Supplier.of(defaultWindows)
+    ).evaluate(simResults, new EvaluationEnvironment());
+
+    final var expected = new Windows(false)
+        .set(Interval.between(-2, -1, SECONDS), true)
+        .set(Interval.between(0, Inclusive, 1, Exclusive, SECONDS), true)
+        .set(Interval.between(Duration.of(2, SECONDS), Exclusive, Duration.MAX_VALUE, Inclusive), true);
+
+    assertIterableEquals(expected, result);
+  }
+
+  @Test
+  public void testWindowsValue() {
+    final var simResults = new SimulationResults(
+        Interval.between(0, 20, SECONDS),
+        List.of(),
+        Map.of(),
+        Map.of()
+    );
+
+    final var result = new WindowsValue(true).evaluate(simResults, new EvaluationEnvironment());
+
+    final var expected = new Windows(Interval.between(0, 20, SECONDS), true);
+
+    assertIterableEquals(expected, result);
+  }
+
+  @Test
   public void testNot() {
     final var simResults = new SimulationResults(
         Interval.between(0, 20, SECONDS),

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -1,6 +1,7 @@
 import type * as API from "./constraints-edsl-fluent-api";
 
 export enum NodeKind {
+  AssignGapsExpression = 'AssignGapsExpression',
   DiscreteProfileResource = 'DiscreteProfileResource',
   DiscreteProfileValue = 'DiscreteProfileValue',
   DiscreteProfileParameter = 'DiscreteProfileParameter',
@@ -60,6 +61,12 @@ export interface ForEachActivitySpans {
   expression: SpansExpression;
 }
 
+export interface AssignGapsExpression<P extends ProfileExpression> {
+  kind: NodeKind.AssignGapsExpression,
+  originalProfile: P,
+  defaultProfile: P
+}
+
 export type WindowsExpression =
   | WindowsExpressionValue
   | WindowsExpressionActivityWindow
@@ -83,7 +90,8 @@ export type WindowsExpression =
   | WindowsExpressionShiftBy
   | WindowsExpressionFromSpans
   | IntervalsExpressionStarts
-  | IntervalsExpressionEnds;
+  | IntervalsExpressionEnds
+  | AssignGapsExpression<WindowsExpression>;
 
 export type SpansExpression =
   | SpansExpressionActivitySpan
@@ -155,13 +163,13 @@ export interface RealProfileLessThan {
   right: RealProfileExpression;
 }
 
-export interface ExpressionNotEqual<T = ProfileExpression> {
+export interface ExpressionNotEqual<T extends ProfileExpression> {
   kind: NodeKind.ExpressionNotEqual;
   left: T;
   right: T;
 }
 
-export interface ExpressionEqual<T = ProfileExpression> {
+export interface ExpressionEqual<T extends ProfileExpression> {
   kind: NodeKind.ExpressionEqual;
   left: T;
   right: T;
@@ -234,7 +242,7 @@ export interface DiscreteProfileTransition {
   to: any;
 }
 
-export type ProfileExpression = RealProfileExpression | DiscreteProfileExpression;
+export type ProfileExpression = WindowsExpression | RealProfileExpression | DiscreteProfileExpression;
 
 export type RealProfileExpression =
   | RealProfileRate
@@ -242,7 +250,8 @@ export type RealProfileExpression =
   | RealProfilePlus
   | RealProfileResource
   | RealProfileValue
-  | RealProfileParameter;
+  | RealProfileParameter
+  | AssignGapsExpression<RealProfileExpression>;
 
 export interface RealProfileRate {
   kind: NodeKind.RealProfileRate;
@@ -277,7 +286,11 @@ export interface RealProfileParameter {
   name: string;
 }
 
-export type DiscreteProfileExpression = DiscreteProfileResource | DiscreteProfileValue | DiscreteProfileParameter;
+export type DiscreteProfileExpression =
+    | DiscreteProfileResource
+    | DiscreteProfileValue
+    | DiscreteProfileParameter
+    | AssignGapsExpression<DiscreteProfileExpression>;
 
 export interface DiscreteProfileResource {
   kind: NodeKind.DiscreteProfileResource;

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -13,6 +13,7 @@ export enum NodeKind {
   DiscreteProfileTransition = 'DiscreteProfileTransition',
   WindowsExpressionActivityWindow = 'WindowsExpressionActivityWindow',
   SpansExpressionActivitySpan = 'SpansExpressionActivitySpan',
+  WindowsExpressionValue = 'WindowsExpressionValue',
   WindowsExpressionStartOf = 'WindowsExpressionStartOf',
   WindowsExpressionEndOf = 'WindowsExpressionEndOf',
   WindowsExpressionLongerThan = 'WindowsExpressionLongerThan',
@@ -60,6 +61,7 @@ export interface ForEachActivitySpans {
 }
 
 export type WindowsExpression =
+  | WindowsExpressionValue
   | WindowsExpressionActivityWindow
   | WindowsExpressionStartOf
   | WindowsExpressionEndOf
@@ -98,6 +100,11 @@ export type IntervalsExpression =
 export interface ProfileChanges {
   kind: NodeKind.ProfileChanges;
   expression: ProfileExpression;
+}
+
+export interface WindowsExpressionValue {
+  kind: NodeKind.WindowsExpressionValue,
+  value: boolean
 }
 
 export interface WindowsExpressionNot {

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -82,7 +82,19 @@ export class Windows {
     this.__astNode = expression;
   }
 
-    /**
+  /**
+   * Produces a single window for all time.
+   *
+   * @param value value for all time
+   */
+  public static Value(value: boolean): Windows {
+    return new Windows({
+      kind: AST.NodeKind.WindowsExpressionValue,
+      value
+    });
+  }
+
+  /**
    * Produces windows for each activity present in the plan and belonging to one of the activity types passed
    *
    * @param activityTypes the activity types
@@ -759,6 +771,13 @@ declare global {
   export class Windows {
     /** Internal AST Node */
     public readonly __astNode: AST.WindowsExpression;
+
+    /**
+     * Produces a single window for all time.
+     *
+     * @param value value for all time
+     */
+    public static Value(value: boolean): Windows;
 
     /**
      * Performs the boolean And operation on any number of Windows.

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -307,6 +307,22 @@ export class Windows {
       windowsExpression: this.__astNode
     })
   }
+
+  /**
+   * Replaces all gaps in this profile with default segments taken from the argument
+   *
+   * @param defaultProfile boolean or windows to take default values from.
+   */
+  public assignGaps(defaultProfile: Windows | boolean): Windows {
+    if (!(defaultProfile instanceof Windows)) {
+      defaultProfile = Windows.Value(defaultProfile);
+    }
+    return new Windows({
+      kind: AST.NodeKind.AssignGapsExpression,
+      originalProfile: this.__astNode,
+      defaultProfile: defaultProfile.__astNode
+    });
+  }
 }
 
 /**
@@ -581,6 +597,22 @@ export class Real {
       expression: this.__astNode,
     });
   }
+
+  /**
+   * Replaces all gaps in this profile with default segments taken from the argument
+   *
+   * @param defaultProfile number or real profile to take default values from.
+   */
+  public assignGaps(defaultProfile: Real | number): Real {
+    if (!(defaultProfile instanceof Real)) {
+      defaultProfile = Real.Value(defaultProfile);
+    }
+    return new Real({
+      kind: AST.NodeKind.AssignGapsExpression,
+      originalProfile: this.__astNode,
+      defaultProfile: defaultProfile.__astNode
+    });
+  }
 }
 
 /**
@@ -674,6 +706,22 @@ export class Discrete<Schema> {
     return new Windows({
       kind: AST.NodeKind.ProfileChanges,
       expression: this.__astNode,
+    });
+  }
+
+  /**
+   * Replaces all gaps in this profile with default segments taken from the argument
+   *
+   * @param defaultProfile value or discrete profile to take default values from.
+   */
+  public assignGaps(defaultProfile: Schema | Discrete<Schema>): Discrete<Schema> {
+    if (!(defaultProfile instanceof Discrete)) {
+      defaultProfile = Discrete.Value(defaultProfile);
+    }
+    return new Discrete({
+      kind: AST.NodeKind.AssignGapsExpression,
+      originalProfile: this.__astNode,
+      defaultProfile: defaultProfile.__astNode
     });
   }
 }
@@ -900,7 +948,14 @@ declare global {
      *
      * @param activityTypes the activity types
      */
-     public static During<A extends Gen.ActivityType>(...activityTypes: Gen.ActivityType[]) : Windows;
+    public static During<A extends Gen.ActivityType>(...activityTypes: Gen.ActivityType[]): Windows;
+
+    /**
+     * Replaces all gaps in this profile with default segments taken from the argument.
+     *
+     * @param defaultProfile boolean or windows to take default values from
+     */
+    public assignGaps(defaultProfile: Windows | boolean): Windows;
   }
 
   /**
@@ -1035,6 +1090,13 @@ declare global {
      * Produce an instantaneous window whenever this profile changes.
      */
     public changes(): Windows;
+
+    /**
+     * Replaces all gaps in this profile with default segments taken from the argument.
+     *
+     * @param defaultProfile number or real profile to take default values from
+     */
+    public assignGaps(defaultProfile: Real | number): Real;
   }
 
   /**
@@ -1097,6 +1159,13 @@ declare global {
      * Produce an instantaneous window whenever this profile changes.
      */
     public changes(): Windows;
+
+    /**
+     * Replaces all gaps in this profile with default segments taken from the argument.
+     *
+     * @param defaultProfile value or discrete profile to take default values from
+     */
+    public assignGaps(defaultProfile: Discrete<Schema> | Schema): Discrete<Schema>;
   }
 
   type Duration = number;


### PR DESCRIPTION
* **Tickets addressed:** AERIE-2198
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This adds the `assignGaps` operation to the `Windows`, `Real`, and `Discrete` classes of the eDSL. To do this, I also had to implement a `WindowsValue` node similar to `RealValue` and `DiscreteValue`, which takes a boolean and produces a constant Windows.

On the java side I also made `Windows` implement `Profile<Windows>` so that I could add `assignGaps` to `Profile`. This means that I had to implement `equal`, `notEqual`, and `changePoints` for Windows. These could be exposed in the eDSL in the future, but aren't in this PR.

## Verification
I added the usual parsing, evaluation, and compilation tests for `AssignGaps` and `WindowsValue`.

## Documentation
Doc comments are included on the new TS functions. The tutorial docs are already written assuming this change is included in 1.0

## Future work
<!-- What next steps can we anticipate from here, if any? -->
