### PR TITLE
Add schema_migrations table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ node_modules
 deployment/postgres-init-db/sql/**/*.sql
 !deployment/postgres-init-db/sql/ui/init.sql
 !deployment/postgres-init-db/sql/ui/tables/view.sql
+!deployment/postgres-init-db/sql/ui/tables/schema_migrations.sql
+!deployment/postgres-init-db/sql/ui/applied_migrations.sql
 
 # Ignore Gradle project-specific cache directory
 .gradle

--- a/deployment/hasura/migrations/AerieMerlin/0_create_schema_migrations/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/0_create_schema_migrations/up.sql
@@ -1,0 +1,33 @@
+create schema migrations;
+create table migrations.schema_migrations (
+  migration_id varchar primary key
+);
+
+create procedure migrations.mark_migration_applied(_migration_id varchar)
+  language plpgsql as $$
+begin
+insert into migrations.schema_migrations (migration_id)
+values (_migration_id);
+end;
+$$;
+
+create procedure migrations.mark_migration_rolled_back(_migration_id varchar)
+  language plpgsql as $$
+begin
+delete from migrations.schema_migrations
+where migration_id = _migration_id;
+end;
+$$;
+
+comment on schema migrations is e''
+  'Tables and procedures associated with tracking schema migrations';
+comment on table migrations.schema_migrations is e''
+  'Tracks what migrations have been applied';
+comment on column migrations.schema_migrations.migration_id is e''
+'An identifier for a migration that has been applied';
+comment on procedure migrations.mark_migration_applied is e''
+  'Given an identifier for a migration, add that migration to the applied set';
+comment on procedure migrations.mark_migration_rolled_back is e''
+  'Given an identifier for a migration, remove that migration from the applied set';
+
+call migrations.mark_migration_applied('0');

--- a/deployment/hasura/migrations/AerieScheduler/0_create_schema_migrations/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/0_create_schema_migrations/up.sql
@@ -1,0 +1,33 @@
+create schema migrations;
+create table migrations.schema_migrations (
+  migration_id varchar primary key
+);
+
+create procedure migrations.mark_migration_applied(_migration_id varchar)
+  language plpgsql as $$
+begin
+insert into migrations.schema_migrations (migration_id)
+values (_migration_id);
+end;
+$$;
+
+create procedure migrations.mark_migration_rolled_back(_migration_id varchar)
+  language plpgsql as $$
+begin
+delete from migrations.schema_migrations
+where migration_id = _migration_id;
+end;
+$$;
+
+comment on schema migrations is e''
+  'Tables and procedures associated with tracking schema migrations';
+comment on table migrations.schema_migrations is e''
+  'Tracks what migrations have been applied';
+comment on column migrations.schema_migrations.migration_id is e''
+'An identifier for a migration that has been applied';
+comment on procedure migrations.mark_migration_applied is e''
+  'Given an identifier for a migration, add that migration to the applied set';
+comment on procedure migrations.mark_migration_rolled_back is e''
+  'Given an identifier for a migration, remove that migration from the applied set';
+
+call migrations.mark_migration_applied('0');

--- a/deployment/hasura/migrations/AerieSequencing/0_create_schema_migrations/up.sql
+++ b/deployment/hasura/migrations/AerieSequencing/0_create_schema_migrations/up.sql
@@ -1,0 +1,33 @@
+create schema migrations;
+create table migrations.schema_migrations (
+  migration_id varchar primary key
+);
+
+create procedure migrations.mark_migration_applied(_migration_id varchar)
+  language plpgsql as $$
+begin
+insert into migrations.schema_migrations (migration_id)
+values (_migration_id);
+end;
+$$;
+
+create procedure migrations.mark_migration_rolled_back(_migration_id varchar)
+  language plpgsql as $$
+begin
+delete from migrations.schema_migrations
+where migration_id = _migration_id;
+end;
+$$;
+
+comment on schema migrations is e''
+  'Tables and procedures associated with tracking schema migrations';
+comment on table migrations.schema_migrations is e''
+  'Tracks what migrations have been applied';
+comment on column migrations.schema_migrations.migration_id is e''
+'An identifier for a migration that has been applied';
+comment on procedure migrations.mark_migration_applied is e''
+  'Given an identifier for a migration, add that migration to the applied set';
+comment on procedure migrations.mark_migration_rolled_back is e''
+  'Given an identifier for a migration, remove that migration from the applied set';
+
+call migrations.mark_migration_applied('0');

