### PR TITLE
Anchors

### DIFF
--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/AnchorTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/AnchorTests.java
@@ -1,0 +1,1219 @@
+package gov.nasa.jpl.aerie.database;
+
+import com.impossibl.postgres.api.data.Interval;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Period;
+import java.util.ArrayList;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AnchorTests {
+  private static final File initSqlScriptFile = new File("../merlin-server/sql/merlin/init.sql");
+  private DatabaseTestHelper helper;
+
+  private Connection connection;
+  int fileId;
+  int missionModelId;
+
+  @BeforeEach
+  void beforeEach() throws SQLException {
+    fileId = insertFileUpload();
+    missionModelId = insertMissionModel(fileId);
+  }
+
+  @AfterEach
+  void afterEach() throws SQLException {
+    helper.clearTable("uploaded_file");
+    helper.clearTable("mission_model");
+    helper.clearTable("plan");
+    helper.clearTable("activity_directive");
+    helper.clearTable("simulation_template");
+    helper.clearTable("simulation");
+    helper.clearTable("dataset");
+    helper.clearTable("plan_dataset");
+    helper.clearTable("simulation_dataset");
+    helper.clearTable("plan_snapshot");
+    helper.clearTable("plan_latest_snapshot");
+    helper.clearTable("plan_snapshot_activities");
+    helper.clearTable("plan_snapshot_parent");
+    helper.clearTable("merge_request");
+    helper.clearTable("merge_staging_area");
+    helper.clearTable("conflicting_activities");
+    helper.clearTable("anchor_validation_status");
+  }
+
+  @BeforeAll
+  void beforeAll() throws SQLException, IOException, InterruptedException {
+    helper = new DatabaseTestHelper(
+        "aerie_merlin_test",
+        "Merlin Database Tests",
+        initSqlScriptFile
+    );
+    helper.startDatabase();
+    connection = helper.connection();
+  }
+
+  @AfterAll
+  void afterAll() throws SQLException, IOException, InterruptedException {
+    helper.stopDatabase();
+    connection = null;
+    helper = null;
+  }
+
+  //region Helper Methods from MerlinDatabaseTests
+  int insertFileUpload() throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement
+          .executeQuery(
+              """
+                  INSERT INTO uploaded_file (path, name)
+                  VALUES ('test-path', 'test-name-%s')
+                  RETURNING id;"""
+                  .formatted(UUID.randomUUID().toString())
+          );
+      res.next();
+      return res.getInt("id");
+    }
+  }
+
+  int insertMissionModel(final int fileId) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement
+          .executeQuery(
+              """
+                  INSERT INTO mission_model (name, mission, owner, version, jar_id)
+                  VALUES ('test-mission-model-%s', 'test-mission', 'tester', '0', %s)
+                  RETURNING id;"""
+                  .formatted(UUID.randomUUID().toString(), fileId)
+          );
+      res.next();
+      return res.getInt("id");
+    }
+  }
+
+  int insertPlan(final int missionModelId) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement
+          .executeQuery(
+              """
+                  INSERT INTO plan (name, model_id, duration, start_time)
+                  VALUES ('test-plan-%s', '%s', '0', '%s')
+                  RETURNING id;"""
+                  .formatted(UUID.randomUUID().toString(), missionModelId, "2020-1-1 00:00:00")
+          );
+      res.next();
+      return res.getInt("id");
+    }
+  }
+
+  int insertActivity(final int planId) throws SQLException {
+    return insertActivity(planId, "00:00:00");
+  }
+
+  int insertActivity(final int planId, final String startOffset) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement
+          .executeQuery(
+              """
+                  INSERT INTO activity_directive (type, plan_id, start_offset, arguments)
+                  VALUES ('test-activity', '%s', '%s', '{}')
+                  RETURNING id;"""
+                  .formatted(planId, startOffset)
+          );
+
+      res.next();
+      return res.getInt("id");
+    }
+  }
+  //endregion
+
+  //region Helper Methods
+
+  /**
+   * To anchor an activity to the plan, set "anchorId" equal to -1.
+   */
+  private void setAnchor(int anchorId, boolean anchoredToStart, int activityId, int planId) throws SQLException {
+    try(final var statement = connection.createStatement()) {
+      if (anchorId == -1) {
+        statement.execute(
+            """
+                update activity_directive
+                set anchor_id = null,
+                    anchored_to_start = %b
+                where id = %d and plan_id = %d;
+                """.formatted(anchoredToStart, activityId, planId));
+      } else {
+        statement.execute(
+            """
+                update activity_directive
+                set anchor_id = %d,
+                    anchored_to_start = %b
+                where id = %d and plan_id = %d;
+                """.formatted(anchorId, anchoredToStart, activityId, planId));
+      }
+    }
+  }
+
+  private void updateOffsetFromAnchor(Interval newOffset, int activityId, int planId) throws SQLException {
+    try(final var statement = connection.createStatement()) {
+      statement.execute(
+          """
+          update activity_directive
+          set start_offset = '%s'
+          where id = %d and plan_id = %d;
+          """.formatted(newOffset.toString(), activityId, planId));
+    }
+  }
+
+  private Activity getActivity(final int planId, final int activityId) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement.executeQuery("""
+        SELECT *
+        FROM activity_directive
+        WHERE id = %d
+        AND plan_id = %d;
+      """.formatted(activityId, planId));
+      res.first();
+      return new Activity(
+          res.getInt("id"),
+          res.getInt("plan_id"),
+          (Interval) res.getObject("start_offset"),
+          res.getString("anchor_id"),
+          res.getBoolean("anchored_to_start")
+      );
+    }
+  }
+
+  private ArrayList<Activity> getActivities(final int planId) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement.executeQuery("""
+        SELECT *
+        FROM activity_directive
+        WHERE plan_id = %d
+        ORDER BY id;
+      """.formatted(planId));
+
+      final var activities = new ArrayList<Activity>();
+      while (res.next()){
+        activities.add(new Activity(
+            res.getInt("id"),
+            res.getInt("plan_id"),
+            (Interval) res.getObject("start_offset"),
+            res.getString("anchor_id"),
+            res.getBoolean("anchored_to_start")
+        ));
+      }
+      return activities;
+    }
+  }
+
+  private void deleteActivityDirective(final int planId, final int activityId) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      statement.executeUpdate("""
+        delete from activity_directive where id = %s and plan_id = %s
+      """.formatted(activityId, planId));
+    }
+  }
+
+  private AnchorValidationStatus getValidationStatus(final int planId, final int activityId) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement.executeQuery("""
+        SELECT *
+        FROM anchor_validation_status
+        WHERE activity_id = %d
+        AND plan_id = %d;
+      """.formatted(activityId, planId));
+      res.first();
+      return new AnchorValidationStatus(
+          res.getInt("activity_id"),
+          res.getInt("plan_id"),
+          res.getString("reason_invalid")
+      );
+    }
+  }
+
+  private AnchorValidationStatus refresh(AnchorValidationStatus original) throws SQLException{
+    return getValidationStatus(original.planId, original.activityId);
+  }
+
+  int insertActivityWithAnchor(final int planId, final Interval startOffset, final int anchorId, final boolean anchoredToStart) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement
+          .executeQuery(
+              """
+                  INSERT INTO activity_directive (type, plan_id, start_offset, arguments, anchor_id, anchored_to_start)
+                  VALUES ('test-activity', '%s', '%s', '{}', %d, %b)
+                  RETURNING id;"""
+                  .formatted(planId, startOffset.toString(), anchorId, anchoredToStart)
+          );
+
+      res.next();
+      return res.getInt("id");
+    }
+  }
+
+  private static void assertActivityEquals(final Activity expected, final Activity actual) {
+    assertEquals(expected.activityId, actual.activityId);
+    assertEquals(expected.planId, actual.planId);
+    assertEquals(expected.startOffset, actual.startOffset);
+    assertEquals(expected.anchorId, actual.anchorId);
+    assertEquals(expected.anchoredToStart, actual.anchoredToStart);
+  }
+  //endregion
+
+  //region Records
+  private record Activity(
+      int activityId,
+      int planId,
+      Interval startOffset,
+      String anchorId,  // Since anchor_id allows for null values, this is a String to avoid confusion over what the number means.
+      boolean anchoredToStart
+  ) {}
+
+  private record AnchorValidationStatus(int activityId, int planId, String reasonInvalid) {}
+  //endregion
+
+  /*
+    Tests left to write:
+      Reanchor function updates the offset as expected
+  */
+
+  @Nested
+  class AnchorCreationAndExceptions {
+    @Test
+    void createAnchor() throws SQLException {
+      final Interval oneDay = Interval.of(Period.ofDays(1));
+      final Interval tenMinutes = Interval.of(Duration.ofMinutes(10));
+
+      final int planId = insertPlan(missionModelId);
+      final int anchorActId = insertActivity(planId);
+      final int otherActId = insertActivity(planId, oneDay.toString());
+
+      // Assert that otherActId has an anchor of null but an offset equal to the input
+      Activity otherActivity = getActivity(planId, otherActId);
+      assertNull(otherActivity.anchorId);
+      assertTrue(otherActivity.anchoredToStart);
+      assertEquals(oneDay, otherActivity.startOffset);
+
+      // Set the anchor and assert that otherActivity was updated as expected.
+      setAnchor(anchorActId, false, otherActId, planId);
+      updateOffsetFromAnchor(tenMinutes, otherActId, planId);
+
+      otherActivity = getActivity(planId, otherActId);
+      assertNotNull(otherActivity.anchorId);
+      assertEquals(anchorActId, Integer.valueOf(otherActivity.anchorId));
+      assertFalse(otherActivity.anchoredToStart);
+      assertEquals(tenMinutes, otherActivity.startOffset);
+    }
+
+    @Test
+    void cantAnchorToSelf() throws SQLException {
+      final int planId = insertPlan(missionModelId);
+      final int activityId = insertActivity(planId);
+
+      try {
+        setAnchor(activityId, true, activityId, planId);
+        fail();
+      } catch (SQLException ex) {
+        if (!ex.getMessage().contains("Cannot anchor activity " + activityId + " to itself.")) {
+          throw ex;
+        }
+      }
+    }
+
+    @Test
+    void noCyclesInAnchors() throws SQLException {
+      final int planId = insertPlan(missionModelId);
+      final int actAId = insertActivity(planId);
+      final int actBId = insertActivity(planId);
+
+      setAnchor(actAId, true, actBId, planId);
+
+      try {
+        setAnchor(actBId, true, actAId, planId);
+        fail();
+      } catch (SQLException ex) {
+        if (!ex.getMessage().contains("Cycle detected. Cannot apply changes.")) {
+          throw ex;
+        }
+      }
+    }
+
+    // This additionally tests that invalid anchor ids fail
+    @Test
+    void cannotAnchorToActivityNotInPlan() throws SQLException {
+      final int planId = insertPlan(missionModelId);
+      final int activityId = insertActivity(planId);
+
+      try {
+        setAnchor(-10, true, activityId, planId);
+        fail();
+      } catch (SQLException ex) {
+        if (!ex.getMessage().contains(
+            "insert or update on table \"activity_directive\" violates foreign key constraint \"anchor_in_plan\"")) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  @Nested
+  class NetNegativeEndTimeStatus {
+    @Test
+    void negativeEndTimeOffsetWritesToStatus() throws SQLException {
+      final Interval minusTenMinutes = Interval.of(Duration.ofMinutes(-10));
+
+      final int planId = insertPlan(missionModelId);
+      final int grandparentActId = insertActivity(planId);
+      final int parentActId = insertActivityWithAnchor(planId, Interval.ZERO, grandparentActId, false);
+      final int negOffsetActId = insertActivity(planId, minusTenMinutes.toString());
+      final int childActId = insertActivityWithAnchor(planId, Interval.ZERO, negOffsetActId, true);
+      final int unrelatedActId = insertActivity(planId);
+
+      // Invalid regarding Plan Start
+      final AnchorValidationStatus negOffsetStatus = getValidationStatus(planId, negOffsetActId);
+      final AnchorValidationStatus childStatus = getValidationStatus(planId, childActId);
+      final AnchorValidationStatus parentStatus = getValidationStatus(planId, parentActId);
+      final AnchorValidationStatus grandparentStatus = getValidationStatus(planId, grandparentActId);
+      final AnchorValidationStatus unrelatedStatus = getValidationStatus(planId, unrelatedActId);
+      assertEquals("Activity Directive "+negOffsetActId +" has a net negative offset relative to Plan Start.", negOffsetStatus.reasonInvalid);
+      assertTrue(childStatus.reasonInvalid.isEmpty());
+      assertTrue(parentStatus.reasonInvalid.isEmpty());
+      assertTrue(grandparentStatus.reasonInvalid.isEmpty());
+      assertTrue(unrelatedStatus.reasonInvalid.isEmpty());
+
+      // Invalid relative to parent
+      setAnchor(parentActId, false, negOffsetActId, planId);
+      assertEquals("Activity Directive " +negOffsetActId +" has a net negative offset relative to an end-time"
+                   + " anchor on Activity Directive " +parentActId +".", refresh(negOffsetStatus).reasonInvalid);
+      assertEquals("Activity Directive " +childActId +" has a net negative offset relative to an end-time"
+                   + " anchor on Activity Directive " +parentActId +".", refresh(childStatus).reasonInvalid);
+      assertTrue(refresh(parentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(grandparentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+
+      // Valid relative to parent, invalid relative to grandparent
+      setAnchor(parentActId, true, negOffsetActId, planId);
+      assertEquals("Activity Directive " +negOffsetActId +" has a net negative offset relative to an end-time"
+                   + " anchor on Activity Directive " +grandparentActId +".", refresh(negOffsetStatus).reasonInvalid);
+      assertEquals("Activity Directive " +childActId +" has a net negative offset relative to an end-time"
+                   + " anchor on Activity Directive " +grandparentActId +".", refresh(childStatus).reasonInvalid);
+      assertTrue(refresh(parentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(grandparentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+
+      // Valid regrading Plan End
+      // This also validates that the validation status is cleared when updated to a valid value
+      setAnchor(-1, false, negOffsetActId, planId );
+      assertTrue(refresh(negOffsetStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(childStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(parentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(grandparentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+    }
+
+    @Test
+    void immediateDescendentBecomesInvalid() throws SQLException {
+      final Interval fiveMinutes = Interval.of(Duration.ofMinutes(5));
+      final Interval fifteenMinutes = Interval.of(Duration.ofMinutes(15));
+      final Interval minusTenMinutes = Interval.of(Duration.ofMinutes(-10));
+
+      final int planId = insertPlan(missionModelId);
+      final int unrelatedActId = insertActivity(planId); // Should always be valid.
+
+      final int parentActId = insertActivity(planId);
+      final int baseActId = insertActivity(planId, fifteenMinutes.toString());
+
+      // Create a chain
+      final int childActId = insertActivityWithAnchor(planId, minusTenMinutes, baseActId, true);
+
+      final AnchorValidationStatus unrelatedValidation = getValidationStatus(planId, unrelatedActId);
+      final AnchorValidationStatus baseValidation = getValidationStatus(planId, baseActId);
+      final AnchorValidationStatus childValidation = getValidationStatus(planId, childActId);
+      assertTrue(unrelatedValidation.reasonInvalid.isEmpty());
+      assertTrue(baseValidation.reasonInvalid.isEmpty());
+      assertTrue(childValidation.reasonInvalid.isEmpty());
+
+      // Anchoring base to the end of parent does not invalidate anything.
+      setAnchor(parentActId, false, baseActId, planId);
+      assertTrue(refresh(unrelatedValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(childValidation).reasonInvalid.isEmpty());
+
+      // Shortening base's offset makes child invalid
+      updateOffsetFromAnchor(fiveMinutes, baseActId, planId);
+      assertTrue(refresh(unrelatedValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseValidation).reasonInvalid.isEmpty());
+      assertEquals("Activity Directive " +childActId +" has a net negative offset "
+                   + "relative to an end-time anchor on Activity Directive " +parentActId +".", refresh(childValidation).reasonInvalid);
+
+      // Updating base back makes child valid.
+      updateOffsetFromAnchor(fifteenMinutes, baseActId, planId);
+      assertTrue(refresh(unrelatedValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(childValidation).reasonInvalid.isEmpty());
+    }
+
+    @Test
+    void childAndGrandchildBecomeInvalid() throws SQLException {
+      final Interval fiveMinutes = Interval.of(Duration.ofMinutes(5));
+      final Interval fifteenMinutes = Interval.of(Duration.ofMinutes(15));
+      final Interval minusTenMinutes = Interval.of(Duration.ofMinutes(-10));
+
+      final int planId = insertPlan(missionModelId);
+      final int unrelatedActId = insertActivity(planId); // Should always be valid.
+
+      final int parentActId = insertActivity(planId);
+      final int baseActId = insertActivity(planId, fifteenMinutes.toString());
+
+      // Create a chain
+      final int childActId = insertActivityWithAnchor(planId, minusTenMinutes, baseActId, true);
+      final int grandchildActId = insertActivityWithAnchor(planId, Interval.ZERO, childActId, true);
+
+      final AnchorValidationStatus unrelatedValidation = getValidationStatus(planId, unrelatedActId);
+      final AnchorValidationStatus baseValidation = getValidationStatus(planId, baseActId);
+      final AnchorValidationStatus childValidation = getValidationStatus(planId, childActId);
+      final AnchorValidationStatus grandchildValidation = getValidationStatus(planId, grandchildActId);
+      assertTrue(unrelatedValidation.reasonInvalid.isEmpty());
+      assertTrue(baseValidation.reasonInvalid.isEmpty());
+      assertTrue(childValidation.reasonInvalid.isEmpty());
+      assertTrue(grandchildValidation.reasonInvalid.isEmpty());
+
+      // Anchoring base to the end of parent does not invalidate anything due to size of base's offset.
+      setAnchor(parentActId, false, baseActId, planId);
+      assertTrue(refresh(unrelatedValidation).reasonInvalid.isEmpty());
+      assertEquals("", refresh(baseValidation).reasonInvalid);
+      assertTrue(refresh(baseValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(childValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(grandchildValidation).reasonInvalid.isEmpty());
+
+      // Shortening base's offset makes child and grandchild invalid
+      updateOffsetFromAnchor(fiveMinutes, baseActId, planId);
+      assertTrue(refresh(unrelatedValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseValidation).reasonInvalid.isEmpty());
+      assertEquals("Activity Directive " +childActId +" has a net negative offset "
+                   + "relative to an end-time anchor on Activity Directive " +parentActId +".", refresh(childValidation).reasonInvalid);
+      assertEquals("Activity Directive " +grandchildActId +" has a net negative offset "
+                   + "relative to an end-time anchor on Activity Directive " +parentActId +".", refresh(grandchildValidation).reasonInvalid);
+
+      // Restoring base makes child and grandchild valid.
+      updateOffsetFromAnchor(fifteenMinutes, baseActId, planId);
+      assertTrue(refresh(unrelatedValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(childValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(grandchildValidation).reasonInvalid.isEmpty());
+    }
+
+    /*
+     * Similar test to childAndGrandchildBecomeInvalid, except grandchild having an end-time anchor will prevent it from
+     * being checked (as whether it's invalid relative to parent's end time depends on the duration of child and base, which is unknowable at anchoring time)
+     */
+    @Test
+    void grandchildEndTimeAnchorIsIgnored() throws SQLException {
+      final Interval fiveMinutes = Interval.of(Duration.ofMinutes(5));
+      final Interval fifteenMinutes = Interval.of(Duration.ofMinutes(15));
+      final Interval minusTenMinutes = Interval.of(Duration.ofMinutes(-10));
+
+      final int planId = insertPlan(missionModelId);
+      final int unrelatedActId = insertActivity(planId); // Should always be valid.
+
+      final int parentActId = insertActivity(planId);
+      final int baseActId = insertActivity(planId, fifteenMinutes.toString());
+
+      // Create a chain
+      final int childActId = insertActivityWithAnchor(planId, minusTenMinutes, baseActId, true);
+      final int grandchildActId = insertActivityWithAnchor(planId, Interval.ZERO, childActId, false);
+
+      final AnchorValidationStatus unrelatedValidation = getValidationStatus(planId, unrelatedActId);
+      final AnchorValidationStatus baseValidation = getValidationStatus(planId, baseActId);
+      final AnchorValidationStatus childValidation = getValidationStatus(planId, childActId);
+      final AnchorValidationStatus grandchildValidation = getValidationStatus(planId, grandchildActId);
+      assertTrue(unrelatedValidation.reasonInvalid.isEmpty());
+      assertTrue(baseValidation.reasonInvalid.isEmpty());
+      assertTrue(childValidation.reasonInvalid.isEmpty());
+      assertTrue(grandchildValidation.reasonInvalid.isEmpty());
+
+      // Anchoring base to the end of parent does not invalidate anything due to size of base's offset.
+      setAnchor(parentActId, false, baseActId, planId);
+      assertTrue(refresh(unrelatedValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(childValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(grandchildValidation).reasonInvalid.isEmpty());
+
+      // Shortening base's offset makes child invalid and does not affect grandchild.
+      updateOffsetFromAnchor(fiveMinutes, baseActId, planId);
+      assertTrue(refresh(unrelatedValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseValidation).reasonInvalid.isEmpty());
+      assertEquals("Activity Directive " +childActId +" has a net negative offset "
+                   + "relative to an end-time anchor on Activity Directive " +parentActId +".", refresh(childValidation).reasonInvalid);
+      assertTrue(refresh(grandchildValidation).reasonInvalid.isEmpty());
+
+      // Restoring base makes child valid.
+      updateOffsetFromAnchor(fifteenMinutes, baseActId, planId);
+      assertTrue(refresh(unrelatedValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(childValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(grandchildValidation).reasonInvalid.isEmpty());
+    }
+
+    @Test
+    void onlyGrandchildBecomesInvalid() throws SQLException {
+      final Interval fiveMinutes = Interval.of(Duration.ofMinutes(5));
+      final Interval fifteenMinutes = Interval.of(Duration.ofMinutes(15));
+      final Interval minusTenMinutes = Interval.of(Duration.ofMinutes(-10));
+
+      final int planId = insertPlan(missionModelId);
+      final int unrelatedActId = insertActivity(planId); // Should always be empty.
+
+      final int parentActId = insertActivity(planId);
+      final int baseActId = insertActivity(planId, fifteenMinutes.toString());
+
+      // Create a chain
+      final int childActId = insertActivityWithAnchor(planId, Interval.ZERO, baseActId, true);
+      final int grandchildActId = insertActivityWithAnchor(planId, minusTenMinutes, childActId, true);
+
+      final AnchorValidationStatus unrelatedValidation = getValidationStatus(planId, unrelatedActId);
+      final AnchorValidationStatus baseValidation = getValidationStatus(planId, baseActId);
+      final AnchorValidationStatus childValidation = getValidationStatus(planId, childActId);
+      final AnchorValidationStatus grandchildValidation = getValidationStatus(planId, grandchildActId);
+      assertTrue(unrelatedValidation.reasonInvalid.isEmpty());
+      assertTrue(baseValidation.reasonInvalid.isEmpty());
+      assertTrue(childValidation.reasonInvalid.isEmpty());
+      assertTrue(grandchildValidation.reasonInvalid.isEmpty());
+
+      // Anchoring base to the end of parent does not invalidate anything due to size of base's offset.
+      setAnchor(parentActId, false, baseActId, planId);
+      assertTrue(refresh(unrelatedValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(childValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(grandchildValidation).reasonInvalid.isEmpty());
+
+      // Shortening base's offset makes grandchild invalid
+      updateOffsetFromAnchor(fiveMinutes, baseActId, planId);
+      assertTrue(refresh(unrelatedValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(childValidation).reasonInvalid.isEmpty());
+      assertEquals("Activity Directive " +grandchildActId +" has a net negative offset "
+                   + "relative to an end-time anchor on Activity Directive " +parentActId +".", refresh(grandchildValidation).reasonInvalid);
+
+      // Restoring base makes grandchild valid.
+      updateOffsetFromAnchor(fifteenMinutes, baseActId, planId);
+      assertTrue(refresh(unrelatedValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(childValidation).reasonInvalid.isEmpty());
+      assertTrue(refresh(grandchildValidation).reasonInvalid.isEmpty());
+    }
+
+    @Test
+    void childIsInvalid() throws SQLException {
+      final Interval fiveMinutes = Interval.of(Duration.ofMinutes(5));
+      final Interval fifteenMinutes = Interval.of(Duration.ofMinutes(15));
+      final Interval minusTenMinutes = Interval.of(Duration.ofMinutes(-10));
+
+      final int planId = insertPlan(missionModelId);
+      final int unrelatedActId = insertActivity(planId); // Should always be empty.
+
+      final int parentActId = insertActivity(planId, fifteenMinutes.toString());
+
+      // Create a chain
+      final int baseActId = insertActivityWithAnchor(planId, minusTenMinutes, parentActId, false);
+      final int childActId = insertActivityWithAnchor(planId, fiveMinutes, baseActId, true);
+
+      final AnchorValidationStatus unrelatedValidation = getValidationStatus(planId, unrelatedActId);
+      final AnchorValidationStatus parentValidation = getValidationStatus(planId, parentActId);
+      final AnchorValidationStatus baseValidation = getValidationStatus(planId, baseActId);
+      final AnchorValidationStatus childValidation = getValidationStatus(planId, childActId);
+
+      assertTrue(unrelatedValidation.reasonInvalid.isEmpty());
+      assertTrue(parentValidation.reasonInvalid.isEmpty());
+      assertEquals("Activity Directive " +baseActId +" has a net negative offset "
+                   + "relative to an end-time anchor on Activity Directive " +parentActId +".", baseValidation.reasonInvalid);
+      assertEquals("Activity Directive " +childActId +" has a net negative offset "
+                   + "relative to an end-time anchor on Activity Directive " +parentActId +".", childValidation.reasonInvalid);
+    }
+
+    @Test
+    void farDescendantIsInvalid() throws SQLException {
+      // Parent, base is anchored to end with negative offset, 100 anchors to start of base with 0 offset. Both parent and child should be invalid
+      final Interval fiveMinutes = Interval.of(Duration.ofMinutes(5));
+      final Interval fifteenMinutes = Interval.of(Duration.ofMinutes(15));
+      final Interval minusTenMinutes = Interval.of(Duration.ofMinutes(-10));
+
+      final int planId = insertPlan(missionModelId);
+      final int unrelatedActId = insertActivity(planId); // Should always be valid.
+
+      final int parentActId = insertActivity(planId, fifteenMinutes.toString());
+
+      // Create a chain
+      final int baseActId = insertActivityWithAnchor(planId, minusTenMinutes, parentActId, false);
+      final int[] interimActIds = new int[100];
+      interimActIds[0] = insertActivityWithAnchor(planId, Interval.ZERO, baseActId, true);
+      for(int i = 1; i < 100; i++){
+        interimActIds[i] = insertActivityWithAnchor(planId, Interval.ZERO, interimActIds[i-1], true);
+      }
+      final int childActId = insertActivityWithAnchor(planId, fiveMinutes, interimActIds[99], true);
+
+      final AnchorValidationStatus unrelatedValidation = getValidationStatus(planId, unrelatedActId);
+      final AnchorValidationStatus parentValidation = getValidationStatus(planId, parentActId);
+      final AnchorValidationStatus baseValidation = getValidationStatus(planId, baseActId);
+      final AnchorValidationStatus[] interimValidations = new AnchorValidationStatus[100];
+      for(int i = 0; i < 100; i++){
+        interimValidations[i] = getValidationStatus(planId, interimActIds[i]);
+      }
+      final AnchorValidationStatus childValidation = getValidationStatus(planId, childActId);
+
+      assertTrue(unrelatedValidation.reasonInvalid.isEmpty());
+      assertTrue(parentValidation.reasonInvalid.isEmpty());
+      assertEquals("Activity Directive " +baseActId +" has a net negative offset "
+                   + "relative to an end-time anchor on Activity Directive " +parentActId +".", baseValidation.reasonInvalid);
+      for(int i = 0; i < 100; i++){
+        assertEquals("Activity Directive " +interimActIds[i] +" has a net negative offset "
+                     + "relative to an end-time anchor on Activity Directive " +parentActId +".", interimValidations[i].reasonInvalid);
+      }
+      assertEquals("Activity Directive " +childActId +" has a net negative offset "
+                   + "relative to an end-time anchor on Activity Directive " +parentActId +".", childValidation.reasonInvalid);
+    }
+  }
+
+  @Nested
+  class NetNegativePlanStartStatus {
+    @Test
+    void negativeToPlanStart() throws SQLException {
+      final Interval minusTenMinutes = Interval.of(Duration.ofMinutes(-10));
+      final Interval tenMinutes = Interval.of(Duration.ofMinutes(10));
+
+      final int planId = insertPlan(missionModelId);
+      final int activityId = insertActivity(planId, tenMinutes.toString());
+      final int unrelatedId = insertActivity(planId);
+
+      // Valid regarding Plan Start
+      final AnchorValidationStatus activityStatus = getValidationStatus(planId, activityId);
+      final AnchorValidationStatus unrelatedStatus = getValidationStatus(planId, unrelatedId);
+      assertTrue(activityStatus.reasonInvalid.isEmpty());
+      assertTrue(unrelatedStatus.reasonInvalid.isEmpty());
+
+      // Make Invalid Relative to Plan Start
+      updateOffsetFromAnchor(minusTenMinutes, activityId, planId);
+      assertEquals("Activity Directive " +activityId +" has a net negative offset relative to Plan Start.", refresh(activityStatus).reasonInvalid);
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+
+      // Restoring base clears the warning
+      updateOffsetFromAnchor(tenMinutes, activityId, planId);
+      assertTrue(refresh(activityStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+    }
+
+    @Test
+    void negativeToPlanStartDownChain() throws SQLException {
+      final Interval minusTenMinutes = Interval.of(Duration.ofMinutes(-10));
+      final Interval elevenMinutes = Interval.of(Duration.ofMinutes(11));
+
+      final int planId = insertPlan(missionModelId);
+      final int unrelatedActId = insertActivity(planId);
+      final int grandparentActId = insertActivity(planId, elevenMinutes.toString());
+      final int parentActId = insertActivityWithAnchor(planId, minusTenMinutes, grandparentActId, true);
+      final int baseId = insertActivityWithAnchor(planId, elevenMinutes, parentActId, true);
+      final int childId = insertActivityWithAnchor(planId, Interval.ZERO, baseId, true);
+
+      // Base is currently valid regarding Plan Start
+      final AnchorValidationStatus baseStatus = getValidationStatus(planId, baseId);
+      final AnchorValidationStatus childStatus = getValidationStatus(planId, childId);
+      final AnchorValidationStatus parentStatus = getValidationStatus(planId, parentActId);
+      final AnchorValidationStatus grandparentStatus = getValidationStatus(planId, grandparentActId);
+      final AnchorValidationStatus unrelatedStatus = getValidationStatus(planId, unrelatedActId);
+      assertTrue(baseStatus.reasonInvalid.isEmpty());
+      assertTrue(childStatus.reasonInvalid.isEmpty());
+      assertTrue(parentStatus.reasonInvalid.isEmpty());
+      assertTrue(grandparentStatus.reasonInvalid.isEmpty());
+      assertTrue(unrelatedStatus.reasonInvalid.isEmpty());
+
+      // Update makes base and child invalid relative to Plan Start
+      updateOffsetFromAnchor(minusTenMinutes, baseId, planId);
+      assertEquals("Activity Directive " +baseId +" has a net negative offset relative to Plan Start.", refresh(baseStatus).reasonInvalid);
+      assertEquals("Activity Directive " +childId +" has a net negative offset relative to Plan Start.", refresh(childStatus).reasonInvalid);
+      //assertTrue(refresh(childStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(parentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(grandparentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+
+      // Restoring the anchor clears the warnings
+      updateOffsetFromAnchor(elevenMinutes, baseId, planId);
+      assertTrue(refresh(baseStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(childStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(parentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(grandparentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+    }
+
+    @Test
+    void immediateDescendentBecomesInvalid() throws SQLException {
+      final Interval minusTenMinutes = Interval.of(Duration.ofMinutes(-10));
+      final Interval minusFifteenMinutes = Interval.of(Duration.ofMinutes(-15));
+      final Interval twentyMinutes = Interval.of(Duration.ofMinutes(20));
+
+      final int planId = insertPlan(missionModelId);
+      final int unrelatedActId = insertActivity(planId);
+
+      final int parentId = insertActivity(planId, twentyMinutes.toString());
+      final int baseId = insertActivityWithAnchor(planId, twentyMinutes, parentId, true);
+      final int childId = insertActivityWithAnchor(planId, minusTenMinutes, baseId, true);
+
+      // Everything is currently valid regarding Plan Start
+      final AnchorValidationStatus childStatus = getValidationStatus(planId, childId);
+      final AnchorValidationStatus baseStatus = getValidationStatus(planId, baseId);
+      final AnchorValidationStatus parentStatus = getValidationStatus(planId, parentId);
+      final AnchorValidationStatus unrelatedStatus = getValidationStatus(planId, unrelatedActId);
+      assertTrue(childStatus.reasonInvalid.isEmpty());
+      assertTrue(baseStatus.reasonInvalid.isEmpty());
+      assertTrue(parentStatus.reasonInvalid.isEmpty());
+      assertTrue(unrelatedStatus.reasonInvalid.isEmpty());
+
+      // Update to base makes child and grandchild invalid relative to Plan Start
+      updateOffsetFromAnchor(minusFifteenMinutes, baseId, planId);
+      assertEquals("Activity Directive " +childId +" has a net negative offset relative to Plan Start.", refresh(childStatus).reasonInvalid);
+      assertTrue(refresh(baseStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(parentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+
+      // Restoring base clears the warning on child
+      updateOffsetFromAnchor(twentyMinutes, baseId, planId);
+      assertTrue(refresh(childStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(parentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+    }
+
+    @Test
+    void childAndGrandchildBecomeInvalid() throws SQLException {
+      final Interval minusTenMinutes = Interval.of(Duration.ofMinutes(-10));
+      final Interval minusFifteenMinutes = Interval.of(Duration.ofMinutes(-15));
+      final Interval twentyMinutes = Interval.of(Duration.ofMinutes(20));
+
+      final int planId = insertPlan(missionModelId);
+      final int unrelatedActId = insertActivity(planId);
+
+      final int parentId = insertActivity(planId, twentyMinutes.toString());
+      final int baseId = insertActivityWithAnchor(planId, twentyMinutes, parentId, true);
+      final int childId = insertActivityWithAnchor(planId, minusTenMinutes, baseId, true);
+      final int grandchildId = insertActivityWithAnchor(planId, minusTenMinutes, childId, true);
+
+      // Everything is currently valid regarding Plan Start
+      final AnchorValidationStatus grandChildStatus = getValidationStatus(planId, grandchildId);
+      final AnchorValidationStatus childStatus = getValidationStatus(planId, childId);
+      final AnchorValidationStatus baseStatus = getValidationStatus(planId, baseId);
+      final AnchorValidationStatus parentStatus = getValidationStatus(planId, parentId);
+      final AnchorValidationStatus unrelatedStatus = getValidationStatus(planId, unrelatedActId);
+      assertTrue(grandChildStatus.reasonInvalid.isEmpty());
+      assertTrue(childStatus.reasonInvalid.isEmpty());
+      assertTrue(baseStatus.reasonInvalid.isEmpty());
+      assertTrue(parentStatus.reasonInvalid.isEmpty());
+      assertTrue(unrelatedStatus.reasonInvalid.isEmpty());
+
+      // Update to base makes child and grandchild invalid relative to Plan Start
+      updateOffsetFromAnchor(minusFifteenMinutes, baseId, planId);
+      assertEquals("Activity Directive " +grandchildId +" has a net negative offset relative to Plan Start.", refresh(grandChildStatus).reasonInvalid);
+      assertEquals("Activity Directive " +childId +" has a net negative offset relative to Plan Start.", refresh(childStatus).reasonInvalid);
+      assertTrue(refresh(baseStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(parentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+
+      // Restoring base clears the warnings on child and grandchild
+      updateOffsetFromAnchor(twentyMinutes, baseId, planId);
+      assertTrue(refresh(grandChildStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(childStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(parentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+    }
+
+    @Test
+    void grandchildEndTimeAnchorIsIgnored() throws SQLException {
+      final Interval minusTenMinutes = Interval.of(Duration.ofMinutes(-10));
+      final Interval minusFifteenMinutes = Interval.of(Duration.ofMinutes(-15));
+      final Interval twentyMinutes = Interval.of(Duration.ofMinutes(20));
+
+      final int planId = insertPlan(missionModelId);
+      final int unrelatedActId = insertActivity(planId);
+
+      final int parentId = insertActivity(planId, twentyMinutes.toString());
+      final int baseId = insertActivityWithAnchor(planId, twentyMinutes, parentId, true);
+      final int childId = insertActivityWithAnchor(planId, minusTenMinutes, baseId, true);
+      final int grandchildId = insertActivityWithAnchor(planId, minusTenMinutes, childId, false);
+
+      // Everything is currently valid regarding Plan Start
+      // Except grandchild, which is invalid regarding child's end time
+      final AnchorValidationStatus grandChildStatus = getValidationStatus(planId, grandchildId);
+      final AnchorValidationStatus childStatus = getValidationStatus(planId, childId);
+      final AnchorValidationStatus baseStatus = getValidationStatus(planId, baseId);
+      final AnchorValidationStatus parentStatus = getValidationStatus(planId, parentId);
+      final AnchorValidationStatus unrelatedStatus = getValidationStatus(planId, unrelatedActId);
+      assertEquals("Activity Directive " +grandchildId +" has a net negative offset "
+                   + "relative to an end-time anchor on Activity Directive " +childId +".", grandChildStatus.reasonInvalid);
+      assertTrue(childStatus.reasonInvalid.isEmpty());
+      assertTrue(baseStatus.reasonInvalid.isEmpty());
+      assertTrue(parentStatus.reasonInvalid.isEmpty());
+      assertTrue(unrelatedStatus.reasonInvalid.isEmpty());
+
+      // Update to base makes child invalid relative to Plan Start, and does not affect grandchild
+      updateOffsetFromAnchor(minusFifteenMinutes, baseId, planId);
+      assertEquals("Activity Directive " +grandchildId +" has a net negative offset "
+                   + "relative to an end-time anchor on Activity Directive " +childId +".", refresh(grandChildStatus).reasonInvalid);
+      assertEquals("Activity Directive " +childId +" has a net negative offset relative to Plan Start.", refresh(childStatus).reasonInvalid);
+      assertTrue(refresh(baseStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(parentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+
+      // Restoring base clears the warning on child, but not on grandchild
+      updateOffsetFromAnchor(twentyMinutes, baseId, planId);
+      assertEquals("Activity Directive " +grandchildId +" has a net negative offset "
+                   + "relative to an end-time anchor on Activity Directive " +childId +".", refresh(grandChildStatus).reasonInvalid);
+      assertTrue(refresh(childStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(parentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+    }
+
+    // This test is the indirect form of negativeToPlanStartDownChain
+    @Test
+    void onlyGrandchildBecomesInvalid() throws SQLException {
+      final Interval minusTenMinutes = Interval.of(Duration.ofMinutes(-10));
+      final Interval twentyMinutes = Interval.of(Duration.ofMinutes(20));
+
+      final int planId = insertPlan(missionModelId);
+      final int unrelatedActId = insertActivity(planId);
+
+      final int parentId = insertActivity(planId, twentyMinutes.toString());
+      final int baseId = insertActivityWithAnchor(planId, twentyMinutes, parentId, true);
+      final int childId = insertActivityWithAnchor(planId, minusTenMinutes, baseId, true);
+      final int grandchildId = insertActivityWithAnchor(planId, minusTenMinutes, childId, true);
+
+      // Everything is currently valid regarding Plan Start
+      final AnchorValidationStatus grandChildStatus = getValidationStatus(planId, grandchildId);
+      final AnchorValidationStatus childStatus = getValidationStatus(planId, childId);
+      final AnchorValidationStatus baseStatus = getValidationStatus(planId, baseId);
+      final AnchorValidationStatus parentStatus = getValidationStatus(planId, parentId);
+      final AnchorValidationStatus unrelatedStatus = getValidationStatus(planId, unrelatedActId);
+      assertTrue(grandChildStatus.reasonInvalid.isEmpty());
+      assertTrue(childStatus.reasonInvalid.isEmpty());
+      assertTrue(baseStatus.reasonInvalid.isEmpty());
+      assertTrue(parentStatus.reasonInvalid.isEmpty());
+      assertTrue(unrelatedStatus.reasonInvalid.isEmpty());
+
+      // Update to base makes grandchild invalid relative to Plan Start
+      updateOffsetFromAnchor(minusTenMinutes, baseId, planId);
+      assertEquals("Activity Directive " +grandchildId +" has a net negative offset relative to Plan Start.", refresh(grandChildStatus).reasonInvalid);
+      assertTrue(refresh(childStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(parentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+
+      // Restoring base clears the warnings
+      updateOffsetFromAnchor(twentyMinutes, baseId, planId);
+      assertTrue(refresh(grandChildStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(childStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(baseStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(parentStatus).reasonInvalid.isEmpty());
+      assertTrue(refresh(unrelatedStatus).reasonInvalid.isEmpty());
+    }
+  }
+
+  @Nested
+  class AnchorDeletion {
+
+    @Test
+    void cantDeleteActivityWithAnchors() throws SQLException {
+      final int planId = insertPlan(missionModelId);
+      final int anchorId = insertActivity(planId);
+      insertActivityWithAnchor(planId, Interval.ZERO, anchorId, true);
+
+      try {
+        deleteActivityDirective(planId, anchorId);
+        fail();
+      } catch (SQLException ex){
+        if(!ex.getMessage().contains(
+            "update or delete on table \"activity_directive\" violates foreign key constraint \"anchor_in_plan\" on table \"activity_directive\"")){
+          throw ex;
+        }
+      }
+    }
+
+    // The Hasura functions are defined as 'STRICT', meaning they immediately return NULL if a parameter is NULL rather than raising an exception
+    @Test
+    void rebasesDoNotRunOnNullParameters() throws SQLException {
+      final int planId = insertPlan(missionModelId);
+      final int activityId = insertActivity(planId);
+
+      try (final var statement = connection.createStatement()) {
+        // Reanchor to Plan Start
+        var results = statement.executeQuery(
+            """
+                select hasura_functions.delete_activity_by_pk_reanchor_plan_start(%d, null)
+                """.formatted(activityId));
+        if (results.first()) {
+          fail();
+        }
+
+        results = statement.executeQuery(
+            """
+                select hasura_functions.delete_activity_by_pk_reanchor_plan_start(null, %d)
+                """.formatted(planId));
+        if (results.first()) {
+          fail();
+        }
+
+        // Reanchor to ascendant anchor
+        results = statement.executeQuery(
+            """
+                select hasura_functions.delete_activity_by_pk_reanchor_to_anchor(%d, null)
+                """.formatted(activityId));
+        if (results.first()) {
+          fail();
+        }
+
+        results = statement.executeQuery(
+            """
+                select hasura_functions.delete_activity_by_pk_reanchor_to_anchor(null, %d)
+                """.formatted(planId));
+        if (results.first()) {
+          fail();
+        }
+
+        // Delete Remaining Chain
+        results = statement.executeQuery(
+            """
+                select hasura_functions.delete_activity_by_pk_delete_subtree(%d, null)
+                """.formatted(activityId));
+        if (results.first()) {
+          fail();
+        }
+
+        results = statement.executeQuery(
+            """
+                select hasura_functions.delete_activity_by_pk_delete_subtree(null, %d)
+                """.formatted(planId));
+        if (results.first()) {
+          fail();
+        }
+      }
+    }
+
+    @Test
+    void cannotRebaseActivityThatDoesNotExist() throws SQLException{
+      final int planId = insertPlan(missionModelId);
+
+      try(final var statement = connection.createStatement()) {
+        statement.execute(
+            """
+             select hasura_functions.delete_activity_by_pk_reanchor_plan_start(-1, %d)
+             """.formatted(planId));
+        fail();
+      } catch (SQLException ex){
+        if(!ex.getMessage().contains("Activity Directive -1 does not exist in Plan "+planId)){
+          throw ex;
+        }
+      }
+
+      try(final var statement = connection.createStatement()) {
+        statement.execute(
+            """
+             select hasura_functions.delete_activity_by_pk_reanchor_to_anchor(-1, %d)
+             """.formatted(planId));
+        fail();
+      } catch (SQLException ex){
+        if(!ex.getMessage().contains("Activity Directive -1 does not exist in Plan "+planId)){
+          throw ex;
+        }
+      }
+
+      try(final var statement = connection.createStatement()) {
+        statement.execute(
+            """
+             select hasura_functions.delete_activity_by_pk_delete_subtree(-1, %d)
+             """.formatted(planId));
+        fail();
+      } catch (SQLException ex){
+        if(!ex.getMessage().contains("Activity Directive -1 does not exist in Plan "+planId)){
+          throw ex;
+        }
+      }
+    }
+
+    @Test
+    void rebaseToAscendantAnchor() throws SQLException{
+      final int planId = insertPlan(missionModelId);
+      final Interval oneDay = Interval.of(Period.ofDays(1));
+      final Interval minusTwoDays = Interval.of(Period.ofDays(-2));
+      final Interval minusFourDays = Interval.of(Period.ofDays(-4));
+
+      int lastInsertedId = insertActivity(planId);
+      for(int i = 0; i<10; i++){
+        lastInsertedId = insertActivityWithAnchor(planId, oneDay, lastInsertedId, true);
+      }
+
+      final var untouchedActivities = getActivities(planId);
+
+      final int baseId = insertActivityWithAnchor(planId, minusTwoDays, lastInsertedId, true);
+
+      final int chain1BaseId = insertActivityWithAnchor(planId, minusTwoDays, baseId, true);
+      final int chain2BaseId = insertActivityWithAnchor(planId, minusTwoDays, baseId, false);
+      final int chain3BaseId = insertActivityWithAnchor(planId, minusTwoDays, baseId, true);
+      int mostRecentChain1Id = chain1BaseId;
+      int mostRecentChain2Id = chain2BaseId;
+      int mostRecentChain3Id = chain3BaseId;
+
+      for(int i = 0; i < 100; i++) {
+        mostRecentChain1Id = insertActivityWithAnchor(planId, Interval.ZERO, mostRecentChain1Id, true);
+        mostRecentChain2Id = insertActivityWithAnchor(planId, Interval.ZERO, mostRecentChain2Id, false);
+        mostRecentChain3Id = insertActivityWithAnchor(planId, Interval.ZERO, mostRecentChain3Id, (i & 1) == 0); // alternates true and false
+      }
+
+      assertEquals(304+untouchedActivities.size(), getActivities(planId).size());
+
+      try(final var statement = connection.createStatement()) {
+        statement.execute(
+            """
+             select hasura_functions.delete_activity_by_pk_reanchor_to_anchor(%d, %d)
+             """.formatted(baseId, planId));
+      }
+
+      final var remainingActivities = getActivities(planId);
+      assertEquals(314, remainingActivities.size());
+
+      for(int i = 0; i < untouchedActivities.size(); i++){
+        assertActivityEquals(untouchedActivities.get(i), remainingActivities.get(i));
+      }
+
+      assertEquals(minusFourDays, getActivity(planId, chain1BaseId).startOffset);
+      assertEquals(""+lastInsertedId, getActivity(planId,chain1BaseId).anchorId);
+      assertEquals(minusFourDays, getActivity(planId, chain2BaseId).startOffset);
+      assertEquals(""+lastInsertedId, getActivity(planId,chain2BaseId).anchorId);
+      assertEquals(minusFourDays, getActivity(planId, chain3BaseId).startOffset);
+      assertEquals(""+lastInsertedId, getActivity(planId,chain3BaseId).anchorId);
+
+      for(int i = untouchedActivities.size()+3; i<remainingActivities.size(); i++){
+        assertEquals(Interval.ZERO, remainingActivities.get(i).startOffset);
+        assertNotNull(remainingActivities.get(i).anchorId);
+      }
+    }
+
+    @Test
+    void rebaseChainsToPlanStart() throws SQLException{
+      final int planId = insertPlan(missionModelId);
+      final Interval oneDay = Interval.of(Period.ofDays(1));
+      final Interval minusTwoDays = Interval.of(Period.ofDays(-2));
+      final Interval sixDays = Interval.of(Period.ofDays(6));
+
+      int lastInsertedId = insertActivity(planId);
+      for(int i = 0; i<10; i++){
+        lastInsertedId = insertActivityWithAnchor(planId, oneDay, lastInsertedId, true);
+      }
+
+      final var untouchedActivities = getActivities(planId);
+
+      final int baseId = insertActivityWithAnchor(planId, minusTwoDays, lastInsertedId, true);
+
+      final int chain1BaseId = insertActivityWithAnchor(planId, minusTwoDays, baseId, true);
+      final int chain2BaseId = insertActivityWithAnchor(planId, minusTwoDays, baseId, false);
+      final int chain3BaseId = insertActivityWithAnchor(planId, minusTwoDays, baseId, true);
+      int mostRecentChain1Id = chain1BaseId;
+      int mostRecentChain2Id = chain2BaseId;
+      int mostRecentChain3Id = chain3BaseId;
+
+      for(int i = 0; i < 100; i++) {
+        mostRecentChain1Id = insertActivityWithAnchor(planId, Interval.ZERO, mostRecentChain1Id, true);
+        mostRecentChain2Id = insertActivityWithAnchor(planId, Interval.ZERO, mostRecentChain2Id, false);
+        mostRecentChain3Id = insertActivityWithAnchor(planId, Interval.ZERO, mostRecentChain3Id, (i & 1) == 0); // alternates true and false
+      }
+
+      assertEquals(304+untouchedActivities.size(), getActivities(planId).size());
+
+      try(final var statement = connection.createStatement()) {
+        statement.execute(
+            """
+             select hasura_functions.delete_activity_by_pk_reanchor_plan_start(%d, %d)
+             """.formatted(baseId, planId));
+      }
+
+      final var remainingActivities = getActivities(planId);
+      assertEquals(314, remainingActivities.size());
+
+      for(int i = 0; i < untouchedActivities.size(); i++){
+        assertActivityEquals(untouchedActivities.get(i), remainingActivities.get(i));
+      }
+
+      assertEquals(sixDays, getActivity(planId, chain1BaseId).startOffset);
+      assertNull(getActivity(planId,chain1BaseId).anchorId);
+      assertEquals(sixDays, getActivity(planId, chain2BaseId).startOffset);
+      assertNull(getActivity(planId,chain2BaseId).anchorId);
+      assertEquals(sixDays, getActivity(planId, chain3BaseId).startOffset);
+      assertNull(getActivity(planId,chain3BaseId).anchorId);
+
+      for(int i = untouchedActivities.size()+3; i<remainingActivities.size(); i++){
+        assertEquals(Interval.ZERO, remainingActivities.get(i).startOffset);
+        assertNotNull(remainingActivities.get(i).anchorId);
+      }
+    }
+
+    @Test
+    void deleteChain() throws SQLException{
+      final int planId = insertPlan(missionModelId);
+      final int grandparentId = insertActivity(planId);
+      final int parentId = insertActivityWithAnchor(planId, Interval.ZERO, grandparentId, true);
+      final int baseId = insertActivityWithAnchor(planId, Interval.ZERO, parentId, true);
+
+      int mostRecentChain1Id = baseId;
+      int mostRecentChain2Id = baseId;
+      int mostRecentChain3Id = baseId;
+      for(int i = 0; i < 100; i++) {
+        mostRecentChain1Id = insertActivityWithAnchor(planId, Interval.ZERO, mostRecentChain1Id, true);
+        mostRecentChain2Id = insertActivityWithAnchor(planId, Interval.ZERO, mostRecentChain2Id, false);
+        mostRecentChain3Id = insertActivityWithAnchor(planId, Interval.ZERO, mostRecentChain3Id, (i & 1) == 0); // alternates true and false
+      }
+
+      assertEquals(303, getActivities(planId).size());
+
+      final Activity grandparentActivity = getActivity(planId, grandparentId);
+      final Activity parentActivity = getActivity(planId, parentId);
+
+      try(final var statement = connection.createStatement()) {
+        statement.execute(
+            """
+             select hasura_functions.delete_activity_by_pk_delete_subtree(%d, %d)
+             """.formatted(baseId, planId));
+      }
+
+      final var remainingActivities = getActivities(planId);
+      assertEquals(2, remainingActivities.size());
+      assertActivityEquals(grandparentActivity, remainingActivities.get(0));
+      assertActivityEquals(parentActivity, remainingActivities.get(1));
+    }
+  }
+
+
+
+
+
+
+
+
+
+}

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/DatabaseTestHelper.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/DatabaseTestHelper.java
@@ -55,7 +55,7 @@ public class DatabaseTestHelper {
     // Apparently, the previous privileges are insufficient on their own
     {
       final var pb = new ProcessBuilder("psql",
-                                        "postgresql://postgres:postgres@localhost:5432/" + dbName,
+                                        "postgresql://aerie:aerie@localhost:5432/" + dbName,
                                         "-v", "ON_ERROR_STOP=1",
                                         "-c", "ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO aerie;",
                                         "-c", "\\ir %s".formatted(initSqlScriptFile.getAbsolutePath())

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PlanCollaborationTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PlanCollaborationTests.java
@@ -31,27 +31,11 @@ public class PlanCollaborationTests {
   private Connection connection;
   int fileId;
   int missionModelId;
-  int planId;
-  int activityId;
-  int simulationTemplateId;
-  int simulationWithTemplateId;
-  int simulationWithoutTemplateId;
-  int datasetId;
-  gov.nasa.jpl.aerie.database.SimulationDatasetRecord simulationDatasetRecord;
-  gov.nasa.jpl.aerie.database.PlanDatasetRecord planDatasetRecord;
 
   @BeforeEach
   void beforeEach() throws SQLException {
     fileId = insertFileUpload();
     missionModelId = insertMissionModel(fileId);
-    planId = insertPlan(missionModelId);
-    activityId = insertActivity(planId);
-    simulationTemplateId = insertSimulationTemplate(missionModelId);
-    simulationWithTemplateId = insertSimulationWithTemplateId(simulationTemplateId, planId);
-    simulationWithoutTemplateId = insertSimulationWithoutTemplateId(planId);
-    planDatasetRecord = insertPlanDataset(planId);
-    datasetId = insertDataset();
-    simulationDatasetRecord = insertSimulationDataset(simulationWithTemplateId, datasetId);
   }
 
   @AfterEach
@@ -124,10 +108,6 @@ public class PlanCollaborationTests {
   }
 
   int insertPlan(final int missionModelId) throws SQLException {
-    return insertPlan(missionModelId, "2020-1-1 00:00:00");
-  }
-
-  int insertPlan(final int missionModelId, final String start_time) throws SQLException {
     try (final var statement = connection.createStatement()) {
       final var res = statement
           .executeQuery(
@@ -135,7 +115,7 @@ public class PlanCollaborationTests {
                   INSERT INTO plan (name, model_id, duration, start_time)
                   VALUES ('test-plan-%s', '%s', '0', '%s')
                   RETURNING id;"""
-                  .formatted(UUID.randomUUID().toString(), missionModelId, start_time)
+                  .formatted(UUID.randomUUID().toString(), missionModelId, "2020-1-1 00:00:00")
           );
       res.next();
       return res.getInt("id");
@@ -161,108 +141,17 @@ public class PlanCollaborationTests {
       return res.getInt("id");
     }
   }
-
-  int insertSimulationTemplate(final int modelId) throws SQLException {
-    try (final var statement = connection.createStatement()) {
-      final var res = statement
-          .executeQuery(
-              """
-                  INSERT INTO simulation_template (model_id, description, arguments)
-                  VALUES ('%s', 'test-description', '{}')
-                  RETURNING id;"""
-                  .formatted(modelId)
-          );
-      res.next();
-      return res.getInt("id");
-    }
-  }
-
-  int insertSimulationWithTemplateId(final int simulationTemplateId, final int planId) throws SQLException {
-    try (final var statement = connection.createStatement()) {
-      final var res = statement
-          .executeQuery(
-              """
-                  INSERT INTO simulation (simulation_template_id, plan_id, arguments)
-                  VALUES ('%s', '%s', '{}')
-                  RETURNING id;"""
-                  .formatted(simulationTemplateId, planId)
-          );
-      res.next();
-      return res.getInt("id");
-    }
-  }
-
-  int insertSimulationWithoutTemplateId(final int planId) throws SQLException {
-    try (final var statement = connection.createStatement()) {
-      final var res = statement
-          .executeQuery(
-              """
-                  INSERT INTO simulation (plan_id, arguments)
-                  VALUES ('%s', '{}')
-                  RETURNING id;"""
-                  .formatted(planId)
-          );
-      res.next();
-      return res.getInt("id");
-    }
-  }
-
-  int insertDataset() throws SQLException {
-    try (final var statement = connection.createStatement()) {
-      final var res = statement
-          .executeQuery(
-              """
-                    INSERT INTO dataset
-                    DEFAULT VALUES
-                    RETURNING id;"""
-          );
-      res.next();
-      return res.getInt("id");
-    }
-  }
-
-  gov.nasa.jpl.aerie.database.PlanDatasetRecord insertPlanDataset(final int planId) throws SQLException {
-    try (final var statement = connection.createStatement()) {
-      final var res = statement
-          .executeQuery(
-              """
-                  INSERT INTO plan_dataset (plan_id, offset_from_plan_start)
-                  VALUES ('%s', '0')
-                  RETURNING plan_id, dataset_id;"""
-                  .formatted(planId)
-          );
-      res.next();
-      return new gov.nasa.jpl.aerie.database.PlanDatasetRecord(res.getInt("plan_id"), res.getInt("dataset_id"));
-    }
-  }
-
-  gov.nasa.jpl.aerie.database.SimulationDatasetRecord insertSimulationDataset(final int simulationId, final int datasetId) throws SQLException {
-    try (final var statement = connection.createStatement()) {
-      final var res = statement
-          .executeQuery(
-              """
-                  INSERT INTO simulation_dataset (simulation_id, dataset_id, offset_from_plan_start)
-                  VALUES ('%s', '%s', '0')
-                  RETURNING simulation_id, dataset_id;"""
-                  .formatted(simulationId, datasetId)
-          );
-      res.next();
-      return new gov.nasa.jpl.aerie.database.SimulationDatasetRecord(
-          res.getInt("simulation_id"),
-          res.getInt("dataset_id"));
-    }
-  }
   //endregion
 
   //region Helper Methods
-  private boolean updateActivityName(String newName, int activityId, int planId) throws SQLException {
+  private void updateActivityName(String newName, int activityId, int planId) throws SQLException {
     try(final var statement = connection.createStatement()) {
-      return statement.execute(
-          """
-          update activity_directive
-          set name = '%s'
-          where id = %d and plan_id = %d;
-          """.formatted(newName, activityId, planId));
+      statement.execute(
+        """
+        update activity_directive
+        set name = '%s'
+        where id = %d and plan_id = %d;
+        """.formatted(newName, activityId, planId));
     }
   }
 
@@ -486,7 +375,9 @@ public class PlanCollaborationTests {
           res.getString("type"),
           res.getString("arguments"),
           res.getString("last_modified_arguments_at"),
-          res.getString("metadata")
+          res.getString("metadata"),
+          res.getString("anchor_id"),
+          res.getBoolean("anchored_to_start")
       );
     }
   }
@@ -514,7 +405,9 @@ public class PlanCollaborationTests {
             res.getString("type"),
             res.getString("arguments"),
             res.getString("last_modified_arguments_at"),
-            res.getString("metadata")
+            res.getString("metadata"),
+            res.getString("anchor_id"),
+            res.getBoolean("anchored_to_start")
         ));
       }
       return activities;
@@ -544,7 +437,9 @@ public class PlanCollaborationTests {
             res.getString("type"),
             res.getString("arguments"),
             res.getString("last_modified_arguments_at"),
-            res.getString("metadata")
+            res.getString("metadata"),
+            res.getString("anchor_id"),
+            res.getBoolean("anchored_to_start")
         ));
       }
       return activities;
@@ -590,6 +485,8 @@ public class PlanCollaborationTests {
     assertEquals(expected.type, actual.type);
     assertEquals(expected.arguments, actual.arguments);
     assertEquals(expected.metadata, actual.metadata);
+    assertEquals(expected.anchorId, actual.anchorId);
+    assertEquals(expected.anchoredToStart, actual.anchoredToStart);
     assertEquals(expected.tags.length, actual.tags.length);
     for(int j = 0; j < expected.tags.length; ++j)
     {
@@ -611,7 +508,9 @@ public class PlanCollaborationTests {
       String type,
       String arguments,
       String lastModifiedArgumentsAt,
-      String metadata
+      String metadata,
+      String anchorId,  // Since anchor_id allows for null values, this is a String to avoid confusion over what the number means.
+      boolean anchoredToStart
   ) {}
   private record SnapshotActivity(
       int activityId,
@@ -625,7 +524,9 @@ public class PlanCollaborationTests {
       String type,
       String arguments,
       String lastModifiedArgumentsAt,
-      String metadata
+      String metadata,
+      String anchorId,  // Since anchor_id allows for null values, this is a String to avoid confusion over what the number means.
+      boolean anchoredToStart
   ) {}
   record ConflictingActivity(int activityId, String changeTypeSupplying, String changeTypeReceiving) {}
   record StagingAreaActivity(int activityId, String changeType) {} //only relevant fields
@@ -669,6 +570,8 @@ public class PlanCollaborationTests {
         assertEquals(planActivities.get(i).arguments, snapshotActivities.get(i).arguments);
         assertEquals(planActivities.get(i).lastModifiedArgumentsAt, snapshotActivities.get(i).lastModifiedArgumentsAt);
         assertEquals(planActivities.get(i).metadata, snapshotActivities.get(i).metadata);
+        assertEquals(planActivities.get(i).anchorId, snapshotActivities.get(i).anchorId);
+        assertEquals(planActivities.get(i).anchoredToStart, snapshotActivities.get(i).anchoredToStart);
 
         assertEquals(planActivities.get(i).tags.length, snapshotActivities.get(i).tags.length);
         for(int j = 0; j < planActivities.get(i).tags.length; ++j)
@@ -796,6 +699,9 @@ public class PlanCollaborationTests {
         assertEquals(planActivities.get(i).arguments, childActivities.get(i).arguments);
         assertEquals(planActivities.get(i).lastModifiedArgumentsAt, childActivities.get(i).lastModifiedArgumentsAt);
         assertEquals(planActivities.get(i).metadata, childActivities.get(i).metadata);
+
+        assertEquals(planActivities.get(i).anchorId, childActivities.get(i).anchorId);
+        assertEquals(planActivities.get(i).anchoredToStart, childActivities.get(i).anchoredToStart);
 
         assertEquals(planActivities.get(i).tags.length, childActivities.get(i).tags.length);
         for(int j = 0; j < planActivities.get(i).tags.length; ++j)
@@ -1027,16 +933,14 @@ public class PlanCollaborationTests {
         unlockPlan(planId);
       }
 
-      try (final var statement = connection.createStatement()) {
-        //Assert that there is one activity and it is the one that was added earlier.
-        final var activitiesBefore = getActivities(planId);
-        assertEquals(1, activitiesBefore.size());
-        assertEquals(activityId, activitiesBefore.get(0).activityId);
+      //Assert that there is one activity and it is the one that was added earlier.
+      final var activitiesBefore = getActivities(planId);
+      assertEquals(1, activitiesBefore.size());
+      assertEquals(activityId, activitiesBefore.get(0).activityId);
 
-        deleteActivityDirective(planId, activityId);
-        final var activitiesAfter = getActivities(planId);
-        assertTrue(activitiesAfter.isEmpty());
-      }
+      deleteActivityDirective(planId, activityId);
+      final var activitiesAfter = getActivities(planId);
+      assertTrue(activitiesAfter.isEmpty());
     }
 
     @Test
@@ -1053,17 +957,15 @@ public class PlanCollaborationTests {
         unlockPlan(planId);
       }
 
-      try (final var statement = connection.createStatement()) {
-        //Assert that there are no activities for this plan.
-        final var activitiesBefore = getActivities(planId);
-        assertTrue(activitiesBefore.isEmpty());
+      //Assert that there are no activities for this plan.
+      final var activitiesBefore = getActivities(planId);
+      assertTrue(activitiesBefore.isEmpty());
 
-        final int insertedId = insertActivity(planId);
+      final int insertedId = insertActivity(planId);
 
-        final var activitiesAfter = getActivities(planId);
-        assertEquals(1, activitiesAfter.size());
-        assertEquals(insertedId, activitiesAfter.get(0).activityId);
-      }
+      final var activitiesAfter = getActivities(planId);
+      assertEquals(1, activitiesAfter.size());
+      assertEquals(insertedId, activitiesAfter.get(0).activityId);
     }
 
     @Test
@@ -1116,10 +1018,7 @@ public class PlanCollaborationTests {
       final int unrelatedPlanId = insertPlan(missionModelId);
       final int unrelatedActivityId = insertActivity(unrelatedPlanId);
 
-
-      try (final var statementRelated = connection.createStatement();
-           final var statementUnrelated = connection.createStatement()
-      ) {
+      try {
         lockPlan(planId);
 
         //Update the activity in the unlocked plans
@@ -2011,8 +1910,8 @@ public class PlanCollaborationTests {
        */
       for(int i = 50;  i < 75;  ++i) { deleteActivityDirective(basePlan, baseActivities[i]); }
       for(int i = 75;  i < 100; ++i) { deleteActivityDirective(childPlan, baseActivities[i]); }
-      for(int i = 100; i < 150; ++i) { updateActivityName("Renamed Activity " + i, activityId, basePlan); }
-      for(int i = 150; i < 200; ++i) { updateActivityName("Renamed Activity " + i, activityId, childPlan); }
+      for(int i = 100; i < 150; ++i) { updateActivityName("Renamed Activity " + i, baseActivities[i], basePlan); }
+      for(int i = 150; i < 200; ++i) { updateActivityName("Renamed Activity " + i, baseActivities[i], childPlan); }
       for(int i = 0;   i < 25;  ++i) { insertActivity(basePlan); }
 
       final int mergeRQ = createMergeRequest(basePlan, childPlan);

--- a/deployment/hasura/metadata/databases/AerieMerlin/functions/functions.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/functions/functions.yaml
@@ -70,3 +70,21 @@
   configuration:
     custom_root_fields:
       function: set_resolution_bulk
+- function:
+    name: delete_activity_by_pk_reanchor_plan_start
+    schema: hasura_functions
+  configuration:
+    custom_root_fields:
+      function: delete_activity_by_pk_reanchor_plan_start
+- function:
+    name: delete_activity_by_pk_reanchor_to_anchor
+    schema: hasura_functions
+  configuration:
+    custom_root_fields:
+      function: delete_activity_by_pk_reanchor_to_anchor
+- function:
+    name: delete_activity_by_pk_delete_subtree
+    schema: hasura_functions
+  configuration:
+    custom_root_fields:
+      function: delete_activity_by_pk_delete_subtree

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
@@ -14,6 +14,15 @@ object_relationships:
       table:
         name: activity_directive_validations
         schema: public
+- name: anchor_validations
+  using:
+    foreign_key_constraint_on:
+      columns:
+        - activity_id
+        - plan_id
+      table:
+        name: anchor_validation_status
+        schema: public
 array_relationships:
 - name: simulated_activities
   using:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_anchor_validation_status.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_anchor_validation_status.yaml
@@ -1,0 +1,3 @@
+table:
+  name: anchor_validation_status
+  schema: public

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
@@ -27,6 +27,7 @@
 - "!include public_merge_staging_area.yaml"
 - "!include public_conflicting_activities.yaml"
 - "!include public_plan_snapshot.yaml"
+- "!include public_anchor_validation_status.yaml"
 # Function return values:
 - table:
     name: create_merge_request_return_value
@@ -51,4 +52,7 @@
     schema: hasura_functions
 - table:
     name: get_conflicting_activities_return_value
+    schema: hasura_functions
+- table:
+    name: delete_anchor_return_value
     schema: hasura_functions

--- a/deployment/hasura/migrations/AerieMerlin/1_anchors/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/1_anchors/down.sql
@@ -1,0 +1,591 @@
+-- Remove the tables locking column changes to activity_directive
+alter table hasura_functions.begin_merge_return_value
+  drop column merge_request_id,
+  drop column non_conflicting_activities,
+  drop column conflicting_activities;
+alter table hasura_functions.get_non_conflicting_activities_return_value
+  drop column activity_id,
+  drop column change_type,
+  drop column source,
+  drop column target;
+alter table hasura_functions.get_conflicting_activities_return_value
+  drop column activity_id,
+  drop column change_type_source,
+  drop column change_type_target,
+  drop column resolution,
+  drop column source,
+  drop column target,
+  drop column merge_base;
+
+-- Remove Anchor Validation
+drop trigger validate_anchors_insert_trigger on activity_directive;
+drop trigger validate_anchors_update_trigger on activity_directive;
+drop procedure validate_nonnegative_net_end_offset(_activity_id integer, _plan_id integer);
+drop procedure validate_nonegative_net_plan_start(_activity_id integer, _plan_id integer);
+drop function validate_anchors();
+drop index anchor_validation_plan_id_index;
+drop table anchor_validation_status;
+
+/*
+  Remove added columns and constraints and add back removed constraint
+   - anchor_in_plan is removed first to ensure that it is properly removed
+   - comments are removed automatically
+*/
+alter table activity_directive
+  drop constraint anchor_in_plan,
+  drop column anchor_id,
+  drop column anchored_to_start,
+  add constraint activity_directive_start_offset_is_nonnegative
+    check (start_offset >= '0');
+
+-- Remove anchor tracking from snapshots
+alter table plan_snapshot_activities
+  drop column anchor_id,
+  drop column anchored_to_start;
+
+create or replace function create_snapshot(plan_id integer)
+  returns integer -- snapshot id inserted into the table
+  language plpgsql as $$
+declare
+  validate_planid integer;
+  inserted_snapshot_id integer;
+begin
+  select id from plan where plan.id = plan_id into validate_planid;
+  if validate_planid is null then
+    raise exception 'Plan % does not exist.', plan_id;
+  end if;
+
+  insert into plan_snapshot(plan_id, revision, name, duration, start_time)
+  select id, revision, name, duration, start_time
+  from plan where id = plan_id
+  returning snapshot_id into inserted_snapshot_id;
+  insert into plan_snapshot_activities(snapshot_id, id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments, last_modified_arguments_at, metadata)
+  select
+    inserted_snapshot_id,                                   --this is the snapshot id
+    id, name, tags,source_scheduling_goal_id, created_at,   -- these are the rest of the data for an activity row
+    last_modified_at, start_offset, type, arguments, last_modified_arguments_at, metadata
+  from activity_directive where activity_directive.plan_id = create_snapshot.plan_id;
+
+  --all snapshots in plan_latest_snapshot for plan plan_id become the parent of the current snapshot
+  insert into plan_snapshot_parent(snapshot_id, parent_snapshot_id)
+  select inserted_snapshot_id, snapshot_id
+  from plan_latest_snapshot where plan_latest_snapshot.plan_id = create_snapshot.plan_id;
+
+  --remove all of those entries from plan_latest_snapshot and add this new snapshot.
+  delete from plan_latest_snapshot where plan_latest_snapshot.plan_id = create_snapshot.plan_id;
+  insert into plan_latest_snapshot(plan_id, snapshot_id) values (create_snapshot.plan_id, inserted_snapshot_id);
+
+  return inserted_snapshot_id;
+end;
+$$;
+
+create or replace function duplicate_plan(plan_id integer, new_plan_name text)
+  returns integer -- plan_id of the new plan
+  security definer
+  language plpgsql as $$
+declare
+  validate_plan_id integer;
+  new_plan_id integer;
+  created_snapshot_id integer;
+begin
+  select id from plan where plan.id = duplicate_plan.plan_id into validate_plan_id;
+  if(validate_plan_id is null) then
+    raise exception 'Plan % does not exist.', plan_id;
+  end if;
+
+  select create_snapshot(plan_id) into created_snapshot_id;
+
+  insert into plan(revision, name, model_id, duration, start_time, parent_id)
+  select
+    0, new_plan_name, model_id, duration, start_time, plan_id
+  from plan where id = plan_id
+  returning id into new_plan_id;
+  insert into activity_directive(
+    id, plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+    last_modified_arguments_at, metadata
+  )
+  select
+    id, new_plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+    last_modified_arguments_at, metadata
+  from activity_directive where activity_directive.plan_id = duplicate_plan.plan_id;
+  insert into simulation (revision, simulation_template_id, plan_id, arguments)
+  select 0, simulation_template_id, new_plan_id, arguments
+  from simulation
+  where simulation.plan_id = duplicate_plan.plan_id;
+
+  insert into plan_latest_snapshot(plan_id, snapshot_id) values(new_plan_id, created_snapshot_id);
+  return new_plan_id;
+end;
+$$;
+
+-- Remove anchor tracking from plan merging
+alter table merge_staging_area
+  drop column anchor_id,
+  drop column anchored_to_start,
+  add constraint staging_area_start_offset_is_nonnegative
+    check (start_offset >= '0');
+
+-- Restore Begin_Merge and Commit_Merge
+create or replace procedure begin_merge(_merge_request_id integer, review_username text)
+  language plpgsql as $$
+declare
+  validate_id integer;
+  validate_status merge_request_status;
+  validate_non_no_op_status activity_change_type;
+  snapshot_id_supplying integer;
+  plan_id_receiving integer;
+  merge_base_id integer;
+begin
+  -- validate id and status
+  select id, status
+  from merge_request
+  where _merge_request_id = id
+  into validate_id, validate_status;
+
+  if validate_id is null then
+    raise exception 'Request ID % is not present in merge_request table.', _merge_request_id;
+  end if;
+
+  if validate_status != 'pending' then
+    raise exception 'Cannot begin request. Merge request % is not in pending state.', _merge_request_id;
+  end if;
+
+  -- select from merge-request the snapshot_sc (s_sc) and plan_rc (p_rc) ids
+  select plan_id_receiving_changes, snapshot_id_supplying_changes
+  from merge_request
+  where id = _merge_request_id
+  into plan_id_receiving, snapshot_id_supplying;
+
+  -- ensure the plan receiving changes isn't locked
+  if (select is_locked from plan where plan.id=plan_id_receiving) then
+    raise exception 'Cannot begin merge request. Plan to receive changes is locked.';
+  end if;
+
+  -- lock plan_rc
+  update plan
+  set is_locked = true
+  where plan.id = plan_id_receiving;
+
+  -- get merge base (mb)
+  select get_merge_base(plan_id_receiving, snapshot_id_supplying)
+  into merge_base_id;
+
+  -- update the status to "in progress"
+  update merge_request
+  set status = 'in-progress',
+      merge_base_snapshot_id = merge_base_id,
+      reviewer_username = review_username
+  where id = _merge_request_id;
+
+
+  -- perform diff between mb and s_sc (s_diff)
+  -- delete is B minus A on key
+  -- add is A minus B on key
+  -- A intersect B is no op
+  -- A minus B on everything except everything currently in the table is modify
+  create temp table supplying_diff(
+                                    activity_id integer,
+                                    change_type activity_change_type not null
+  );
+
+  insert into supplying_diff (activity_id, change_type)
+  select activity_id, 'delete'
+  from(
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id
+        except
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = snapshot_id_supplying) a;
+
+  insert into supplying_diff (activity_id, change_type)
+  select activity_id, 'add'
+  from(
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = snapshot_id_supplying
+        except
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id) a;
+
+  insert into supplying_diff (activity_id, change_type)
+  select activity_id, 'none'
+  from(
+        select id as activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at,
+               start_offset, type, arguments, last_modified_arguments_at, metadata
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id
+        intersect
+        select id as activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at,
+               start_offset, type, arguments, last_modified_arguments_at, metadata
+        from plan_snapshot_activities
+        where snapshot_id = snapshot_id_supplying) a;
+
+  insert into supplying_diff (activity_id, change_type)
+  select activity_id, 'modify'
+  from(
+        select id as activity_id from plan_snapshot_activities
+        where snapshot_id = merge_base_id or snapshot_id = snapshot_id_supplying
+        except
+        select activity_id from supplying_diff) a;
+
+  -- perform diff between mb and p_rc (r_diff)
+  create temp table receiving_diff(
+                                    activity_id integer,
+                                    change_type activity_change_type not null
+  );
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'delete'
+  from(
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id
+        except
+        select id as activity_id
+        from activity_directive
+        where plan_id = plan_id_receiving) a;
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'add'
+  from(
+        select id as activity_id
+        from activity_directive
+        where plan_id = plan_id_receiving
+        except
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id) a;
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'none'
+  from(
+        select id as activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at,
+               start_offset, type, arguments, last_modified_arguments_at, metadata
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id
+        intersect
+        select id as activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at,
+               start_offset, type, arguments, last_modified_arguments_at, metadata
+        from activity_directive
+        where plan_id = plan_id_receiving) a;
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'modify'
+  from (
+         (select id as activity_id
+          from plan_snapshot_activities
+          where snapshot_id = merge_base_id
+          union
+          select id as activity_id
+          from activity_directive
+          where plan_id = plan_id_receiving)
+         except
+         select activity_id
+         from receiving_diff) a;
+
+
+  -- perform diff between s_diff and r_diff
+  -- upload the non-conflicts into merge_staging_area
+  -- upload conflict into conflicting_activities
+  create temp table diff_diff(
+                               activity_id integer,
+                               change_type_supplying activity_change_type not null,
+                               change_type_receiving activity_change_type not null
+  );
+
+  -- this is going to require us to do the "none" operation again on the remaining modifies
+  -- but otherwise we can just dump the 'adds' and 'none' into the merge staging area table
+
+  -- 'delete' against a 'delete' does not enter the merge staging area table
+  -- receiving 'delete' against supplying 'none' does not enter the merge staging area table
+
+  insert into merge_staging_area (
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    start_offset, type, arguments, metadata, change_type
+  )
+    -- 'adds' can go directly into the merge staging area table
+  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, change_type
+  from supplying_diff as  s_diff
+         join plan_snapshot_activities psa
+              on s_diff.activity_id = psa.id
+  where snapshot_id = snapshot_id_supplying and change_type = 'add'
+  union
+  -- an 'add' between the receiving plan and merge base is actually a 'none'
+  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, 'none'::activity_change_type
+  from receiving_diff as r_diff
+         join activity_directive ad
+              on r_diff.activity_id = ad.id
+  where plan_id = plan_id_receiving and change_type = 'add';
+
+  -- put the rest in diff_diff
+  insert into diff_diff (activity_id, change_type_supplying, change_type_receiving)
+  select activity_id, supplying_diff.change_type as change_type_supplying, receiving_diff.change_type as change_type_receiving
+  from receiving_diff
+         join supplying_diff using (activity_id)
+  where receiving_diff.change_type != 'add' or supplying_diff.change_type != 'add';
+
+  -- ...except for that which is not recorded
+  delete from diff_diff
+  where (change_type_receiving = 'delete' and  change_type_supplying = 'delete')
+     or (change_type_receiving = 'delete' and change_type_supplying = 'none');
+
+  insert into merge_staging_area (
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    start_offset, type, arguments, metadata, change_type
+  )
+    -- receiving 'none' and 'modify' against 'none' in the supplying side go into the merge staging area as 'none'
+  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, 'none'
+  from diff_diff
+         join activity_directive
+              on activity_id=id
+  where plan_id = plan_id_receiving
+    and change_type_supplying = 'none'
+    and (change_type_receiving = 'modify' or change_type_receiving = 'none')
+  union
+  -- supplying 'modify' against receiving 'none' go into the merge staging area as 'modify'
+  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, change_type_supplying
+  from diff_diff
+         join plan_snapshot_activities p
+              on diff_diff.activity_id = p.id
+  where snapshot_id = snapshot_id_supplying
+    and (change_type_receiving = 'none' and diff_diff.change_type_supplying = 'modify')
+  union
+  -- supplying 'delete' against receiving 'none' go into the merge staging area as 'delete'
+  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, change_type_supplying
+  from diff_diff
+         join activity_directive p
+              on diff_diff.activity_id = p.id
+  where plan_id = plan_id_receiving
+    and (change_type_receiving = 'none' and diff_diff.change_type_supplying = 'delete')
+  union
+  -- 'modify' against a 'modify' must be checked for equality first.
+  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, 'none'
+  from (
+         select activity_id, name, tags,  source_scheduling_goal_id, created_at,
+                start_offset, type, arguments, metadata
+         from plan_snapshot_activities psa
+                join diff_diff dd
+                     on dd.activity_id = psa.id
+         where psa.snapshot_id = snapshot_id_supplying
+           and (dd.change_type_receiving = 'modify' and dd.change_type_supplying = 'modify')
+         intersect
+         select activity_id, name, tags,  source_scheduling_goal_id, created_at,
+                start_offset, type, arguments, metadata
+         from diff_diff dd
+                join activity_directive ad
+                     on dd.activity_id = ad.id
+         where ad.plan_id = plan_id_receiving
+           and (dd.change_type_supplying = 'modify' and dd.change_type_receiving = 'modify')
+       ) a;
+
+  -- 'modify' against 'delete' and inequal 'modify' against 'modify' goes into conflict table (aka everything left in diff_diff)
+  insert into conflicting_activities (merge_request_id, activity_id, change_type_supplying, change_type_receiving)
+  select begin_merge._merge_request_id, activity_id, change_type_supplying, change_type_receiving
+  from (select begin_merge._merge_request_id, activity_id
+        from diff_diff
+        except
+        select msa.merge_request_id, activity_id
+        from merge_staging_area msa) a
+         join diff_diff using (activity_id);
+
+  -- Fail if there are no differences between the snapshot and the plan getting merged
+  validate_non_no_op_status := null;
+  select change_type_receiving
+  from conflicting_activities
+  where merge_request_id = _merge_request_id
+  limit 1
+  into validate_non_no_op_status;
+
+  if validate_non_no_op_status is null then
+    select change_type
+    from merge_staging_area msa
+    where merge_request_id = _merge_request_id
+      and msa.change_type != 'none'
+    limit 1
+    into validate_non_no_op_status;
+
+    if validate_non_no_op_status is null then
+      raise exception 'Cannot begin merge. The contents of the two plans are identical.';
+    end if;
+  end if;
+
+
+  -- clean up
+  drop table supplying_diff;
+  drop table receiving_diff;
+  drop table diff_diff;
+end
+$$;
+
+create or replace procedure commit_merge(request_id integer)
+  language plpgsql as $$
+declare
+  validate_noConflicts integer;
+  plan_id_R integer;
+  snapshot_id_S integer;
+begin
+  if(select id from merge_request where id = request_id) is null then
+    raise exception 'Invalid merge request id %.', request_id;
+  end if;
+
+  -- Stop if this merge is not 'in-progress'
+  if (select status from merge_request where id = request_id) != 'in-progress' then
+    raise exception 'Cannot commit a merge request that is not in-progress.';
+  end if;
+
+  -- Stop if any conflicts have not been resolved
+  select * from conflicting_activities
+  where merge_request_id = request_id and resolution = 'none'
+  limit 1
+  into validate_noConflicts;
+
+  if(validate_noConflicts is not null) then
+    raise exception 'There are unresolved conflicts in merge request %. Cannot commit merge.', request_id;
+  end if;
+
+  select plan_id_receiving_changes from merge_request mr where mr.id = request_id into plan_id_R;
+  select snapshot_id_supplying_changes from merge_request mr where mr.id = request_id into snapshot_id_S;
+
+  insert into merge_staging_area(
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    start_offset, type, arguments, metadata, change_type)
+    -- gather delete data from the opposite tables
+  select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata, 'delete'::activity_change_type
+  from  conflicting_activities ca
+          join  activity_directive ad
+                on  ca.activity_id = ad.id
+  where ca.resolution = 'supplying'
+    and ca.merge_request_id = commit_merge.request_id
+    and plan_id = plan_id_R
+    and ca.change_type_supplying = 'delete'
+  union
+  select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata, 'delete'::activity_change_type
+  from  conflicting_activities ca
+          join  plan_snapshot_activities psa
+                on  ca.activity_id = psa.id
+  where ca.resolution = 'receiving'
+    and ca.merge_request_id = commit_merge.request_id
+    and snapshot_id = snapshot_id_S
+    and ca.change_type_receiving = 'delete'
+  union
+  select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata, 'none'::activity_change_type
+  from  conflicting_activities ca
+          join  activity_directive ad
+                on  ca.activity_id = ad.id
+  where ca.resolution = 'receiving'
+    and ca.merge_request_id = commit_merge.request_id
+    and plan_id = plan_id_R
+    and ca.change_type_receiving = 'modify'
+  union
+  select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata, 'modify'::activity_change_type
+  from  conflicting_activities ca
+          join  plan_snapshot_activities psa
+                on  ca.activity_id = psa.id
+  where ca.resolution = 'supplying'
+    and ca.merge_request_id = commit_merge.request_id
+    and snapshot_id = snapshot_id_S
+    and ca.change_type_supplying = 'modify';
+
+  -- Unlock so that updates can be written
+  update plan
+  set is_locked = false
+  where id = plan_id_R;
+
+  -- Update the plan's activities to match merge-staging-area's activities
+  -- Add
+  insert into activity_directive(
+    id, plan_id, name, tags, source_scheduling_goal_id, created_at,
+    start_offset, type, arguments, metadata )
+  select  activity_id, plan_id_R, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata
+  from merge_staging_area
+  where merge_staging_area.merge_request_id = commit_merge.request_id
+    and change_type = 'add';
+
+  -- Modify
+  insert into activity_directive(
+    id, plan_id, "name", tags, source_scheduling_goal_id, created_at,
+    start_offset, "type", arguments, metadata )
+  select  activity_id, plan_id_R, "name", tags, source_scheduling_goal_id, created_at,
+          start_offset, "type", arguments, metadata
+  from merge_staging_area
+  where merge_staging_area.merge_request_id = commit_merge.request_id
+    and change_type = 'modify'
+  on conflict (id, plan_id)
+    do update
+    set name = excluded.name,
+        tags = excluded.tags,
+        source_scheduling_goal_id = excluded.source_scheduling_goal_id,
+        created_at = excluded.created_at,
+        start_offset = excluded.start_offset,
+        type = excluded.type,
+        arguments = excluded.arguments,
+        metadata = excluded.metadata;
+
+  -- Delete
+  delete from activity_directive ad
+    using merge_staging_area msa
+  where ad.id = msa.activity_id
+    and ad.plan_id = plan_id_R
+    and msa.merge_request_id = commit_merge.request_id
+    and msa.change_type = 'delete';
+
+  -- Clean up
+  delete from conflicting_activities where merge_request_id = request_id;
+  delete from merge_staging_area where merge_staging_area.merge_request_id = commit_merge.request_id;
+
+  update merge_request
+  set status = 'accepted'
+  where id = request_id;
+
+  -- Attach snapshot history
+  insert into plan_latest_snapshot(plan_id, snapshot_id)
+  select plan_id_receiving_changes, snapshot_id_supplying_changes
+  from merge_request
+  where id = request_id;
+end
+$$;
+
+-- Add back the dropped tables/functions in reverse order
+alter table hasura_functions.get_conflicting_activities_return_value
+  add column activity_id integer,
+  add column change_type_source activity_change_type,
+  add column change_type_target activity_change_type,
+  add column resolution resolution_type,
+  add column source plan_snapshot_activities,
+  add column target activity_directive,
+  add column merge_base plan_snapshot_activities;
+alter table hasura_functions.get_non_conflicting_activities_return_value
+  add column activity_id integer,
+  add column change_type activity_change_type,
+  add column source plan_snapshot_activities,
+  add column target activity_directive;
+alter table hasura_functions.begin_merge_return_value
+  add column merge_request_id integer,
+  add column non_conflicting_activities hasura_functions.get_non_conflicting_activities_return_value[],
+  add column conflicting_activities hasura_functions.get_conflicting_activities_return_value[];
+
+-- Hasura functions for handling anchors during delete
+drop function hasura_functions.delete_activity_by_pk_reanchor_plan_start(_activity_id int, _plan_id int);
+drop function hasura_functions.delete_activity_by_pk_reanchor_to_anchor(_activity_id int, _plan_id int);
+drop function hasura_functions.delete_activity_by_pk_delete_subtree(_activity_id int, _plan_id int);
+drop table hasura_functions.delete_anchor_return_value;
+
+-- Drop rebasing functions
+drop function anchor_direct_descendents_to_plan(_activity_id int, _plan_id int);
+drop function anchor_direct_descendents_to_ancestor(_activity_id int, _plan_id int);
+
+call migrations.mark_migration_rolled_back('1');

--- a/deployment/hasura/migrations/AerieMerlin/1_anchors/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/1_anchors/up.sql
@@ -1,0 +1,1071 @@
+/*
+  This migration adds in the concept of anchoring one activity directive's start time to another activity_directive's start or end time.
+  Alternatively, an activity directive can be anchored to the plan's start or end time.
+ */
+
+/*
+ Once https://github.com/NASA-AMMOS/aerie/issues/567 has been resolved, future migrations will only need to drop the relative columns,
+ instead of dropping all columns and recreating them in the correct order (done in this fashion to limit the amount of functions dropped).
+
+ Additionally, dropping these tables is only possible because they are return types and *do not* hold any data.
+*/
+alter table hasura_functions.begin_merge_return_value
+  drop column merge_request_id,
+  drop column non_conflicting_activities,
+  drop column conflicting_activities;
+alter table hasura_functions.get_non_conflicting_activities_return_value
+  drop column activity_id,
+  drop column change_type,
+  drop column source,
+  drop column target;
+alter table hasura_functions.get_conflicting_activities_return_value
+  drop column activity_id,
+  drop column change_type_source,
+  drop column change_type_target,
+  drop column resolution,
+  drop column source,
+  drop column target,
+  drop column merge_base;
+
+-- Modify activity_directive
+alter table activity_directive
+  add column anchor_id integer default null,
+  add column anchored_to_start boolean default true not null,
+  drop constraint activity_directive_start_offset_is_nonnegative,
+  add constraint anchor_in_plan
+    foreign key (anchor_id, plan_id)
+      references activity_directive
+      on update cascade
+      on delete restrict;
+
+comment on column activity_directive.anchor_id is e''
+  'The id of the activity_directive this activity_directive is anchored to. '
+  'The value null indicates that this activity_directive is anchored to the plan.';
+comment on column activity_directive.anchored_to_start is e''
+  'If true, this activity_directive is anchored to the start time of its anchor. '
+  'If false, this activity_directive is anchored to the end time of its anchor.';
+
+-- Add rebasing functions
+create function anchor_direct_descendents_to_plan(_activity_id int, _plan_id int)
+  returns setof activity_directive
+  language plpgsql as $$
+declare
+  _total_offset interval;
+begin
+  if _plan_id is null then
+    raise exception 'Plan ID cannot be null.';
+  end if;
+  if _activity_id is null then
+    raise exception 'Activity ID cannot be null.';
+  end if;
+  if not exists(select id from activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+    raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+  end if;
+
+  with recursive history(activity_id, anchor_id, total_offset) as (
+    select ad.id, ad.anchor_id, ad.start_offset
+    from activity_directive ad
+    where (ad.id, ad.plan_id) = (_activity_id, _plan_id)
+    union
+    select ad.id, ad.anchor_id, h.total_offset + ad.start_offset
+    from activity_directive ad, history h
+    where (ad.id, ad.plan_id) = (h.anchor_id, _plan_id)
+      and h.anchor_id is not null
+  ) select total_offset
+  from history
+  where history.anchor_id is null
+  into _total_offset;
+
+  return query update activity_directive
+    set start_offset = start_offset + _total_offset,
+      anchor_id = null,
+      anchored_to_start = true
+    where (anchor_id, plan_id) = (_activity_id, _plan_id)
+    returning *;
+end
+$$;
+comment on function anchor_direct_descendents_to_plan(_activity_id integer, _plan_id integer) is e''
+  'Given the primary key of an activity, reanchor all anchor chains attached to the activity to the plan.\n'
+  'In the event of an end-time anchor, this function assumes all simulated activities have a duration of 0.';
+
+create function anchor_direct_descendents_to_ancestor(_activity_id int, _plan_id int)
+  returns setof activity_directive
+  language plpgsql as $$
+declare
+  _current_offset interval;
+  _current_anchor_id int;
+begin
+  if _plan_id is null then
+    raise exception 'Plan ID cannot be null.';
+  end if;
+  if _activity_id is null then
+    raise exception 'Activity ID cannot be null.';
+  end if;
+  if not exists(select id from activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+    raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+  end if;
+
+  select start_offset, anchor_id
+  from activity_directive
+  where (id, plan_id) = (_activity_id, _plan_id)
+  into _current_offset, _current_anchor_id;
+
+  return query
+    update activity_directive
+      set start_offset = start_offset + _current_offset,
+        anchor_id = _current_anchor_id
+      where (anchor_id, plan_id) = (_activity_id, _plan_id)
+      returning *;
+end
+$$;
+comment on function anchor_direct_descendents_to_ancestor(_activity_id integer, _plan_id integer) is e''
+  'Given the primary key of an activity, reanchor all anchor chains attached to the activity to the anchor of said activity.\n'
+  'In the event of an end-time anchor, this function assumes all simulated activities have a duration of 0.';
+
+-- Track anchors in snapshots
+alter table plan_snapshot_activities
+  add column anchor_id integer default null,
+  add column anchored_to_start boolean default true not null;
+
+create or replace function create_snapshot(plan_id integer)
+  returns integer -- snapshot id inserted into the table
+  language plpgsql as $$
+declare
+  validate_planid integer;
+  inserted_snapshot_id integer;
+begin
+  select id from plan where plan.id = plan_id into validate_planid;
+  if validate_planid is null then
+    raise exception 'Plan % does not exist.', plan_id;
+  end if;
+
+  insert into plan_snapshot(plan_id, revision, name, duration, start_time)
+  select id, revision, name, duration, start_time
+  from plan where id = plan_id
+  returning snapshot_id into inserted_snapshot_id;
+  insert into plan_snapshot_activities(
+    snapshot_id, id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
+    arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+  )
+  select
+    inserted_snapshot_id,                                   -- this is the snapshot id
+    id, name, tags,source_scheduling_goal_id, created_at,   -- these are the rest of the data for an activity row
+    last_modified_at, start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+  from activity_directive where activity_directive.plan_id = create_snapshot.plan_id;
+
+  --all snapshots in plan_latest_snapshot for plan plan_id become the parent of the current snapshot
+  insert into plan_snapshot_parent(snapshot_id, parent_snapshot_id)
+  select inserted_snapshot_id, snapshot_id
+  from plan_latest_snapshot where plan_latest_snapshot.plan_id = create_snapshot.plan_id;
+
+  --remove all of those entries from plan_latest_snapshot and add this new snapshot.
+  delete from plan_latest_snapshot where plan_latest_snapshot.plan_id = create_snapshot.plan_id;
+  insert into plan_latest_snapshot(plan_id, snapshot_id) values (create_snapshot.plan_id, inserted_snapshot_id);
+
+  return inserted_snapshot_id;
+end;
+$$;
+
+create or replace function duplicate_plan(plan_id integer, new_plan_name text)
+  returns integer -- plan_id of the new plan
+  security definer
+  language plpgsql as $$
+declare
+  validate_plan_id integer;
+  new_plan_id integer;
+  created_snapshot_id integer;
+begin
+  select id from plan where plan.id = duplicate_plan.plan_id into validate_plan_id;
+  if(validate_plan_id is null) then
+    raise exception 'Plan % does not exist.', plan_id;
+  end if;
+
+  select create_snapshot(plan_id) into created_snapshot_id;
+
+  insert into plan(revision, name, model_id, duration, start_time, parent_id)
+  select
+    0, new_plan_name, model_id, duration, start_time, plan_id
+  from plan where id = plan_id
+  returning id into new_plan_id;
+  insert into activity_directive(
+    id, plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+    last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+  )
+  select
+    id, new_plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+    last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+  from activity_directive where activity_directive.plan_id = duplicate_plan.plan_id;
+  insert into simulation (revision, simulation_template_id, plan_id, arguments)
+  select 0, simulation_template_id, new_plan_id, arguments
+  from simulation
+  where simulation.plan_id = duplicate_plan.plan_id;
+
+  insert into plan_latest_snapshot(plan_id, snapshot_id) values(new_plan_id, created_snapshot_id);
+  return new_plan_id;
+end;
+$$;
+
+-- Track anchors in plan merging
+alter table merge_staging_area
+  add column anchor_id integer default null,
+  add column anchored_to_start boolean default true not null,
+  drop constraint staging_area_start_offset_is_nonnegative;
+
+comment on column merge_staging_area.anchor_id is e''
+  'The identifier of the anchor of this activity directive to be committed.';
+comment on column merge_staging_area.anchored_to_start is e''
+  'The status of whether this activity directive is anchored to its anchor''s start time to be committed.';
+
+-- Modify Begin_Merge and Commit_Merge
+create or replace procedure begin_merge(_merge_request_id integer, review_username text)
+  language plpgsql as $$
+declare
+  validate_id integer;
+  validate_status merge_request_status;
+  validate_non_no_op_status activity_change_type;
+  snapshot_id_supplying integer;
+  plan_id_receiving integer;
+  merge_base_id integer;
+begin
+  -- validate id and status
+  select id, status
+  from merge_request
+  where _merge_request_id = id
+  into validate_id, validate_status;
+
+  if validate_id is null then
+    raise exception 'Request ID % is not present in merge_request table.', _merge_request_id;
+  end if;
+
+  if validate_status != 'pending' then
+    raise exception 'Cannot begin request. Merge request % is not in pending state.', _merge_request_id;
+  end if;
+
+  -- select from merge-request the snapshot_sc (s_sc) and plan_rc (p_rc) ids
+  select plan_id_receiving_changes, snapshot_id_supplying_changes
+  from merge_request
+  where id = _merge_request_id
+  into plan_id_receiving, snapshot_id_supplying;
+
+  -- ensure the plan receiving changes isn't locked
+  if (select is_locked from plan where plan.id=plan_id_receiving) then
+    raise exception 'Cannot begin merge request. Plan to receive changes is locked.';
+  end if;
+
+  -- lock plan_rc
+  update plan
+  set is_locked = true
+  where plan.id = plan_id_receiving;
+
+  -- get merge base (mb)
+  select get_merge_base(plan_id_receiving, snapshot_id_supplying)
+  into merge_base_id;
+
+  -- update the status to "in progress"
+  update merge_request
+  set status = 'in-progress',
+      merge_base_snapshot_id = merge_base_id,
+      reviewer_username = review_username
+  where id = _merge_request_id;
+
+
+  -- perform diff between mb and s_sc (s_diff)
+  -- delete is B minus A on key
+  -- add is A minus B on key
+  -- A intersect B is no op
+  -- A minus B on everything except everything currently in the table is modify
+  create temp table supplying_diff(
+                                    activity_id integer,
+                                    change_type activity_change_type not null
+  );
+
+  insert into supplying_diff (activity_id, change_type)
+  select activity_id, 'delete'
+  from(
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id
+        except
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = snapshot_id_supplying) a;
+
+  insert into supplying_diff (activity_id, change_type)
+  select activity_id, 'add'
+  from(
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = snapshot_id_supplying
+        except
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id) a;
+
+  insert into supplying_diff (activity_id, change_type)
+  select activity_id, 'none'
+  from(
+        select id as activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at,
+               start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id
+        intersect
+        select id as activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at,
+               start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+        from plan_snapshot_activities
+        where snapshot_id = snapshot_id_supplying) a;
+
+  insert into supplying_diff (activity_id, change_type)
+  select activity_id, 'modify'
+  from(
+        select id as activity_id from plan_snapshot_activities
+        where snapshot_id = merge_base_id or snapshot_id = snapshot_id_supplying
+        except
+        select activity_id from supplying_diff) a;
+
+  -- perform diff between mb and p_rc (r_diff)
+  create temp table receiving_diff(
+                                    activity_id integer,
+                                    change_type activity_change_type not null
+  );
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'delete'
+  from(
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id
+        except
+        select id as activity_id
+        from activity_directive
+        where plan_id = plan_id_receiving) a;
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'add'
+  from(
+        select id as activity_id
+        from activity_directive
+        where plan_id = plan_id_receiving
+        except
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id) a;
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'none'
+  from(
+        select id as activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at,
+               start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id
+        intersect
+        select id as activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at,
+               start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+        from activity_directive
+        where plan_id = plan_id_receiving) a;
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'modify'
+  from (
+         (select id as activity_id
+          from plan_snapshot_activities
+          where snapshot_id = merge_base_id
+          union
+          select id as activity_id
+          from activity_directive
+          where plan_id = plan_id_receiving)
+         except
+         select activity_id
+         from receiving_diff) a;
+
+
+  -- perform diff between s_diff and r_diff
+  -- upload the non-conflicts into merge_staging_area
+  -- upload conflict into conflicting_activities
+  create temp table diff_diff(
+                               activity_id integer,
+                               change_type_supplying activity_change_type not null,
+                               change_type_receiving activity_change_type not null
+  );
+
+  -- this is going to require us to do the "none" operation again on the remaining modifies
+  -- but otherwise we can just dump the 'adds' and 'none' into the merge staging area table
+
+  -- 'delete' against a 'delete' does not enter the merge staging area table
+  -- receiving 'delete' against supplying 'none' does not enter the merge staging area table
+
+  insert into merge_staging_area (
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type
+  )
+    -- 'adds' can go directly into the merge staging area table
+  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type
+  from supplying_diff as  s_diff
+         join plan_snapshot_activities psa
+              on s_diff.activity_id = psa.id
+  where snapshot_id = snapshot_id_supplying and change_type = 'add'
+  union
+  -- an 'add' between the receiving plan and merge base is actually a 'none'
+  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'::activity_change_type
+  from receiving_diff as r_diff
+         join activity_directive ad
+              on r_diff.activity_id = ad.id
+  where plan_id = plan_id_receiving and change_type = 'add';
+
+  -- put the rest in diff_diff
+  insert into diff_diff (activity_id, change_type_supplying, change_type_receiving)
+  select activity_id, supplying_diff.change_type as change_type_supplying, receiving_diff.change_type as change_type_receiving
+  from receiving_diff
+         join supplying_diff using (activity_id)
+  where receiving_diff.change_type != 'add' or supplying_diff.change_type != 'add';
+
+  -- ...except for that which is not recorded
+  delete from diff_diff
+  where (change_type_receiving = 'delete' and  change_type_supplying = 'delete')
+     or (change_type_receiving = 'delete' and change_type_supplying = 'none');
+
+  insert into merge_staging_area (
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type
+  )
+    -- receiving 'none' and 'modify' against 'none' in the supplying side go into the merge staging area as 'none'
+  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'
+  from diff_diff
+         join activity_directive
+              on activity_id=id
+  where plan_id = plan_id_receiving
+    and change_type_supplying = 'none'
+    and (change_type_receiving = 'modify' or change_type_receiving = 'none')
+  union
+  -- supplying 'modify' against receiving 'none' go into the merge staging area as 'modify'
+  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type_supplying
+  from diff_diff
+         join plan_snapshot_activities p
+              on diff_diff.activity_id = p.id
+  where snapshot_id = snapshot_id_supplying
+    and (change_type_receiving = 'none' and diff_diff.change_type_supplying = 'modify')
+  union
+  -- supplying 'delete' against receiving 'none' go into the merge staging area as 'delete'
+  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type_supplying
+  from diff_diff
+         join activity_directive p
+              on diff_diff.activity_id = p.id
+  where plan_id = plan_id_receiving
+    and (change_type_receiving = 'none' and diff_diff.change_type_supplying = 'delete')
+  union
+  -- 'modify' against a 'modify' must be checked for equality first.
+  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'
+  from (
+         select activity_id, name, tags,  source_scheduling_goal_id, created_at,
+                start_offset, type, arguments, metadata, anchor_id, anchored_to_start
+         from plan_snapshot_activities psa
+                join diff_diff dd
+                     on dd.activity_id = psa.id
+         where psa.snapshot_id = snapshot_id_supplying
+           and (dd.change_type_receiving = 'modify' and dd.change_type_supplying = 'modify')
+         intersect
+         select activity_id, name, tags,  source_scheduling_goal_id, created_at,
+                start_offset, type, arguments, metadata, anchor_id, anchored_to_start
+         from diff_diff dd
+                join activity_directive ad
+                     on dd.activity_id = ad.id
+         where ad.plan_id = plan_id_receiving
+           and (dd.change_type_supplying = 'modify' and dd.change_type_receiving = 'modify')
+       ) a;
+
+  -- 'modify' against 'delete' and inequal 'modify' against 'modify' goes into conflict table (aka everything left in diff_diff)
+  insert into conflicting_activities (merge_request_id, activity_id, change_type_supplying, change_type_receiving)
+  select begin_merge._merge_request_id, activity_id, change_type_supplying, change_type_receiving
+  from (select begin_merge._merge_request_id, activity_id
+        from diff_diff
+        except
+        select msa.merge_request_id, activity_id
+        from merge_staging_area msa) a
+         join diff_diff using (activity_id);
+
+  -- Fail if there are no differences between the snapshot and the plan getting merged
+  validate_non_no_op_status := null;
+  select change_type_receiving
+  from conflicting_activities
+  where merge_request_id = _merge_request_id
+  limit 1
+  into validate_non_no_op_status;
+
+  if validate_non_no_op_status is null then
+    select change_type
+    from merge_staging_area msa
+    where merge_request_id = _merge_request_id
+      and msa.change_type != 'none'
+    limit 1
+    into validate_non_no_op_status;
+
+    if validate_non_no_op_status is null then
+      raise exception 'Cannot begin merge. The contents of the two plans are identical.';
+    end if;
+  end if;
+
+
+  -- clean up
+  drop table supplying_diff;
+  drop table receiving_diff;
+  drop table diff_diff;
+end
+$$;
+
+create or replace procedure commit_merge(request_id integer)
+  language plpgsql as $$
+declare
+  validate_noConflicts integer;
+  plan_id_R integer;
+  snapshot_id_S integer;
+begin
+  if(select id from merge_request where id = request_id) is null then
+    raise exception 'Invalid merge request id %.', request_id;
+  end if;
+
+  -- Stop if this merge is not 'in-progress'
+  if (select status from merge_request where id = request_id) != 'in-progress' then
+    raise exception 'Cannot commit a merge request that is not in-progress.';
+  end if;
+
+  -- Stop if any conflicts have not been resolved
+  select * from conflicting_activities
+  where merge_request_id = request_id and resolution = 'none'
+  limit 1
+  into validate_noConflicts;
+
+  if(validate_noConflicts is not null) then
+    raise exception 'There are unresolved conflicts in merge request %. Cannot commit merge.', request_id;
+  end if;
+
+  select plan_id_receiving_changes from merge_request mr where mr.id = request_id into plan_id_R;
+  select snapshot_id_supplying_changes from merge_request mr where mr.id = request_id into snapshot_id_S;
+
+  insert into merge_staging_area(
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type)
+    -- gather delete data from the opposite tables
+  select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'delete'::activity_change_type
+  from  conflicting_activities ca
+          join  activity_directive ad
+                on  ca.activity_id = ad.id
+  where ca.resolution = 'supplying'
+    and ca.merge_request_id = commit_merge.request_id
+    and plan_id = plan_id_R
+    and ca.change_type_supplying = 'delete'
+  union
+  select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'delete'::activity_change_type
+  from  conflicting_activities ca
+          join  plan_snapshot_activities psa
+                on  ca.activity_id = psa.id
+  where ca.resolution = 'receiving'
+    and ca.merge_request_id = commit_merge.request_id
+    and snapshot_id = snapshot_id_S
+    and ca.change_type_receiving = 'delete'
+  union
+  select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'::activity_change_type
+  from  conflicting_activities ca
+          join  activity_directive ad
+                on  ca.activity_id = ad.id
+  where ca.resolution = 'receiving'
+    and ca.merge_request_id = commit_merge.request_id
+    and plan_id = plan_id_R
+    and ca.change_type_receiving = 'modify'
+  union
+  select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'modify'::activity_change_type
+  from  conflicting_activities ca
+          join  plan_snapshot_activities psa
+                on  ca.activity_id = psa.id
+  where ca.resolution = 'supplying'
+    and ca.merge_request_id = commit_merge.request_id
+    and snapshot_id = snapshot_id_S
+    and ca.change_type_supplying = 'modify';
+
+  -- Unlock so that updates can be written
+  update plan
+  set is_locked = false
+  where id = plan_id_R;
+
+  -- Update the plan's activities to match merge-staging-area's activities
+  -- Add
+  insert into activity_directive(
+    id, plan_id, name, tags, source_scheduling_goal_id, created_at,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start )
+  select  activity_id, plan_id_R, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata, anchor_id, anchored_to_start
+  from merge_staging_area
+  where merge_staging_area.merge_request_id = commit_merge.request_id
+    and change_type = 'add';
+
+  -- Modify
+  insert into activity_directive(
+    id, plan_id, "name", tags, source_scheduling_goal_id, created_at,
+    start_offset, "type", arguments, metadata, anchor_id, anchored_to_start )
+  select  activity_id, plan_id_R, "name", tags, source_scheduling_goal_id, created_at,
+          start_offset, "type", arguments, metadata, anchor_id, anchored_to_start
+  from merge_staging_area
+  where merge_staging_area.merge_request_id = commit_merge.request_id
+    and change_type = 'modify'
+  on conflict (id, plan_id)
+    do update
+    set name = excluded.name,
+        tags = excluded.tags,
+        source_scheduling_goal_id = excluded.source_scheduling_goal_id,
+        created_at = excluded.created_at,
+        start_offset = excluded.start_offset,
+        type = excluded.type,
+        arguments = excluded.arguments,
+        metadata = excluded.metadata,
+        anchor_id = excluded.anchor_id,
+        anchored_to_start = excluded.anchored_to_start;
+
+  -- Delete
+  delete from activity_directive ad
+    using merge_staging_area msa
+  where ad.id = msa.activity_id
+    and ad.plan_id = plan_id_R
+    and msa.merge_request_id = commit_merge.request_id
+    and msa.change_type = 'delete';
+
+  -- Clean up
+  delete from conflicting_activities where merge_request_id = request_id;
+  delete from merge_staging_area where merge_staging_area.merge_request_id = commit_merge.request_id;
+
+  update merge_request
+  set status = 'accepted'
+  where id = request_id;
+
+  -- Attach snapshot history
+  insert into plan_latest_snapshot(plan_id, snapshot_id)
+  select plan_id_receiving_changes, snapshot_id_supplying_changes
+  from merge_request
+  where id = request_id;
+end
+$$;
+
+-- Add Anchor Validation
+create table anchor_validation_status(
+                                       activity_id integer not null,
+                                       plan_id integer not null,
+                                       reason_invalid text default null,
+                                       primary key (activity_id, plan_id),
+                                       foreign key (activity_id, plan_id)
+                                         references activity_directive
+                                         on update cascade
+                                         on delete cascade
+);
+
+create index anchor_validation_plan_id_index on anchor_validation_status (plan_id);
+
+comment on index anchor_validation_plan_id_index is e''
+  'A similar index to that on activity_directive, as we often want to filter by plan_id';
+
+comment on table anchor_validation_status is e''
+  'The validation status of the anchor of a single activity_directive within a plan.';
+comment on column anchor_validation_status.activity_id is e''
+  'The synthetic identifier for the activity_directive.\n'
+  'Unique within a given plan.';
+comment on column anchor_validation_status.plan_id is e''
+  'The plan within which the activity_directive is located';
+comment on column anchor_validation_status.reason_invalid is e''
+  'If null, the anchor is valid. If not null, this contains a reason why the anchor is invalid.';
+
+/*
+    An activity directive may have a negative offset from its anchor's start time.
+    If its anchor is anchored to the end time of another activity (or so on up the chain), the activity with a
+    negative offset must come out to have a positive offset relative to that end time anchor.
+*/
+create procedure validate_nonnegative_net_end_offset(_activity_id integer, _plan_id integer)
+  security definer
+  language plpgsql as $$
+declare
+  end_anchor_id integer;
+  offset_from_end_anchor interval;
+  _anchor_id integer;
+  _start_offset interval;
+  _anchored_to_start boolean;
+begin
+  select anchor_id, start_offset, anchored_to_start
+  from activity_directive
+  where (id, plan_id) = (_activity_id, _plan_id)
+  into _anchor_id, _start_offset, _anchored_to_start;
+
+  if (_anchor_id is not null)           -- if the activity is anchored to the plan, then it can't be anchored to the end of another activity directive
+  then
+    /*
+      Postgres ANDs don't "short-circuit" -- all clauses are evaluated. Therefore, this query is placed here so that
+      it only runs iff the outer 'if' is true
+    */
+    with recursive end_time_anchor(activity_id, anchor_id, anchored_to_start, start_offset, total_offset) as (
+      select _activity_id, _anchor_id, _anchored_to_start, _start_offset, _start_offset
+      union
+      select ad.id, ad.anchor_id, ad.anchored_to_start, ad.start_offset, eta.total_offset + ad.start_offset
+      from activity_directive ad, end_time_anchor eta
+      where (ad.id, ad.plan_id) = (eta.anchor_id, _plan_id)
+        and eta.anchor_id is not null                               -- stop at plan
+        and eta.anchored_to_start                                   -- or stop at end time anchor
+    ) select into end_anchor_id, offset_from_end_anchor
+        anchor_id, total_offset from end_time_anchor eta -- get the id of the activity that the selected activity is anchored to
+    where not eta.anchored_to_start and eta.anchor_id is not null
+    limit 1;
+
+    if end_anchor_id is not null and offset_from_end_anchor < '0' then
+      raise notice 'Activity Directive % has a net negative offset relative to an end-time anchor on Activity Directive %.', _activity_id, end_anchor_id;
+
+      insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+      values (_activity_id, _plan_id, 'Activity Directive ' || _activity_id || ' has a net negative offset relative to an end-time' ||
+                                      ' anchor on Activity Directive ' || end_anchor_id ||'.')
+      on conflict (activity_id, plan_id) do update
+        set reason_invalid = 'Activity Directive ' || excluded.activity_id || ' has a net negative offset relative to an end-time' ||
+                             ' anchor on Activity Directive ' || end_anchor_id ||'.';
+    end if;
+  end if;
+end
+$$;
+comment on procedure validate_nonnegative_net_end_offset(_activity_id integer, _plan_id integer) is e''
+  'Returns true if the specified activity has a net negative offset from a non-plan activity end-time anchor. Otherwise, returns false.\n'
+  'If true, writes to anchor_validation_status.';
+
+create procedure validate_nonegative_net_plan_start(_activity_id integer, _plan_id integer)
+  security definer
+  language plpgsql as $$
+declare
+  net_offset interval;
+  _anchor_id integer;
+  _start_offset interval;
+  _anchored_to_start boolean;
+begin
+  select anchor_id, start_offset, anchored_to_start
+  from activity_directive
+  where (id, plan_id) = (_activity_id, _plan_id)
+  into _anchor_id, _start_offset, _anchored_to_start;
+
+  if (_start_offset < '0' and _anchored_to_start) then -- only need to check if anchored to start or something with a negative offset
+    with recursive anchors(activity_id, anchor_id, anchored_to_start, start_offset, total_offset) as (
+      select _activity_id, _anchor_id, _anchored_to_start, _start_offset, _start_offset
+      union
+      select ad.id, ad.anchor_id, ad.anchored_to_start, ad.start_offset, anchors.total_offset + ad.start_offset
+      from activity_directive ad, anchors
+      where anchors.anchor_id is not null                               -- stop at plan
+        and  (ad.id, ad.plan_id) = (anchors.anchor_id, _plan_id)
+        and anchors.anchored_to_start                                  -- or, stop at end-time offset
+    )
+    select total_offset  -- get the id of the activity that the selected activity is anchored to
+    from anchors a
+    where a.anchor_id is null
+      and a.anchored_to_start
+    limit 1
+    into net_offset;
+
+    if(net_offset < '0') then
+      raise notice 'Activity Directive % has a net negative offset relative to Plan Start.', _activity_id;
+
+      insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+      values (_activity_id, _plan_id, 'Activity Directive ' || _activity_id || ' has a net negative offset relative to Plan Start.')
+      on conflict (activity_id, plan_id) do update
+        set reason_invalid = 'Activity Directive ' || excluded.activity_id || ' has a net negative offset relative to Plan Start.';
+    end if;
+  end if;
+end
+$$;
+comment on procedure validate_nonegative_net_plan_start(_activity_id integer, _plan_id integer) is e''
+  'Returns true if the specified activity has a net negative offset from plan start. Otherwise, returns false.\n'
+  'If true, writes to anchor_validation_status.';
+
+create function validate_anchors()
+  returns trigger
+  security definer
+  language plpgsql as $$
+declare
+  end_anchor_id integer;
+  invalid_descendant_act_ids integer[];
+  offset_from_end_anchor interval;
+  offset_from_plan_start interval;
+begin
+  -- Clear the reason invalid field (if an exception is thrown, this will be rolled back)
+  insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+  values (new.id, new.plan_id, '')
+  on conflict (activity_id, plan_id) do update
+    set reason_invalid = '';
+
+  -- An activity cannot anchor to itself
+  if(new.anchor_id = new.id) then
+    raise exception 'Cannot anchor activity % to itself.', new.anchor_id;
+  end if;
+
+  -- Validate that no cycles were added
+  if exists(
+      with recursive history(activity_id, anchor_id, is_cycle, path) as (
+        select new.id, new.anchor_id, false, array[new.id]
+        union all
+        select ad.id, ad.anchor_id,
+               ad.id = any(path),
+               path || ad.id
+        from activity_directive ad, history h
+        where (ad.id, ad.plan_id) = (h.anchor_id, new.plan_id)
+          and not is_cycle
+      ) select * from history
+      where is_cycle
+      limit 1
+    ) then
+    raise exception 'Cycle detected. Cannot apply changes.';
+  end if;
+
+  /*
+    An activity directive may have a negative offset from its anchor's start time.
+    If its anchor is anchored to the end time of another activity (or so on up the chain), the activity with a
+    negative offset must come out to have a positive offset relative to that end time anchor.
+  */
+  call validate_nonnegative_net_end_offset(new.id, new.plan_id);
+  call validate_nonegative_net_plan_start(new.id, new.plan_id);
+
+  /*
+    Everything below validates that the activities anchored to this one did not become invalid as a result of these changes.
+
+    This only checks descendent start-time anchors, as we know that the state after an end-time anchor is valid
+    (As if it no longer is, it will be caught when that activity's row is processed by this trigger)
+  */
+  -- Get collection of dependent activities, with offset relative to this activity
+  create temp table dependent_activities as
+  with recursive d_activities(activity_id, anchor_id, anchored_to_start, start_offset, total_offset) as (
+    select ad.id, ad.anchor_id, ad.anchored_to_start, ad.start_offset, ad.start_offset
+    from activity_directive ad
+    where (ad.anchor_id, ad.plan_id) = (new.id, new.plan_id) -- select all activities anchored to this one
+    union
+    select ad.id, ad.anchor_id, ad.anchored_to_start, ad.start_offset, da.total_offset + ad.start_offset
+    from activity_directive ad, d_activities da
+    where (ad.anchor_id, ad.plan_id) = (da.activity_id, new.plan_id) -- select all activities anchored to those in the selection
+      and ad.anchored_to_start  -- stop at next end-time anchor
+  ) select activity_id, total_offset
+  from d_activities da;
+
+  -- Get the total offset from the most recent end-time anchor earlier in this activity's chain (or null if there is none)
+  with recursive end_time_anchor(activity_id, anchor_id, anchored_to_start, start_offset, total_offset) as (
+    select new.id, new.anchor_id, new.anchored_to_start, new.start_offset, new.start_offset
+    union
+    select ad.id, ad.anchor_id, ad.anchored_to_start, ad.start_offset, eta.total_offset + ad.start_offset
+    from activity_directive ad, end_time_anchor eta
+    where (ad.id, ad.plan_id) = (eta.anchor_id, new.plan_id)
+      and eta.anchor_id is not null                               -- stop at plan
+      and eta.anchored_to_start                                   -- or stop at end time anchor
+  ) select into end_anchor_id, offset_from_end_anchor
+      anchor_id, total_offset from end_time_anchor eta -- get the id of the activity that the selected activity is anchored to
+  where not eta.anchored_to_start and eta.anchor_id is not null
+  limit 1;
+
+  -- Not null iff the activity being looked at has some end anchor to another activity in its chain
+  if offset_from_end_anchor is not null then
+    select array_agg(activity_id) from dependent_activities
+    where total_offset + offset_from_end_anchor < '0'
+    into invalid_descendant_act_ids;
+
+    if invalid_descendant_act_ids is not null then
+      raise info 'The following Activity Directives now have a net negative offset relative to an end-time anchor on Activity Directive %: % \n'
+        'There may be additional activities that are invalid relative to this activity.',
+        end_anchor_id, array_to_string(invalid_descendant_act_ids, ',');
+
+      insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+      select id, new.plan_id, 'Activity Directive ' || id || ' has a net negative offset relative to an end-time' ||
+                              ' anchor on Activity Directive ' || end_anchor_id ||'.'
+      from unnest(invalid_descendant_act_ids) as id
+      on conflict (activity_id, plan_id) do update
+        set reason_invalid = 'Activity Directive ' || excluded.activity_id || ' has a net negative offset relative to an end-time' ||
+                             ' anchor on Activity Directive ' || end_anchor_id ||'.';
+    end if;
+  end if;
+
+  -- Gets the total offset from plan start (or null if there's an end-time anchor in the way)
+  with recursive anchors(activity_id, anchor_id, anchored_to_start, start_offset, total_offset) as (
+    select new.id, new.anchor_id, new.anchored_to_start, new.start_offset, new.start_offset
+    union
+    select ad.id, ad.anchor_id, ad.anchored_to_start, ad.start_offset, anchors.total_offset + ad.start_offset
+    from activity_directive ad, anchors
+    where anchors.anchor_id is not null                               -- stop at plan
+      and (ad.id, ad.plan_id) = (anchors.anchor_id, new.plan_id)
+      and anchors.anchored_to_start                                  -- or, stop at end-time offset
+  )
+  select total_offset  -- get the id of the activity that the selected activity is anchored to
+  from anchors a
+  where a.anchor_id is null
+    and a.anchored_to_start
+  limit 1
+  into offset_from_plan_start;
+
+  -- Not null iff the activity being looked at is connected to plan start via a chain of start anchors
+  if offset_from_plan_start is not null then
+    -- Validate descendents
+    invalid_descendant_act_ids := null;
+    select array_agg(activity_id) from dependent_activities
+    where total_offset + offset_from_plan_start < '0' into invalid_descendant_act_ids;  -- grab all and split
+
+    if invalid_descendant_act_ids is not null then
+      raise info 'The following Activity Directives now have a net negative offset relative to Plan Start: % \n'
+        'There may be additional activities that are invalid relative to this activity.',
+        array_to_string(invalid_descendant_act_ids, ',');
+
+      insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+      select id, new.plan_id, 'Activity Directive ' || id || ' has a net negative offset relative to Plan Start.'
+      from unnest(invalid_descendant_act_ids) as id
+      on conflict (activity_id, plan_id) do update
+        set reason_invalid = 'Activity Directive ' || excluded.activity_id || ' has a net negative offset relative to Plan Start.';
+    end if;
+  end if;
+
+  -- These are both null iff the activity is anchored to plan end
+  if(offset_from_plan_start is null and offset_from_end_anchor is null) then
+    -- All dependent activities should have no errors, as Plan End can have an offset of any value.
+    insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+    select da.activity_id, new.plan_id, ''
+    from dependent_activities as da
+    on conflict (activity_id, plan_id) do update
+      set reason_invalid = '';
+  end if;
+
+  -- Remove the error from the dependent activities that wouldn't have been flagged by the earlier checks.
+  insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+  select da.activity_id, new.plan_id, ''
+  from dependent_activities as da
+  where total_offset + offset_from_plan_start >= '0'
+     or total_offset + offset_from_end_anchor >= '0' -- only one of these checks will run depending on which one has `null` behind the offset
+  on conflict (activity_id, plan_id) do update
+    set reason_invalid = '';
+
+  drop table dependent_activities;
+  return new;
+end $$;
+
+create constraint trigger validate_anchors_update_trigger
+  after update
+  on activity_directive
+  deferrable initially deferred
+  for each row
+  when (old.anchor_id is distinct from new.anchor_id -- != but allows for one side to be null
+    or old.anchored_to_start != new.anchored_to_start
+    or old.start_offset != new.start_offset)
+execute procedure validate_anchors();
+
+create constraint trigger validate_anchors_insert_trigger
+  after insert
+  on activity_directive
+  deferrable initially deferred
+  for each row
+execute procedure validate_anchors();
+
+-- Hasura functions for handling anchors during delete
+create table hasura_functions.delete_anchor_return_value(
+                                                          affected_row activity_directive,
+                                                          change_type text
+);
+
+create function hasura_functions.delete_activity_by_pk_reanchor_plan_start(_activity_id int, _plan_id int)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+  language plpgsql as $$
+begin
+  if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+    raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+  end if;
+
+  return query
+    with updated as (
+      select public.anchor_direct_descendents_to_plan(_activity_id := _activity_id, _plan_id := _plan_id)
+    )
+    select updated.*, 'updated'
+    from updated;
+
+  return query
+    with deleted as (
+      delete from activity_directive where (id, plan_id) = (_activity_id, _plan_id) returning *
+    )
+    select (deleted.id, deleted.plan_id, deleted.name, deleted.tags, deleted.source_scheduling_goal_id,
+            deleted.created_at, deleted.last_modified_at, deleted.start_offset, deleted.type, deleted.arguments,
+            deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
+end
+$$;
+
+create function hasura_functions.delete_activity_by_pk_reanchor_to_anchor(_activity_id int, _plan_id int)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+  language plpgsql as $$
+begin
+  if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+    raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+  end if;
+
+  return query
+    with updated as (
+      select public.anchor_direct_descendents_to_ancestor(_activity_id := _activity_id, _plan_id := _plan_id)
+    )
+    select updated.*, 'updated'
+    from updated;
+  return query
+    with deleted as (
+      delete from activity_directive where (id, plan_id) = (_activity_id, _plan_id) returning *
+    )
+    select (deleted.id, deleted.plan_id, deleted.name, deleted.tags, deleted.source_scheduling_goal_id,
+            deleted.created_at, deleted.last_modified_at, deleted.start_offset, deleted.type, deleted.arguments,
+            deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
+end
+$$;
+
+create function hasura_functions.delete_activity_by_pk_delete_subtree(_activity_id int, _plan_id int)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+  language plpgsql as $$
+begin
+  if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+    raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+  end if;
+
+  return query
+    with recursive
+      descendents(activity_id, p_id) as (
+        select _activity_id, _plan_id
+        from activity_directive ad
+        where (ad.id, ad.plan_id) = (_activity_id, _plan_id)
+        union
+        select ad.id, ad.plan_id
+        from activity_directive ad, descendents d
+        where (ad.anchor_id, ad.plan_id) = (d.activity_id, d.p_id)
+      ),
+      deleted as (
+        delete from activity_directive ad
+          using descendents
+          where (ad.plan_id, ad.id) = (_plan_id, descendents.activity_id)
+          returning *
+      )
+    select (deleted.id, deleted.plan_id, deleted.name, deleted.tags, deleted.source_scheduling_goal_id,
+            deleted.created_at, deleted.last_modified_at, deleted.start_offset, deleted.type, deleted.arguments,
+            deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
+end
+$$;
+
+-- Add back the dropped tables in reverse order
+alter table hasura_functions.get_conflicting_activities_return_value
+  add column activity_id integer,
+  add column change_type_source activity_change_type,
+  add column change_type_target activity_change_type,
+  add column resolution resolution_type,
+  add column source plan_snapshot_activities,
+  add column target activity_directive,
+  add column merge_base plan_snapshot_activities;
+alter table hasura_functions.get_non_conflicting_activities_return_value
+  add column activity_id integer,
+  add column change_type activity_change_type,
+  add column source plan_snapshot_activities,
+  add column target activity_directive;
+alter table hasura_functions.begin_merge_return_value
+  add column merge_request_id integer,
+  add column non_conflicting_activities hasura_functions.get_non_conflicting_activities_return_value[],
+  add column conflicting_activities hasura_functions.get_conflicting_activities_return_value[];
+
+call migrations.mark_migration_applied('1');

--- a/merlin-server/sql/merlin/hasura_functions.sql
+++ b/merlin-server/sql/merlin/hasura_functions.sql
@@ -231,3 +231,91 @@ begin
     select * from hasura_functions.get_conflicting_activities(_merge_request_id);
 end
 $$;
+
+-- Hasura functions for handling anchors during delete
+create table hasura_functions.delete_anchor_return_value(
+  affected_row activity_directive,
+  change_type text
+);
+create function hasura_functions.delete_activity_by_pk_reanchor_plan_start(_activity_id int, _plan_id int)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+language plpgsql as $$
+  begin
+    if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+      raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+    end if;
+
+    return query
+      with updated as (
+        select public.anchor_direct_descendents_to_plan(_activity_id := _activity_id, _plan_id := _plan_id)
+      )
+      select updated.*, 'updated'
+        from updated;
+
+    return query
+      with deleted as (
+        delete from activity_directive where (id, plan_id) = (_activity_id, _plan_id) returning *
+      )
+      select (deleted.id, deleted.plan_id, deleted.name, deleted.tags, deleted.source_scheduling_goal_id,
+              deleted.created_at, deleted.last_modified_at, deleted.start_offset, deleted.type, deleted.arguments,
+              deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
+  end
+$$;
+
+create function hasura_functions.delete_activity_by_pk_reanchor_to_anchor(_activity_id int, _plan_id int)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+  language plpgsql as $$
+begin
+  if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+    raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+  end if;
+
+    return query
+      with updated as (
+        select public.anchor_direct_descendents_to_ancestor(_activity_id := _activity_id, _plan_id := _plan_id)
+      )
+      select updated.*, 'updated'
+        from updated;
+    return query
+      with deleted as (
+        delete from activity_directive where (id, plan_id) = (_activity_id, _plan_id) returning *
+      )
+      select (deleted.id, deleted.plan_id, deleted.name, deleted.tags, deleted.source_scheduling_goal_id,
+              deleted.created_at, deleted.last_modified_at, deleted.start_offset, deleted.type, deleted.arguments,
+              deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
+end
+$$;
+
+create function hasura_functions.delete_activity_by_pk_delete_subtree(_activity_id int, _plan_id int)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+  language plpgsql as $$
+begin
+  if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+    raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+  end if;
+
+  return query
+    with recursive
+      descendents(activity_id, p_id) as (
+          select _activity_id, _plan_id
+          from activity_directive ad
+          where (ad.id, ad.plan_id) = (_activity_id, _plan_id)
+        union
+          select ad.id, ad.plan_id
+          from activity_directive ad, descendents d
+          where (ad.anchor_id, ad.plan_id) = (d.activity_id, d.p_id)
+      ),
+      deleted as (
+          delete from activity_directive ad
+            using descendents
+            where (ad.plan_id, ad.id) = (_plan_id, descendents.activity_id)
+            returning *
+      )
+      select (deleted.id, deleted.plan_id, deleted.name, deleted.tags, deleted.source_scheduling_goal_id,
+              deleted.created_at, deleted.last_modified_at, deleted.start_offset, deleted.type, deleted.arguments,
+              deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
+end
+$$;

--- a/merlin-server/sql/merlin/init.sql
+++ b/merlin-server/sql/merlin/init.sql
@@ -22,6 +22,7 @@ begin;
   \ir tables/plan.sql
   \ir tables/activity_directive.sql
   \ir tables/activity_directive_validations.sql
+  \ir tables/anchor_validation_status.sql
   \ir tables/simulation_template.sql
   \ir tables/simulation.sql
 

--- a/merlin-server/sql/merlin/tables/anchor_validation_status.sql
+++ b/merlin-server/sql/merlin/tables/anchor_validation_status.sql
@@ -1,0 +1,321 @@
+create table anchor_validation_status(
+  activity_id integer not null,
+  plan_id integer not null,
+  reason_invalid text default null,
+  primary key (activity_id, plan_id),
+  foreign key (activity_id, plan_id)
+    references activity_directive
+    on update cascade
+    on delete cascade
+);
+
+create index anchor_validation_plan_id_index on anchor_validation_status (plan_id);
+
+comment on index anchor_validation_plan_id_index is e''
+  'A similar index to that on activity_directive, as we often want to filter by plan_id';
+
+comment on table anchor_validation_status is e''
+  'The validation status of the anchor of a single activity_directive within a plan.';
+comment on column anchor_validation_status.activity_id is e''
+  'The synthetic identifier for the activity_directive.\n'
+  'Unique within a given plan.';
+comment on column anchor_validation_status.plan_id is e''
+  'The plan within which the activity_directive is located';
+comment on column anchor_validation_status.reason_invalid is e''
+  'If null, the anchor is valid. If not null, this contains a reason why the anchor is invalid.';
+
+/*
+    An activity directive may have a negative offset from its anchor's start time.
+    If its anchor is anchored to the end time of another activity (or so on up the chain), the activity with a
+    negative offset must come out to have a positive offset relative to that end time anchor.
+*/
+create procedure validate_nonnegative_net_end_offset(_activity_id integer, _plan_id integer)
+  security definer
+  language plpgsql as $$
+declare
+  end_anchor_id integer;
+  offset_from_end_anchor interval;
+  _anchor_id integer;
+  _start_offset interval;
+  _anchored_to_start boolean;
+begin
+  select anchor_id, start_offset, anchored_to_start
+  from activity_directive
+  where (id, plan_id) = (_activity_id, _plan_id)
+  into _anchor_id, _start_offset, _anchored_to_start;
+
+  if (_anchor_id is not null)           -- if the activity is anchored to the plan, then it can't be anchored to the end of another activity directive
+  then
+    /*
+      Postgres ANDs don't "short-circuit" -- all clauses are evaluated. Therefore, this query is placed here so that
+      it only runs iff the outer 'if' is true
+    */
+    with recursive end_time_anchor(activity_id, anchor_id, anchored_to_start, start_offset, total_offset) as (
+      select _activity_id, _anchor_id, _anchored_to_start, _start_offset, _start_offset
+      union
+      select ad.id, ad.anchor_id, ad.anchored_to_start, ad.start_offset, eta.total_offset + ad.start_offset
+      from activity_directive ad, end_time_anchor eta
+      where (ad.id, ad.plan_id) = (eta.anchor_id, _plan_id)
+        and eta.anchor_id is not null                               -- stop at plan
+        and eta.anchored_to_start                                   -- or stop at end time anchor
+    ) select into end_anchor_id, offset_from_end_anchor
+        anchor_id, total_offset from end_time_anchor eta -- get the id of the activity that the selected activity is anchored to
+    where not eta.anchored_to_start and eta.anchor_id is not null
+    limit 1;
+
+    if end_anchor_id is not null and offset_from_end_anchor < '0' then
+      raise notice 'Activity Directive % has a net negative offset relative to an end-time anchor on Activity Directive %.', _activity_id, end_anchor_id;
+
+      insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+      values (_activity_id, _plan_id, 'Activity Directive ' || _activity_id || ' has a net negative offset relative to an end-time' ||
+                                      ' anchor on Activity Directive ' || end_anchor_id ||'.')
+      on conflict (activity_id, plan_id) do update
+        set reason_invalid = 'Activity Directive ' || excluded.activity_id || ' has a net negative offset relative to an end-time' ||
+                             ' anchor on Activity Directive ' || end_anchor_id ||'.';
+    end if;
+  end if;
+end
+$$;
+comment on procedure validate_nonnegative_net_end_offset(_activity_id integer, _plan_id integer) is e''
+  'Returns true if the specified activity has a net negative offset from a non-plan activity end-time anchor. Otherwise, returns false.\n'
+  'If true, writes to anchor_validation_status.';
+
+-- An activity may not have a start time before the plan
+create procedure validate_nonegative_net_plan_start(_activity_id integer, _plan_id integer)
+  security definer
+  language plpgsql as $$
+  declare
+    net_offset interval;
+    _anchor_id integer;
+    _start_offset interval;
+    _anchored_to_start boolean;
+  begin
+    select anchor_id, start_offset, anchored_to_start
+    from activity_directive
+    where (id, plan_id) = (_activity_id, _plan_id)
+    into _anchor_id, _start_offset, _anchored_to_start;
+
+    if (_start_offset < '0' and _anchored_to_start) then -- only need to check if anchored to start or something with a negative offset
+      with recursive anchors(activity_id, anchor_id, anchored_to_start, start_offset, total_offset) as (
+          select _activity_id, _anchor_id, _anchored_to_start, _start_offset, _start_offset
+        union
+          select ad.id, ad.anchor_id, ad.anchored_to_start, ad.start_offset, anchors.total_offset + ad.start_offset
+          from activity_directive ad, anchors
+          where anchors.anchor_id is not null                               -- stop at plan
+            and  (ad.id, ad.plan_id) = (anchors.anchor_id, _plan_id)
+            and anchors.anchored_to_start                                  -- or, stop at end-time offset
+      )
+      select total_offset  -- get the id of the activity that the selected activity is anchored to
+      from anchors a
+      where a.anchor_id is null
+        and a.anchored_to_start
+      limit 1
+      into net_offset;
+
+      if(net_offset < '0') then
+        raise notice 'Activity Directive % has a net negative offset relative to Plan Start.', _activity_id;
+
+        insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+        values (_activity_id, _plan_id, 'Activity Directive ' || _activity_id || ' has a net negative offset relative to Plan Start.')
+        on conflict (activity_id, plan_id) do update
+          set reason_invalid = 'Activity Directive ' || excluded.activity_id || ' has a net negative offset relative to Plan Start.';
+     end if;
+    end if;
+    end
+  $$;
+comment on procedure validate_nonegative_net_plan_start(_activity_id integer, _plan_id integer) is e''
+  'Returns true if the specified activity has a net negative offset from plan start. Otherwise, returns false.\n'
+  'If true, writes to anchor_validation_status.';
+
+/*
+  When an activity directive is anchored to another activity directive's end time, it must simplify to a positive offset,
+  as simulation can't handle a negative offset (since simulation won't know its start time until the anchoring activity has finished,
+  which will always place the anchored activity's start time in the past)
+
+  Throws an exception if:
+    - The activity is anchored to itself
+    - A cycle is detected
+  For all other invalid states, it writes to 'anchor_validation_status's 'reason_invalid' field and then returns.
+  If the activity's anchor is valid, then the 'reason_invalid' field on the activity's entry in 'anchor_validation_status' is set to ''.
+*/
+create function validate_anchors()
+  returns trigger
+  security definer
+  language plpgsql as $$
+declare
+  end_anchor_id integer;
+  invalid_descendant_act_ids integer[];
+  offset_from_end_anchor interval;
+  offset_from_plan_start interval;
+begin
+  -- Clear the reason invalid field (if an exception is thrown, this will be rolled back)
+  insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+  values (new.id, new.plan_id, '')
+  on conflict (activity_id, plan_id) do update
+    set reason_invalid = '';
+
+  -- An activity cannot anchor to itself
+  if(new.anchor_id = new.id) then
+    raise exception 'Cannot anchor activity % to itself.', new.anchor_id;
+  end if;
+
+  -- Validate that no cycles were added
+  if exists(
+      with recursive history(activity_id, anchor_id, is_cycle, path) as (
+        select new.id, new.anchor_id, false, array[new.id]
+        union all
+        select ad.id, ad.anchor_id,
+               ad.id = any(path),
+               path || ad.id
+        from activity_directive ad, history h
+        where (ad.id, ad.plan_id) = (h.anchor_id, new.plan_id)
+          and not is_cycle
+      ) select * from history
+      where is_cycle
+      limit 1
+    ) then
+    raise exception 'Cycle detected. Cannot apply changes.';
+  end if;
+
+  /*
+    An activity directive may have a negative offset from its anchor's start time.
+    If its anchor is anchored to the end time of another activity (or so on up the chain), the activity with a
+    negative offset must come out to have a positive offset relative to that end time anchor.
+  */
+  call validate_nonnegative_net_end_offset(new.id, new.plan_id);
+  call validate_nonegative_net_plan_start(new.id, new.plan_id);
+
+  /*
+    Everything below validates that the activities anchored to this one did not become invalid as a result of these changes.
+
+    This only checks descendent start-time anchors, as we know that the state after an end-time anchor is valid
+    (As if it no longer is, it will be caught when that activity's row is processed by this trigger)
+  */
+  -- Get collection of dependent activities, with offset relative to this activity
+  create temp table dependent_activities as
+  with recursive d_activities(activity_id, anchor_id, anchored_to_start, start_offset, total_offset) as (
+      select ad.id, ad.anchor_id, ad.anchored_to_start, ad.start_offset, ad.start_offset
+      from activity_directive ad
+      where (ad.anchor_id, ad.plan_id) = (new.id, new.plan_id) -- select all activities anchored to this one
+    union
+      select ad.id, ad.anchor_id, ad.anchored_to_start, ad.start_offset, da.total_offset + ad.start_offset
+      from activity_directive ad, d_activities da
+      where (ad.anchor_id, ad.plan_id) = (da.activity_id, new.plan_id) -- select all activities anchored to those in the selection
+        and ad.anchored_to_start  -- stop at next end-time anchor
+  ) select activity_id, total_offset
+  from d_activities da;
+
+  -- Get the total offset from the most recent end-time anchor earlier in this activity's chain (or null if there is none)
+  with recursive end_time_anchor(activity_id, anchor_id, anchored_to_start, start_offset, total_offset) as (
+    select new.id, new.anchor_id, new.anchored_to_start, new.start_offset, new.start_offset
+    union
+    select ad.id, ad.anchor_id, ad.anchored_to_start, ad.start_offset, eta.total_offset + ad.start_offset
+    from activity_directive ad, end_time_anchor eta
+    where (ad.id, ad.plan_id) = (eta.anchor_id, new.plan_id)
+      and eta.anchor_id is not null                               -- stop at plan
+      and eta.anchored_to_start                                   -- or stop at end time anchor
+  ) select into end_anchor_id, offset_from_end_anchor
+        anchor_id, total_offset from end_time_anchor eta -- get the id of the activity that the selected activity is anchored to
+  where not eta.anchored_to_start and eta.anchor_id is not null
+  limit 1;
+
+  -- Not null iff the activity being looked at has some end anchor to another activity in its chain
+  if offset_from_end_anchor is not null then
+    select array_agg(activity_id) from dependent_activities
+    where total_offset + offset_from_end_anchor < '0'
+    into invalid_descendant_act_ids;
+
+    if invalid_descendant_act_ids is not null then
+      raise info 'The following Activity Directives now have a net negative offset relative to an end-time anchor on Activity Directive %: % \n'
+        'There may be additional activities that are invalid relative to this activity.',
+        end_anchor_id, array_to_string(invalid_descendant_act_ids, ',');
+
+      insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+      select id, new.plan_id, 'Activity Directive ' || id || ' has a net negative offset relative to an end-time' ||
+                              ' anchor on Activity Directive ' || end_anchor_id ||'.'
+      from unnest(invalid_descendant_act_ids) as id
+      on conflict (activity_id, plan_id) do update
+      set reason_invalid = 'Activity Directive ' || excluded.activity_id || ' has a net negative offset relative to an end-time' ||
+                           ' anchor on Activity Directive ' || end_anchor_id ||'.';
+    end if;
+  end if;
+
+  -- Gets the total offset from plan start (or null if there's an end-time anchor in the way)
+  with recursive anchors(activity_id, anchor_id, anchored_to_start, start_offset, total_offset) as (
+    select new.id, new.anchor_id, new.anchored_to_start, new.start_offset, new.start_offset
+    union
+    select ad.id, ad.anchor_id, ad.anchored_to_start, ad.start_offset, anchors.total_offset + ad.start_offset
+    from activity_directive ad, anchors
+    where anchors.anchor_id is not null                               -- stop at plan
+      and (ad.id, ad.plan_id) = (anchors.anchor_id, new.plan_id)
+      and anchors.anchored_to_start                                  -- or, stop at end-time offset
+  )
+  select total_offset  -- get the id of the activity that the selected activity is anchored to
+  from anchors a
+  where a.anchor_id is null
+    and a.anchored_to_start
+  limit 1
+  into offset_from_plan_start;
+
+  -- Not null iff the activity being looked at is connected to plan start via a chain of start anchors
+  if offset_from_plan_start is not null then
+    -- Validate descendents
+    invalid_descendant_act_ids := null;
+    select array_agg(activity_id) from dependent_activities
+    where total_offset + offset_from_plan_start < '0' into invalid_descendant_act_ids;  -- grab all and split
+
+    if invalid_descendant_act_ids is not null then
+      raise info 'The following Activity Directives now have a net negative offset relative to Plan Start: % \n'
+        'There may be additional activities that are invalid relative to this activity.',
+        array_to_string(invalid_descendant_act_ids, ',');
+
+      insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+      select id, new.plan_id, 'Activity Directive ' || id || ' has a net negative offset relative to Plan Start.'
+      from unnest(invalid_descendant_act_ids) as id
+      on conflict (activity_id, plan_id) do update
+        set reason_invalid = 'Activity Directive ' || excluded.activity_id || ' has a net negative offset relative to Plan Start.';
+    end if;
+  end if;
+
+  -- These are both null iff the activity is anchored to plan end
+  if(offset_from_plan_start is null and offset_from_end_anchor is null) then
+    -- All dependent activities should have no errors, as Plan End can have an offset of any value.
+    insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+    select da.activity_id, new.plan_id, ''
+    from dependent_activities as da
+    on conflict (activity_id, plan_id) do update
+      set reason_invalid = '';
+  end if;
+
+  -- Remove the error from the dependent activities that wouldn't have been flagged by the earlier checks.
+  insert into anchor_validation_status (activity_id, plan_id, reason_invalid)
+  select da.activity_id, new.plan_id, ''
+  from dependent_activities as da
+  where total_offset + offset_from_plan_start >= '0'
+    or total_offset + offset_from_end_anchor >= '0' -- only one of these checks will run depending on which one has `null` behind the offset
+  on conflict (activity_id, plan_id) do update
+    set reason_invalid = '';
+
+  drop table dependent_activities;
+  return new;
+end $$;
+
+create constraint trigger validate_anchors_update_trigger
+  after update
+  on activity_directive
+  deferrable initially deferred
+  for each row
+  when (old.anchor_id is distinct from new.anchor_id -- != but allows for one side to be null
+    or old.anchored_to_start != new.anchored_to_start
+    or old.start_offset != new.start_offset)
+execute procedure validate_anchors();
+
+
+--  The insert trigger is separate in order to allow the update trigger to have a 'when' clause
+create constraint trigger validate_anchors_insert_trigger
+  after insert
+  on activity_directive
+  deferrable initially deferred
+  for each row
+execute procedure validate_anchors();
+


### PR DESCRIPTION
* **Tickets addressed:** Closes #449
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This is the database changes to allow for anchors.

Changes to DB: 
- adds the `anchor_ID` and `anchored_to_start` columns to `activity_directives`, `plan_snapshot_activities`, and `merge_staging_area`.
- adds a new table, `anchor_validation_status`. The `reason_invalid` column contains the reason why an activity's anchor is invalid.
- removes the "start time offsets must be nonnegative" constraints on tables `activity_directives` and `merge_staging_area`
- adds new constraint "anchor_in_plan" to `activity_directives`
- adds new functions in `hasura_functions` to resolve how to handle any activities anchored to an activity getting deleted

Note: `validate_anchors` raises INFO-level notes when it finds a invalid anchor that doesn't throw an exception (right before it writes to `anchor_validation_status`).

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
- DatabaseTestHelper was modified to give `aerie` USAGE access on all schemas in a test database. Prior to this, it only had access to the `public` schema
- AnchorTests was created
- PlanCollaborationTests was modified:
     - Anchor-related fields are also tracked and checked during existing tests
     - AnchorMergeTests were added to test edge cases that can occur from merging plans

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Updates to the simulation engine to use the relative offsets
