### PR TITLE
Add standalone Aerie Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 *
 
 # Explicitly whitelist files relevant to image creation.
+!deployment
 !merlin-server/build/distributions/*.tar
 !merlin-worker/build/distributions/*.tar
 !scheduler-server/build/distributions/*.tar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,35 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
+      # Build, scan, and push aerie-hasura Docker artifacts.
+      - name: Extract metadata (tags, labels) for aerie-hasura Docker image
+        id: aerieHasura
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/nasa-ammos/aerie-hasura
+      - name: Build aerie-hasura Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/Dockerfile.hasura
+          load: true
+          tags: ${{ env.REGISTRY }}/nasa-ammos/aerie-hasura:${{ github.sha }}
+      - name: Scan aerie-hasura Docker image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/nasa-ammos/aerie-hasura:${{ github.sha }}
+          format: 'table'
+          exit-code: '0'
+          ignore-unfixed: true
+          severity: 'CRITICAL'
+      - name: Push aerie-hasura Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/Dockerfile.hasura
+          push: true
+          tags: ${{ steps.aerieHasura.outputs.tags }}
+          labels: ${{ steps.aerieHasura.outputs.labels }}
       # Build, scan, and push aerie-merlin Docker artifacts.
       - name: Extract metadata (tags, labels) for aerie-merlin Docker image
         id: aerieMerlin
@@ -99,6 +128,35 @@ jobs:
           push: true
           tags: ${{ steps.aerieMerlinWorker.outputs.tags }}
           labels: ${{ steps.aerieMerlinWorker.outputs.labels }}
+      # Build, scan, and push aerie-postgres Docker artifacts.
+      - name: Extract metadata (tags, labels) for aerie-postgres Docker image
+        id: aeriePostgres
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/nasa-ammos/aerie-postgres
+      - name: Build aerie-postgres Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/Dockerfile.postgres
+          load: true
+          tags: ${{ env.REGISTRY }}/nasa-ammos/aerie-postgres:${{ github.sha }}
+      - name: Scan aerie-postgres Docker image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/nasa-ammos/aerie-postgres:${{ github.sha }}
+          format: 'table'
+          exit-code: '0'
+          ignore-unfixed: true
+          severity: 'CRITICAL'
+      - name: Push aerie-postgres Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/Dockerfile.postgres
+          push: true
+          tags: ${{ steps.aeriePostgres.outputs.tags }}
+          labels: ${{ steps.aeriePostgres.outputs.labels }}
       # Build, scan, and push aerie-scheduler-worker Docker artifacts.
       - name: Extract metadata (tags, labels) for aerie-scheduler-worker Docker image
         id: aerieSchedulerWorker

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To get started with a first Aerie deployment head over to the [deployment direct
 ├── contrib                     # Java convenience classes for mission models
 ├── db-tests                    # Database unit tests
 ├── deployment                  # Deployment artifacts and documentation
+├── docker                      # Additional Dockerfiles for Aerie-specific images
 ├── docs                        # Documentation
 ├── e2e-tests                   # End-to-end tests
 ├── examples                    # Example mission models

--- a/docker/Dockerfile.hasura
+++ b/docker/Dockerfile.hasura
@@ -1,0 +1,2 @@
+FROM hasura/graphql-engine:v2.12.0.cli-migrations-v3
+COPY deployment/hasura/metadata /hasura-metadata

--- a/docker/Dockerfile.postgres
+++ b/docker/Dockerfile.postgres
@@ -1,0 +1,2 @@
+FROM postgres:14.1
+COPY deployment/postgres-init-db /docker-entrypoint-initdb.d

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,31 @@
+# Docker
+
+This directory contains additional Dockerfiles for images built by Aerie.
+
+- [Dockerfile.hasura](./Dockerfile.hasura) - A Hasura Docker image with bundled Aerie-specific Hasura metadata
+- [Dockerfile.postgres](./Dockerfile.postgres) - A Postgres Docker image with bundled Aerie-specific SQL
+
+## Build
+
+First build Aerie to make sure the SQL files are properly added to the [deployment](../deployment/) directory:
+
+```sh
+cd aerie
+./gradlew assemble
+```
+
+Next, still from the top-level Aerie directory, build the images from the provided Dockerfiles:
+
+```sh
+docker build -t aerie-hasura -f ./docker/Dockerfile.hasura .
+docker build -t aerie-postgres -f ./docker/Dockerfile.postgres .
+```
+
+## Run
+
+To run the images you can use the following commands. Note these are just for testing purposes:
+
+```sh
+docker run --name aerie-hasura -d -p 8080:8080 aerie-hasura
+docker run --name aerie-postgres -d -p 5432:5432 --env-file ./.env aerie-postgres
+```


### PR DESCRIPTION
* **Tickets addressed:** Resolves https://github.com/NASA-AMMOS/aerie/issues/463
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

* Create Hasura docker image with Aerie data
* Create Postgres Docker image with Aerie data
* Used for quick-starting with Aerie

## Verification

N/A

## Documentation

README included.

## Future work

Add a `docker-compose-standalone.yml` to our deployment directory that uses the new images.