### PR TITLE
Added the path param to schema types

### DIFF
--- a/sequencing-server/src/lib/batchLoaders/activitySchemaBatchLoader.ts
+++ b/sequencing-server/src/lib/batchLoaders/activitySchemaBatchLoader.ts
@@ -57,6 +57,7 @@ export enum SchemaTypes {
   Series = 'series',
   Struct = 'struct',
   Variant = 'variant',
+  Path = 'path',
 }
 
 export type Schema =
@@ -67,7 +68,8 @@ export type Schema =
   | StringSchema
   | SeriesSchema
   | StructSchema
-  | VariantSchema;
+  | VariantSchema
+  | PathSchema;
 
 interface BaseSchema<T extends SchemaTypes | unknown> {
   type: T;
@@ -78,6 +80,7 @@ type BooleanSchema = BaseSchema<SchemaTypes.Boolean>;
 type IntSchema = BaseSchema<SchemaTypes.Int>;
 type RealSchema = BaseSchema<SchemaTypes.Real>;
 type DurationSchema = BaseSchema<SchemaTypes.Duration>;
+type PathSchema = BaseSchema<SchemaTypes.Path>;
 
 interface SeriesSchema extends BaseSchema<SchemaTypes.Series> {
   items: Schema;

--- a/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
+++ b/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
@@ -4,6 +4,7 @@ import { ErrorWithStatusCode } from '../../utils/ErrorWithStatusCode.js';
 import parse from 'postgres-interval';
 import { GraphQLActivitySchema, Schema, SchemaTypes } from './activitySchemaBatchLoader.js';
 import type { activitySchemaBatchLoader } from './activitySchemaBatchLoader.js';
+import { assertUnreachable } from '../../utils/assertions.js';
 
 export const simulatedActivitiesBatchLoader: BatchLoader<
   { simulationDatasetId: number },
@@ -246,6 +247,6 @@ function convertType(value: any, schema: Schema): any {
       }
       return value;
     default:
-      throw new Error(`Unknown schema type: ${(schema as any).type}`);
+      assertUnreachable(schema);
   }
 }

--- a/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
+++ b/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
@@ -228,6 +228,8 @@ function convertType(value: any, schema: Schema): any {
       return Temporal.Duration.from(parse(value).toISOString());
     case SchemaTypes.Boolean:
       return value;
+    case SchemaTypes.Path:
+      return value;
     case SchemaTypes.String:
       return value;
     case SchemaTypes.Series:

--- a/sequencing-server/src/utils/assertions.ts
+++ b/sequencing-server/src/utils/assertions.ts
@@ -116,5 +116,5 @@ export function assert(expression: boolean, message?: string, context?: any) {
 }
 
 export function assertUnreachable(x: never): never {
-  throw new Error('This code should never be reached!');
+  throw new Error(x + ' This code should never be reached!');
 }

--- a/sequencing-server/src/utils/assertions.ts
+++ b/sequencing-server/src/utils/assertions.ts
@@ -114,3 +114,7 @@ export function assert(expression: boolean, message?: string, context?: any) {
     throw new AssertionError(message ?? `Assertion failed`, context ?? expression);
   }
 }
+
+export function assertUnreachable(x: never): never {
+  throw new Error('This code should never be reached!');
+}


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Closes #481. The `path` type was missing from the Schema types, so it was added.

## Verification
Tested manually by adding and removing activities that had a path parameter and then running the expansion.

