### PR TITLE
Remove Scylla links

### DIFF
--- a/docs/source/contribute/documentation/examples/admonitions.rst
+++ b/docs/source/contribute/documentation/examples/admonitions.rst
@@ -1,7 +1,7 @@
 Admonitions
 ===========
 
-At Scylla, we limit the admonitions. Although |rst| will allow for more, use the following:
+Although |rst| allows for more, we limit the admonitions we use to one of the following:
 
 * Note_
 * Caution_

--- a/docs/source/contribute/documentation/examples/links.rst
+++ b/docs/source/contribute/documentation/examples/links.rst
@@ -14,8 +14,8 @@ There are a few links you can use with different purposes.
    * - External Link
      - .. code-block:: rst
 
-          `External Link <https://docs.scylladb.com/>`_
-     - `External Link <https://docs.scylladb.com/>`_
+          `External Link <https://github.com/NASA-AMMOS/aerie>`_
+     - `External Link <https://github.com/NASA-AMMOS/aerie>`_
      - Use this markup to create a link to another site or project. When rendered it has an arrow pointing out icon. It opens the content in a new tab.
    * - Internal Cross-reference
      - .. code-block:: rst

--- a/docs/source/contribute/documentation/examples/tabs.rst
+++ b/docs/source/contribute/documentation/examples/tabs.rst
@@ -1,54 +1,65 @@
 Tabs
 ====
 
-When there are several languages or options available and the reader will use one and keep using that option throughout the procedure, a tabbed content box is the best way to display this informaiton.
+When there are several languages or options available and the reader will use one and keep using that option throughout the procedure, a tabbed content box is the best way to display this information.
 
 For example:
 
 .. code-block:: none
 
-   .. tabs::
+  .. tabs::
 
-      .. group-tab:: CentOS 7, Ubuntu 16.04/18.04, Debian 8/9
+    .. group-tab:: MacOS (BSD sed)
 
-         .. code-block:: shell
+      To replace every instance of the word "Hello" with the word "World" in a file using BSD sed, use the following command:
 
-            sudo systemctl stop scylla-server
+      .. code-block:: shell
 
-      .. group-tab:: Ubuntu 14.04, Debian 7
+         sed -i '' 's/Hello/World/g' index.rst
 
-         .. code-block:: shell
+    .. group-tab:: Linux (GNU sed)
 
-            sudo service scylla-server stop
+      To replace every instance of the word "Hello" with the word "World" in a file using GNU sed, use the following command:
 
-      .. group-tab:: Docker
+      .. code-block:: shell
 
-         .. code-block:: shell
+         sed -i -e 's/README/index/g' index.rst
 
-            docker exec -it some-scylla supervisorctl stop scylla
+    .. group-tab:: Windows (Powershell)
 
-         (without stopping *some-scylla* container)
+      Windows has no ``sed`` equivalent natively installed. Instead, in order to replace every instance of the word "Hello" with the word "World" in a file,
+      use the following command in Powershell:
+
+      .. code-block:: shell
+
+         (Get-Content index.rst) -replace 'Hello', 'World' | Out-File -encoding ASCII index.rst
+
 
 Renders as:
 
 .. tabs::
 
-   .. group-tab:: CentOS 7, Ubuntu 16.04/18.04, Debian 8/9
+   .. group-tab:: MacOS (BSD sed)
+
+      To replace every instance of the word "Hello" with the word "World" in a file using BSD sed, use the following syntax:
 
       .. code-block:: shell
 
-         sudo systemctl stop scylla-server
+         sed -i '' 's/Hello/World/g' index.rst
 
-   .. group-tab:: Ubuntu 14.04, Debian 7
+   .. group-tab:: Linux (GNU sed)
 
-      .. code-block:: shell
-
-         sudo service scylla-server stop
-
-   .. group-tab:: Docker
+      To replace every instance of the word "Hello" with the word "World" in a file using GNU sed, use the following syntax:
 
       .. code-block:: shell
 
-         docker exec -it some-scylla supervisorctl stop scylla
+         sed -i -e 's/README/index/g' index.rst
 
-      (without stopping *some-scylla* container)
+   .. group-tab:: Windows (Powershell)
+
+      Windows has no ``sed`` equivalent natively installed. Instead, in order to replace every instance of the word "Hello" with the word "World" in a file,
+      use the following command in Powershell:
+
+      .. code-block:: shell
+
+         (Get-Content index.rst) -replace 'Hello', 'World' | Out-File -encoding ASCII index.rst

--- a/docs/source/contribute/documentation/examples/topic-box.rst
+++ b/docs/source/contribute/documentation/examples/topic-box.rst
@@ -122,7 +122,7 @@ Using:
 
     .. topic-box::
         :title: Lorem Ipsum
-        :link: https://scylladb.com
+        :link: https://nasa-ammos.github.io/aerie/stable/
         :anchor: Lorem ipsum
 
         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -131,7 +131,7 @@ Results in:
 
 .. topic-box::
     :title: Lorem Ipsum
-    :link: https://scylladb.com
+    :link: https://nasa-ammos.github.io/aerie/stable/
     :anchor: Lorem ipsum
 
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -152,7 +152,7 @@ Using:
 
     .. topic-box::
         :title: Lorem ipsum
-        :link: scylla-cloud
+        :link: https://nasa-ammos.github.io/aerie/stable/
         :class: large-4
         :anchor: Lorem ipsum
 
@@ -160,7 +160,7 @@ Using:
 
     .. topic-box::
         :title: Lorem ipsum
-        :link: scylla-cloud
+        :link: https://nasa-ammos.github.io/aerie/stable/
         :class: large-4
         :anchor: Lorem ipsum
 
@@ -168,7 +168,7 @@ Using:
 
     .. topic-box::
         :title: Lorem ipsum
-        :link: scylla-cloud
+        :link: https://nasa-ammos.github.io/aerie/stable/
         :class: large-4
         :anchor: Lorem ipsum
 
@@ -189,7 +189,7 @@ Results in:
 
 .. topic-box::
     :title: Lorem ipsum
-    :link: scylla-cloud
+    :link: https://nasa-ammos.github.io/aerie/stable/
     :class: large-4
     :anchor: Lorem ipsum
 
@@ -197,7 +197,7 @@ Results in:
 
 .. topic-box::
     :title: Lorem ipsum
-    :link: scylla-cloud
+    :link: https://nasa-ammos.github.io/aerie/stable/
     :class: large-4
     :anchor: Lorem ipsum
 
@@ -205,7 +205,7 @@ Results in:
 
 .. topic-box::
     :title: Lorem ipsum
-    :link: scylla-cloud
+    :link: https://nasa-ammos.github.io/aerie/stable/
     :class: large-4
     :anchor: Lorem ipsum
 


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR removes the final references to Scylla in the body of our documentation.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
For verifying that these are the final references, I went file-by-file through all files in `docs` besides those in `_build` and `old_site` and checked for the word `Scylla`. The only remaining instances of `Scylla` found are related to theme functionality.

For verifying the docs:
- `make clean ; make test` had no errors
- `make clean ; make dirhtml-ext ; make linkcheck` had only the expected issues
- `make preview` looks as expected
