### PR TITLE
docs: add GitHub release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,35 @@
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking change
+    - title: New Features
+      labels:
+        - feature
+    - title: Bug Fixes
+      labels:
+        - fix
+    - title: Performance Improvements
+      labels:
+        - performance
+    - title: Refactoring
+      labels:
+        - refactor
+    - title: Testing
+      labels:
+        - test
+    - title: Continuous Integration
+      labels:
+        - ci
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Build System and Dependencies
+      labels:
+        - build
+    - title: Style
+      labels:
+        - style
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Description

* Helps with auto-generating release notes
* See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes