### PR TITLE
Spans based scheduling basic AST

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/EvaluationEnvironment.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/EvaluationEnvironment.java
@@ -1,14 +1,17 @@
 package gov.nasa.jpl.aerie.constraints.model;
 
+import gov.nasa.jpl.aerie.constraints.time.Spans;
+
 import java.util.Map;
 
 /** A container for additional context needed for Constraints AST evaluation. */
 public record EvaluationEnvironment(
     Map<String, ActivityInstance> activityInstances,
+    Map<String, Spans> spansInstances,
     Map<String, LinearProfile> realExternalProfiles,
     Map<String, DiscreteProfile> discreteExternalProfiles
 ) {
   public EvaluationEnvironment() {
-    this(Map.of(), Map.of(), Map.of());
+    this(Map.of(), Map.of(), Map.of(), Map.of());
   }
 }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivitySpans.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivitySpans.java
@@ -31,6 +31,7 @@ public final class ForEachActivitySpans implements Expression<Spans> {
       if (activity.type.equals(this.activityType)) {
         final var newEnvironment = new EvaluationEnvironment(
             new HashMap<>(environment.activityInstances()),
+            environment.spansInstances(),
             environment.realExternalProfiles(),
             environment.discreteExternalProfiles()
         );
@@ -61,8 +62,7 @@ public final class ForEachActivitySpans implements Expression<Spans> {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof ForEachActivitySpans)) return false;
-    final var o = (ForEachActivitySpans)obj;
+    if (!(obj instanceof final ForEachActivitySpans o)) return false;
 
     return Objects.equals(this.activityType, o.activityType) &&
            Objects.equals(this.alias, o.alias) &&

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivityViolations.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivityViolations.java
@@ -33,6 +33,7 @@ public final class ForEachActivityViolations implements Expression<List<Violatio
       if (activity.type.equals(this.activityType)) {
         final var newEnvironment = new EvaluationEnvironment(
             new HashMap<>(environment.activityInstances()),
+            environment.spansInstances(),
             environment.realExternalProfiles(),
             environment.discreteExternalProfiles()
         );

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansAlias.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansAlias.java
@@ -1,0 +1,31 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.Segment;
+import gov.nasa.jpl.aerie.constraints.time.Spans;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+
+import java.util.Objects;
+import java.util.Set;
+
+public record SpansAlias(String spansAlias) implements Expression<Spans> {
+
+  @Override
+  public Spans evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+    return environment.spansInstances().get(this.spansAlias);
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {}
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return String.format(
+        "\n%s(spansAlias %s)",
+        prefix,
+        this.spansAlias
+    );
+  }
+}

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -461,7 +461,7 @@ public class ASTTests {
         Map.of(),
         Map.of()
     );
-    final var environment = new EvaluationEnvironment(Map.of("act", act), Map.of(), Map.of());
+    final var environment = new EvaluationEnvironment(Map.of("act", act), Map.of(), Map.of(), Map.of());
 
     final var result = new RealParameter("act", "p1").evaluate(simResults, environment);
 
@@ -726,6 +726,7 @@ public class ASTTests {
                 Interval.between(4, 8, SECONDS))
         ),
         Map.of(),
+        Map.of(),
         Map.of()
     );
 
@@ -756,6 +757,7 @@ public class ASTTests {
                 Map.of(),
                 Interval.between(4, 8, SECONDS))
         ),
+        Map.of(),
         Map.of(),
         Map.of()
     );
@@ -788,6 +790,7 @@ public class ASTTests {
                 Map.of(),
                 Interval.between(4, 8, SECONDS))
         ),
+        Map.of(),
         Map.of(),
         Map.of()
     );
