### PR TITLE
Add multi-arch image builds in `publish` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       # Build, scan, and push aerie-hasura Docker artifacts.
       - name: Extract metadata (tags, labels) for aerie-hasura Docker image
         id: aerieHasura
@@ -71,6 +73,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile.hasura
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aerieHasura.outputs.tags }}
           labels: ${{ steps.aerieHasura.outputs.labels }}
@@ -98,6 +101,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./merlin-server
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aerieMerlin.outputs.tags }}
           labels: ${{ steps.aerieMerlin.outputs.labels }}
@@ -125,6 +129,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./merlin-worker
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aerieMerlinWorker.outputs.tags }}
           labels: ${{ steps.aerieMerlinWorker.outputs.labels }}
@@ -154,6 +159,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile.postgres
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aeriePostgres.outputs.tags }}
           labels: ${{ steps.aeriePostgres.outputs.labels }}
@@ -181,6 +187,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./scheduler-worker
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aerieSchedulerWorker.outputs.tags }}
           labels: ${{ steps.aerieSchedulerWorker.outputs.labels }}
@@ -208,6 +215,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./scheduler-server
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aerieScheduler.outputs.tags }}
           labels: ${{ steps.aerieScheduler.outputs.labels }}
@@ -235,6 +243,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./sequencing-server
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aerieSequencing.outputs.tags }}
           labels: ${{ steps.aerieSequencing.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
@@ -40,7 +40,7 @@ jobs:
       - name: Assemble
         run: ./gradlew assemble
       - name: Login to the Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -48,11 +48,11 @@ jobs:
       # Build, scan, and push aerie-hasura Docker artifacts.
       - name: Extract metadata (tags, labels) for aerie-hasura Docker image
         id: aerieHasura
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/nasa-ammos/aerie-hasura
       - name: Build aerie-hasura Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./docker/Dockerfile.hasura
@@ -67,7 +67,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL'
       - name: Push aerie-hasura Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./docker/Dockerfile.hasura
@@ -77,11 +77,11 @@ jobs:
       # Build, scan, and push aerie-merlin Docker artifacts.
       - name: Extract metadata (tags, labels) for aerie-merlin Docker image
         id: aerieMerlin
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/nasa-ammos/aerie-merlin
       - name: Build aerie-merlin Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./merlin-server
           load: true
@@ -95,7 +95,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL'
       - name: Push aerie-merlin Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./merlin-server
           push: true
@@ -104,11 +104,11 @@ jobs:
       # Build, scan, and push aerie-merlin-worker Docker artifacts.
       - name: Extract metadata (tags, labels) for aerie-merlin-worker Docker image
         id: aerieMerlinWorker
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/nasa-ammos/aerie-merlin-worker
       - name: Build aerie-merlin-worker Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./merlin-worker
           load: true
@@ -122,7 +122,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL'
       - name: Push aerie-merlin-worker Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./merlin-worker
           push: true
@@ -131,11 +131,11 @@ jobs:
       # Build, scan, and push aerie-postgres Docker artifacts.
       - name: Extract metadata (tags, labels) for aerie-postgres Docker image
         id: aeriePostgres
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/nasa-ammos/aerie-postgres
       - name: Build aerie-postgres Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./docker/Dockerfile.postgres
@@ -150,7 +150,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL'
       - name: Push aerie-postgres Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./docker/Dockerfile.postgres
@@ -160,11 +160,11 @@ jobs:
       # Build, scan, and push aerie-scheduler-worker Docker artifacts.
       - name: Extract metadata (tags, labels) for aerie-scheduler-worker Docker image
         id: aerieSchedulerWorker
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/nasa-ammos/aerie-scheduler-worker
       - name: Build aerie-scheduler-worker Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./scheduler-worker
           load: true
@@ -178,7 +178,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL'
       - name: Push aerie-scheduler-worker Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./scheduler-worker
           push: true
@@ -187,11 +187,11 @@ jobs:
       # Build, scan, and push aerie-scheduler Docker artifacts.
       - name: Extract metadata (tags, labels) for aerie-scheduler Docker image
         id: aerieScheduler
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/nasa-ammos/aerie-scheduler
       - name: Build aerie-scheduler Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./scheduler-server
           load: true
@@ -205,7 +205,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL'
       - name: Push aerie-scheduler Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./scheduler-server
           push: true
@@ -214,11 +214,11 @@ jobs:
       # Build, scan, and push aerie-sequencing Docker artifacts.
       - name: Extract metadata (tags, labels) for aerie-sequencing Docker image
         id: aerieSequencing
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/nasa-ammos/aerie-sequencing
       - name: Build aerie-sequencing Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./sequencing-server
           load: true
@@ -232,7 +232,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL'
       - name: Push aerie-sequencing Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./sequencing-server
           push: true
@@ -247,7 +247,7 @@ jobs:
       - name: Create deployment archive
         run: ./gradlew archiveDeployment
       - name: Publish deployment
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Deployment
           path: deployment.tar


### PR DESCRIPTION
* **Tickets addressed:** closes #555 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Adds docker buildx support to our github `publish` action, which allows us to build multi-arch images, i.e. images that automagically work on both amd64 and arm64. This allows our images to easily run on [arm-based cloud VMs](https://aws.amazon.com/ec2/graviton/), as well as removes the need for M1 mac users to virtualize amd64 (though they still need to virtualize linux).

Additionally bumped the versions for most actions in the workflow, since those use deprecated versions of `node`. This should remove the ~50 warnings we get every time this workflow runs :laughing: 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Unfortunately, github actions are hard to validate when only run on merge to `develop` but there are no breaking changes on version updates, and buildx should be able to push multi-arch images directly to `ghcr` according to their docs, since all our base images are also multi-arch

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A
