### PR TITLE
Fix broken links in Docs

### DIFF
--- a/docs/source/user-guide/mission-modeler-guide/activity-mappers/activity-mapper-interface.rst
+++ b/docs/source/user-guide/mission-modeler-guide/activity-mappers/activity-mapper-interface.rst
@@ -45,8 +45,8 @@ as such:
 
 The ``getParameters()`` method returns a ``Map<String, ValueSchema>``.
 In this map should be a key for every parameter, with a ``ValueSchema``
-describing the structure of that parameter. See our `Value Schema
-documentation <../../custom-value-types/value-schema-basics>`__ for more
+describing the structure of that parameter. See our :doc:`Value Schema
+documentation <../custom-value-types/value-schema-basics>` for more
 information on creating value schemas.
 
 Generated Activity Mappers
@@ -58,7 +58,7 @@ the Merlin Annotation Processor. When compiling your code with the
 Merlin annotation processor, the processor will produce an activity
 mapper for each activity type. This is made possible by the use of the
 ``@WithMappers()`` annotations in your
-`package-info.java <developing-a-mission-model.md#package-info-file>`__.
+:ref:`package-info.java <package-info-file>`.
 Each java-file specified by these annotations is parsed to determine
 what types of values can be mapped. As long as there is a mapper for
 each activity parameter type used in the model, the annotation processor
@@ -138,8 +138,8 @@ mapper for an apache ``Vector3D`` type as an example:
 
 Notice there are just 3 methods to implement for a ``ValueMapper``. The
 first is ``getValueSchema()``, which should return a ``ValueSchema``
-describing the structure of the value being mapped (see `value
-schemas <../../custom-value-types/value-schema-basics>`__ for more info)
+describing the structure of the value being mapped (see :doc:`value
+schemas <../custom-value-types/value-schema-basics>` for more info)
 
 The next two methods are inverses of each other: ``deserializeValue()``
 and ``serializeValue()``. It is the job of ``deserializeValue()`` to

--- a/docs/source/user-guide/mission-modeler-guide/index.rst
+++ b/docs/source/user-guide/mission-modeler-guide/index.rst
@@ -15,6 +15,8 @@ Creating a Mission Model
 ------------------------
 To see how to create a mission model, see our :doc:`Quickstart Guide <../quickstart/create-mission-model>`.
 
+.. _package-info-file:
+
 The Package-info File
 ---------------------
 A mission model must contain, at the very least, a
@@ -55,7 +57,7 @@ types. If multiple mapper classes are included via the
 ``@WithMappers`` annotations, and multiple mappers declare a mapping
 rule to the same data type, the rule found in the earlier declared
 mapper will take precedence. For more information on allowing custom
-values, see `value mappers <./custom-value-mappers>`__.
+values, see :doc:`value mappers <./custom-value-mappers/index>`.
 
 The Mission Model Class
 -----------------------

--- a/docs/source/user-guide/ui-api-guide/constraints/writing-constraints.md
+++ b/docs/source/user-guide/ui-api-guide/constraints/writing-constraints.md
@@ -29,6 +29,7 @@ comes up most often when dealing with external datasets. In most cases
 it is best to apply a default value to a profile’s gaps ASAP using the
 `profile.assignGaps(defaultValue)` method.
 
+(windows)= 
 ### Windows
 
 Windows are like a boolean profile, augmented with some extra
@@ -88,4 +89,4 @@ matter for constraint authors, but for this reason you cannot directly
 inspect a profile’s values or a plan’s activities. This is also why
 there are no plans to support querying external profiles directly from a
 web request or filesystem access _inside_ the constraint code. For that,
-see the [external dataset documentation](../external-datasets/index.md).
+see the [external dataset documentation](../external-datasets/index.rst).

--- a/docs/source/user-guide/ui-api-guide/scheduling/scheduling-conditions.rst
+++ b/docs/source/user-guide/ui-api-guide/scheduling/scheduling-conditions.rst
@@ -22,7 +22,7 @@ Restricting when any activity type can be scheduled
 This condition takes an expression of type ``Windows`` and prevents the scheduler from inserting any activity outside the
 time intervals produced by the expression when evaluated.
 
