### PR TITLE
Updated the hausra and postgres container names with the aerie prefix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,7 +205,7 @@ services:
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store:ro
   hasura:
-    container_name: hasura
+    container_name: aerie_hasura
     depends_on: ["postgres"]
     environment:
       AERIE_MERLIN_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_merlin"
@@ -224,7 +224,7 @@ services:
     volumes:
       - ./deployment/hasura/metadata:/hasura-metadata
   postgres:
-    container_name: postgres
+    container_name: aerie_postgres
     environment:
       POSTGRES_DB: postgres
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"


### PR DESCRIPTION
* **Tickets addressed:** Partial address of #463 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
On my initial run I had conflicting container names with another project that was using Hasura and Postgres. This attempts to avoid those errors going forward by using Aerie prefixed names for those 2 containers.

## Verification
I tested by recreating and running the docker containers, and then seeing if they conflict with another application that uses generic `hasura` and `postgres` container names.

## Documentation

N/A

## Future work

N/A