### PR TITLE
Ignore gaps outside of evaluation bounds for intospans

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/IntervalContainer.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/IntervalContainer.java
@@ -3,7 +3,7 @@ package gov.nasa.jpl.aerie.constraints.time;
 import gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity;
 
 public interface IntervalContainer<T extends IntervalContainer<T>> {
-  Spans split(final int numberOfSubIntervals, final Inclusivity internalStartInclusivity, final Inclusivity internalEndInclusivity);
+  Spans split(final Interval bounds, final int numberOfSubIntervals, final Inclusivity internalStartInclusivity, final Inclusivity internalEndInclusivity);
   T starts();
   T ends();
 }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Spans.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Spans.java
@@ -115,7 +115,7 @@ public class Spans implements IntervalContainer<Spans>, Iterable<Segment<Optiona
    * @throws UnsplittableSpanException if any span contains {@link Duration#MIN_VALUE} or {@link Duration#MAX_VALUE} (representing unbounded intervals)
    */
   @Override
-  public Spans split(final int numberOfSubSpans, final Inclusivity internalStartInclusivity, final Inclusivity internalEndInclusivity) {
+  public Spans split(final Interval bounds, final int numberOfSubSpans, final Inclusivity internalStartInclusivity, final Inclusivity internalEndInclusivity) {
     if (numberOfSubSpans == 1) {
       return new Spans(this);
     }
@@ -153,7 +153,7 @@ public class Spans implements IntervalContainer<Spans>, Iterable<Segment<Optiona
         cursor = nextCursor;
       }
       ret.add(Interval.between(cursor, internalStartInclusivity, x.end, x.endInclusivity));
-      return ret.stream();
+      return ret.stream().map($ -> Interval.intersect(bounds, $));
     });
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansFromWindows.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansFromWindows.java
@@ -13,7 +13,7 @@ public record SpansFromWindows(Expression<Windows> expression) implements Expres
   @Override
   public Spans evaluate(SimulationResults results, final Interval bounds, EvaluationEnvironment environment) {
     final var windows = this.expression.evaluate(results, bounds, environment);
-    return windows.intoSpans();
+    return windows.intoSpans(bounds);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Split.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/Split.java
@@ -29,7 +29,7 @@ public final class Split<I extends IntervalContainer<?>> implements Expression<S
   @Override
   public Spans evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var intervals = this.intervals.evaluate(results, bounds, environment);
-    return intervals.split(this.numberOfSubIntervals, this.internalStartInclusivity, this.internalEndInclusivity);
+    return intervals.split(bounds, this.numberOfSubIntervals, this.internalStartInclusivity, this.internalEndInclusivity);
   }
 
   @Override

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/time/WindowsTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/time/WindowsTest.java
@@ -495,19 +495,25 @@ public class WindowsTest {
 
     assertThrows(
         InvalidGapsException.class,
-        windowsWithGaps::intoSpans,
+        () -> windowsWithGaps.intoSpans(Interval.between(0, 10, SECONDS)),
         "cannot convert Windows with gaps into Spans (unbounded gap to -infinity)"
     );
 
     final var windowsWithoutGaps = new Windows(false).set(windowsWithGaps);
 
-    final var expected = new Spans(
+    var expected = new Spans(
         interval(0, 3, SECONDS),
         interval(5, 5, SECONDS)
     );
 
-    assertIterableEquals(expected, windowsWithoutGaps.intoSpans());
+    assertIterableEquals(expected, windowsWithoutGaps.intoSpans(Interval.FOREVER));
 
-
+    expected = new Spans(
+        interval(1, 2, SECONDS)
+    );
+    assertIterableEquals(
+        expected,
+        windowsWithGaps.intoSpans(interval(1, 2, SECONDS))
+    );
   }
 }

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -600,7 +600,7 @@ public class ASTTests {
     );
 
     final var spansSupplied = new Windows(Segment.of(Interval.FOREVER, false),
-                                              Segment.of(interval(4, 6, SECONDS), true)).intoSpans();
+                                              Segment.of(interval(4, 6, SECONDS), true)).intoSpans(simResults.bounds);
     final var result = new ForEachActivitySpans(
         "TypeA",
         "act",


### PR DESCRIPTION
* **Tickets addressed:** closes #509 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This is a temporary and quick bodge to make `intoSpans` (and by extension `split`) not throw an error when gaps are outside the evaluation bounds. This will be made obsolete when #488  is finalized and merged, because it will do this by default.

I'm going to close #454. The problems with shiftBy are not resolved, but #454 wasn't the full solution anyway and this is a more important operation. #488 should resolve both issues at the same time, but that refactor won't be complete for a hot minute.

## Verification
Some tests broke (which is good), and they are updated. I also added a test that makes sure gaps outside the bounds are OK.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