--- a/deployment/hasura/migrations/AerieUI/0_create_schema_migrations/up.sql
+++ b/deployment/hasura/migrations/AerieUI/0_create_schema_migrations/up.sql
@@ -1,0 +1,33 @@
+create schema migrations;
+create table migrations.schema_migrations (
+  migration_id varchar primary key
+);
+
+create procedure migrations.mark_migration_applied(_migration_id varchar)
+  language plpgsql as $$
+begin
+insert into migrations.schema_migrations (migration_id)
+values (_migration_id);
+end;
+$$;
+
+create procedure migrations.mark_migration_rolled_back(_migration_id varchar)
+  language plpgsql as $$
+begin
+delete from migrations.schema_migrations
+where migration_id = _migration_id;
+end;
+$$;
+
+comment on schema migrations is e''
+  'Tables and procedures associated with tracking schema migrations';
+comment on table migrations.schema_migrations is e''
+  'Tracks what migrations have been applied';
+comment on column migrations.schema_migrations.migration_id is e''
+'An identifier for a migration that has been applied';
+comment on procedure migrations.mark_migration_applied is e''
+  'Given an identifier for a migration, add that migration to the applied set';
+comment on procedure migrations.mark_migration_rolled_back is e''
+  'Given an identifier for a migration, remove that migration from the applied set';
+
+call migrations.mark_migration_applied('0');

--- a/deployment/postgres-init-db/sql/ui/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/ui/applied_migrations.sql
@@ -1,0 +1,5 @@
+/*
+This file denotes which migrations occur "before" this version of the schema.
+*/
+
+call migrations.mark_migration_applied('0');

--- a/deployment/postgres-init-db/sql/ui/init.sql
+++ b/deployment/postgres-init-db/sql/ui/init.sql
@@ -1,4 +1,8 @@
 begin;
+  -- Schema migrations
+  \ir tables/schema_migrations.sql
+  \ir applied_migrations.sql
+
   -- Tables.
   \ir tables/view.sql
 end;

--- a/deployment/postgres-init-db/sql/ui/tables/schema_migrations.sql
+++ b/deployment/postgres-init-db/sql/ui/tables/schema_migrations.sql
@@ -1,0 +1,31 @@
+create schema migrations;
+create table migrations.schema_migrations (
+  migration_id varchar primary key
+);
+
+create procedure migrations.mark_migration_applied(_migration_id varchar)
+language plpgsql as $$
+begin
+  insert into migrations.schema_migrations (migration_id)
+  values (_migration_id);
+end;
+$$;
+
+create procedure migrations.mark_migration_rolled_back(_migration_id varchar)
+language plpgsql as $$
+begin
+  delete from migrations.schema_migrations
+  where migration_id = _migration_id;
+end;
+$$;
+
+comment on schema migrations is e''
+  'Tables and procedures associated with tracking schema migrations';
+comment on table migrations.schema_migrations is e''
+  'Tracks what migrations have been applied';
+comment on column migrations.schema_migrations.migration_id is e''
+  'An identifier for a migration that has been applied';
+comment on procedure migrations.mark_migration_applied is e''
+  'Given an identifier for a migration, add that migration to the applied set';
+comment on procedure migrations.mark_migration_rolled_back is e''
+  'Given an identifier for a migration, remove that migration from the applied set';

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -1,0 +1,5 @@
+/*
+This file denotes which migrations occur "before" this version of the schema.
+*/
+
+call migrations.mark_migration_applied('0');

--- a/merlin-server/sql/merlin/init.sql
+++ b/merlin-server/sql/merlin/init.sql
@@ -1,6 +1,10 @@
 -- The order of inclusion is important! Tables referenced by foreign keys must be loaded before their dependants.
 
 begin;
+  -- Schema migrations
+  \ir tables/schema_migrations.sql
+  \ir applied_migrations.sql
+
   -- Domain types.
   \ir domain-types/merlin-arguments.sql
   \ir domain-types/merlin-activity-directive-metadata.sql

--- a/merlin-server/sql/merlin/tables/schema_migrations.sql
+++ b/merlin-server/sql/merlin/tables/schema_migrations.sql
@@ -1,0 +1,31 @@
+create schema migrations;
+create table migrations.schema_migrations (
+  migration_id varchar primary key
+);
+
+create procedure migrations.mark_migration_applied(_migration_id varchar)
+language plpgsql as $$
+begin
+  insert into migrations.schema_migrations (migration_id)
+  values (_migration_id);
+end;
+$$;
+
+create procedure migrations.mark_migration_rolled_back(_migration_id varchar)
+language plpgsql as $$
+begin
+  delete from migrations.schema_migrations
+  where migration_id = _migration_id;
+end;
+$$;
+
+comment on schema migrations is e''
+  'Tables and procedures associated with tracking schema migrations';
+comment on table migrations.schema_migrations is e''
+  'Tracks what migrations have been applied';
+comment on column migrations.schema_migrations.migration_id is e''
+  'An identifier for a migration that has been applied';
+comment on procedure migrations.mark_migration_applied is e''
+  'Given an identifier for a migration, add that migration to the applied set';
+comment on procedure migrations.mark_migration_rolled_back is e''
+  'Given an identifier for a migration, remove that migration from the applied set';

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -1,0 +1,5 @@
+/*
+This file denotes which migrations occur "before" this version of the schema.
+*/
+
+call migrations.mark_migration_applied('0');