-The ``Windows`` type is described in the `Constraints DSL documentation <../../constraints/writing-constraints>`_.
+The ``Windows`` type is described in the :ref:`Constraints DSL documentation <windows>`.
 
 Example:
 
@@ -42,7 +42,7 @@ Restricting when some activity types can be scheduled
 This condition takes a list of activity types and an expression of type ``Windows``. It prevents the scheduler from
 inserting activity of the given activity types outside the time intervals produced by the expression when evaluated.
 
-The ``Windows`` type is described in the `Constraints DSL documentation <../../constraints/writing-constraints>`_.
+The ``Windows`` type is described in the :ref:`Constraints DSL documentation <windows>`.
 
 Example:
 

--- a/docs/source/user-guide/ui-api-guide/scheduling/scheduling-goals.rst
+++ b/docs/source/user-guide/ui-api-guide/scheduling/scheduling-goals.rst
@@ -73,7 +73,7 @@ The Coexistence Goal specifies that a certain activity should occur once **for e
 
 **Inputs**
 
-* **forEach**: a set of time windows (`see constraints documentation <../../constraints/writing-constraints>`_) on how to produce such an expression) or a set of activities (``ActivityExpression``)
+* **forEach**: a set of time Windows (:ref:`See the constraints documentation <windows>` on how to produce such an expression) or a set of activities (``ActivityExpression``)
 * **activityTemplate**: the description of the activity to insert after each activity identified by ``forEach``
 * **startsAt**: optionally specify a specific time when the activity should start relative to the window
 * **startsWithin**: optionally specify a range when the activity should start relative to the window
@@ -283,8 +283,8 @@ Restricting when a goal is applied
 ==================================
 
 By default, a goal applies on the whole planning horizon. The Aerie scheduler provides support for restricting *when*
-a goal applies with the ``.applyWhen()`` method in the ``Goal`` class. This node allows users to provide a set of windows
-(`see constraints documentation <../../constraints/writing-constraints>`_) which could be a time
+a goal applies with the ``.applyWhen()`` method in the ``Goal`` class. This node allows users to provide a set of Windows
+(:ref:`see constraints documentation <windows>`) which could be a time
 or a resource-based window.
 
 The ``.applyWhen()`` method, takes one argument: the windows (in the form of an expression) that the goal should apply


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR fixes the broken links in our docs. This includes updating a couple of internal links to use either a `ref` or `doc` directive (depending on whether the link was pointing at a page header or a page, respectively) instead of using RST's external link syntax.

At the end of this PR, running `make clean ; make dirhtml-ext ; make linkcheck` now has the following expected errors:
- `aerie/docs/source/user-guide/ui-api-guide/constraints/index.rst:70: WARNING: circular inclusion in "include" directive: source/user-guide/ui-api-guide/api-examples.rst < source/user-guide/ui-api-guide/api-examples.rst < source/user-guide/ui-api-guide/constraints/index.rst` <- This is a false positive that appears related to [this Sphinx Issue](https://github.com/sphinx-doc/sphinx/issues/10951).
- `(contribute/documentation/docs-pr: line   33) broken    http://127.0.0.1:5500/ - HTTPConnectionPool(host='127.0.0.1', port=5500): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x106284ac0>: Failed to establish a new connection: [Errno 61] Connection refused'))` <- This is a localhost link to where the documentation is hosted when `make preview` is running, and is therefore expected to be broken when `make linkcheck` is run.
- `(user-guide/upgrade-guides/0-13-2-to-1-0-0: line  161) broken    https://github.com/NASA-AMMOS/aerie/blob/develop/deployment/Environment.md#aerie-scheduler-worker - Anchor 'aerie-scheduler-worker' not found
(user-guide/upgrade-guides/0-13-2-to-1-0-0: line  161) broken    https://github.com/NASA-AMMOS/aerie/blob/develop/deployment/Environment.md#aerie-scheduler - Anchor 'aerie-scheduler' not found` <- These links both work, however the current working theory is that they appear as broken since the anchors don't exist until GitHub renders `Enviornment.md`

## Verification
- `make clean ; make dirhtml-ext` throws no errors
- `make clean ; make dirhtml-ext ; make linkcheck` throws only the expected errors
- The links work in `make preview-ext`
- The links work in `make mutliversionpreview-ext` (After updating `conf.py` to build the branch)