### PR TITLE
Fix infinite loop issue with recurrence goal and global scheduling condition + warning message

### DIFF
--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/ActivityCreationTemplate.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/ActivityCreationTemplate.java
@@ -160,8 +160,9 @@ public class ActivityCreationTemplate extends ActivityExpression {
                                      + " because its DurationType is Uncontrollable");
         }
         if(this.acceptableAbsoluteTimingError.isZero()){
-          logger.warn("Root-finding is likely to fail as activity has an uncontrollable duration and the timing "
-          + "precision is 0. Setting it for you at 1s. Next time, use withTimingPrecision() when building the template.");
+          //TODO: uncomment when precision can be set by user
+          //logger.warn("Root-finding is likely to fail as activity has an uncontrollable duration and the timing "
+          //+ "precision is 0. Setting it for you at 1s. Next time, use withTimingPrecision() when building the template.");
           this.acceptableAbsoluteTimingError = Duration.of(500, Duration.MILLISECOND);
         }
       }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/RecurrenceGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/RecurrenceGoal.java
@@ -202,7 +202,7 @@ public class RecurrenceGoal extends ActivityTemplateGoal {
          ;
          intervalT = intervalT.plus(recurrenceInterval.max)
     ) {
-      final var windows = new Windows(false).set(Interval.between(intervalT.minus(recurrenceInterval.max), Duration.min(intervalT, end)), true);
+      final var windows = new Windows(false).set(Interval.betweenClosedOpen(intervalT.minus(recurrenceInterval.max), Duration.min(intervalT, end)), true);
       conflicts.add(new MissingActivityTemplateConflict(this, windows, this.getActTemplate()));
       if(intervalT.compareTo(end) >= 0){
         break;


### PR DESCRIPTION
Resolves #524 
Resolves #458 

* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The interval for specifying when to schedule activities was specified as Closed/Closed when it should have been Closed/Open to avoid multiple schedulings at the same time (at the end of the interval). 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
The bug reported in #524 was reproduced and has been added as test. Instead of looping forever, the scheduler only adds one activity as expected. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None