### PR TITLE
Added an override for qs to fix dependabot vulnerability

### DIFF
--- a/sequencing-server/package-lock.json
+++ b/sequencing-server/package-lock.json
@@ -2432,9 +2432,9 @@
       }
     },
     "node_modules/express/node_modules/qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
       "engines": {
         "node": ">=0.6"
       },
@@ -6866,7 +6866,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.9.7",
         "raw-body": "2.5.1",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -7396,7 +7396,7 @@
         "parseurl": "~1.3.3",
         "path-is-absolute": "1.0.1",
         "proxy-addr": "~2.0.7",
-        "qs": "6.9.6",
+        "qs": "6.9.7",
         "range-parser": "~1.2.1",
         "router": "2.0.0-beta.1",
         "safe-buffer": "5.2.1",
@@ -7421,7 +7421,7 @@
             "http-errors": "1.8.1",
             "iconv-lite": "0.4.24",
             "on-finished": "~2.3.0",
-            "qs": "6.9.6",
+            "qs": "6.9.7",
             "raw-body": "2.4.2",
             "type-is": "~1.6.18"
           },
@@ -7475,9 +7475,9 @@
           }
         },
         "qs": {
-          "version": "6.9.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+          "version": "6.9.7",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+          "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
         },
         "raw-body": {
           "version": "2.4.2",
@@ -9032,8 +9032,7 @@
       }
     },
     "qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "version": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
       "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "requires": {
         "side-channel": "^1.0.4"

--- a/sequencing-server/package.json
+++ b/sequencing-server/package.json
@@ -55,5 +55,10 @@
     "supervisor": "^0.12.0",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1"
+  },
+  "overrides": {
+    "express": {
+      "qs": "6.9.7"
+    }
   }
 }


### PR DESCRIPTION
* **Tickets addressed:** AERIE-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Partial fix of #536. This just overrides the `qs` version to fix the security vulnerability because we're still locked to express beta `1.0.0`.

## Verification
Automated and manual tests were both performed.

## Documentation
N/A

## Future work
I still need to update the other dependencies, but I wanted to fix the vulnerability asap.
