### PR TITLE
Scheduling uniqueness migrations

### DIFF
--- a/db-tests/build.gradle
+++ b/db-tests/build.gradle
@@ -8,10 +8,6 @@ java {
   }
 }
 
-test {
-  useJUnitPlatform()
-}
-
 task e2eTest(type: Test) {
   useJUnitPlatform()
 }

--- a/db-tests/build.gradle
+++ b/db-tests/build.gradle
@@ -10,6 +10,7 @@ java {
 
 task e2eTest(type: Test) {
   useJUnitPlatform()
+  environment 'AERIE_ROOT', rootDir.toString()
 }
 
 dependencies {

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/CommandExpansionDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/CommandExpansionDatabaseTests.java
@@ -29,7 +29,7 @@ class CommandExpansionDatabaseTests {
         "Command Expansion Database Tests",
         initSqlScriptFile
     );
-    helper.startDatabase();
+    helper.startDatabaseWithLatestSchema();
     connection = helper.connection();
   }
 

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/DatabaseTestHelper.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/DatabaseTestHelper.java
@@ -226,6 +226,12 @@ public class DatabaseTestHelper {
     }
   }
 
+  void executeUpdate(final String sql, final Object... args) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      statement.executeUpdate(sql.formatted(args));
+    }
+  }
+
   String dumpSchema() throws IOException, InterruptedException {
     final var pb = new ProcessBuilder(
         "pg_dump",

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/DatabaseTestHelper.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/DatabaseTestHelper.java
@@ -226,6 +226,21 @@ public class DatabaseTestHelper {
     }
   }
 
+  String dumpSchema() throws IOException, InterruptedException {
+    final var pb = new ProcessBuilder(
+        "pg_dump",
+        "--schema-only",
+        "postgresql://postgres:postgres@localhost:5432/" + dbName);
+
+    final var proc = pb.start();
+    try {
+      proc.waitFor();
+      return new String(proc.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    } finally {
+      proc.destroy();
+    }
+  }
+
   record Migration(int version, String name) {
     static Migration of(final String migrationName) {
       return new Migration(Integer.parseInt(migrationName.split("_")[0]), migrationName);

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/EnsureMigrationsAndSchemasMatch.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/EnsureMigrationsAndSchemasMatch.java
@@ -1,0 +1,57 @@
+package gov.nasa.jpl.aerie.database;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This test brings up two databases - one using migrations, and one using the latest state, and makes sure that
+ * their schemas match.
+ */
+public class EnsureMigrationsAndSchemasMatch {
+  @Test
+  void testMigrationsAndSchemasMatch() throws SQLException, IOException, InterruptedException {
+    // bring up a database using migrations
+    // bring up a database using the state
+    // do a diff
+    final File initSqlScriptFile = new File("../scheduler-server/sql/scheduler/init.sql");
+    final Path migrationsDirectory = Path.of(System.getenv("AERIE_ROOT"), "deployment", "hasura", "migrations", "AerieScheduler");
+    final var migrationsDbHelper = new DatabaseTestHelper(
+        "aerie_scheduler_schema_test_migrations",
+        "Scheduler Database Schema Test using Migrations",
+        initSqlScriptFile
+    );
+    migrationsDbHelper.stopDatabase();
+    migrationsDbHelper.startDatabaseWithLatestSchema();
+    final var stateDbHelper = new DatabaseTestHelper(
+        "aerie_scheduler_schema_test_state",
+        "Scheduler Database Schema Test using State",
+        initSqlScriptFile,
+        migrationsDirectory
+    );
+    stateDbHelper.stopDatabase();
+    stateDbHelper.startDatabaseWithLatestSchema();
+    assertEquals(migrationsDbHelper.dumpSchema(), stateDbHelper.dumpSchema());
+    assertEquals(getSchemaMigrations(migrationsDbHelper), getSchemaMigrations(stateDbHelper));
+  }
+
+  private List<String> getSchemaMigrations(DatabaseTestHelper helper) throws SQLException {
+    try (final var statement = helper.connection().createStatement()) {
+      final var res = statement.executeQuery("""
+        select version from schema_migrations order by version
+      """);
+      final var versions = new ArrayList<String>();
+      while (res.next()) {
+        versions.add(res.getString("version"));
+      }
+      return versions;
+    }
+  }
+}

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MakeSchedulingGoalsUniqueMigrationTest.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MakeSchedulingGoalsUniqueMigrationTest.java
@@ -1,0 +1,397 @@
+package gov.nasa.jpl.aerie.database;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+public class MakeSchedulingGoalsUniqueMigrationTest {
+  private static final String migrationName = "1_make_scheduling_goals_unique";
+  private static final File initSqlScriptFile = new File("../scheduler-server/sql/scheduler/init.sql");
+  public static final Path migrationsDirectory = Path.of(System.getenv("AERIE_ROOT"), "deployment", "hasura", "migrations", "AerieScheduler");
+  private DatabaseTestHelper helper;
+
+  private Connection connection;
+
+  @BeforeEach
+  void beforeEach() throws SQLException, IOException, InterruptedException {
+    helper = new DatabaseTestHelper(
+        "aerie_scheduler_migration_test",
+        "Scheduler Database Migration Tests",
+        initSqlScriptFile,
+        migrationsDirectory
+    );
+    helper.startDatabaseBeforeMigration(migrationName);
+    connection = helper.connection();
+  }
+
+  @AfterEach
+  void afterEach() throws SQLException, IOException, InterruptedException {
+    helper.stopDatabase();
+    connection = null;
+    helper = null;
+  }
+
+  @Test
+  void testMigration() throws IOException, InterruptedException, SQLException {
+    // Populate with test data
+    final List<Integer> goalIds;
+    {
+      try (final var statement = connection.createStatement()) {
+        final var res = statement.executeQuery("""
+          insert into scheduling_goal (name, definition, model_id)
+          values
+            ('alpha', '', 0),
+            ('beta', '', 0),
+            ('gamma', '', 0),
+            ('delta', '', 0)
+          returning id;
+        """);
+        final var results = new ArrayList<Integer>(4);
+        while (res.next()) {
+          results.add(res.getInt("id"));
+        }
+        goalIds = List.copyOf(results);
+      }
+    }
+
+    final List<Integer> specificationIds;
+    {
+      try (final var statement = connection.createStatement()) {
+        final var res = statement.executeQuery("""
+          insert into scheduling_specification (
+            plan_id,
+            plan_revision,
+            horizon_start,
+            horizon_end,
+            simulation_arguments,
+            analysis_only
+          )
+          values
+            (1, 1, now(), now(), '{}', false),
+            (1, 1, now(), now(), '{}', false),
+            (2, 1, now(), now(), '{}', false)
+          returning id;
+        """);
+        final var results = new ArrayList<Integer>(4);
+        while (res.next()) {
+          results.add(res.getInt("id"));
+        }
+        specificationIds = List.copyOf(results);
+      }
+    }
+
+    /*
+     Cases:
+     1. Goal belongs to no specifications (0)
+     2. Goal belongs to one specification (1)
+     3. Goal belongs to two specifications (2)
+     4. Goal belongs to three specifications (3)
+     */
+
+    // Goal 0 belongs to no specifications
+    // Goal 1 is contained in specification 0
+    helper.executeUpdate(
+        "insert into scheduling_specification_goals (specification_id, goal_id, priority) values (%d, %d, 0)",
+        specificationIds.get(0),
+        goalIds.get(1));
+
+    // Goal 2 is contained in specifications 0 and 1
+    helper.executeUpdate(
+        "insert into scheduling_specification_goals (specification_id, goal_id, priority) values (%d, %d, 1)",
+        specificationIds.get(0),
+        goalIds.get(2));
+    helper.executeUpdate(
+        "insert into scheduling_specification_goals (specification_id, goal_id, priority) values (%d, %d, 0)",
+        specificationIds.get(1),
+        goalIds.get(2));
+
+    // Goal 3 is contained in specifications 0, 1, and 2
+    helper.executeUpdate(
+        "insert into scheduling_specification_goals (specification_id, goal_id, priority) values (%d, %d, 2)",
+        specificationIds.get(0),
+        goalIds.get(3));
+    helper.executeUpdate(
+        "insert into scheduling_specification_goals (specification_id, goal_id, priority) values (%d, %d, 1)",
+        specificationIds.get(1),
+        goalIds.get(3));
+    helper.executeUpdate(
+        "insert into scheduling_specification_goals (specification_id, goal_id, priority) values (%d, %d, 0)",
+        specificationIds.get(2),
+        goalIds.get(3));
+
+    {
+      try (final var statement = connection.createStatement()) {
+        final var res = statement.executeQuery("select count(1) from scheduling_goal;");
+        res.next();
+        final var numberOfGoals = res.getInt(1);
+        assertEquals(4, numberOfGoals);
+      }
+    }
+
+    final var originalGoalsBySpecification = getGoalsBySpecification();
+
+    // Run migration. It should fail due to goals being shared across specifications.
+    try {
+      helper.applyMigration(migrationName);
+      fail("Should have thrown exception due to goals being shared across specifications.");
+    } catch (SQLException e) {
+      assertTrue(e.getMessage().contains("ERROR:  could not create unique index \"scheduling_specification_unique_goal_id\""), "Message: \"" + e.getMessage() + '\"');
+    }
+
+    // Run prepare.sql, which will make copies of the shared goals.
+    {
+      helper.runSqlFile(
+          migrationsDirectory
+              .resolve(migrationName)
+              .resolve("prepare.sql")
+              .toString());
+    }
+
+    assertEquals(originalGoalsBySpecification, getGoalsBySpecification());
+
+    // Now the migration should succeed:
+    helper.applyMigration(migrationName);
+
+    assertEquals(originalGoalsBySpecification, getGoalsBySpecification());
+
+    // Number of goals should now be 7, since one additional copy of Goal 2 and two additional copies of Goal 3 must be made
+    {
+      try (final var statement = connection.createStatement()) {
+        final var res = statement.executeQuery("select count(1) from scheduling_goal;");
+        res.next();
+        final var numberOfGoals = res.getInt(1);
+        assertEquals(7, numberOfGoals);
+      }
+    }
+
+    // Goal 0 belongs to zero scheduling specifications. Adding it to two of them should fail due to the new constraint:
+    helper.executeUpdate(
+        "insert into scheduling_specification_goals (specification_id, goal_id, priority) values (%d, %d, 2)",
+        specificationIds.get(0),
+        goalIds.get(0));
+
+    try {
+      helper.executeUpdate(
+          "insert into scheduling_specification_goals (specification_id, goal_id, priority) values (%d, %d, 2)",
+          specificationIds.get(1),
+          goalIds.get(0));
+      fail("Should have thrown exception due to violating the new constraint.");
+    } catch (SQLException e) {
+      assertEquals("duplicate key value violates unique constraint \"scheduling_specification_unique_goal_id\"", e.getMessage());
+    }
+
+    // Rollback
+    helper.rollbackMigration(migrationName);
+
+    // It should now be possible to associate Goal 0 with a second specification:
+    helper.executeUpdate(
+        "insert into scheduling_specification_goals (specification_id, goal_id, priority) values (%d, %d, 2)",
+        specificationIds.get(1),
+        goalIds.get(0));
+    helper.executeUpdate(
+        "delete from scheduling_specification_goals where specification_id = %d and goal_id = %d",
+        specificationIds.get(1),
+        goalIds.get(0));
+
+    // Re-do migration
+    helper.applyMigration(migrationName);
+
+    try {
+      helper.executeUpdate(
+          "insert into scheduling_specification_goals (specification_id, goal_id, priority) values (%d, %d, 2)",
+          specificationIds.get(1),
+          goalIds.get(0));
+      fail("Should have thrown exception due to violating the new constraint.");
+    } catch (SQLException e) {
+      assertEquals("duplicate key value violates unique constraint \"scheduling_specification_unique_goal_id\"", e.getMessage());
+    }
+  }
+
+  private HashMap<Integer, List<GoalRecord>> getGoalsBySpecification() throws SQLException {
+    final var goalsBySpecification = new HashMap<Integer, List<GoalRecord>>();
+    try (final var statement = helper.connection().createStatement()) {
+      final var res = statement.executeQuery(
+          """
+              select
+                specification_id,
+                priority,
+                revision,
+                name,
+                definition,
+                model_id,
+                description,
+                author,
+                last_modified_by,
+                created_date,
+                modified_date
+              from scheduling_goal g
+              join scheduling_specification_goals ssg
+              on g.id = ssg.goal_id
+              order by priority
+              """
+      );
+      while (res.next()) {
+        goalsBySpecification.computeIfAbsent(res.getInt("specification_id"), $ -> new ArrayList<>())
+            .add(new GoalRecord(
+                res.getInt("revision"),
+                res.getString("name"),
+                res.getString("definition"),
+                res.getInt("model_id"),
+                res.getString("description"),
+                res.getString("author"),
+                res.getString("last_modified_by"),
+                res.getString("created_date"),
+                res.getString("modified_date")
+            ));
+      }
+    }
+    return goalsBySpecification;
+  }
+
+  record GoalRecord(int revision,
+                    String name,
+                    String definition,
+                    int model_id,
+                    String description,
+                    String author,
+                    String last_modified_by,
+                    String created_date,
+                    String modified_date) {}
+
+  @Test
+  void testRollbackIdempotent() throws SQLException, IOException, InterruptedException {
+    helper.runSqlFile(
+        migrationsDirectory
+            .resolve(migrationName)
+            .resolve("prepare.sql")
+            .toString());
+    helper.applyMigration(migrationName);
+    try {
+      helper.applyMigration(migrationName);
+      fail("Should have thrown exception due to attempting to re-add an existing constraint.");
+    } catch (SQLException e) {
+      assertTrue(e.getMessage().contains("ERROR:  relation \"scheduling_specification_unique_goal_id\" already exists"), e.getMessage());
+    }
+
+    helper.rollbackMigration(migrationName);
+    helper.applyMigration(migrationName);
+
+    helper.rollbackMigration(migrationName);
+    helper.rollbackMigration(migrationName);
+
+    helper.runSqlFile(
+        migrationsDirectory
+            .resolve(migrationName)
+            .resolve("prepare.sql")
+            .toString());
+    helper.applyMigration(migrationName);
+  }
+
+  @Test
+  void testRealisticVolume() throws SQLException, IOException, InterruptedException {
+    // Insert 1000 goals
+    // Associate 50 with 0 specifications, 500 with 1 specification, 300 with 2 specifications, 149 with 3 specifications and 1 with 100 specifications
+    record SpecificationCount(int numGoals, int numSpecifications) {}
+    final var specificationCounts = List.of(
+        new SpecificationCount(50, 0),
+        new SpecificationCount(500, 1),
+        new SpecificationCount(300, 2),
+        new SpecificationCount(149, 3),
+        new SpecificationCount(1, 100)
+    );
+
+    final var goalIds = new ArrayList<Long>();
+    for (var i = 0; i < 1000; i++) {
+      try (final var statement = connection.createStatement()) {
+        final var res = statement.executeQuery("""
+           insert into scheduling_goal (name, definition, model_id)
+           values
+             ('%s', '', 0)
+           returning id;
+         """.formatted(UUID.randomUUID()));
+        while (res.next()) {
+          goalIds.add(res.getLong("id"));
+        }
+      }
+    }
+
+    final var specificationIds = new ArrayList<Long>();
+    try (final var statement = connection.prepareStatement("""
+         insert into scheduling_specification (
+           plan_id,
+           plan_revision,
+           horizon_start,
+           horizon_end,
+           simulation_arguments,
+           analysis_only
+         )
+         values
+           (?, 1, now(), now(), '{}', false);
+       """, Statement.RETURN_GENERATED_KEYS)) {
+      for (var i = 0; i < 100; i++) {
+        statement.setInt(1, i);
+        statement.addBatch();
+      }
+      statement.executeBatch();
+      final var res = statement.getGeneratedKeys();
+      while (res.next()) {
+        specificationIds.add(res.getLong(1));
+      }
+    }
+
+    final var goalIdIterator = goalIds.iterator();
+    try (final var statement = helper.connection().prepareStatement(
+        """
+            insert into scheduling_specification_goals (specification_id, goal_id, priority) values (?, ?, 0)
+            """
+    )) {
+      for (final var specificationCount : specificationCounts) {
+        for (var i = 0; i < specificationCount.numGoals; i++) {
+          final var goalId = goalIdIterator.next();
+          for (var j = 0; j < specificationCount.numSpecifications; j++) {
+            statement.setLong(1, specificationIds.get(j));
+            statement.setLong(2, goalId);
+            statement.addBatch();
+          }
+        }
+        statement.executeBatch();
+      }
+    }
+
+    final var originalGoalsBySpecification = getGoalsBySpecification();
+
+    try {
+      helper.applyMigration(migrationName);
+      fail("Should have thrown exception due to goals being shared across specifications.");
+    } catch (SQLException e) {
+      assertTrue(e.getMessage().contains("ERROR:  could not create unique index \"scheduling_specification_unique_goal_id\""), "Message: \"" + e.getMessage() + '\"');
+    }
+
+    helper.runSqlFile(
+        migrationsDirectory
+            .resolve(migrationName)
+            .resolve("prepare.sql")
+            .toString());
+
+    assertEquals(originalGoalsBySpecification, getGoalsBySpecification());
+
+    helper.applyMigration(migrationName);
+  }
+}

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MerlinDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MerlinDatabaseTests.java
@@ -37,7 +37,7 @@ class MerlinDatabaseTests {
         "Merlin Database Tests",
         initSqlScriptFile
     );
-    helper.startDatabase();
+    helper.startDatabaseWithLatestSchema();
     connection = helper.connection();
   }
 

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/OneSchedulingSpecificationPerPlanMigrationTest.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/OneSchedulingSpecificationPerPlanMigrationTest.java
@@ -1,0 +1,151 @@
+package gov.nasa.jpl.aerie.database;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+public class OneSchedulingSpecificationPerPlanMigrationTest {
+  private static final String migrationName = "2_one_scheduling_spec_per_plan";
+  private static final File initSqlScriptFile = new File("../scheduler-server/sql/scheduler/init.sql");
+  public static final Path migrationsDirectory = Path.of(System.getenv("AERIE_ROOT"), "deployment", "hasura", "migrations", "AerieScheduler");
+  private DatabaseTestHelper helper;
+
+  private Connection connection;
+
+  @BeforeEach
+  void beforeEach() throws SQLException, IOException, InterruptedException {
+    helper = new DatabaseTestHelper(
+        "aerie_scheduler_migration_test",
+        "Scheduler Database Migration Tests",
+        initSqlScriptFile,
+        migrationsDirectory
+    );
+    helper.startDatabaseBeforeMigration(migrationName);
+    connection = helper.connection();
+  }
+
+  @AfterEach
+  void afterEach() throws SQLException, IOException, InterruptedException {
+    helper.stopDatabase();
+    connection = null;
+    helper = null;
+  }
+
+  @Test
+  void testMigration() throws IOException, InterruptedException, SQLException {
+    // Populate with test data
+    final List<Integer> specificationIds;
+    {
+      try (final var statement = connection.createStatement()) {
+        final var res = statement.executeQuery("""
+          insert into scheduling_specification (
+            plan_id,
+            plan_revision,
+            horizon_start,
+            horizon_end,
+            simulation_arguments,
+            analysis_only
+          )
+          values
+            (1, 1, now(), now(), '{}', false),
+            (1, 1, now(), now(), '{}', false),
+            (2, 1, now(), now(), '{}', false)
+          returning id;
+        """);
+        final var results = new ArrayList<Integer>(4);
+        while (res.next()) {
+          results.add(res.getInt("id"));
+        }
+        specificationIds = List.copyOf(results);
+      }
+    }
+
+    // Run migration. It should fail due to specs 0 and 1 being associated with the same plan
+    try {
+      helper.applyMigration(migrationName);
+      fail("Migration should have failed because there are two scheduling specifications associated with the same plan");
+    } catch (SQLException e) {
+      assertTrue(e.getMessage().contains("ERROR:  could not create unique index \"scheduling_specification_unique_plan_id\""), "Message: \"" + e.getMessage() + '\"');
+    }
+
+    helper.executeUpdate(
+        "delete from scheduling_specification where id = %d",
+        specificationIds.get(1)
+    );
+
+    helper.applyMigration(migrationName);
+
+    try {
+      helper.executeUpdate(
+          """
+                insert into scheduling_specification (
+                  plan_id,
+                  plan_revision,
+                  horizon_start,
+                  horizon_end,
+                  simulation_arguments,
+                  analysis_only
+                )
+                values
+                  (1, 1, now(), now(), '{}', false)
+              """
+      );
+    } catch (SQLException e) {
+      assertEquals("duplicate key value violates unique constraint \"scheduling_specification_unique_plan_id\"", e.getMessage());
+    }
+
+    // Inserting a specification for another plan should work fine:
+    helper.executeUpdate(
+        """
+              insert into scheduling_specification (
+                plan_id,
+                plan_revision,
+                horizon_start,
+                horizon_end,
+                simulation_arguments,
+                analysis_only
+              )
+              values
+                (3, 1, now(), now(), '{}', false)
+            """
+    );
+
+    // Deleting specifications should work fine:
+    helper.executeUpdate(
+        "delete from scheduling_specification where plan_id = 1",
+        specificationIds.get(1)
+    );
+  }
+
+  @Test
+  void testRollbackIdempotent() throws SQLException, IOException, InterruptedException {
+    helper.applyMigration(migrationName);
+    try {
+      helper.applyMigration(migrationName);
+      fail("Should have thrown exception due to re-adding an existing constraint.");
+    } catch (SQLException e) {
+      assertTrue(e.getMessage().contains("ERROR:  relation \"scheduling_specification_unique_plan_id\" already exists"), e.getMessage());
+    }
+
+    helper.rollbackMigration(migrationName);
+    helper.applyMigration(migrationName);
+
+    helper.rollbackMigration(migrationName);
+    helper.rollbackMigration(migrationName);
+    helper.applyMigration(migrationName);
+  }
+}

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PlanCollaborationTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PlanCollaborationTests.java
@@ -81,7 +81,7 @@ public class PlanCollaborationTests {
         "Merlin Database Tests",
         initSqlScriptFile
     );
-    helper.startDatabase();
+    helper.startDatabaseWithLatestSchema();
     connection = helper.connection();
   }
 

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
@@ -6,12 +6,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -19,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SchedulerDatabaseTests {
   private static final File initSqlScriptFile = new File("../scheduler-server/sql/scheduler/init.sql");
+  private static final Path migrationsDirectory = Path.of(System.getenv("AERIE_ROOT"), "deployment", "hasura", "migrations", "AerieScheduler");
   private DatabaseTestHelper helper;
 
   private Connection connection;
@@ -28,9 +27,10 @@ class SchedulerDatabaseTests {
     helper = new DatabaseTestHelper(
         "aerie_scheduler_test",
         "Scheduler Database Tests",
-        initSqlScriptFile
+        initSqlScriptFile,
+        migrationsDirectory
     );
-    helper.startDatabase();
+    helper.startDatabaseWithLatestSchema();
     connection = helper.connection();
   }
 

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
@@ -41,13 +41,13 @@ class SchedulerDatabaseTests {
     helper = null;
   }
 
-  int insertSpecification() throws SQLException {
+  int insertSpecification(final long planId) throws SQLException {
     try (final var statement = connection.createStatement()) {
       final var res = statement.executeQuery("""
         insert into scheduling_specification(
           revision, plan_id, plan_revision, horizon_start, horizon_end, simulation_arguments, analysis_only
-        ) values (0, 0, 0, now(), now(), '{}', false) returning id;
-      """);
+        ) values (0, %d, 0, now(), now(), '{}', false) returning id;
+      """.formatted(planId));
       res.next();
       return res.getInt("id");
     }
@@ -91,7 +91,7 @@ class SchedulerDatabaseTests {
     @BeforeEach
     void beforeEach() throws SQLException {
       specAndTemplateIds = new HashMap<>();
-      specAndTemplateIds.put("specification", new int[]{insertSpecification(), insertSpecification()});
+      specAndTemplateIds.put("specification", new int[]{insertSpecification(0), insertSpecification(1)});
       specAndTemplateIds.put("template", new int[]{insertTemplate(), insertTemplate()});
       goalIds = new int[]{insertGoal(), insertGoal(), insertGoal(), insertGoal(), insertGoal(), insertGoal()};
     }

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
@@ -93,7 +93,7 @@ class SchedulerDatabaseTests {
       specAndTemplateIds = new HashMap<>();
       specAndTemplateIds.put("specification", new int[]{insertSpecification(), insertSpecification()});
       specAndTemplateIds.put("template", new int[]{insertTemplate(), insertTemplate()});
-      goalIds = new int[]{insertGoal(), insertGoal(), insertGoal()};
+      goalIds = new int[]{insertGoal(), insertGoal(), insertGoal(), insertGoal(), insertGoal(), insertGoal()};
     }
 
     @AfterEach
@@ -105,7 +105,7 @@ class SchedulerDatabaseTests {
       clearTable("scheduling_template_goals");
     }
 
-    void insertGoalPriorities(String tableStem, int specOrTemplateIndex, int[] priorities) throws SQLException {
+    void insertGoalPriorities(String tableStem, int specOrTemplateIndex, final int[] goalIndices, int[] priorities) throws SQLException {
       for (int i = 0; i < priorities.length; i++) {
         connection.createStatement().executeUpdate("""
           insert into scheduling_%s_goals(%s_id, goal_id, priority)
@@ -113,7 +113,7 @@ class SchedulerDatabaseTests {
         """.formatted(
             tableStem, tableStem,
             specAndTemplateIds.get(tableStem)[specOrTemplateIndex],
-            goalIds[i],
+            goalIds[goalIndices[i]],
             priorities[i]
         ));
       }
@@ -140,21 +140,22 @@ class SchedulerDatabaseTests {
     @ParameterizedTest
     @ValueSource(strings = {"specification", "template"})
     void shouldIncrementPrioritiesOnCollision(String tableStem) throws SQLException {
+      clearTable("scheduling_%s_goals".formatted(tableStem));
       // untouched values in table, should be unchanged
-      insertGoalPriorities(tableStem, 1, new int[]{0, 1, 2});
-
-      // should cause increments
-      insertGoalPriorities(tableStem, 0, new int[]{0, 0, 0});
-
-      checkPriorities(
-          tableStem, 0,
-          new int[]{0, 1},
-          new int[]{2, 1}
-      );
+      insertGoalPriorities(tableStem, 1, new int[] {0, 1, 2}, new int[]{0, 1, 2});
       checkPriorities(
           tableStem, 1,
           new int[]{0, 1, 2},
           new int[]{0, 1, 2}
+      );
+
+      clearTable("scheduling_%s_goals".formatted(tableStem));
+      // should cause increments
+      insertGoalPriorities(tableStem, 0, new int[] {0, 1, 2}, new int[]{0, 0, 0});
+      checkPriorities(
+          tableStem, 0,
+          new int[]{0, 1, 2},
+          new int[]{2, 1, 0}
       );
     }
 
@@ -162,24 +163,24 @@ class SchedulerDatabaseTests {
     @ValueSource(strings = {"specification", "template"})
     void shouldErrorWhenInsertingNegativePriority(String tableStem) {
       assertThrows(SQLException.class, () -> insertGoalPriorities(
-          tableStem, 0, new int[]{-1}
+          tableStem, 0, new int[] {0, 1, 2}, new int[]{-1}
       ));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"specification", "template"})
     void shouldErrorWhenInsertingNonConsecutivePriority(String tableStem) throws SQLException {
-      insertGoalPriorities(tableStem, 1, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 1, new int[] {0, 1, 2}, new int[]{0, 1, 2});
       assertThrows(SQLException.class, () -> insertGoalPriorities(
-          tableStem, 0, new int[]{1}
+          tableStem, 0, new int[] {0, 1, 2}, new int[]{1}
       ));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"specification", "template"})
     void shouldReorderPrioritiesOnUpdate(String tableStem) throws SQLException {
-      insertGoalPriorities(tableStem, 0, new int[]{0, 1, 2});
-      insertGoalPriorities(tableStem, 1, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 0, new int[] {0, 1, 2}, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 1, new int[] {3, 4, 5}, new int[]{0, 1, 2});
 
       // First test lowering a priority
       connection.createStatement().executeUpdate("""
@@ -193,7 +194,7 @@ class SchedulerDatabaseTests {
       );
       checkPriorities(
           tableStem, 1,
-          new int[]{0, 1, 2},
+          new int[]{3, 4, 5},
           new int[]{0, 1, 2}
       );
 
@@ -202,20 +203,23 @@ class SchedulerDatabaseTests {
         update scheduling_%s_goals
         set priority = 2 where %s_id = %d and goal_id = %d;
       """.formatted(tableStem, tableStem, specAndTemplateIds.get(tableStem)[0], goalIds[2]));
-      for (int i : new int[]{0, 1}) {
-        checkPriorities(
-            tableStem, i,
-            new int[]{0, 1, 2},
-            new int[]{0, 1, 2}
-        );
-      }
+      checkPriorities(
+          tableStem, 0,
+          new int[] {0, 1, 2},
+          new int[] {0, 1, 2}
+      );
+      checkPriorities(
+          tableStem, 1,
+          new int[] {3, 4, 5},
+          new int[] {0, 1, 2}
+      );
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"specification", "template"})
     void shouldDecrementPrioritiesOnDelete(String tableStem) throws SQLException {
-      insertGoalPriorities(tableStem, 0, new int[]{0, 1, 2});
-      insertGoalPriorities(tableStem, 1, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 0, new int[] {0, 1, 2}, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 1, new int[] {3, 4, 5}, new int[]{0, 1, 2});
 
       connection.createStatement().executeUpdate("""
         delete from scheduling_%s_goals
@@ -228,7 +232,7 @@ class SchedulerDatabaseTests {
       );
       checkPriorities(
           tableStem, 1,
-          new int[]{0, 1, 2},
+          new int[]{3, 4, 5},
           new int[]{0, 1, 2}
       );
     }
@@ -236,26 +240,33 @@ class SchedulerDatabaseTests {
     @ParameterizedTest
     @ValueSource(strings = {"specification", "template"})
     void shouldTriggerMultipleReorders(String tableStem) throws SQLException {
-      insertGoalPriorities(tableStem, 0, new int[]{0, 1, 2});
-      insertGoalPriorities(tableStem, 1, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 0, new int[] {0, 1, 2}, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 1, new int[] {3, 4, 5}, new int[]{0, 1, 2});
 
       connection.createStatement().executeUpdate("""
         delete from scheduling_%s_goals
         where goal_id = %d;
       """.formatted(tableStem, goalIds[1]));
-      for (int i : new int[]{0, 1}) {
-        checkPriorities(
-            tableStem, i,
-            new int[]{0, 2},
-            new int[]{0, 1}
-        );
-      }
+      connection.createStatement().executeUpdate("""
+        delete from scheduling_%s_goals
+        where goal_id = %d;
+      """.formatted(tableStem, goalIds[4]));
+      checkPriorities(
+          tableStem, 0,
+          new int[] {0, 2},
+          new int[] {0, 1}
+      );
+      checkPriorities(
+          tableStem, 1,
+          new int[] {3, 5},
+          new int[] {0, 1}
+      );
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"specification", "template"})
     void shouldNotTriggerWhenPriorityIsUnchanged(String tableStem) throws SQLException {
-      insertGoalPriorities(tableStem, 1, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 1, new int[] {0, 1, 2}, new int[]{0, 1, 2});
       connection.createStatement().executeUpdate("""
         update scheduling_%s_goals
         set %s_id = %d

--- a/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_analysis.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_analysis.sql
@@ -1,0 +1,11 @@
+create table scheduling_analysis (
+  id integer generated always as identity,
+
+  constraint scheduling_analysis_synthetic_key
+    primary key (id)
+);
+
+comment on table scheduling_analysis is e''
+  'The analysis associated with a scheduling run';
+comment on column scheduling_analysis.id is e''
+  'The synthetic identifier for this scheduling analysis.';

--- a/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_condition.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_condition.sql
@@ -1,0 +1,54 @@
+create table scheduling_condition (
+  id integer generated always as identity,
+  revision integer not null default 0,
+  name text not null,
+  definition text not null,
+
+  model_id integer not null,
+  description text null,
+  author text null,
+  last_modified_by text null,
+  created_date timestamptz not null default now(),
+  modified_date timestamptz not null default now(),
+
+  constraint scheduling_condition_synthetic_key
+    primary key (id)
+);
+
+comment on table scheduling_condition is e''
+  'A condition restricting scheduling of a plan.';
+comment on column scheduling_condition.id is e''
+  'The synthetic identifier for this scheduling condition.';
+comment on column scheduling_condition.revision is e''
+  'A monotonic clock that ticks for every change to this scheduling condition.';
+comment on column scheduling_condition.definition is e''
+  'The source code for a Typescript module defining this scheduling condition';
+comment on column scheduling_condition.model_id is e''
+  'The mission model used to which this scheduling condition is associated.';
+comment on column scheduling_condition.name is e''
+  'A short human readable name for this condition';
+comment on column scheduling_condition.description is e''
+  'A longer text description of this scheduling condition.';
+comment on column scheduling_condition.author is e''
+  'The original user who authored this scheduling condition.';
+comment on column scheduling_condition.last_modified_by is e''
+  'The last user who modified this scheduling condition.';
+comment on column scheduling_condition.created_date is e''
+  'The date this scheduling condition was created.';
+comment on column scheduling_condition.modified_date is e''
+  'The date this scheduling condition was last modified.';
+
+create function update_logging_on_update_scheduling_condition()
+  returns trigger
+  security definer
+language plpgsql as $$begin
+  new.revision = old.revision + 1;
+  new.modified_date = now();
+return new;
+end$$;
+
+create trigger update_logging_on_update_scheduling_condition_trigger
+  before update on scheduling_condition
+  for each row
+  when (pg_trigger_depth() < 1)
+  execute function update_logging_on_update_scheduling_condition();

--- a/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_goal.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_goal.sql
@@ -1,0 +1,54 @@
+create table scheduling_goal (
+  id integer generated always as identity,
+  revision integer not null default 0,
+  name text not null,
+  definition text not null,
+
+  model_id integer not null,
+  description text null,
+  author text null,
+  last_modified_by text null,
+  created_date timestamptz not null default now(),
+  modified_date timestamptz not null default now(),
+
+  constraint scheduling_goal_synthetic_key
+    primary key (id)
+);
+
+comment on table scheduling_goal is e''
+  'A goal for scheduling of a plan.';
+comment on column scheduling_goal.id is e''
+  'The synthetic identifier for this scheduling goal.';
+comment on column scheduling_goal.revision is e''
+  'A monotonic clock that ticks for every change to this scheduling goal.';
+comment on column scheduling_goal.definition is e''
+  'The source code for a Typescript module defining this scheduling goal';
+comment on column scheduling_goal.model_id is e''
+  'The mission model used to which this scheduling goal is associated.';
+comment on column scheduling_goal.name is e''
+  'A short human readable name for this goal';
+comment on column scheduling_goal.description is e''
+  'A longer text description of this scheduling goal.';
+comment on column scheduling_goal.author is e''
+  'The original user who authored this scheduling goal.';
+comment on column scheduling_goal.last_modified_by is e''
+  'The last user who modified this scheduling goal.';
+comment on column scheduling_goal.created_date is e''
+  'The date this scheduling goal was created.';
+comment on column scheduling_goal.modified_date is e''
+  'The date this scheduling goal was last modified.';
+
+create function update_logging_on_update_scheduling_goal()
+  returns trigger
+  security definer
+language plpgsql as $$begin
+  new.revision = old.revision + 1;
+  new.modified_date = now();
+return new;
+end$$;
+
+create trigger update_logging_on_update_scheduling_goal_trigger
+  before update on scheduling_goal
+  for each row
+  when (pg_trigger_depth() < 1)
+  execute function update_logging_on_update_scheduling_goal();

--- a/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_goal_analysis.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_goal_analysis.sql
@@ -1,0 +1,28 @@
+create table scheduling_goal_analysis (
+  analysis_id integer not null,
+  goal_id integer not null,
+
+  satisfied boolean not null,
+
+  constraint scheduling_goal_analysis_primary_key
+    primary key (analysis_id, goal_id),
+  constraint scheduling_goal_analysis_references_scheduling_analysis
+    foreign key (analysis_id)
+      references scheduling_analysis
+      on update cascade
+      on delete cascade,
+  constraint scheduling_goal_analysis_references_scheduling_goal
+    foreign key (goal_id)
+      references scheduling_goal
+      on update cascade
+      on delete cascade
+);
+
+comment on table scheduling_goal_analysis is e''
+  'The analysis of single goal from a scheduling run.';
+comment on column scheduling_goal_analysis.analysis_id is e''
+  'The associated analysis ID.';
+comment on column scheduling_goal_analysis.goal_id is e''
+  'The associated goal ID.';
+comment on column scheduling_goal_analysis.satisfied is e''
+  'Whether the associated goal was satisfied by the scheduling run.';

--- a/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_goal_analysis_created_activities.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_goal_analysis_created_activities.sql
@@ -1,0 +1,27 @@
+create table scheduling_goal_analysis_created_activities (
+  analysis_id integer not null,
+  goal_id integer not null,
+  activity_id integer not null,
+
+  constraint created_activities_primary_key
+    primary key (analysis_id, goal_id, activity_id),
+  constraint created_activities_references_scheduling_analysis
+    foreign key (analysis_id)
+      references scheduling_analysis
+      on update cascade
+      on delete cascade,
+  constraint created_activities_references_scheduling_goal
+    foreign key (goal_id)
+      references scheduling_goal
+      on update cascade
+      on delete cascade
+);
+
+comment on table scheduling_goal_analysis_created_activities is e''
+  'The activity instances created by a scheduling run to satisfy a goal.';
+comment on column scheduling_goal_analysis_created_activities.analysis_id is e''
+  'The associated analysis ID.';
+comment on column scheduling_goal_analysis_created_activities.goal_id is e''
+  'The associated goal ID.';
+comment on column scheduling_goal_analysis_created_activities.activity_id is e''
+  'The ID of an activity instance created to satisfy the associated goal.';

--- a/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_goal_analysis_satisfying_activities.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_goal_analysis_satisfying_activities.sql
@@ -1,0 +1,27 @@
+create table scheduling_goal_analysis_satisfying_activities (
+  analysis_id integer not null,
+  goal_id integer not null,
+  activity_id integer not null,
+
+  constraint satisfying_activities_primary_key
+    primary key (analysis_id, goal_id, activity_id),
+  constraint satisfying_activities_references_scheduling_analysis
+    foreign key (analysis_id)
+      references scheduling_analysis
+      on update cascade
+      on delete cascade,
+  constraint satisfying_activities_references_scheduling_goal
+    foreign key (goal_id)
+      references scheduling_goal
+      on update cascade
+      on delete cascade
+);
+
+comment on table scheduling_goal_analysis_satisfying_activities is e''
+  'The activity instances satisfying a scheduling goal.';
+comment on column scheduling_goal_analysis_satisfying_activities.analysis_id is e''
+  'The associated analysis ID.';
+comment on column scheduling_goal_analysis_satisfying_activities.goal_id is e''
+  'The associated goal ID.';
+comment on column scheduling_goal_analysis_satisfying_activities.activity_id is e''
+  'The ID of an activity instance satisfying the associated goal.';

--- a/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_request.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_request.sql
@@ -1,0 +1,89 @@
+create type status_t as enum('pending', 'incomplete', 'failed', 'success');
+
+create table scheduling_request (
+  specification_id integer not null,
+  analysis_id integer not null,
+
+  status status_t not null default 'pending',
+  reason jsonb null,
+  canceled boolean not null default false,
+
+  specification_revision integer not null,
+
+  constraint scheduling_request_primary_key
+    primary key(specification_id, specification_revision),
+  constraint scheduling_request_analysis_unique
+    unique (analysis_id),
+  constraint scheduling_request_references_scheduling_specification
+    foreign key(specification_id)
+      references scheduling_specification
+      on update cascade
+      on delete cascade,
+  constraint scheduling_request_references_analysis
+    foreign key(analysis_id)
+      references scheduling_analysis
+      on update cascade
+      on delete cascade
+);
+
+comment on table scheduling_request is e''
+  'The status of a scheduling run that is to be performed (or has been performed).';
+comment on column scheduling_request.specification_id is e''
+  'The ID of scheduling specification for this scheduling run.';
+comment on column scheduling_request.analysis_id is e''
+  'The ID associated with the analysis of this scheduling run.';
+comment on column scheduling_request.status is e''
+  'The state of the the scheduling request.';
+comment on column scheduling_request.reason is e''
+  'The reason for failure when a scheduling request fails.';
+comment on column scheduling_request.specification_revision is e''
+  'The revision of the scheduling_specification associated with this request.';
+
+create or replace function create_scheduling_analysis()
+returns trigger
+security definer
+language plpgsql as $$begin
+  insert into scheduling_analysis
+  default values
+  returning id into new.analysis_id;
+return new;
+end$$;
+
+do $$ begin
+create trigger create_scheduling_analysis_trigger
+  before insert on scheduling_request
+  for each row
+  execute function create_scheduling_analysis();
+exception
+  when duplicate_object then null;
+end $$;
+
+-- Scheduling request NOTIFY triggers
+-- These triggers NOTIFY LISTEN(ing) scheduler worker clients of pending scheduling requests
+
+create or replace function notify_scheduler_workers ()
+returns trigger
+security definer
+language plpgsql as $$
+begin
+  perform (
+    with payload(specification_revision,
+                 specification_id,
+                 analysis_id) as
+    (
+      select NEW.specification_revision,
+             NEW.specification_id,
+             NEW.analysis_id
+    )
+    select pg_notify('scheduling_request_notification', json_strip_nulls(row_to_json(payload))::text)
+    from payload
+  );
+  return null;
+end$$;
+
+do $$ begin
+create trigger notify_scheduler_workers
+  after insert on scheduling_request
+  for each row
+  execute function notify_scheduler_workers();
+end $$;

--- a/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_specification.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_specification.sql
@@ -1,0 +1,62 @@
+create table scheduling_specification (
+  id integer generated always as identity,
+  revision integer not null default 0,
+
+  plan_id integer not null,
+  plan_revision integer not null,
+  horizon_start timestamptz not null,
+  horizon_end timestamptz not null,
+  simulation_arguments jsonb not null,
+  analysis_only boolean not null,
+  constraint scheduling_specification_synthetic_key
+    primary key(id)
+);
+
+comment on table scheduling_specification is e''
+  'The specification for a scheduling run.';
+comment on column scheduling_specification.id is e''
+  'The synthetic identifier for this scheduling specification.';
+comment on column scheduling_specification.revision is e''
+  'A monotonic clock that ticks for every change to this scheduling specification.';
+comment on column scheduling_specification.plan_id is e''
+  'The ID of the plan to be scheduled.';
+comment on column scheduling_specification.horizon_start is e''
+  'The start of the scheduling horizon within which the scheduler may place activities.';
+comment on column scheduling_specification.horizon_end is e''
+  'The end of the scheduling horizon within which the scheduler may place activities.';
+comment on column scheduling_specification.simulation_arguments is e''
+  'The arguments to use for simulation during scheduling.';
+comment on column scheduling_specification.analysis_only is e''
+  'The boolean stating whether this is an analysis run only';
+
+create function increment_revision_on_update()
+  returns trigger
+  security definer
+language plpgsql as $$begin
+  new.revision = old.revision + 1;
+return new;
+end$$;
+
+create function increment_revision_on_goal_update()
+  returns trigger
+  security definer
+language plpgsql as $$begin
+  with goals as (
+    select g.specification_id from scheduling_specification_goals as g
+    where g.specification_id = new.id
+  )
+  update scheduling_specification set revision = revision + 1
+  where exists(select 1 from goals where specification_id = id);
+return new;
+end$$;
+
+create trigger increment_revision_on_update_trigger
+  before update on scheduling_specification
+  for each row
+  when (pg_trigger_depth() < 1)
+  execute function increment_revision_on_update();
+
+create trigger increment_revision_on_goal_update
+  before update on scheduling_goal
+  for each row
+  execute function increment_revision_on_goal_update();

--- a/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_specification_conditions.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_specification_conditions.sql
@@ -1,0 +1,25 @@
+create table scheduling_specification_conditions (
+  specification_id integer not null,
+  condition_id integer not null,
+  enabled boolean default true,
+
+  constraint scheduling_specification_conditions_primary_key
+    primary key (specification_id, condition_id),
+  constraint scheduling_specification_conditions_references_scheduling_specification
+    foreign key (specification_id)
+      references scheduling_specification
+      on update cascade
+      on delete cascade,
+  constraint scheduling_specification_conditions_references_scheduling_conditions
+    foreign key (condition_id)
+      references scheduling_condition
+      on update cascade
+      on delete cascade
+);
+
+comment on table scheduling_specification_conditions is e''
+  'A join table associating scheduling specifications with scheduling conditions.';
+comment on column scheduling_specification_conditions.specification_id is e''
+  'The ID of the scheduling specification a scheduling goal is associated with.';
+comment on column scheduling_specification_conditions.condition_id is e''
+  'The ID of the condition a scheduling specification is associated with.';

--- a/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_specification_goals.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_specification_goals.sql
@@ -1,0 +1,121 @@
+create table scheduling_specification_goals (
+  specification_id integer not null,
+  goal_id integer not null,
+  priority integer
+    not null
+    default null -- Nulls are detected and replaced with the next
+                 -- available priority by the insert trigger
+    constraint non_negative_specification_goal_priority check (priority >= 0),
+  enabled boolean default true,
+
+  constraint scheduling_specification_goals_primary_key
+    primary key (specification_id, goal_id),
+  constraint scheduling_specification_goals_unique_priorities
+    unique (specification_id, priority) deferrable initially deferred,
+  constraint scheduling_specification_goals_references_scheduling_specification
+    foreign key (specification_id)
+      references scheduling_specification
+      on update cascade
+      on delete cascade,
+  constraint scheduling_specification_goals_references_scheduling_goals
+    foreign key (goal_id)
+      references scheduling_goal
+      on update cascade
+      on delete cascade
+);
+
+comment on table scheduling_specification_goals is e''
+  'A join table associating scheduling specifications with scheduling goals.';
+comment on column scheduling_specification_goals.specification_id is e''
+  'The ID of the scheduling specification a scheduling goal is associated with.';
+comment on column scheduling_specification_goals.goal_id is e''
+  'The ID of the scheduling goal a scheduling specification is associated with.';
+comment on column scheduling_specification_goals.priority is e''
+  'The relative priority of a scheduling goal in relation to other '
+  'scheduling goals within the same specification.';
+
+create or replace function insert_scheduling_specification_goal_func()
+  returns trigger as $$begin
+    if NEW.priority IS NULL then
+      NEW.priority = (
+        select coalesce(max(priority), -1) from scheduling_specification_goals
+        where specification_id = NEW.specification_id
+      ) + 1;
+    elseif NEW.priority > (
+      select coalesce(max(priority), -1) from scheduling_specification_goals
+        where specification_id = new.specification_id
+    ) + 1 then
+      raise exception 'Inserted priority % for specification_id % is not consecutive', NEW.priority, NEW.specification_id;
+    end if;
+    update scheduling_specification_goals
+      set priority = priority + 1
+      where specification_id = NEW.specification_id
+        and priority >= NEW.priority;
+    return NEW;
+  end;$$
+language plpgsql;
+
+comment on function insert_scheduling_specification_goal_func is e''
+  'Checks that the inserted priority is consecutive, and reorders (increments) higher or equal priorities to make room.';
+
+create or replace function update_scheduling_specification_goal_func()
+  returns trigger as $$begin
+  if (pg_trigger_depth() = 1) then
+      if NEW.priority > OLD.priority then
+        if NEW.priority > (
+          select coalesce(max(priority), -1) from scheduling_specification_goals
+            where specification_id = new.specification_id
+        ) + 1 then
+          raise exception 'Updated priority % for specification_id % is not consecutive', NEW.priority, new.specification_id;
+        end if;
+        update scheduling_specification_goals
+          set priority = priority - 1
+          where specification_id = NEW.specification_id
+            and priority between OLD.priority + 1 and NEW.priority
+            and goal_id <> NEW.goal_id;
+      else
+        update scheduling_specification_goals
+          set priority = priority + 1
+          where specification_id = NEW.specification_id
+            and priority between NEW.priority and OLD.priority - 1
+            and goal_id <> NEW.goal_id;
+      end if;
+    end if;
+    return NEW;
+  end;$$
+language plpgsql;
+
+comment on function update_scheduling_specification_goal_func is e''
+  'Checks that the updated priority is consecutive, and reorders priorities to make room.';
+
+create function delete_scheduling_specification_goal_func()
+  returns trigger as $$begin
+    update scheduling_specification_goals
+      set priority = priority - 1
+      where specification_id = OLD.specification_id
+        and priority > OLD.priority;
+    return null;
+  end;$$
+language plpgsql;
+
+comment on function delete_scheduling_specification_goal_func() is e''
+  'Reorders (decrements) priorities to fill the gap from deleted priority.';
+
+create trigger insert_scheduling_specification_goal
+  before insert
+  on scheduling_specification_goals
+  for each row
+execute function insert_scheduling_specification_goal_func();
+
+create trigger update_scheduling_specification_goal
+  before update
+  on scheduling_specification_goals
+  for each row
+  when (OLD.priority is distinct from NEW.priority)
+execute function update_scheduling_specification_goal_func();
+
+create trigger delete_scheduling_specification_goal
+  after delete
+  on scheduling_specification_goals
+  for each row
+execute function delete_scheduling_specification_goal_func();

--- a/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_template.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_template.sql
@@ -1,0 +1,40 @@
+create table scheduling_template (
+  id integer generated always as identity,
+  revision integer not null default 0,
+
+  model_id integer not null,
+  description text not null,
+  simulation_arguments jsonb not null,
+
+  constraint scheduling_template_synthetic_key
+    primary key (id)
+);
+
+comment on table scheduling_template is e''
+  'A template scheduling spec from which scheduling requests may be based.'
+'\n'
+  'The associated scheduling goals are stored in the scheduling_template_goals table.';
+comment on column scheduling_template.id is e''
+  'The synthetic identifier for this scheduling template.';
+comment on column scheduling_template.revision is e''
+  'A monotonic clock that ticks for every change to this scheduling template.';
+comment on column scheduling_template.model_id is e''
+  'The mission model used to which this scheduling template is associated.';
+comment on column scheduling_template.description is e''
+  'A text description of this scheduling template.';
+comment on column scheduling_template.simulation_arguments is e''
+  'A set of simulation arguments to be used for simulation during scheduling.';
+
+create function increment_revision_on_update_scheduling_template()
+  returns trigger
+  security definer
+language plpgsql as $$begin
+  new.revision = old.revision + 1;
+return new;
+end$$;
+
+create trigger increment_revision_on_update_scheduling_template_trigger
+  before update on scheduling_template
+  for each row
+  when (pg_trigger_depth() < 1)
+  execute function increment_revision_on_update_scheduling_template();

--- a/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_template_goals.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/tables/scheduling_template_goals.sql
@@ -1,0 +1,120 @@
+create table scheduling_template_goals (
+  template_id integer not null,
+  goal_id integer not null,
+  priority integer
+    not null
+    default null -- Nulls are detected and replaced with the next
+                 -- available priority by the insert trigger
+    constraint non_negative_template_goal_priority check (priority >= 0),
+
+  constraint scheduling_template_goals_primary_key
+    primary key (template_id, goal_id),
+  constraint scheduling_template_goals_unique_priorities
+    unique (template_id, priority) deferrable initially deferred,
+  constraint scheduling_template_goals_references_scheduling_template
+    foreign key (template_id)
+      references scheduling_template
+      on update cascade
+      on delete cascade,
+  constraint scheduling_template_goals_references_scheduling_goals
+    foreign key (goal_id)
+      references scheduling_goal
+      on update cascade
+      on delete cascade
+);
+
+comment on table scheduling_template_goals is e''
+  'A join table associating scheduling templates with scheduling goals.';
+comment on column scheduling_template_goals.template_id is e''
+  'The ID of the scheduling template a scheduling goal is associated with.';
+comment on column scheduling_template_goals.goal_id is e''
+  'The ID of the scheduling goal a scheduling template is associated with.';
+comment on column scheduling_template_goals.priority is e''
+  'The relative priority of a scheduling goal in relation to other '
+  'scheduling goals within the same template.';
+
+create or replace function insert_scheduling_template_goal_func()
+  returns trigger as $$begin
+    if NEW.priority IS NULL then
+      NEW.priority = (
+        select coalesce(max(priority), -1) from scheduling_template_goals
+        where template_id = NEW.template_id
+      ) + 1;
+    elseif NEW.priority > (
+      select coalesce(max(priority), -1) from scheduling_template_goals
+      where template_id = NEW.template_id
+    ) + 1 then
+      raise exception 'Inserted priority % for template_id % is not consecutive', NEW.priority, NEW.template_id;
+    end if;
+    update scheduling_template_goals
+      set priority = priority + 1
+      where template_id = NEW.template_id
+        and priority >= NEW.priority;
+    return NEW;
+  end;$$
+language plpgsql;
+
+comment on function insert_scheduling_template_goal_func is e''
+  'Checks that the inserted priority is consecutive, and reorders (increments) higher or equal priorities to make room.';
+
+create or replace function update_scheduling_template_goal_func()
+  returns trigger as $$begin
+    if (pg_trigger_depth() = 1) then
+      if NEW.priority > OLD.priority then
+        if NEW.priority > (
+          select coalesce(max(priority), -1) from scheduling_template_goals
+          where template_id = new.template_id
+        ) + 1 then
+          raise exception 'Updated priority % for template_id % is not consecutive', NEW.priority, new.template_id;
+        end if;
+        update scheduling_template_goals
+          set priority = priority - 1
+          where template_id = NEW.template_id
+            and priority between OLD.priority + 1 and NEW.priority
+            and goal_id <> NEW.goal_id;
+      else
+        update scheduling_template_goals
+        set priority = priority + 1
+        where template_id = NEW.template_id
+          and priority between NEW.priority and OLD.priority - 1
+          and goal_id <> NEW.goal_id;
+      end if;
+    end if;
+    return NEW;
+  end;$$
+language plpgsql;
+
+comment on function update_scheduling_template_goal_func is e''
+  'Checks that the updated priority is consecutive, and reorders priorities to make room.';
+
+create function delete_scheduling_template_goal_func()
+  returns trigger as $$begin
+    update scheduling_template_goals
+      set priority = priority - 1
+      where template_id = OLD.template_id
+        and priority > OLD.priority;
+    return null;
+  end;$$
+language plpgsql;
+
+comment on function delete_scheduling_template_goal_func() is e''
+  'Reorders (decrements) priorities to fill the gap from deleted priority.';
+
+create trigger insert_scheduling_template_goal
+  before insert
+  on scheduling_template_goals
+  for each row
+execute function insert_scheduling_template_goal_func();
+
+create trigger update_scheduling_template_goal
+  before update
+  on scheduling_template_goals
+  for each row
+  when (OLD.priority is distinct from NEW.priority)
+execute function update_scheduling_template_goal_func();
+
+create trigger delete_scheduling_template_goal
+  after delete
+  on scheduling_template_goals
+  for each row
+execute function delete_scheduling_template_goal_func();

--- a/deployment/hasura/migrations/AerieScheduler/0_init/tables/schema_migrations.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/tables/schema_migrations.sql
@@ -1,0 +1,23 @@
+create table "schema_migrations" (
+  "version" varchar not null primary key
+);
+
+create function mark_migration_applied(migration_version varchar)
+returns void
+language plpgsql as $$
+begin
+  insert into schema_migrations (version)
+  values (migration_version);
+end;
+$$;
+
+create function mark_migration_rolled_back(migration_version varchar)
+returns void
+language plpgsql as $$
+begin
+  delete from schema_migrations
+  where version = migration_version;
+end;
+$$;
+
+select mark_migration_applied('0');

--- a/deployment/hasura/migrations/AerieScheduler/0_init/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_init/up.sql
@@ -1,0 +1,20 @@
+-- The order of inclusion is important! Tables referenced by foreign keys must be loaded before their dependants.
+
+begin;
+  -- Schema migrations
+  \ir tables/schema_migrations.sql
+
+  -- Scheduling intents.
+  \ir tables/scheduling_goal.sql
+  \ir tables/scheduling_template.sql
+  \ir tables/scheduling_template_goals.sql
+  \ir tables/scheduling_specification.sql
+  \ir tables/scheduling_specification_goals.sql
+  \ir tables/scheduling_analysis.sql
+  \ir tables/scheduling_request.sql
+  \ir tables/scheduling_goal_analysis.sql
+  \ir tables/scheduling_goal_analysis_created_activities.sql
+  \ir tables/scheduling_goal_analysis_satisfying_activities.sql
+  \ir tables/scheduling_condition.sql
+  \ir tables/scheduling_specification_conditions.sql
+end;

--- a/deployment/hasura/migrations/AerieScheduler/1_make_scheduling_goals_unique/down.sql
+++ b/deployment/hasura/migrations/AerieScheduler/1_make_scheduling_goals_unique/down.sql
@@ -1,0 +1,19 @@
+/*
+This script restores the schema to its state before the migration. It is to be used if the Aerie upgrade is deemed,
+unsuccessful, and the database needs to be restored to compatibility with the previous version of Aerie.
+
+Note that this migration does not affect Aerie compatibility - it does not violate any assumptions that Aerie makes.
+The only possible compatibility issue is if API clients assume that they can share goals across specifications.
+
+Note that it does not restore data to its state before the migration. If you ran prepare.sql, the copies of your shared
+goals are left alone by this script. If you need to restore those goals to the way they were, you can do this manually
+via SQL or GraphQL using the output of prepare.sql to see which goals were copied.
+
+Essentially, that would involve:
+1. Update the scheduling_specification_goals entries to point to the original goal id
+2. (Optional) Delete the new copies of the goals.
+*/
+
+alter table scheduling_specification_goals drop constraint if exists scheduling_specification_unique_goal_id;
+
+select mark_migration_rolled_back('1');

--- a/deployment/hasura/migrations/AerieScheduler/1_make_scheduling_goals_unique/prepare.sql
+++ b/deployment/hasura/migrations/AerieScheduler/1_make_scheduling_goals_unique/prepare.sql
@@ -1,0 +1,56 @@
+/*
+This script will make copies of any goals that are shared across multiple specifications.
+*/
+create schema "migration_1_make_scheduling_goals_unique";
+
+create table "migration_1_make_scheduling_goals_unique".spec_goals_to_leave_alone(
+  specification_id integer,
+  goal_id integer unique
+);
+
+insert into "migration_1_make_scheduling_goals_unique".spec_goals_to_leave_alone (goal_id, specification_id)
+select goal_id, min(specification_id) from scheduling_specification_goals group by goal_id;
+
+alter table scheduling_goal add column specification_id integer default null;
+alter table scheduling_goal add column old_goal_id integer default null;
+
+insert into scheduling_goal (
+  revision,
+  name,
+  definition,
+  model_id,
+  description,
+  author,
+  last_modified_by,
+  created_date,
+  modified_date,
+  specification_id,
+  old_goal_id)
+(select revision,
+       name,
+       definition,
+       model_id,
+       description,
+       author,
+       last_modified_by,
+       created_date,
+       modified_date,
+       ssg.specification_id,
+       id
+from scheduling_goal
+join scheduling_specification_goals ssg
+on id = goal_id
+where (goal_id, ssg.specification_id) not in
+      (select goal_id, spec_goals_to_leave_alone.specification_id
+       from "migration_1_make_scheduling_goals_unique".spec_goals_to_leave_alone)
+);
+
+update scheduling_specification_goals ssg
+set goal_id = g.id
+from scheduling_goal g
+where g.specification_id = ssg.specification_id and g.old_goal_id = ssg.goal_id;
+
+alter table scheduling_goal drop column specification_id;
+alter table scheduling_goal drop column old_goal_id;
+drop table "migration_1_make_scheduling_goals_unique".spec_goals_to_leave_alone;
+drop schema "migration_1_make_scheduling_goals_unique";

--- a/deployment/hasura/migrations/AerieScheduler/1_make_scheduling_goals_unique/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/1_make_scheduling_goals_unique/up.sql
@@ -1,0 +1,17 @@
+/*
+make_scheduling_goals_unique
+
+The purpose of this migration is to limit the flexibility of scheduling specifications. The current schema allows for
+the same goal to be part of multiple scheduling specifications, which can be problematic when that goal is mutated.
+
+This mutation imposes a constraint that every goal must be part of no more than one specification.
+
+It is desirable to keep API compatibility with the previous schema.
+
+This sql file will fail if there are pre-existing goals that are members of multiple specifications. These cases must
+either be addressed manually, or with the help of prepare.sql.
+*/
+
+alter table scheduling_specification_goals add constraint scheduling_specification_unique_goal_id unique (goal_id);
+
+select mark_migration_applied('1');

--- a/deployment/hasura/migrations/AerieScheduler/2_one_scheduling_spec_per_plan/down.sql
+++ b/deployment/hasura/migrations/AerieScheduler/2_one_scheduling_spec_per_plan/down.sql
@@ -1,0 +1,3 @@
+alter table scheduling_specification drop constraint if exists scheduling_specification_unique_plan_id;
+
+select mark_migration_rolled_back('2');

--- a/deployment/hasura/migrations/AerieScheduler/2_one_scheduling_spec_per_plan/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/2_one_scheduling_spec_per_plan/up.sql
@@ -1,0 +1,12 @@
+/*
+one_scheduling_spec_per_plan
+
+This migration adds a requirement that no two specifications refer to the same plan.
+
+This script will fail if there are pre-existing specifications that refer to the same plan. This will need to be
+resolved manually.
+*/
+
+alter table scheduling_specification add constraint scheduling_specification_unique_plan_id unique (plan_id);
+
+select mark_migration_applied('2');

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -3,3 +3,4 @@ This file denotes which migrations occur "before" this version of the schema.
 */
 
 select mark_migration_applied('0');
+select mark_migration_applied('1');

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -1,0 +1,5 @@
+/*
+This file denotes which migrations occur "before" this version of the schema.
+*/
+
+select mark_migration_applied('0');

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -4,3 +4,4 @@ This file denotes which migrations occur "before" this version of the schema.
 
 select mark_migration_applied('0');
 select mark_migration_applied('1');
+select mark_migration_applied('2');

--- a/scheduler-server/sql/scheduler/init.sql
+++ b/scheduler-server/sql/scheduler/init.sql
@@ -1,6 +1,10 @@
 -- The order of inclusion is important! Tables referenced by foreign keys must be loaded before their dependants.
 
 begin;
+  -- Schema migrations
+  \ir tables/schema_migrations.sql
+  \ir applied_migrations.sql
+
   -- Scheduling intents.
   \ir tables/scheduling_goal.sql
   \ir tables/scheduling_template.sql

--- a/scheduler-server/sql/scheduler/tables/scheduling_specification.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_specification.sql
@@ -9,7 +9,9 @@ create table scheduling_specification (
   simulation_arguments jsonb not null,
   analysis_only boolean not null,
   constraint scheduling_specification_synthetic_key
-    primary key(id)
+    primary key(id),
+  constraint scheduling_specification_unique_plan_id
+    unique (plan_id)
 );
 
 comment on table scheduling_specification is e''

--- a/scheduler-server/sql/scheduler/tables/scheduling_specification_goals.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_specification_goals.sql
@@ -21,7 +21,9 @@ create table scheduling_specification_goals (
     foreign key (goal_id)
       references scheduling_goal
       on update cascade
-      on delete cascade
+      on delete cascade,
+  constraint scheduling_specification_unique_goal_id
+    unique (goal_id)
 );
 
 comment on table scheduling_specification_goals is e''

--- a/scheduler-server/sql/scheduler/tables/schema_migrations.sql
+++ b/scheduler-server/sql/scheduler/tables/schema_migrations.sql
@@ -1,0 +1,21 @@
+create table "schema_migrations" (
+  "version" varchar not null primary key
+);
+
+create function mark_migration_applied(migration_version varchar)
+returns void
+language plpgsql as $$
+begin
+  insert into schema_migrations (version)
+  values (migration_version);
+end;
+$$;
+
+create function mark_migration_rolled_back(migration_version varchar)
+returns void
+language plpgsql as $$
+begin
+  delete from schema_migrations
+  where version = migration_version;
+end;
+$$;


### PR DESCRIPTION
* **Tickets addressed:** Closes #471
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR is a second attempt - the first attempt was #471 . The key difference is that the first attempt directly edited our init.sql files, while this PR makes the change as a database migration.

The purpose of this PR is to restrict the flexibility of scheduling specifications. Currently, it is possible for a single goal to be a member of multiple specifications - which means that editing a scheduling goal from the context of one plan will cause it to be changed for all plans whose scheduling specifications contain this goal. This was deemed undesirable in a recent use case working group. It was also deemed undesirable to allow multiple scheduling specifications per plan.

If we commit to this approach long-term, we should consider normalizing our data structures as pointed out by @JoelCourtney https://github.com/NASA-AMMOS/aerie/pull/475#pullrequestreview-1177885404. In the interest of not changing the API (yet) - I've opted to merely add constraints without restructuring the data. I'm also not sure that we've really ironed out the use cases around scheduling specifications - especially in the context of plan branching - so I'd like to keep our over-engineered data structures around a little longer.

This PR includes two migrations - one to add a constraint to the `scheduling_specification_goals` table to make sure that each goal id is present at most once - and another to add a constraint to the `scheduling_specification` table to make sure that no two specifications refer to the same plan.

### A note about migration numbering:
In this PR I have elected to number migrations sequentially. Hasura seems to be perfectly happy with this - so although hasura's "create" function will number migrations based on timestamp - manually renaming the folder to use a sequential ID seems to have no detrimental effects. As discussed here: #346 a sequential numbering scheme forces us to think carefully about the order in which migrations are applied - and will cause helpful collisions if we rebase onto develop after another branch has introduced a migration with the same ID. Whether we choose to use sequential IDs or timestamps, we will still need to re-number our migrations after rebase - and my impression is that renumbering sequential IDs is less error-prone. 

- [x] TODO: Before merging this PR, I'd like to figure out what changes should be made to our current `init.sql` and related files - we could move them all into a zeroth migration.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
This PR introduces migrations to our `db-tests` suite. Each migration has its own test file, in which the `helper.startDatabaseBeforeMigration` method is used to bring the schema up to but not including the migration under test. After inserting seed data, a test can use the `applyMigration`, `rollbackMigration`, and `runSqlFile` to verify that the migration behaves as expected.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
- [ ] TODO instructions for how to run migrations are necessary

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Put some thought into whether or not a similar change need be applied for templates
- Consider refactoring the tables to be more normalized