@@ -879,6 +882,7 @@ public class ASTTests {
 
     final var environment = new EvaluationEnvironment(
         Map.of(),
+        Map.of(),
         Map.of(
             "real1", new LinearProfile(Segment.of(Interval.at(1, SECONDS), new LinearEquation(Duration.of(1, SECONDS), 0, 1))),
             "real2", new LinearProfile(Segment.of(Interval.at(2, SECONDS), new LinearEquation(Duration.of(2, SECONDS), 0, 1))),
@@ -908,6 +912,7 @@ public class ASTTests {
     );
 
     final var environment = new EvaluationEnvironment(
+        Map.of(),
         Map.of(),
         Map.of(
             "real1", new LinearProfile(Segment.of(Interval.at(1, SECONDS), new LinearEquation(Duration.of(1, SECONDS), 0, 1))),

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -933,6 +933,31 @@ public class ASTTests {
     assertEquivalent(expected, result);
   }
 
+  @Test
+  public void testSpansAlias() {
+    final var simResults = new SimulationResults(
+        Interval.between(0, 20, SECONDS),
+        List.of(),
+        Map.of(),
+        Map.of()
+    );
+
+    final var spans = new Spans(
+        Interval.between(0, 1, SECONDS)
+    );
+
+    final var environment = new EvaluationEnvironment(
+        Map.of(),
+        Map.of("my spans", spans),
+        Map.of(),
+        Map.of()
+    );
+
+    final var result = new SpansAlias("my spans").evaluate(simResults, environment);
+
+    assertEquivalent(spans, result);
+  }
+
   private static final class Supplier<T> implements Expression<T> {
     private final T value;
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -188,7 +188,7 @@ public final class GetSimulationResultsAction {
       }
     }
 
-    final var environment = new EvaluationEnvironment(Map.of(), realExternalProfiles, discreteExternalProfiles);
+    final var environment = new EvaluationEnvironment(Map.of(), Map.of(), realExternalProfiles, discreteExternalProfiles);
 
     final var planDuration = Duration.of(
         plan.startTimestamp.toInstant().until(plan.endTimestamp.toInstant(), ChronoUnit.MICROS),

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/RelativeActivityTemplate.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/RelativeActivityTemplate.java
@@ -1,0 +1,26 @@
+package gov.nasa.jpl.aerie.scheduler.constraints.activities;
+
+import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
+import gov.nasa.jpl.aerie.constraints.time.Spans;
+import gov.nasa.jpl.aerie.constraints.tree.Expression;
+import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.IntervalRelation;
+import gov.nasa.jpl.aerie.scheduler.model.ActivityType;
+
+import java.util.Map;
+
+/**
+ * Defines an activity that should be scheduled relative to a span. Used by SpansGoal.
+ *
+ * @param type activity type to schedule
+ * @param parameterProfiles the parameters of the activity should be equal to the value of these profiles at the start of the activity
+ * @param relativeTo one activity should be placed relative to each span in this expression
+ * @param relation Allen Interval Algebra relation for how the activity should be placed relative to the span
+ * @param allowReuse if a single existing activity or activity conflict satisfies the relations for multiple spans, whether
+ *                   it can be used to satisfy all of them, or just one.
+ */
+public record RelativeActivityTemplate(
+    ActivityType type,
+    Map<String, DiscreteProfile> parameterProfiles,
+    Expression<Spans> relativeTo,
+    IntervalRelation relation
+) {}

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/timeexpressions/IntervalRelation.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/timeexpressions/IntervalRelation.java
@@ -1,0 +1,17 @@
+package gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions;
+
+public enum IntervalRelation {
+  Precedes,
+  PrecededBy,
+  Meets,
+  MetBy,
+  Overlaps,
+  OverlappedBy,
+  Starts,
+  StartedBy,
+  Finishes,
+  FinishedBy,
+  During,
+  Contains,
+  EqualTo
+}

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/SpansGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/SpansGoal.java
@@ -1,0 +1,79 @@
+package gov.nasa.jpl.aerie.scheduler.goals;
+
+import gov.nasa.jpl.aerie.constraints.time.Spans;
+import gov.nasa.jpl.aerie.constraints.tree.Expression;
+import gov.nasa.jpl.aerie.scheduler.constraints.activities.RelativeActivityTemplate;
+
+import java.util.Map;
+
+/**
+ * Describes the desired relation between activities and a set of Spans computed from simulation results.
+ *
+ * This definition doesn't currently allow for recursive goal definitions (i.e. true recurrence goal).
+ */
+public class SpansGoal {
+
+  /*
+  IMPLEMENTATION NOTES:
+  1. first evaluate initialSpansExpression from simulation results
+  2. FOR EACH span in initialSpansExpression, set a spans alias in (Constraints package) EvaluationEnvironment.spansInstances
+     using spanAlias and evaluate relativeActivity.relativeTo().
+  3. FOR EACH span in relativeActivity.relativeTo(), either find an existing activity that matches the directive or try to create
+     a conflict, while trying to respect relativeActivity.allowReuse.
+   */
+
+  private Expression<Spans> initialSpansExpression;
+  private String spanAlias;
+  private RelativeActivityTemplate relativeActivity;
+  private Boolean allowResuse;
+
+  public static class Builder {
+    private Expression<Spans> spansExpression;
+    private String spanAlias;
+    private RelativeActivityTemplate relativeActivity;
+    private boolean allowReuse = false;
+
+    public Builder spansExpression(Expression<Spans> expression) {
+      spansExpression = expression;
+      return this;
+    }
+
+    public Builder spanAlias(String alias) {
+      spanAlias = alias;
+      return this;
+    }
+
+    public Builder relativeActivity(RelativeActivityTemplate activity) {
+      relativeActivity = activity;
+      return this;
+    }
+
+    public Builder allowReuse(final boolean allowReuse) {
+      this.allowReuse = allowReuse;
+      return this;
+    }
+
+    public SpansGoal build() {
+      if (spansExpression == null) {
+        throw new IllegalArgumentException(
+            "Creating spans goal requires non-null \"spansExpression\"");
+      }
+      if (spanAlias == null) {
+        throw new IllegalArgumentException(
+            "Creating spans goal requires non-null \"spanAlias\"");
+      }
+      if (relativeActivity == null) {
+        throw new IllegalArgumentException(
+            "Creating spans goal requires non-null \"relativeActivity\" directive");
+      }
+      final var goal = new SpansGoal();
+      goal.initialSpansExpression = spansExpression;
+      goal.spanAlias = spanAlias;
+      goal.relativeActivity = relativeActivity;
+      goal.allowResuse = allowReuse;
+      return goal;
+    }
+  }
+
+  private SpansGoal() { }
+}


### PR DESCRIPTION
* **Tickets addressed:** closes #466 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

This adds the basic Java data structure that represents a Spans-based scheduling goal. It also adds a `SpansAlias` node to the constraints AST that accesses a string alias for a spans object in the EvaluationEnvironment, similar to how we handle activity aliases.

This PR does not include any behavior, including getting conflicts or parsing. So `SpansGoal` does not yet inherit from Goal because there is nothing to put in getConflicts. SpansGoal can be added to the inheritance tree when its behavior is implemented.

## Verification
SpansAlias got a basic test, but that's it. SpansGoal doesn't yet have behavior to test.

## Documentation

## Future work
yes.
