### PR TITLE
[HOTFIX] Fix broken links in Docs

### DIFF
--- a/docs/source/contribute/guidelines/CODE_OF_CONDUCT.md
+++ b/docs/source/contribute/guidelines/CODE_OF_CONDUCT.md
@@ -123,7 +123,7 @@ version 2.0, available at
 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
+enforcement ladder](https://github.com/mozilla/inclusion).
 
 [homepage]: https://www.contributor-covenant.org
 

--- a/docs/source/user-guide/ui-api-guide/constraints/index.rst
+++ b/docs/source/user-guide/ui-api-guide/constraints/index.rst
@@ -7,7 +7,8 @@ When analyzing a simulation's results, it may be useful to detect windows where 
 Managing Constraints
 ====================
 
-All constraints are associated with either a mission model or a specific plan. If associated with a model, a constraint will be applied to all plans made with that model. If associated with a plan, it will only applied to the plan, and it will have access to any `external profiles <../external-datasets>`_ associated with the plan as well.
+All constraints are associated with either a mission model or a specific plan. If associated with a model, a constraint will be applied to all plans made with that model.
+If associated with a plan, it will only applied to the plan, and it will have access to any :doc:`external profiles <../external-datasets/index>` associated with the plan as well.
 
 .. tabs::
   .. group-tab:: UI
@@ -26,12 +27,12 @@ All constraints are associated with either a mission model or a specific plan. I
         }
 
      You then write some constraint that returns a constraint, and click *save*. For details on how to write constraints,
-     see the sub-pages of this section and the `API documentation for the constraints eDSL <../constraints-edsl-api>`_.
+     see the sub-pages of this section and the :doc:`API documentation for the constraints eDSL <../../../constraints-edsl-api/index>`.
 
 
   .. group-tab:: API
 
-     Constraints can be uploaded, updated, and deleted directly using the GraphQL API. See `this section <../graphql-api>`_ for information on the basics of GraphQL. To create a single constraint, send the following mutation:
+     Constraints can be uploaded, updated, and deleted directly using the GraphQL API. See `here <https://graphql.org/learn/>`__ for information on the basics of GraphQL. To create a single constraint, send the following mutation:
 
      .. code-block::
 

--- a/docs/source/user-guide/ui-api-guide/constraints/writing-constraints.md
+++ b/docs/source/user-guide/ui-api-guide/constraints/writing-constraints.md
@@ -1,27 +1,24 @@
-===================
-Writing Constraints
-===================
+# Writing Constraints
+
 
 The goal of most constraints is to produce a ``Windows`` object through
 operations on profiles and activity instances. This is a conceptual
 guide to what they represent. More specific documentation is generated
-for the `Constraints API
-documentation <../../constraints-edsl-api>`_.
+for the [Constraints API
+documentation](../../../constraints-edsl-api/index).
 
-Important Concepts
-==================
+## Important Concepts
 
-Profiles
-________
+### Profiles
 
 Profiles represent functions over time to a specific type, and usually
 come from mission model resources. For example, a “mission phase”
 resource might be simulated by the mission model and exposed to the
-constraints with intervals of time labelled as ``cruise``, ``edl``, and
-``surface``; a “battery charge” resource could be represented as a real
+constraints with intervals of time labelled as `cruise`, `edl`, and
+`surface`; a “battery charge” resource could be represented as a real
 number between 0 and 1 that varies with activities; etc. These resources
-can be referenced by calling ``Discrete.Resource("mission phase")`` or
-``Real.Resource("battery charge")`` in the constraint, allowing you to
+can be referenced by calling `Discrete.Resource("mission phase")` or
+`Real.Resource("battery charge")` in the constraint, allowing you to
 transform them and do comparisons.
 
 Real profiles are for integers and floating point numbers, and provide
@@ -31,64 +28,59 @@ Discrete profiles are for everything else, like strings or objects.
 Profiles can have *gaps*, or intervals where the value is unknown. This
 comes up most often when dealing with external datasets. In most cases
 it is best to apply a default value to a profile’s gaps ASAP using the
-``profile.assignGaps(defaultValue)`` method.
+`profile.assignGaps(defaultValue)` method.
 
-Windows
-_______
+### Windows
 
 Windows are like a boolean profile, augmented with some extra
-functionality. For many constraints, the final result is a ``Windows``
+functionality. For many constraints, the final result is a `Windows`
 object, which tells Aerie what times are violations of the constraint.
-``true`` means the state is nominal and ``false`` means the state is a
+`true` means the state is nominal and `false` means the state is a
 violation. This means that you should describe the conditions you *want*
 to happen, not the conditions you *don’t* want to happen.
 
-There are a few ways to calculate a ``Windows`` object from profiles,
+There are a few ways to calculate a `Windows` object from profiles,
 and many operations that can be done on them; including the traditional
