### PR TITLE
Remove eager profile truncation in constraints

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfile.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfile.java
@@ -35,10 +35,6 @@ public final class DiscreteProfile implements Profile<DiscreteProfile>, Iterable
     this.profilePieces = IntervalMap.of(profilePieces);
   }
 
-  private static boolean profileOutsideBounds(final Segment<SerializedValue> piece, final Interval bounds){
-    return piece.interval().isStrictlyBefore(bounds) || piece.interval().isStrictlyAfter(bounds);
-  }
-
   @Override
   public Windows equalTo(final DiscreteProfile other) {
     return new Windows(

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ActivitySpan.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ActivitySpan.java
@@ -18,7 +18,7 @@ public final class ActivitySpan implements Expression<Spans> {
   }
 
   @Override
-  public Spans evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public Spans evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     final var activity = environment.activityInstances().get(this.activityAlias);
     return new Spans(Segment.of(activity.interval, Optional.of(new Spans.Metadata(activity.id))));
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ActivityWindow.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ActivityWindow.java
@@ -17,7 +17,7 @@ public final class ActivityWindow implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     final var activity = environment.activityInstances().get(this.activityAlias);
     return new Windows(
         Segment.of(Interval.FOREVER, false),

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/And.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/And.java
@@ -22,12 +22,12 @@ public final class And implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     Windows windows = new Windows(true);
     for (final var expression : this.expressions) {
-      windows = windows.and(expression.evaluate(results, bounds, environment));
+      windows = windows.and(expression.evaluate(results, environment));
     }
-    return windows.select(bounds);
+    return windows;
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Changes.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Changes.java
@@ -17,8 +17,8 @@ public final class Changes<P extends Profile<P>> implements Expression<Windows> 
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    return this.expression.evaluate(results, bounds, environment).changePoints().select(bounds);
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    return this.expression.evaluate(results, environment).changePoints();
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteParameter.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteParameter.java
@@ -19,7 +19,7 @@ public final class DiscreteParameter implements Expression<DiscreteProfile> {
   }
 
   @Override
-  public DiscreteProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public DiscreteProfile evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     final var activity = environment.activityInstances().get(this.activityAlias);
     return new DiscreteProfile(
         Segment.of(activity.interval, activity.parameters.get(this.parameterName))

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteResource.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteResource.java
@@ -17,7 +17,7 @@ public final class DiscreteResource implements Expression<DiscreteProfile> {
   }
 
   @Override
-  public DiscreteProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public DiscreteProfile evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     if (results.discreteProfiles.containsKey(this.name)) {
       return results.discreteProfiles.get(this.name);
     } else if (environment.discreteExternalProfiles().containsKey(this.name)) {

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteValue.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteValue.java
@@ -18,8 +18,8 @@ public final class DiscreteValue implements Expression<DiscreteProfile> {
   }
 
   @Override
-  public DiscreteProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    return new DiscreteProfile(Segment.of(bounds, this.value));
+  public DiscreteProfile evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    return new DiscreteProfile(Segment.of(Interval.FOREVER, this.value));
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/EndOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/EndOf.java
@@ -17,7 +17,7 @@ public final class EndOf implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     final var activity = environment.activityInstances().get(this.activityAlias);
     return new Windows(
         Segment.of(Interval.FOREVER, false),

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Ends.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Ends.java
@@ -16,8 +16,8 @@ public final class Ends<I extends IntervalContainer<I>> implements Expression<I>
   }
 
   @Override
-  public I evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var expression = this.expression.evaluate(results, bounds, environment);
+  public I evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    final var expression = this.expression.evaluate(results, environment);
     return expression.ends();
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Equal.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Equal.java
@@ -19,11 +19,11 @@ public final class Equal<P extends Profile<P>> implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var leftProfile = this.left.evaluate(results, bounds, environment);
-    final var rightProfile = this.right.evaluate(results, bounds, environment);
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    final var leftProfile = this.left.evaluate(results, environment);
+    final var rightProfile = this.right.evaluate(results, environment);
 
-    return leftProfile.equalTo(rightProfile).select(bounds);
+    return leftProfile.equalTo(rightProfile);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Expression.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Expression.java
@@ -7,22 +7,15 @@ import gov.nasa.jpl.aerie.constraints.time.Interval;
 import java.util.Set;
 
 public interface Expression<T> {
-  T evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment);
+  T evaluate(final SimulationResults results, final EvaluationEnvironment environment);
   String prettyPrint(final String prefix);
   /** Add the resources referenced by this expression to the given set. **/
   void extractResources(Set<String> names);
 
-  default T evaluate(final SimulationResults results, final EvaluationEnvironment environment){
-    return this.evaluate(results, results.bounds, environment);
-  }
-
-  default T evaluate(final SimulationResults results, final Interval bounds){
-    return this.evaluate(results, bounds, new EvaluationEnvironment());
-  }
-
-  default T evaluate(final SimulationResults results) {
+  default T evaluate(final SimulationResults results){
     return this.evaluate(results, new EvaluationEnvironment());
   }
+
   default String prettyPrint() {
     return this.prettyPrint("");
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivitySpans.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivitySpans.java
@@ -25,7 +25,7 @@ public final class ForEachActivitySpans implements Expression<Spans> {
   }
 
   @Override
-  public Spans evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public Spans evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     final var spans = new Spans();
     for (final var activity : results.activities) {
       if (activity.type.equals(this.activityType)) {
@@ -36,7 +36,7 @@ public final class ForEachActivitySpans implements Expression<Spans> {
         );
         newEnvironment.activityInstances().put(this.alias, activity);
 
-        final var expressionSpans = this.expression.evaluate(results, bounds, newEnvironment);
+        final var expressionSpans = this.expression.evaluate(results, newEnvironment);
         spans.addAll(expressionSpans);
       }
     }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivityViolations.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivityViolations.java
@@ -27,7 +27,7 @@ public final class ForEachActivityViolations implements Expression<List<Violatio
   }
 
   @Override
-  public List<Violation> evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public List<Violation> evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     final var violations = new ArrayList<Violation>();
     for (final var activity : results.activities) {
       if (activity.type.equals(this.activityType)) {
@@ -38,7 +38,7 @@ public final class ForEachActivityViolations implements Expression<List<Violatio
         );
         newEnvironment.activityInstances().put(this.alias, activity);
 
-        final var expressionViolations = this.expression.evaluate(results, bounds, newEnvironment);
+        final var expressionViolations = this.expression.evaluate(results, newEnvironment);
         for (final var violation : expressionViolations) {
           if (!violation.violationWindows.isEmpty()) {
             final var newViolation = new Violation(violation);

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/GreaterThan.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/GreaterThan.java
@@ -19,11 +19,11 @@ public final class GreaterThan implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var leftProfile = this.left.evaluate(results, bounds, environment);
-    final var rightProfile = this.right.evaluate(results, bounds, environment);
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    final var leftProfile = this.left.evaluate(results, environment);
+    final var rightProfile = this.right.evaluate(results, environment);
 
-    return leftProfile.greaterThan(rightProfile).select(bounds);
+    return leftProfile.greaterThan(rightProfile);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/GreaterThanOrEqual.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/GreaterThanOrEqual.java
@@ -19,11 +19,11 @@ public final class GreaterThanOrEqual implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var leftProfile = this.left.evaluate(results, bounds, environment);
-    final var rightProfile = this.right.evaluate(results, bounds, environment);
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    final var leftProfile = this.left.evaluate(results, environment);
+    final var rightProfile = this.right.evaluate(results, environment);
 
-    return leftProfile.greaterThanOrEqualTo(rightProfile).select(bounds);
+    return leftProfile.greaterThanOrEqualTo(rightProfile);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LessThan.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LessThan.java
@@ -19,11 +19,11 @@ public final class LessThan implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    LinearProfile leftProfile = this.left.evaluate(results, bounds, environment);
-    LinearProfile rightProfile = this.right.evaluate(results, bounds, environment);
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    LinearProfile leftProfile = this.left.evaluate(results, environment);
+    LinearProfile rightProfile = this.right.evaluate(results, environment);
 
-    return leftProfile.lessThan(rightProfile).select(bounds);
+    return leftProfile.lessThan(rightProfile);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LessThanOrEqual.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LessThanOrEqual.java
@@ -19,11 +19,11 @@ public final class LessThanOrEqual implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var leftProfile = this.left.evaluate(results, bounds, environment);
-    final var rightProfile = this.right.evaluate(results, bounds, environment);
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    final var leftProfile = this.left.evaluate(results, environment);
+    final var rightProfile = this.right.evaluate(results, environment);
 
-    return leftProfile.lessThanOrEqualTo(rightProfile).select(bounds);
+    return leftProfile.lessThanOrEqualTo(rightProfile);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LongerThan.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/LongerThan.java
@@ -19,8 +19,8 @@ public final class LongerThan implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var windows = this.windows.evaluate(results, bounds, environment);
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    final var windows = this.windows.evaluate(results, environment);
     return windows.filterByDuration(this.duration, Duration.MAX_VALUE);
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Not.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Not.java
@@ -16,8 +16,8 @@ public final class Not implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    return this.expression.evaluate(results, bounds, environment).not();
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    return this.expression.evaluate(results, environment).not();
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/NotEqual.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/NotEqual.java
@@ -19,11 +19,11 @@ public final class NotEqual<P extends Profile<P>> implements Expression<Windows>
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var leftProfile = this.left.evaluate(results, bounds, environment);
-    final var rightProfile = this.right.evaluate(results, bounds, environment);
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    final var leftProfile = this.left.evaluate(results, environment);
+    final var rightProfile = this.right.evaluate(results, environment);
 
-    return leftProfile.notEqualTo(rightProfile).select(bounds);
+    return leftProfile.notEqualTo(rightProfile);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Or.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Or.java
@@ -22,14 +22,14 @@ public final class Or implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     Windows windows = new Windows(false);
     for (final var expression : this.expressions) {
       windows = windows.or(
-          expression.evaluate(results, bounds, environment)
+          expression.evaluate(results, environment)
       );
     }
-    return windows.select(bounds);
+    return windows;
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Plus.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Plus.java
@@ -18,9 +18,9 @@ public final class Plus implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    return left.evaluate(results, bounds, environment)
-               .plus(right.evaluate(results, bounds, environment));
+  public LinearProfile evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    return left.evaluate(results, environment)
+               .plus(right.evaluate(results, environment));
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ProfileExpression.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ProfileExpression.java
@@ -16,8 +16,8 @@ public final class ProfileExpression<P extends Profile<P>> implements Expression
   }
 
   @Override
-  public Profile<P> evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    return this.expression.evaluate(results, bounds, environment);
+  public Profile<P> evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    return this.expression.evaluate(results, environment);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Rate.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Rate.java
@@ -17,8 +17,8 @@ public final class Rate implements Expression<LinearProfile> {
 
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    return this.profile.evaluate(results, bounds, environment).rate();
+  public LinearProfile evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    return this.profile.evaluate(results, environment).rate();
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealParameter.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealParameter.java
@@ -25,7 +25,7 @@ public final class RealParameter implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public LinearProfile evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     final var activity = environment.activityInstances().get(this.activityAlias);
     final var parameter = activity.parameters.get(this.parameterName);
     final var value = parameter.asReal().orElseThrow(

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealResource.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealResource.java
@@ -23,7 +23,7 @@ public final class RealResource implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public LinearProfile evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     if (results.realProfiles.containsKey(this.name)) {
       return results.realProfiles.get(this.name);
     } else if (results.discreteProfiles.containsKey(this.name)) {

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealValue.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RealValue.java
@@ -20,9 +20,9 @@ public final class RealValue implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public LinearProfile evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     return new LinearProfile(
-        Segment.of(bounds, new LinearEquation(Duration.ZERO, value, 0.0))
+        Segment.of(Interval.FOREVER, new LinearEquation(Duration.ZERO, value, 0.0))
     );
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShiftBy.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShiftBy.java
@@ -21,8 +21,8 @@ public final class ShiftBy implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var windows = this.windows.evaluate(results, bounds, environment);
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    final var windows = this.windows.evaluate(results, environment);
     return windows.shiftBy(this.fromStart, this.fromEnd);
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShorterThan.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShorterThan.java
@@ -19,8 +19,8 @@ public final class ShorterThan implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var windows = this.windows.evaluate(results, bounds, environment);
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    final var windows = this.windows.evaluate(results, environment);
     return windows.filterByDuration(Duration.ZERO, duration);
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansFromWindows.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansFromWindows.java
@@ -11,8 +11,8 @@ import java.util.Set;
 public record SpansFromWindows(Expression<Windows> expression) implements Expression<Spans> {
 
   @Override
-  public Spans evaluate(SimulationResults results, final Interval bounds, EvaluationEnvironment environment) {
-    final var windows = this.expression.evaluate(results, bounds, environment);
+  public Spans evaluate(SimulationResults results, EvaluationEnvironment environment) {
+    final var windows = this.expression.evaluate(results, environment);
     return windows.intoSpans();
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Split.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Split.java
@@ -27,8 +27,8 @@ public final class Split<I extends IntervalContainer<?>> implements Expression<S
   }
 
   @Override
-  public Spans evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var intervals = this.intervals.evaluate(results, bounds, environment);
+  public Spans evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    final var intervals = this.intervals.evaluate(results, environment);
     return intervals.split(this.numberOfSubIntervals, this.internalStartInclusivity, this.internalEndInclusivity);
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/StartOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/StartOf.java
@@ -17,7 +17,7 @@ public final class StartOf implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     final var activity = environment.activityInstances().get(this.activityAlias);
     return new Windows(
         Segment.of(Interval.FOREVER, false),

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Starts.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Starts.java
@@ -16,8 +16,8 @@ public final class Starts<I extends IntervalContainer<I>> implements Expression<
   }
 
   @Override
-  public I evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var expression = this.expression.evaluate(results, bounds, environment);
+  public I evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    final var expression = this.expression.evaluate(results, environment);
     return expression.starts();
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Times.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Times.java
@@ -18,8 +18,8 @@ public final class Times implements Expression<LinearProfile> {
   }
 
   @Override
-  public LinearProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    return this.profile.evaluate(results, bounds, environment).times(this.multiplier);
+  public LinearProfile evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    return this.profile.evaluate(results, environment).times(this.multiplier);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Transition.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Transition.java
@@ -22,8 +22,8 @@ public final class Transition implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    return this.profile.evaluate(results, bounds, environment).transitions(oldState, newState).select(bounds);
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
+    return this.profile.evaluate(results, environment).transitions(oldState, newState);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ViolationsOfWindows.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ViolationsOfWindows.java
@@ -18,9 +18,9 @@ public final class ViolationsOfWindows implements Expression<List<Violation>> {
   }
 
   @Override
-  public List<Violation> evaluate(SimulationResults results, final Interval bounds, EvaluationEnvironment environment) {
-    final var satisfiedWindows = this.expression.evaluate(results, bounds, environment);
-    return List.of(new Violation(satisfiedWindows.not().select(bounds)));
+  public List<Violation> evaluate(SimulationResults results, EvaluationEnvironment environment) {
+    final var satisfiedWindows = this.expression.evaluate(results, environment);
+    return List.of(new Violation(satisfiedWindows.not()));
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsFromSpans.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsFromSpans.java
@@ -11,8 +11,8 @@ import java.util.Set;
 public record WindowsFromSpans(Expression<Spans> expression) implements Expression<Windows> {
 
   @Override
-  public Windows evaluate(SimulationResults results, final Interval bounds, EvaluationEnvironment environment) {
-    final var spans = this.expression.evaluate(results, bounds, environment);
+  public Windows evaluate(SimulationResults results, EvaluationEnvironment environment) {
+    final var spans = this.expression.evaluate(results, environment);
     return spans.intoWindows();
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsOf.java
@@ -18,9 +18,9 @@ public final class WindowsOf implements Expression<Windows> {
   }
 
   @Override
-  public Windows evaluate(SimulationResults results, final Interval bounds, EvaluationEnvironment environment) {
-    var ret = new Windows(bounds, false);
-    final var unsatisfiedWindows = this.expression.evaluate(results, bounds, environment);
+  public Windows evaluate(SimulationResults results, EvaluationEnvironment environment) {
+    var ret = new Windows(false);
+    final var unsatisfiedWindows = this.expression.evaluate(results, environment);
     for(var unsatisfiedWindow : unsatisfiedWindows){
       ret = ret.set(unsatisfiedWindow.violationWindows, true);
     }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsWrapperExpression.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/WindowsWrapperExpression.java
@@ -13,7 +13,7 @@ public class WindowsWrapperExpression implements Expression<Windows> {
   public WindowsWrapperExpression(final Windows windows) { this.windows = windows; }
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+  public Windows evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
     return windows;
   }
 

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -378,7 +378,7 @@ public class ASTTests {
     final var result = new RealValue(7).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new LinearProfile(
-        Segment.of(simResults.bounds, new LinearEquation(Duration.ZERO, 7, 0))
+        Segment.of(FOREVER, new LinearEquation(Duration.ZERO, 7, 0))
     );
 
     assertEquivalent(expected, result);
@@ -396,7 +396,7 @@ public class ASTTests {
     final var result = new DiscreteValue(SerializedValue.of("IDLE")).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new DiscreteProfile(
-        Segment.of(simResults.bounds, SerializedValue.of("IDLE"))
+        Segment.of(FOREVER, SerializedValue.of("IDLE"))
     );
 
     assertEquivalent(expected, result);
@@ -882,7 +882,7 @@ public class ASTTests {
 
 
     @Override
-    public T evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+    public T evaluate(final SimulationResults results, final EvaluationEnvironment environment) {
       return this.value;
     }
 

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/TimeRangeExpression.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/TimeRangeExpression.java
@@ -71,7 +71,7 @@ public class TimeRangeExpression {
 
     for (var expr : stateExpr) {
       final var domainOfInter = Interval.between(inter.minTrueTimePoint().get().getKey(), inter.maxTrueTimePoint().get().getKey());
-      Windows windowsState = expr.evaluate(simulationResults, domainOfInter, new EvaluationEnvironment());
+      Windows windowsState = expr.evaluate(simulationResults, new EvaluationEnvironment()).select(domainOfInter);
       inter = inter.and(windowsState);
       if(inter.stream().noneMatch(Segment::value)) return inter;
     }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/filters/FilterEverViolated.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/filters/FilterEverViolated.java
@@ -22,6 +22,6 @@ public class FilterEverViolated extends FilterFunctional {
 
   @Override
   public boolean shouldKeep(final SimulationResults simulationResults, final Plan plan, final Interval range) {
-    return !(expr.evaluate(simulationResults, range, new EvaluationEnvironment()).equals(new Windows(range, true)));
+    return !(expr.evaluate(simulationResults, new EvaluationEnvironment()).equals(new Windows(range, true)));
   }
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -706,7 +706,7 @@ public class PrioritySolver implements Solver {
     //REVIEW: could be some optimization in constraint ordering (smallest domain first to fail fast)
     for (final var constraint : constraints) {
       //REVIEW: loop through windows more efficient than enveloppe(windows) ?
-      final var validity = constraint.evaluate(simulationFacade.getLatestConstraintSimulationResults(), totalDomain);
+      final var validity = constraint.evaluate(simulationFacade.getLatestConstraintSimulationResults()).select(totalDomain);
       ret = ret.and(validity);
       //short-circuit if no possible windows left
       if (ret.stream().noneMatch(Segment::value)) {

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
@@ -197,7 +197,8 @@ public class SimulationFacadeTest {
   public void whenValueAboveDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
-    var actual = new GreaterThan(getFruitRes(), new RealValue(2.9)).evaluate(facade.getLatestConstraintSimulationResults());
+    final var simResults = facade.getLatestConstraintSimulationResults();
+    var actual = new GreaterThan(getFruitRes(), new RealValue(2.9)).evaluate(simResults).select(simResults.bounds);
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 2, Exclusive, SECONDS), true),
         Segment.of(interval(2, 5, SECONDS), false)
@@ -209,7 +210,8 @@ public class SimulationFacadeTest {
   public void whenValueBelowDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
-    var actual = new LessThan(getFruitRes(), new RealValue(3.0)).evaluate(facade.getLatestConstraintSimulationResults());
+    final var simResults = facade.getLatestConstraintSimulationResults();
+    var actual = new LessThan(getFruitRes(), new RealValue(3.0)).evaluate(simResults).select(simResults.bounds);
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 2, Exclusive, SECONDS), false),
         Segment.of(interval(2, 5, SECONDS), true)
@@ -221,7 +223,8 @@ public class SimulationFacadeTest {
   public void whenValueBetweenDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
-    var actual = new And(new GreaterThanOrEqual(getFruitRes(), new RealValue(3.0)), new LessThanOrEqual(getFruitRes(), new RealValue(3.99))).evaluate(facade.getLatestConstraintSimulationResults());
+    final var simResults = facade.getLatestConstraintSimulationResults();
+    var actual = new And(new GreaterThanOrEqual(getFruitRes(), new RealValue(3.0)), new LessThanOrEqual(getFruitRes(), new RealValue(3.99))).evaluate(simResults).select(simResults.bounds);
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 1, Exclusive, SECONDS), false),
         Segment.of(interval(1, Inclusive, 2, Exclusive, SECONDS), true),
@@ -234,7 +237,8 @@ public class SimulationFacadeTest {
   public void whenValueEqualDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
-    var actual = new Equal<>(getFruitRes(), new RealValue(3.0)).evaluate(facade.getLatestConstraintSimulationResults());
+    final var simResults = facade.getLatestConstraintSimulationResults();
+    var actual = new Equal<>(getFruitRes(), new RealValue(3.0)).evaluate(simResults).select(simResults.bounds);
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 1, Exclusive, SECONDS), false),
         Segment.of(interval(1, Inclusive, 2, Exclusive, SECONDS), true),
@@ -247,7 +251,8 @@ public class SimulationFacadeTest {
   public void whenValueNotEqualDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
     facade.simulateActivities(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
-    var actual = new NotEqual<>(getFruitRes(), new RealValue(3.0)).evaluate(facade.getLatestConstraintSimulationResults());
+    final var simResults = facade.getLatestConstraintSimulationResults();
+    var actual = new NotEqual<>(getFruitRes(), new RealValue(3.0)).evaluate(simResults).select(simResults.bounds);
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 1, Exclusive, SECONDS), true),
         Segment.of(interval(1, Inclusive, 2, Exclusive, SECONDS), false),


### PR DESCRIPTION
***Closes #452***
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Removed the bounds argument from `Expression.evaluate`. It will eventually be added back in, but for now truncating results manually must be done with `windows.select(bounds)` or `profile.select(bounds)`.

This change can be merged for 1.0 if possible, but it is not necessary.

## Verification
Any tests that broke were fixed.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
Finish the rest of the solution proposed in #417.
