### PR TITLE
[HOTFIX] Commit merge with delete-modify conflict resolution edge cases

### DIFF
--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PlanCollaborationTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PlanCollaborationTests.java
@@ -2045,8 +2045,8 @@ public class PlanCollaborationTests {
       final int deleteUncontestedActId = insertActivity(basePlan);
       final int modifyContestedSupplyingActId = insertActivity(basePlan);
       final int modifyContestedReceivingActId = insertActivity(basePlan);
-      final int deleteContestedSupplyingActId = insertActivity(basePlan);
-      final int deleteContestedReceivingActId = insertActivity(basePlan);
+      final int deleteContestedSupplyingResolveSupplyingActId = insertActivity(basePlan);
+      final int deleteContestedReceivingResolveReceivingActId = insertActivity(basePlan);
       final int childPlan = duplicatePlan(basePlan, "Child");
 
       assertEquals(6, getActivities(basePlan).size());
@@ -2062,11 +2062,11 @@ public class PlanCollaborationTests {
       updateActivityName("Modify Contested Receiving Parent", modifyContestedReceivingActId, basePlan);
       updateActivityName("Modify Contested Receiving Child", modifyContestedReceivingActId, childPlan);
 
-      updateActivityName("Delete Contested Supplying Parent", deleteContestedSupplyingActId, basePlan);
-      deleteActivityDirective(childPlan, deleteContestedSupplyingActId);
+      updateActivityName("Delete Contested Supplying Parent Resolve Supplying", deleteContestedSupplyingResolveSupplyingActId, basePlan);
+      deleteActivityDirective(childPlan, deleteContestedSupplyingResolveSupplyingActId);
 
-      deleteActivityDirective(basePlan, deleteContestedReceivingActId);
-      updateActivityName("Delete Contested Receiving Child", deleteContestedReceivingActId, childPlan);
+      deleteActivityDirective(basePlan, deleteContestedReceivingResolveReceivingActId);
+      updateActivityName("Delete Contested Receiving Child Resolve Receiving", deleteContestedReceivingResolveReceivingActId, childPlan);
 
       final int mergeRQ = createMergeRequest(basePlan, childPlan);
       beginMerge(mergeRQ);
@@ -2074,8 +2074,8 @@ public class PlanCollaborationTests {
       assertEquals(4, getConflictingActivities(mergeRQ).size());
       setResolution(mergeRQ, modifyContestedSupplyingActId, "supplying");
       setResolution(mergeRQ, modifyContestedReceivingActId, "receiving");
-      setResolution(mergeRQ, deleteContestedSupplyingActId, "supplying");
-      setResolution(mergeRQ, deleteContestedReceivingActId, "receiving");
+      setResolution(mergeRQ, deleteContestedSupplyingResolveSupplyingActId, "supplying");
+      setResolution(mergeRQ, deleteContestedReceivingResolveReceivingActId, "receiving");
 
       final Activity muActivityBefore = getActivity(basePlan, modifyUncontestedActId);
       final Activity mcsActivityBefore = getActivity(basePlan, modifyContestedSupplyingActId);

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PlanCollaborationTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PlanCollaborationTests.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.TestInstance;
 import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -585,6 +584,22 @@ public class PlanCollaborationTests {
           WHERE id = %d;
           """.formatted(newStatus, requestId)
       );
+    }
+  }
+
+  private static void assertActivityEquals(final Activity expected, final Activity actual) {
+    // validate all shared properties
+    assertEquals(expected.name, actual.name);
+    assertEquals(expected.sourceSchedulingGoalId, actual.sourceSchedulingGoalId);
+    assertEquals(expected.createdAt, actual.createdAt);
+    assertEquals(expected.startOffset, actual.startOffset);
+    assertEquals(expected.type, actual.type);
+    assertEquals(expected.arguments, actual.arguments);
+    assertEquals(expected.metadata, actual.metadata);
+    assertEquals(expected.tags.length, actual.tags.length);
+    for(int j = 0; j < expected.tags.length; ++j)
+    {
+      assertEquals(expected.tags[j], actual.tags[j]);
     }
   }
   //endregion
@@ -2077,47 +2092,14 @@ public class PlanCollaborationTests {
         if (activity.activityId == muActivityBefore.activityId) {
           final var muActivityChild = getActivity(childPlan, modifyUncontestedActId);
           // validate all shared properties
-          assertEquals(muActivityChild.name, activity.name);
-          assertEquals(muActivityChild.sourceSchedulingGoalId, activity.sourceSchedulingGoalId);
-          assertEquals(muActivityChild.createdAt, activity.createdAt);
-          assertEquals(muActivityChild.startOffset, activity.startOffset);
-          assertEquals(muActivityChild.type, activity.type);
-          assertEquals(muActivityChild.arguments, activity.arguments);
-          assertEquals(muActivityChild.metadata, activity.metadata);
-          assertEquals(muActivityChild.tags.length, activity.tags.length);
-          for(int j = 0; j < muActivityChild.tags.length; ++j)
-          {
-            assertEquals(muActivityChild.tags[j], activity.tags[j]);
-          }
+          assertActivityEquals(muActivityChild, activity);
         } else if (activity.activityId == mcsActivityBefore.activityId) {
           final var mcsActivityChild = getActivity(childPlan, modifyContestedSupplyingActId);
           // validate all shared properties
-          assertEquals(mcsActivityChild.name, activity.name);
-          assertEquals(mcsActivityChild.sourceSchedulingGoalId, activity.sourceSchedulingGoalId);
-          assertEquals(mcsActivityChild.createdAt, activity.createdAt);
-          assertEquals(mcsActivityChild.startOffset, activity.startOffset);
-          assertEquals(mcsActivityChild.type, activity.type);
-          assertEquals(mcsActivityChild.arguments, activity.arguments);
-          assertEquals(mcsActivityChild.metadata, activity.metadata);
-          assertEquals(mcsActivityChild.tags.length, activity.tags.length);
-          for(int j = 0; j < mcsActivityChild.tags.length; ++j)
-          {
-            assertEquals(mcsActivityChild.tags[j], activity.tags[j]);
-          }
+          assertActivityEquals(mcsActivityChild, activity);
         } else if (activity.activityId == mcrActivityBefore.activityId) {
           // validate all shared properties
-          assertEquals(mcrActivityBefore.name, activity.name);
-          assertEquals(mcrActivityBefore.sourceSchedulingGoalId, activity.sourceSchedulingGoalId);
-          assertEquals(mcrActivityBefore.createdAt, activity.createdAt);
-          assertEquals(mcrActivityBefore.startOffset, activity.startOffset);
-          assertEquals(mcrActivityBefore.type, activity.type);
-          assertEquals(mcrActivityBefore.arguments, activity.arguments);
-          assertEquals(mcrActivityBefore.metadata, activity.metadata);
-          assertEquals(mcrActivityBefore.tags.length, activity.tags.length);
-          for(int j = 0; j < mcrActivityBefore.tags.length; ++j)
-          {
-            assertEquals(mcrActivityBefore.tags[j], activity.tags[j]);
-          }
+          assertActivityEquals(mcrActivityBefore, activity);
         } else fail();
       }
     }

--- a/merlin-server/sql/merlin/tables/activity_directive.sql
+++ b/merlin-server/sql/merlin/tables/activity_directive.sql
@@ -122,7 +122,9 @@ returns trigger
 security definer
 language plpgsql as $$begin
   call plan_locked_exception(new.plan_id);
-  new.name = new.type || ' ' || new.id;
+  if new.name is null
+  then new.name = new.type || ' ' || new.id;
+  end if;
   return new;
 end$$;
 


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
When doing some manual testing of the new merge UI, I noticed an unexpected behavior:

1. I deleted an activity in the parent
2. I modified that same activity in the child
3. During merge conflict resolution, I chose to use the activity from the child
4. After accepting the changes, the parent plan should have contained this activity, but it did not

For each merge staging area entry with the `'modify'` change type, the `commit_merge` function updates the corresponding activity in the target plan. However, if there are no corresponding activities in the target plan (as in the case of a delete-modify conflict), no change is applied to the target plan. This is not quite what we want.

The desired behavior is to "update the corresponding activity if it exists, and insert it if it does not". This "update or insert" behavior (colloquially known as an "upsert") is supported by postgres via the "[insert on conflict](https://www.postgresql.org/docs/devel/sql-insert.html#SQL-ON-CONFLICT)" statement, which we use in other places, such as the [CreateActivityType](https://github.com/NASA-AMMOS/aerie/blob/0d70641dadfcb949d8ff9a8cb631e89e77a92164/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateActivityTypeAction.java#L16-L22) action.

This PR starts by adding a failing test (described below), then making the changes necessary to fix it.

One note is that I modified the `generate_activity_directive_name` trigger function to avoid overwriting a name that has been provided. This makes its behavior more like "generated by default" and allows us to copy activity directives into the table without losing their names.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Two new cases have been added to the existing `modifyAndDeletesApplyCorrectly` test - to help cover the options of:
- Delete activity in base, modify in child
- Modify activity in base, delete in child

And, for each of those:
- Resolve supplying
- Resolve receiving

(two of the four cases were already covered by the existing test - this PR just adds the remaining two)

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No documentation updates were made.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Perhaps a survey of our triggers for gotchas like the generated activity directive name would be helpful. We may also consider adding a test case that adds are applied correctly.