--- a/scheduler-server/sql/scheduler/init.sql
+++ b/scheduler-server/sql/scheduler/init.sql
@@ -1,6 +1,10 @@
 -- The order of inclusion is important! Tables referenced by foreign keys must be loaded before their dependants.
 
 begin;
+  -- Schema migrations
+  \ir tables/schema_migrations.sql
+  \ir applied_migrations.sql
+
   -- Scheduling intents.
   \ir tables/scheduling_goal.sql
   \ir tables/scheduling_template.sql

--- a/scheduler-server/sql/scheduler/tables/schema_migrations.sql
+++ b/scheduler-server/sql/scheduler/tables/schema_migrations.sql
@@ -1,0 +1,31 @@
+create schema migrations;
+create table migrations.schema_migrations (
+  migration_id varchar primary key
+);
+
+create procedure migrations.mark_migration_applied(_migration_id varchar)
+language plpgsql as $$
+begin
+  insert into migrations.schema_migrations (migration_id)
+  values (_migration_id);
+end;
+$$;
+
+create procedure migrations.mark_migration_rolled_back(_migration_id varchar)
+language plpgsql as $$
+begin
+  delete from migrations.schema_migrations
+  where migration_id = _migration_id;
+end;
+$$;
+
+comment on schema migrations is e''
+  'Tables and procedures associated with tracking schema migrations';
+comment on table migrations.schema_migrations is e''
+  'Tracks what migrations have been applied';
+comment on column migrations.schema_migrations.migration_id is e''
+  'An identifier for a migration that has been applied';
+comment on procedure migrations.mark_migration_applied is e''
+  'Given an identifier for a migration, add that migration to the applied set';
+comment on procedure migrations.mark_migration_rolled_back is e''
+  'Given an identifier for a migration, remove that migration from the applied set';

--- a/sequencing-server/sql/sequencing/applied_migrations.sql
+++ b/sequencing-server/sql/sequencing/applied_migrations.sql
@@ -1,0 +1,5 @@
+/*
+This file denotes which migrations occur "before" this version of the schema.
+*/
+
+call migrations.mark_migration_applied('0');

--- a/sequencing-server/sql/sequencing/init.sql
+++ b/sequencing-server/sql/sequencing/init.sql
@@ -1,6 +1,9 @@
 -- The order of inclusion is important! Tables referenced by foreign keys must be loaded before their dependants.
 
 begin;
+  -- Schema migrations
+  \ir tables/schema_migrations.sql
+  \ir applied_migrations.sql
 
   -- Command Expansion Tables.
   \ir tables/command_dictionary.sql

--- a/sequencing-server/sql/sequencing/tables/schema_migrations.sql
+++ b/sequencing-server/sql/sequencing/tables/schema_migrations.sql
@@ -1,0 +1,31 @@
+create schema migrations;
+create table migrations.schema_migrations (
+  migration_id varchar primary key
+);
+
+create procedure migrations.mark_migration_applied(_migration_id varchar)
+language plpgsql as $$
+begin
+  insert into migrations.schema_migrations (migration_id)
+  values (_migration_id);
+end;
+$$;
+
+create procedure migrations.mark_migration_rolled_back(_migration_id varchar)
+language plpgsql as $$
+begin
+  delete from migrations.schema_migrations
+  where migration_id = _migration_id;
+end;
+$$;
+
+comment on schema migrations is e''
+  'Tables and procedures associated with tracking schema migrations';
+comment on table migrations.schema_migrations is e''
+  'Tracks what migrations have been applied';
+comment on column migrations.schema_migrations.migration_id is e''
+  'An identifier for a migration that has been applied';
+comment on procedure migrations.mark_migration_applied is e''
+  'Given an identifier for a migration, add that migration to the applied set';
+comment on procedure migrations.mark_migration_rolled_back is e''
+  'Given an identifier for a migration, remove that migration from the applied set';


### PR DESCRIPTION
* **Tickets addressed:** This is related to #521 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR adds the `schema_migrations` table to each of our four databases. It does it both by creating a migration, and by editing the latest schema.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I brought up a fresh database using the latest schema, and checked that there were no SQL errors. I then visually inspected the database to see that the table was present.

I then brought down the system, removed volumes, checked out develop, and brought it up again. I then checked out this branch, and used our aerie_db_migrations script to apply the new migrations. I checked that no SQL errors occurred, and did another visual inspection of the database.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
For now, the existing migrations documentation continues to apply. When we get around to modifying the `aerie_db_migrations` script we may want to include documentation on how it leverages the contents of the `schema_migrations` tables.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Automated migration testing