### PR TITLE
Fix serialization of Duration to avoid rounding to millisecond

### DIFF
--- a/e2e-tests/src/tests/simulation-microsecond-resolution.test.ts
+++ b/e2e-tests/src/tests/simulation-microsecond-resolution.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+import req from '../utilities/requests.js';
+import time from "../utilities/time.js";
+
+test.describe('Simulation microsecond resolution', () => {
+  test('GrowBanana with duration of 1 microsecond should finish with a successful simulation', async ({ request }) => {
+    const rd = Math.random() * 100;
+    const plan_start_timestamp = "2021-001T00:00:00.000";
+    const plan_end_timestamp = "2021-001T12:00:00.000";
+    let jar_id: number;
+    let mission_model_id: number;
+    jar_id = await req.uploadJarFile(request);
+    const model: MissionModelInsertInput = {
+      jar_id,
+      mission: 'aerie_e2e_tests',
+      name: 'Banananation (e2e tests)',
+      version: rd + "",
+    };
+    mission_model_id = await req.createMissionModel(request, model);
+    const plan_input : CreatePlanInput = {
+      model_id : mission_model_id,
+      name : 'test_plan' + rd,
+      start_time : plan_start_timestamp,
+      duration : time.getIntervalFromDoyRange(plan_start_timestamp, plan_end_timestamp)
+    };
+    const plan_id = await req.createPlan(request, plan_input);
+    const simulation : SimulationCreation = {
+      plan_id: plan_id,
+      arguments : {},
+    };
+    await req.createSimulation(request, simulation);
+    const activityToInsert : ActivityInsertInput =
+        {
+          arguments : {
+            "duration": 1
+          },
+          plan_id: plan_id,
+          type : "ControllableDurationActivity",
+          start_offset : "1h"
+        };
+
+    const max_it = 10;
+    let it = 0;
+    await req.insertActivity(request, activityToInsert);
+    while (it++ < max_it) {
+      const { reason, status, simulationDatasetId } = await req.simulate(request, plan_id);
+      if (!(status == "pending" || status == "incomplete")) {
+        if (!(status === "complete")) {
+          console.error(JSON.stringify({reason}, undefined, 4));
+          expect(status).toEqual("complete");
+        }
+        return;
+      }
+      await delay(1000);
+    }
+    throw Error("Simulation timed out after " + max_it + " iterations");
+  });
+});
+
+function delay(ms: number) {
+  return new Promise( resolve => setTimeout(resolve, ms) );
+}

--- a/e2e-tests/src/types/simulation.d.ts
+++ b/e2e-tests/src/types/simulation.d.ts
@@ -36,3 +36,11 @@ type SimulationResponseActivity = Omit<ActivityDirective, 'id' | 'startTime'> & 
   computedAttributes: string;
   startTimestamp: string;
 };
+
+type SimulationResponseStatus = 'pending' | 'complete' | 'failed' | 'incomplete';
+
+type SimulationResponse = {
+  reason: any;
+  status: SimulationResponseStatus;
+  simulationDatasetId: number;
+};

