### PR TITLE
Use a record instead of a pair for profile segments

### DIFF
--- a/constraints/build.gradle
+++ b/constraints/build.gradle
@@ -17,6 +17,7 @@ repositories {
 }
 
 dependencies {
+  implementation project(':merlin-driver')
   implementation project(':merlin-sdk')
   implementation project(':parsing-utilities')
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfile.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfile.java
@@ -4,13 +4,11 @@ import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.IntervalMap;
 import gov.nasa.jpl.aerie.constraints.time.Segment;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
-import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Iterator;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -117,25 +115,25 @@ public final class DiscreteProfile implements Profile<DiscreteProfile>, Iterable
     );
   }
 
-  public static DiscreteProfile fromSimulatedProfile(final List<Pair<Duration, SerializedValue>> simulatedProfile) {
+  public static DiscreteProfile fromSimulatedProfile(final List<ProfileSegment<SerializedValue>> simulatedProfile) {
     return fromProfileHelper(Duration.ZERO, simulatedProfile, Optional::of);
   }
 
-  public static DiscreteProfile fromExternalProfile(final Duration offsetFromPlanStart, final List<Pair<Duration, Optional<SerializedValue>>> externalProfile) {
+  public static DiscreteProfile fromExternalProfile(final Duration offsetFromPlanStart, final List<ProfileSegment<Optional<SerializedValue>>> externalProfile) {
     return fromProfileHelper(offsetFromPlanStart, externalProfile, $ -> $);
   }
 
   private static <T> DiscreteProfile fromProfileHelper(
       final Duration offsetFromPlanStart,
-      final List<Pair<Duration, T>> profile,
+      final List<ProfileSegment<T>> profile,
       final Function<T, Optional<SerializedValue>> transform
   ) {
     final var result = new IntervalMap.Builder<SerializedValue>();
     var cursor = offsetFromPlanStart;
     for (final var pair: profile) {
-      final var nextCursor = cursor.plus(pair.getKey());
+      final var nextCursor = cursor.plus(pair.extent());
 
-      final var value = transform.apply(pair.getValue());
+      final var value = transform.apply(pair.dynamics());
       final Duration finalCursor = cursor;
       value.ifPresent(
           $ -> result.set(

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/LinearProfile.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/LinearProfile.java
@@ -4,9 +4,9 @@ import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.IntervalMap;
 import gov.nasa.jpl.aerie.constraints.time.Segment;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Iterator;
 import java.util.List;
@@ -139,25 +139,25 @@ public final class LinearProfile implements Profile<LinearProfile>, Iterable<Seg
     );
   }
 
-  public static LinearProfile fromSimulatedProfile(final List<Pair<Duration, RealDynamics>> simulatedProfile) {
+  public static LinearProfile fromSimulatedProfile(final List<ProfileSegment<RealDynamics>> simulatedProfile) {
     return fromProfileHelper(Duration.ZERO, simulatedProfile, Optional::of);
   }
 
-  public static LinearProfile fromExternalProfile(final Duration offsetFromPlanStart, final List<Pair<Duration, Optional<RealDynamics>>> externalProfile) {
+  public static LinearProfile fromExternalProfile(final Duration offsetFromPlanStart, final List<ProfileSegment<Optional<RealDynamics>>> externalProfile) {
     return fromProfileHelper(offsetFromPlanStart, externalProfile, $ -> $);
   }
 
   private static <T> LinearProfile fromProfileHelper(
       final Duration offsetFromPlanStart,
-      final List<Pair<Duration, T>> profile,
+      final List<ProfileSegment<T>> profile,
       final Function<T, Optional<RealDynamics>> transform
   ) {
     final var result = new IntervalMap.Builder<LinearEquation>();
     var cursor = offsetFromPlanStart;
     for (final var pair: profile) {
-      final var nextCursor = cursor.plus(pair.getKey());
+      final var nextCursor = cursor.plus(pair.extent());
 
-      final var value = transform.apply(pair.getValue());
+      final var value = transform.apply(pair.dynamics());
       final Duration finalCursor = cursor;
       value.ifPresent(
           $ -> result.set(

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfileTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfileTest.java
@@ -3,20 +3,18 @@ package gov.nasa.jpl.aerie.constraints.model;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Segment;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
 
-import static gov.nasa.jpl.aerie.constraints.Assertions.assertEquivalent;
 import static gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity.Exclusive;
 import static gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity.Inclusive;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECOND;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 public class DiscreteProfileTest {
@@ -110,9 +108,9 @@ public class DiscreteProfileTest {
   @Test
   public void testConvertFromExternalFormat() {
     final var externalProfile = List.of(
-        Pair.of(Duration.of(1, SECOND), Optional.of(SerializedValue.of(true))),
-        Pair.of(Duration.of(1, SECOND), Optional.<SerializedValue>empty()),
-        Pair.of(Duration.of(1, SECOND), Optional.of(SerializedValue.of(false)))
+        new ProfileSegment<>(Duration.of(1, SECOND), Optional.of(SerializedValue.of(true))),
+        new ProfileSegment<>(Duration.of(1, SECOND), Optional.<SerializedValue>empty()),
+        new ProfileSegment<>(Duration.of(1, SECOND), Optional.of(SerializedValue.of(false)))
     );
 
     final var profile = DiscreteProfile.fromExternalProfile(Duration.of(1, SECOND), externalProfile);

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/LinearProfileTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/LinearProfileTest.java
@@ -3,10 +3,9 @@ package gov.nasa.jpl.aerie.constraints.model;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Segment;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
-import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -325,9 +324,9 @@ public class LinearProfileTest {
   @Test
   public void testConvertFromExternalFormat() {
     final var externalProfile = List.of(
-        Pair.of(Duration.of(1, SECOND), Optional.of(RealDynamics.linear(1, 1))),
-        Pair.of(Duration.of(1, SECOND), Optional.<RealDynamics>empty()),
-        Pair.of(Duration.of(1, SECOND), Optional.of(RealDynamics.linear(5, -1)))
+        new ProfileSegment<>(Duration.of(1, SECOND), Optional.of(RealDynamics.linear(1, 1))),
+        new ProfileSegment<>(Duration.of(1, SECOND), Optional.<RealDynamics>empty()),
+        new ProfileSegment<>(Duration.of(1, SECOND), Optional.of(RealDynamics.linear(5, -1)))
     );
 
     final var profile = LinearProfile.fromExternalProfile(Duration.of(1, SECOND), externalProfile);

--- a/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/SimulateMapSchedule.java
+++ b/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/SimulateMapSchedule.java
@@ -50,12 +50,12 @@ public class SimulateMapSchedule {
 
       simulationResults.realProfiles.forEach((name, samples) -> {
         System.out.println(name + ":");
-        samples.getRight().forEach(point -> System.out.format("\t%s\t%s\n", point.getKey(), point.getValue()));
+        samples.getRight().forEach(point -> System.out.format("\t%s\t%s\n", point.extent(), point.dynamics()));
       });
 
       simulationResults.discreteProfiles.forEach((name, samples) -> {
         System.out.println(name + ":");
-        samples.getRight().forEach(point -> System.out.format("\t%s\t%s\n", point.getKey(), point.getValue()));
+        samples.getRight().forEach(point -> System.out.format("\t%s\t%s\n", point.extent(), point.dynamics()));
       });
 
     simulationResults.simulatedActivities.forEach((name, activity) -> {

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationResults.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationResults.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.driver;
 
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
 import gov.nasa.jpl.aerie.merlin.driver.timeline.EventGraph;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
@@ -15,16 +16,16 @@ import java.util.SortedMap;
 
 public final class SimulationResults {
   public final Instant startTime;
-  public final Map<String, Pair<ValueSchema, List<Pair<Duration, RealDynamics>>>> realProfiles;
-  public final Map<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>> discreteProfiles;
+  public final Map<String, Pair<ValueSchema, List<ProfileSegment<RealDynamics>>>> realProfiles;
+  public final Map<String, Pair<ValueSchema, List<ProfileSegment<SerializedValue>>>> discreteProfiles;
   public final Map<ActivityInstanceId, SimulatedActivity> simulatedActivities;
   public final Map<ActivityInstanceId, UnfinishedActivity> unfinishedActivities;
   public final List<Triple<Integer, String, ValueSchema>> topics;
   public final Map<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>> events;
 
     public SimulationResults(
-        final Map<String, Pair<ValueSchema, List<Pair<Duration, RealDynamics>>>> realProfiles,
-        final Map<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>> discreteProfiles,
+        final Map<String, Pair<ValueSchema, List<ProfileSegment<RealDynamics>>>> realProfiles,
+        final Map<String, Pair<ValueSchema, List<ProfileSegment<SerializedValue>>>> discreteProfiles,
         final Map<ActivityInstanceId, SimulatedActivity> simulatedActivities,
         final Map<ActivityInstanceId, UnfinishedActivity> unfinishedActivities,
         final Instant startTime,

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/ProfileSegment.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/ProfileSegment.java
@@ -1,0 +1,12 @@
+package gov.nasa.jpl.aerie.merlin.driver.engine;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+/**
+ * A period of time over which a dynamics occurs.
+ * @param extent The duration from the start to the end of this segment
+ * @param dynamics The behavior of the resource during this segment
+ * @param <Dynamics> A choice between Real and SerializedValue
+ */
+public record ProfileSegment<Dynamics>(Duration extent, Dynamics dynamics) {
+}

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -457,8 +457,8 @@ public final class SimulationEngine implements AutoCloseable {
     }
 
     // Extract profiles for every resource.
-    final var realProfiles = new HashMap<String, Pair<ValueSchema, List<Pair<Duration, RealDynamics>>>>();
-    final var discreteProfiles = new HashMap<String, Pair<ValueSchema, List<Pair<Duration, SerializedValue>>>>();
+    final var realProfiles = new HashMap<String, Pair<ValueSchema, List<ProfileSegment<RealDynamics>>>>();
+    final var discreteProfiles = new HashMap<String, Pair<ValueSchema, List<ProfileSegment<SerializedValue>>>>();
 
     for (final var entry : engine.resources.entrySet()) {
       final var id = entry.getKey();
@@ -630,12 +630,12 @@ public final class SimulationEngine implements AutoCloseable {
   }
 
   private static <Target, Dynamics>
-  List<Pair<Duration, Target>> serializeProfile(
+  List<ProfileSegment<Target>> serializeProfile(
       final Duration elapsedTime,
       final ProfilingState<Dynamics> state,
       final Translator<Target> translator
   ) {
-    final var profile = new ArrayList<Pair<Duration, Target>>(state.profile().segments().size());
+    final var profile = new ArrayList<ProfileSegment<Target>>(state.profile().segments().size());
 
     final var iter = state.profile().segments().iterator();
     if (iter.hasNext()) {
@@ -643,13 +643,13 @@ public final class SimulationEngine implements AutoCloseable {
       while (iter.hasNext()) {
         final var nextSegment = iter.next();
 
-        profile.add(Pair.of(
+        profile.add(new ProfileSegment<>(
             nextSegment.startOffset().minus(segment.startOffset()),
             translator.apply(state.resource(), segment.dynamics())));
         segment = nextSegment;
       }
 
-      profile.add(Pair.of(
+      profile.add(new ProfileSegment<>(
           elapsedTime.minus(segment.startOffset()),
           translator.apply(state.resource(), segment.dynamics())));
     }

--- a/merlin-driver/src/test/java/gov/nasa/jpl/aerie/merlin/driver/CellExpiryTest.java
+++ b/merlin-driver/src/test/java/gov/nasa/jpl/aerie/merlin/driver/CellExpiryTest.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.driver;
 
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Querier;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.model.CellType;
@@ -9,7 +10,6 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.Resource;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -33,22 +33,22 @@ public final class CellExpiryTest {
     final var actual = results.discreteProfiles.get("/key").getRight();
 
     final var expected = List.of(
-        Pair.of(duration(500, MILLISECONDS), SerializedValue.of("value")),
-        Pair.of(duration(500, MILLISECONDS), SerializedValue.of("value")),
+        new ProfileSegment<>(duration(500, MILLISECONDS), SerializedValue.of("value")),
+        new ProfileSegment<>(duration(500, MILLISECONDS), SerializedValue.of("value")),
 
-        Pair.of(duration(500, MILLISECONDS), SerializedValue.of("value")),
-        Pair.of(duration(500, MILLISECONDS), SerializedValue.of("value")),
+        new ProfileSegment<>(duration(500, MILLISECONDS), SerializedValue.of("value")),
+        new ProfileSegment<>(duration(500, MILLISECONDS), SerializedValue.of("value")),
 
-        Pair.of(duration(500, MILLISECONDS), SerializedValue.of("value")),
-        Pair.of(duration(500, MILLISECONDS), SerializedValue.of("value")),
+        new ProfileSegment<>(duration(500, MILLISECONDS), SerializedValue.of("value")),
+        new ProfileSegment<>(duration(500, MILLISECONDS), SerializedValue.of("value")),
 
-        Pair.of(duration(500, MILLISECONDS), SerializedValue.of("value")),
-        Pair.of(duration(500, MILLISECONDS), SerializedValue.of("value")),
+        new ProfileSegment<>(duration(500, MILLISECONDS), SerializedValue.of("value")),
+        new ProfileSegment<>(duration(500, MILLISECONDS), SerializedValue.of("value")),
 
-        Pair.of(duration(500, MILLISECONDS), SerializedValue.of("value")),
-        Pair.of(duration(500, MILLISECONDS), SerializedValue.of("value")),
+        new ProfileSegment<>(duration(500, MILLISECONDS), SerializedValue.of("value")),
+        new ProfileSegment<>(duration(500, MILLISECONDS), SerializedValue.of("value")),
 
-        Pair.of(Duration.ZERO, SerializedValue.of("value")));
+        new ProfileSegment<>(Duration.ZERO, SerializedValue.of("value")));
 
     assertEquals(expected, actual);
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/DiscreteProfile.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/DiscreteProfile.java
@@ -1,13 +1,12 @@
 package gov.nasa.jpl.aerie.merlin.server.models;
 
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 import java.util.Optional;
 
 public record DiscreteProfile(
     ValueSchema schema,
-    List<Pair<Duration, Optional<SerializedValue>>> segments) {}
+    List<ProfileSegment<Optional<SerializedValue>>> segments) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/RealProfile.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/RealProfile.java
@@ -1,13 +1,12 @@
 package gov.nasa.jpl.aerie.merlin.server.models;
 
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 import java.util.Optional;
 
 public record RealProfile(
     ValueSchema schema,
-    List<Pair<Duration, Optional<RealDynamics>>> segments) {}
+    List<ProfileSegment<Optional<RealDynamics>>> segments) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetProfileSegmentsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetProfileSegmentsAction.java
@@ -1,22 +1,18 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.json.JsonParser;
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
-import org.apache.commons.lang3.tuple.Pair;
 import org.intellij.lang.annotations.Language;
 
-import javax.json.Json;
-import java.io.Reader;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.getJsonColumn;
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.parseOffset;
 
 /*package-local*/ final class GetProfileSegmentsAction implements AutoCloseable {
   private final @Language("SQL") String sql = """
@@ -36,13 +32,13 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
     this.statement = connection.prepareStatement(sql);
   }
 
-  public <Dynamics> List<Pair<Duration, Optional<Dynamics>>> get(
+  public <Dynamics> List<ProfileSegment<Optional<Dynamics>>> get(
       final long datasetId,
       final long profileId,
       final Duration profileDuration,
       final JsonParser<Dynamics> dynamicsP
   ) throws SQLException {
-    final var segments = new ArrayList<Pair<Duration, Optional<Dynamics>>>();
+    final var segments = new ArrayList<ProfileSegment<Optional<Dynamics>>>();
     PreparedStatements.setIntervalStyle(statement.getConnection(), PreparedStatements.PGIntervalStyle.ISO8601);
     this.statement.setLong(1, datasetId);
     this.statement.setLong(2, profileId);
@@ -64,7 +60,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
       while (resultSet.next()) {
         final var nextOffset = Duration.fromISO8601String(resultSet.getString(1));
         final var duration = nextOffset.minus(offset);
-        segments.add(Pair.of(duration, dynamics));
+        segments.add(new ProfileSegment<>(duration, dynamics));
         offset = nextOffset;
 
         isGap = resultSet.getBoolean("is_gap");
@@ -78,7 +74,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
       }
 
       final var duration = profileDuration.minus(offset);
-      segments.add(Pair.of(duration, dynamics));
+      segments.add(new ProfileSegment<>(duration, dynamics));
     } else {
       throw new Error("No profile segments found for `dataset_id` (%d) and `profile_id` (%d)".formatted(datasetId, profileId));
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostProfileSegmentsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostProfileSegmentsAction.java
@@ -1,9 +1,8 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.json.JsonParser;
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
-import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
-import org.apache.commons.lang3.tuple.Pair;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
@@ -12,8 +11,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 import java.util.Optional;
-
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatements.setTimestamp;
 
 public final class PostProfileSegmentsAction implements AutoCloseable {
   private final @Language("SQL") String sql = """
@@ -29,7 +26,7 @@ public final class PostProfileSegmentsAction implements AutoCloseable {
   public <Dynamics> void apply(
       final long datasetId,
       final ProfileRecord profileRecord,
-      final List<Pair<Duration, Optional<Dynamics>>> segments,
+      final List<ProfileSegment<Optional<Dynamics>>> segments,
       final JsonParser<Dynamics> dynamicsP
       ) throws SQLException {
 
@@ -38,8 +35,8 @@ public final class PostProfileSegmentsAction implements AutoCloseable {
     // we need to convert to offsets from the simulation start so order can be preserved
     var accumulatedOffset = Duration.ZERO;
     for (final var pair : segments) {
-      final var duration = pair.getLeft();
-      final var dynamics = pair.getRight();
+      final var duration = pair.extent();
+      final var dynamics = pair.dynamics();
 
       this.statement.setLong(1, datasetId);
       this.statement.setLong(2, profileRecord.id());

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostProfilesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostProfilesAction.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
@@ -32,8 +33,8 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
 
   public Map<String, ProfileRecord> apply(
       final long datasetId,
-      final Map<String, Pair<ValueSchema, List<Pair<Duration, Optional<RealDynamics>>>>> realProfiles,
-      final Map<String, Pair<ValueSchema, List<Pair<Duration, Optional<SerializedValue>>>>> discreteProfiles
+      final Map<String, Pair<ValueSchema, List<ProfileSegment<Optional<RealDynamics>>>>> realProfiles,
+      final Map<String, Pair<ValueSchema, List<ProfileSegment<Optional<SerializedValue>>>>> discreteProfiles
   ) throws SQLException {
     final var resourceNames = new ArrayList<String>();
     final var resourceTypes = new ArrayList<Pair<String, ValueSchema>>();
@@ -92,10 +93,10 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
     return profileRecords;
   }
 
-  private static <T> Duration sumDurations(final List<Pair<Duration, Optional<T>>> segments) {
+  private static <T> Duration sumDurations(final List<ProfileSegment<Optional<T>>> segments) {
     return segments.stream().reduce(
         Duration.ZERO,
-        (acc, pair) -> acc.plus(pair.getLeft()),
+        (acc, pair) -> acc.plus(pair.extent()),
         Duration::plus
     );
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ProfileRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ProfileRepository.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
@@ -11,7 +12,6 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,8 +25,8 @@ import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.se
       final Connection connection,
       final long datasetId
   ) throws SQLException {
-    final var realProfiles = new HashMap<String, Pair<ValueSchema, List<Pair<Duration, Optional<RealDynamics>>>>>();
-    final var discreteProfiles = new HashMap<String, Pair<ValueSchema, List<Pair<Duration, Optional<SerializedValue>>>>>();
+    final var realProfiles = new HashMap<String, Pair<ValueSchema, List<ProfileSegment<Optional<RealDynamics>>>>>();
+    final var discreteProfiles = new HashMap<String, Pair<ValueSchema, List<ProfileSegment<Optional<SerializedValue>>>>>();
 
     final var profileRecords = getProfileRecords(connection, datasetId);
     for (final var record : profileRecords) {
@@ -81,7 +81,7 @@ import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.se
     }
   }
 
-  static List<Pair<Duration, Optional<RealDynamics>>> getRealProfileSegments(
+  static List<ProfileSegment<Optional<RealDynamics>>> getRealProfileSegments(
       final Connection connection,
       final long datasetId,
       final long profileId,
@@ -92,7 +92,7 @@ import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.se
     }
   }
 
-  static List<Pair<Duration, Optional<SerializedValue>>> getDiscreteProfileSegments(
+  static List<ProfileSegment<Optional<SerializedValue>>> getDiscreteProfileSegments(
       final Connection connection,
       final long datasetId,
       final long profileId,
@@ -153,7 +153,7 @@ import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.se
       final Connection connection,
       final long datasetId,
       final ProfileRecord profileRecord,
-      final List<Pair<Duration, Optional<RealDynamics>>> segments
+      final List<ProfileSegment<Optional<RealDynamics>>> segments
   ) throws SQLException {
     try (final var postProfileSegmentsAction = new PostProfileSegmentsAction(connection)) {
       postProfileSegmentsAction.apply(datasetId, profileRecord, segments, realDynamicsP);
@@ -164,7 +164,7 @@ import static gov.nasa.jpl.aerie.merlin.server.http.SerializedValueJsonParser.se
       final Connection connection,
       final long datasetId,
       final ProfileRecord profileRecord,
-      final List<Pair<Duration, Optional<SerializedValue>>> segments
+      final List<ProfileSegment<Optional<SerializedValue>>> segments
   ) throws SQLException {
     try (final var postProfileSegmentsAction = new PostProfileSegmentsAction(connection)) {
       postProfileSegmentsAction.apply(datasetId, profileRecord, segments, serializedValueP);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -86,8 +86,8 @@ public final class GetSimulationResultsAction {
 
       final var timeline = new ArrayList<Pair<Duration, SerializedValue>>();
       for (final var piece : profile) {
-        final var extent = piece.getLeft();
-        final var dynamics = piece.getRight();
+        final var extent = piece.extent();
+        final var dynamics = piece.dynamics();
 
         timeline.add(Pair.of(elapsed, SerializedValue.of(
             dynamics.initial)));
@@ -104,8 +104,8 @@ public final class GetSimulationResultsAction {
 
       final var timeline = new ArrayList<Pair<Duration, SerializedValue>>();
       for (final var piece : profile) {
-        final var extent = piece.getLeft();
-        final var value = piece.getRight();
+        final var extent = piece.extent();
+        final var value = piece.dynamics();
 
         timeline.add(Pair.of(elapsed, value));
         elapsed = elapsed.plus(extent);

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/IncrementalSimulationTest.java
@@ -40,7 +40,7 @@ public class IncrementalSimulationTest {
     final var now = Instant.now();
     //ensures that simulation results are generated until the end of the last act;
     var simResults = incrementalSimulationDriver.getSimulationResults(now);
-    assert(simResults.realProfiles.get("/utcClock").getRight().get(0).getLeft().isEqualTo(endOfLastAct));
+    assert(simResults.realProfiles.get("/utcClock").getRight().get(0).extent().isEqualTo(endOfLastAct));
     /* ensures that when current simulation results cover more than the asked period and that nothing has happened
     between two requests, the same results are returned */
     var simResults2 = incrementalSimulationDriver.getSimulationResultsUpTo(now, Duration.of(7, SECONDS));
@@ -51,7 +51,7 @@ public class IncrementalSimulationTest {
   public void simulationResultsTest2(){
     /* ensures that when the passed start epoch is not equal to the one used for previously computed results, the results are re-computed */
     var simResults = incrementalSimulationDriver.getSimulationResults(Instant.now());
-    assert(simResults.realProfiles.get("/utcClock").getRight().get(0).getLeft().isEqualTo(endOfLastAct));
+    assert(simResults.realProfiles.get("/utcClock").getRight().get(0).extent().isEqualTo(endOfLastAct));
     var simResults2 = incrementalSimulationDriver.getSimulationResultsUpTo(Instant.now(), Duration.of(7, SECONDS));
     assertNotEquals(simResults, simResults2);
   }
@@ -63,7 +63,7 @@ public class IncrementalSimulationTest {
     final var now = Instant.now();
     var simResults2 = incrementalSimulationDriver.getSimulationResultsUpTo(now, Duration.of(7, SECONDS));
     var simResults = incrementalSimulationDriver.getSimulationResults(now);
-    assert(simResults.realProfiles.get("/utcClock").getRight().get(0).getLeft().isEqualTo(endOfLastAct));
+    assert(simResults.realProfiles.get("/utcClock").getRight().get(0).extent().isEqualTo(endOfLastAct));
     assertNotEquals(simResults, simResults2);
   }
 


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Profile segments in simulation results are currently represented as a `Pair<Duration, Dynamics>` - it is difficult to tell from this representation what the meaning of the "Duration" should be. By convention, we interpret the `Duration` to be the `extent` of the Profile Segment - i.e. the length of this segment. Other plausible interpretations would be the offset from the start of the plan, as well as the length of the _previous_ segment.

This PR introduces a `ProfileSegment` record to make it clear which interpretation is being used, and to pave the way for changing that interpretation in the near future. (The current interpretation is somewhat incompatible with streaming - since as it stands you cannot emit a segment until its end time is known).

This PR updates `SimulationResults` as well as all uses of profiles that have `merlin-driver` as a dependency. It draws the line at the `constraints` package, which does not depend on `merlin-driver`.

As @JoelCourtney pointed out, we have numerous representations of profiles, and it's hard to keep them all straight - while this PR does not reduce the number of representations, it hopefully makes one of those representations a little easier to work with.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I spun up a local aerie and ran constraints checking, just to make sure that pipeline still works. Otherwise, I consider the fact that the code compiles, and that the tests pass on this PR to be sufficient verification.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
The `ProfileSegment` class has associated javadoc, but aside from that no documentation has been updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Future work: simulation results streaming