### PR TITLE
Include gaps in violations

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/Violation.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/Violation.java
@@ -12,26 +12,38 @@ public final class Violation {
   public final List<Long> activityInstanceIds;
   public final List<String> resourceNames;
   public final List<Interval> violationWindows;
+  public final List<Interval> gaps;
 
   public Violation(final List<Long> activityInstanceIds, final List<String> resourceNames, final Windows violationWindows) {
     this.activityInstanceIds = new ArrayList<>(activityInstanceIds);
     this.resourceNames = new ArrayList<>(resourceNames);
     this.violationWindows = new ArrayList<>(violationWindows.size());
-    for (final var interval: violationWindows.iterateEqualTo(true)) this.violationWindows.add(interval);
+    this.gaps = new ArrayList<>();
+    for (final var interval: violationWindows.iterateEqualTo(true)) {
+      this.violationWindows.add(interval);
+    }
+
+    // Set all known segments to false and assign true to the gaps
+    final var gapsWindows = violationWindows.notEqualTo(violationWindows).assignGaps(new Windows(true));
+
+    for (final var interval: gapsWindows.iterateEqualTo(true)) {
+      this.gaps.add(interval);
+    }
   }
 
   public Violation(final Windows violationWindows) {
     this(new ArrayList<>(), new ArrayList<>(), violationWindows);
   }
 
-  public Violation(final List<Long> activityInstanceIds, final List<String> resourceNames, final List<Interval> intervals) {
+  public Violation(final List<Long> activityInstanceIds, final List<String> resourceNames, final List<Interval> intervals, final List<Interval> gaps) {
     this.activityInstanceIds = new ArrayList<>(activityInstanceIds);
     this.resourceNames = List.copyOf(resourceNames);
     this.violationWindows = List.copyOf(intervals);
+    this.gaps = List.copyOf(gaps);
   }
 
   public Violation(final Violation other) {
-    this(other.activityInstanceIds, other.resourceNames, other.violationWindows);
+    this(other.activityInstanceIds, other.resourceNames, other.violationWindows, other.gaps);
   }
 
   public void addActivityId(final long activityId) {
@@ -46,7 +58,7 @@ public final class Violation {
       s.append(" ").append(iter.next());
       if (iter.hasNext()) s.append(",");
     }
-    s.append(prefix).append("  Resource Names: [");
+    s.append(prefix).append(" ], Resource Names: [");
     final var resources = this.resourceNames.iterator();
     while (resources.hasNext()) {
       s.append(" ").append(resources.next());
@@ -54,21 +66,27 @@ public final class Violation {
     }
 
     s.append(" ],\n").append(prefix).append("  Windows: [").append(violationWindows).append("]\n");
+    s.append(" ],\n").append(prefix).append("  Gaps: [").append(gaps).append("]\n");
     s.append("}");
     return s.toString();
   }
 
   @Override
+  public String toString() {
+    return prettyPrint("");
+  }
+
+  @Override
   public boolean equals(final Object obj) {
-    if (!(obj instanceof Violation)) return false;
-    final var other = (Violation)obj;
+    if (!(obj instanceof final Violation other)) return false;
     return Objects.equals(this.activityInstanceIds, other.activityInstanceIds) &&
            Objects.equals(this.resourceNames, other.resourceNames) &&
-           Objects.equals(this.violationWindows, other.violationWindows);
+           Objects.equals(this.violationWindows, other.violationWindows) &&
+           Objects.equals(this.gaps, other.gaps);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.activityInstanceIds, this.resourceNames, this.violationWindows);
+    return Objects.hash(this.activityInstanceIds, this.resourceNames, this.violationWindows, this.gaps);
   }
 }

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -692,7 +692,17 @@ public class ASTTests {
 
     final var result = new ViolationsOfWindows(new Supplier<>(windows)).evaluate(simResults, new EvaluationEnvironment());
 
-    final var expected = List.of(new Violation(windows.not().select(simResults.bounds)));
+    final var expected = List.of(new Violation(
+        List.of(),
+        List.of(),
+        List.of(Interval.between(5, 6, SECONDS)),
+        List.of(
+            Interval.between(Duration.MIN_VALUE, Inclusive, Duration.SECOND, Exclusive),
+            Interval.between(4, Exclusive, 5, Exclusive, SECONDS),
+            Interval.between(6, Exclusive, 7, Exclusive, SECONDS),
+            Interval.between(Duration.of(20, SECONDS), Exclusive, Duration.MAX_VALUE, Inclusive)
+        )
+    ));
 
     assertEquivalent(expected, result);
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -130,11 +130,12 @@ public final class ResponseSerializers {
             .add("activityInstanceIds", serializeIterable(Json::createValue, violation.activityInstanceIds))
             .add("resourceIds", serializeIterable(Json::createValue, violation.resourceNames))
             .build())
-        .add("windows", serializeIterable(ResponseSerializers::serializeWindow, violation.violationWindows))
+        .add("windows", serializeIterable(ResponseSerializers::serializeInterval, violation.violationWindows))
+        .add("gaps", serializeIterable(ResponseSerializers::serializeInterval, violation.gaps))
         .build();
   }
 
-  public static JsonValue serializeWindow(final Interval interval) {
+  public static JsonValue serializeInterval(final Interval interval) {
     return Json.createObjectBuilder()
                .add("start", interval.start.in(Duration.MICROSECONDS))
                .add("end", interval.end.in(Duration.MICROSECONDS))

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -247,7 +247,8 @@ public final class GetSimulationResultsAction {
       violationEvents.forEach(violation -> violationEventsWithNames.add(new Violation(
           violation.activityInstanceIds,
           resourceNames,
-          violation.violationWindows)));
+          violation.violationWindows,
+          violation.gaps)));
 
       violations.put(entry.getKey(), violationEventsWithNames);
     }


### PR DESCRIPTION
* **Tickets addressed:** closes #462 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This adds two small pieces:
- store gaps in the Violation object by extracting them from the input Windows
- serialize the gaps in the getConstraintViolations action

Do not merge until a [sister PR](https://github.com/NASA-AMMOS/aerie-ui/issues/301) is ready in the UI to handle these gaps.

## Verification
I changed an existing test to explicitly check for gaps in the Violation object.

## Documentation
Documentation is already written for this.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