--- a/e2e-tests/src/utilities/gql.ts
+++ b/e2e-tests/src/utilities/gql.ts
@@ -28,6 +28,14 @@ const gql = {
     }
   `,
 
+  SIMULATE: `#graphql
+  query Simulate($plan_id: Int!) {
+    simulate(planId: $plan_id){
+      status
+      reason
+    }
+  }`,
+
   CREATE_PLAN: `#graphql
     mutation CreatePlan($plan: plan_insert_input!) {
       insert_plan_one(object: $plan) {
@@ -36,6 +44,7 @@ const gql = {
       }
     }
   `,
+
   CREATE_SIMULATION: `#graphql
     mutation CreateSimulation($simulation: simulation_insert_input!) {
       insert_simulation_one(object: $simulation) {
@@ -68,14 +77,6 @@ const gql = {
       }
     }
   `,
-
-  TRIGGER_SCHEDULING: `#graphql
-  query TriggerSchedulingRun($spec_id: Int!) {
-    schedule(specificationId: $spec_id){
-      status
-      reason
-    }
-  }`,
 
   INSERT_SCHEDULING_SPECIFICATION: `#graphql
   mutation MakeSchedulingSpec($scheduling_spec: scheduling_specification_insert_input!) {

--- a/e2e-tests/src/utilities/requests.ts
+++ b/e2e-tests/src/utilities/requests.ts
@@ -162,6 +162,14 @@ const req = {
     return schedule;
   },
 
+  async simulate(request: APIRequestContext, planId: number): Promise<SimulationResponse> {
+    const data = await req.hasura(request, gql.SIMULATE, {
+      plan_id: planId,
+    });
+    const { simulate } = data;
+    return simulate;
+  },
+
   async createSchedulingSpecGoal(request: APIRequestContext, spec_goal: SchedulingSpecGoalInsertInput): Promise<void> {
     const data = await req.hasura(request, gql.CREATE_SCHEDULING_SPEC_GOAL, {spec_goal});
     const { insert_scheduling_specification_goals_one } = data;

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/ControllableDurationActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/ControllableDurationActivity.java
@@ -1,0 +1,24 @@
+package gov.nasa.jpl.aerie.banananation.activities;
+
+import gov.nasa.jpl.aerie.banananation.Mission;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
+
+/**
+ * This activity type intentionally takes a duration as a parameter, but is not a ControllableDuration activity
+ */
+@ActivityType("ControllableDurationActivity")
+public record ControllableDurationActivity(Duration duration) {
+
+  @EffectModel
+  @ActivityType.ControllableDuration(parameterName = "duration")
+  public void run(Mission mission) {
+    // Creates a profile segment of at most the given duration
+    mission.plant.add(1);
+    delay(duration);
+    mission.plant.add(-1);
+  }
+}

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
@@ -20,6 +20,7 @@
 @WithActivityType(BakeBananaBreadActivity.class)
 @WithActivityType(BananaNapActivity.class)
 @WithActivityType(DurationParameterActivity.class)
+@WithActivityType(ControllableDurationActivity.class)
 
 package gov.nasa.jpl.aerie.banananation;
 
@@ -27,6 +28,7 @@ import gov.nasa.jpl.aerie.banananation.activities.BakeBananaBreadActivity;
 import gov.nasa.jpl.aerie.banananation.activities.BananaNapActivity;
 import gov.nasa.jpl.aerie.banananation.activities.BiteBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ChangeProducerActivity;
+import gov.nasa.jpl.aerie.banananation.activities.ControllableDurationActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DecomposingActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DecomposingSpawnActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DurationParameterActivity;

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/Duration.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/Duration.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.protocol.types;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 
@@ -494,11 +495,12 @@ public final class Duration implements Comparable<Duration> {
   }
 
   public static Duration fromISO8601String(final String iso8601String){
-    return of(java.time.Duration.parse(iso8601String).toMillis(), MILLISECOND);
+    final var javaDuration = java.time.Duration.parse(iso8601String);
+    return of((javaDuration.getSeconds() * 1_000_000L) + (javaDuration.getNano() / 1000L), MICROSECONDS);
   }
 
   public String toISO8601String() {
-    return java.time.Duration.ofMillis(dividedBy(Duration.MILLISECONDS)).toString();
+    return java.time.Duration.of(this.durationInMicroseconds, ChronoUnit.MICROS).toString();
   }
 
   @Override

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/Duration.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/Duration.java
@@ -1,6 +1,5 @@
 package gov.nasa.jpl.aerie.merlin.protocol.types;
 
-import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 
@@ -497,10 +496,6 @@ public final class Duration implements Comparable<Duration> {
   public static Duration fromISO8601String(final String iso8601String){
     final var javaDuration = java.time.Duration.parse(iso8601String);
     return of((javaDuration.getSeconds() * 1_000_000L) + (javaDuration.getNano() / 1000L), MICROSECONDS);
-  }
-
-  public String toISO8601String() {
-    return java.time.Duration.of(this.durationInMicroseconds, ChronoUnit.MICROS).toString();
   }
 
   @Override

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/Duration.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/Duration.java
@@ -493,11 +493,6 @@ public final class Duration implements Comparable<Duration> {
     return this.isEqualTo(other);
   }
 
-  public static Duration fromISO8601String(final String iso8601String){
-    final var javaDuration = java.time.Duration.parse(iso8601String);
-    return of((javaDuration.getSeconds() * 1_000_000L) + (javaDuration.getNano() / 1000L), MICROSECONDS);
-  }
-
   @Override
   public int hashCode() {
     return Long.hashCode(this.durationInMicroseconds);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetProfileSegmentsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetProfileSegmentsAction.java
@@ -47,7 +47,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
     // Profile segments are stored with their start offset relative to simulation start
     // We must convert these to durations describing how long each segment lasts
     if (resultSet.next()) {
-      var offset = Duration.fromISO8601String(resultSet.getString(1));
+      var offset = PostgresParsers.parseDurationISO8601(resultSet.getString(1));
       Optional<Dynamics> dynamics;
       var isGap = resultSet.getBoolean("is_gap");
       if (!isGap) {
@@ -58,7 +58,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
       }
 
       while (resultSet.next()) {
-        final var nextOffset = Duration.fromISO8601String(resultSet.getString(1));
+        final var nextOffset = PostgresParsers.parseDurationISO8601(resultSet.getString(1));
         final var duration = nextOffset.minus(offset);
         segments.add(new ProfileSegment<>(duration, dynamics));
         offset = nextOffset;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetProfilesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetProfilesAction.java
@@ -1,6 +1,5 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
@@ -41,7 +40,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
       final var type = getJsonColumn(resultSet, "type", profileTypeP).getSuccessOrThrow(
               failureReason -> new Error(
                   "Corrupt profile type: " + failureReason.reason()));
-      final var duration = Duration.fromISO8601String(resultSet.getString(4));
+      final var duration = PostgresParsers.parseDurationISO8601(resultSet.getString(4));
       records.add(new ProfileRecord(profileId, datasetId, resourceName, type, duration));
     }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostProfileSegmentsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostProfileSegmentsAction.java
@@ -40,7 +40,7 @@ public final class PostProfileSegmentsAction implements AutoCloseable {
 
       this.statement.setLong(1, datasetId);
       this.statement.setLong(2, profileRecord.id());
-      this.statement.setString(3, accumulatedOffset.toISO8601String());
+      PreparedStatements.setDuration(this.statement, 3, accumulatedOffset);
       if (dynamics.isPresent()) {
         this.statement.setString(4, serializeDynamics(dynamics.get(), dynamicsP));
         this.statement.setBoolean(5, false);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostProfilesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostProfilesAction.java
@@ -51,7 +51,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
       this.statement.setLong(1, datasetId);
       this.statement.setString(2, resource);
       this.statement.setString(3, realProfileTypeP.unparse(realResourceType).toString());
-      this.statement.setString(4, duration.toISO8601String());
+      PreparedStatements.setDuration(this.statement, 4, duration);
       this.statement.addBatch();
     }
 
@@ -67,7 +67,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
       this.statement.setLong(1, datasetId);
       this.statement.setString(2, resource);
       this.statement.setString(3, discreteProfileTypeP.unparse(resourceType).toString());
-      this.statement.setString(4, duration.toISO8601String());
+      PreparedStatements.setDuration(this.statement, 4, duration);
       this.statement.addBatch();
     }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
@@ -104,7 +104,13 @@ public final class PostgresParsers {
     return parseOffset(resultSet, index, new Timestamp(epoch));
   }
 
+  public static Duration parseDurationISO8601(final String iso8601String){
+    final var javaDuration = java.time.Duration.parse(iso8601String);
+    return Duration.of((javaDuration.getSeconds() * 1_000_000L) + (javaDuration.getNano() / 1000L), Duration.MICROSECONDS);
+  }
+
   public static final JsonParser<Map<String, SerializedValue>> activityArgumentsP = mapP(serializedValueP);
+
   public static final JsonParser<Map<String, SerializedValue>> simulationArgumentsP = mapP(serializedValueP);
 
   public static final JsonParser<ActivityAttributesRecord> activityAttributesP = productP

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PreparedStatements.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PreparedStatements.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationFailure;
 import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.ValidationNotice;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.server.http.MerlinParsers;
 import gov.nasa.jpl.aerie.merlin.server.http.ResponseSerializers;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
@@ -65,6 +66,11 @@ public final class PreparedStatements {
   public static void setTimestamp(final PreparedStatement statement, final int parameter, final Timestamp argument)
   throws SQLException {
     statement.setString(parameter, TIMESTAMP_FORMAT.format(argument.time()));
+  }
+
+  public static void setDuration(final PreparedStatement statement, final int parameter, final Duration argument) throws SQLException {
+    final var micros = argument.in(Duration.MICROSECONDS);
+    statement.setString(parameter, "PT%d.%06dS".formatted(micros / 1_000_000, micros % 1_000_000));
   }
 
   public static void setParameters(final PreparedStatement statement, final int parameter, final List<Parameter> parameters)


### PR DESCRIPTION
* **Tickets addressed:** Fixes #513 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR is in response to a bug found in #513 where profile segments shorter than one millisecond would cause writing simulation results to the database to fail.

The root cause was found to be in the serialization logic from Durations to iso8601 strings:
https://github.com/NASA-AMMOS/aerie/blob/59f3fcde69a88cb6f413b3995efbce7474c8432b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/Duration.java#L500-L502

This rounds Durations from microseconds to milliseconds - causing a collision when the start offsets of two profile segments fall within the same millisecond.

The first commit updates this logic, as well as the corresponding deserialization logic, to use nanoseconds instead of milliseconds.

The subsequent commits move the (de)serialization logic out of the Duration class - serialization is not be one of its concerns. (I should have brought this up originally in #187, but it did not catch my eye).

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
#### Before making a fix, I reproduced the issue as follows:

I modified BiteBanana in the following way:

```diff
+@Parameter
+public int delayMicros = 1;
@EffectModel
  public ComputedAttributes run(final Mission mission) {
    final var bigBiteSize = biteSize > 1.0;
    final var newFlag = bigBiteSize ? Flag.B : Flag.A;
    mission.flag.set(newFlag);
-    mission.fruit.subtract(biteSize);
+    mission.fruit.subtract(biteSize / 2);
+    delay(delayMicros, MICROSECONDS);
+    mission.fruit.subtract(biteSize / 2);
    return new ComputedAttributes(bigBiteSize, newFlag);
  }
```

I ran a local deployment of Aerie, uploaded my modified banananation, and added a single BiteBanana to the plan. Running simulation triggered the error described in #513 .

#### After making the fix...
I assembled the merlin worker, rebuilt the docker image, re-created the docker container, invalidated the simulation results by modifying a parameter, and ran simulation again. This time, no error occurred, and a visual inspection of the profile segments using IntelliJ's database viewer showed that they had the correct start offsets.

If anyone has thoughts on how to make this an automated test, I'm all ears.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No documentation needs to be updated for this bugfix... except possibly putting it on a list of known bugs for Aerie 1.0.0.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None