-boolean ``and``, ``or``, and ``not``. These are all in the `API
-documentation <../../constraints-edsl-api>`__. Like all profiles,
+boolean `and`, `or`, and `not`. These are all in the [API
+documentation](../../../constraints-edsl-api/index). Like all profiles,
 Windows can have gaps too. However, some operations (such as converting
-to ``Spans`` or splitting segments) are not possible on gaps, so you’ll
+to `Spans` or splitting segments) are not possible on gaps, so you’ll
 be required to apply a default value using
-``windows.assignGaps(boolean)``.
+`windows.assignGaps(boolean)`.
 
-You can directly return your ``Windows`` object from the constraint function,
-and it will be automatically converted in to a ``Constraint`` object.
+You can directly return your `Windows` object from the constraint function,
+and it will be automatically converted in to a `Constraint` object.
 
-Spans
-_____
+### Spans
 
-``Spans`` are designed to work around a limitation of ``Windows``: if
-two ``true`` segments of a ``Windows`` object are transformed so that
+`Spans` are designed to work around a limitation of `Windows`: if
+two `true` segments of a `Windows` object are transformed so that
 they touch, they are combined or “coalesced” into a single segment, and
 the knowledge that they were originally separate is lost. In situations
 where this is not acceptable (such as when working with activities that
-can overlap), ``Spans`` can be used. ``Spans`` are not a type of profile
+can overlap), `Spans` can be used. `Spans` are not a type of profile
 at all; instead they’re just a collection of intervals on the timeline.
-They share some operations available for ``Windows``, but not all are
-valid (such as ``not``).
+They share some operations available for `Windows`, but not all are
+valid (such as `not`).
 
-Activity Instances
-__________________
+### Activity Instances
 
 Activity instances are accessible through two functions:
-``Constraint.ForEachActivity`` and ``Spans.ForEachActivity``. These
+`Constraint.ForEachActivity` and `Spans.ForEachActivity`. These
 functions provide you with a reference to each activity of a given type,
-and allow you to access the activity’s location in time as a ``Windows``
-or ``Spans`` object, and exposes its parameters as profiles.
+and allow you to access the activity’s location in time as a `Windows`
+or `Spans` object, and exposes its parameters as profiles.
 
-Other constraint types
-______________________
+### Other constraint types
 
-Not all constraints are based solely off of a ``Windows`` object. The main exceptions are constraints that deal with
+Not all constraints are based solely off of a `Windows` object. The main exceptions are constraints that deal with
 individual activity instances, because these will use the
-`Constraint.ForEachActivity(...) <../../constraints-edsl-api/classes/Constraint/#foreachactivity>`_ function instead of
-returning a basic ``Windows``. This will evaluate your ``Windows`` expression once for each instance of the given activity
+[Constraint.ForEachActivity(...)](../../../constraints-edsl-api/classes/Constraint.md#foreachactivity) function instead of
+returning a basic `Windows`. This will evaluate your `Windows` expression once for each instance of the given activity
 type, and associate any violations in those expressions with the activity instance it was evaluated on, which can be helpful
 in the UI to figure out which activity caused the violation.
 
-Mental Model for Evaluation
-===========================
+## Mental Model for Evaluation
 
 A constraint doesn’t directly query simulation data, or directly return
 violations. Instead, your constraint code defines an expression to be
@@ -97,4 +89,4 @@ matter for constraint authors, but for this reason you cannot directly
 inspect a profile’s values or a plan’s activities. This is also why
 there are no plans to support querying external profiles directly from a
 web request or filesystem access *inside* the constraint code. For that,
-see the `external dataset documentation <../../external-datasets>`__.
+see the [external dataset documentation](../external-datasets/index.md).


### PR DESCRIPTION
* Converted writing-constraints from rst to md in order to crossreference a header in a MarkDown file

* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
* Fixed the broken internal links in `constraints/index` and `constraints/writing-constraints`
* Converted writing-constraints from an `rst` to an `md` in order to crossreference a header in the EDSL docs (while in general it is possible to [create an reference anchor in `md`s](https://myst-parser.readthedocs.io/en/latest/syntax/syntax.html?highlight=anchor#targets-and-cross-referencing) that are recognized by [the `rst` `:ref:` role](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-ref), because the EDSL docs are autogenerated, that option isn't easily available here)
* Migrated a permanently-relocated link in `CODE_OF_CONDUCT.md`


## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
* For the changed external links, ran `make clean ; make dirhtml-ext ; make linkcheck` and verified it came back clean (aside from the local host link, which is an expected failure)
* For the internal links, ran `make clean ; make preview-ext` and `make clean ; make dirhtml-ext` and verified there were no build errors
* Modified `conf.py` to build this branch, then ran `make clean ;  make multiversionpreview-ext` and manually verified the links work

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
