### PR TITLE
Add QEMU and buildx action for multi-arch container images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,12 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       # Build, scan, and push aerie-hasura Docker artifacts.
       - name: Extract metadata (tags, labels) for aerie-hasura Docker image
         id: aerieHasura
@@ -71,6 +77,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile.hasura
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aerieHasura.outputs.tags }}
           labels: ${{ steps.aerieHasura.outputs.labels }}
@@ -98,6 +105,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./merlin-server
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aerieMerlin.outputs.tags }}
           labels: ${{ steps.aerieMerlin.outputs.labels }}
@@ -125,6 +133,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./merlin-worker
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aerieMerlinWorker.outputs.tags }}
           labels: ${{ steps.aerieMerlinWorker.outputs.labels }}
@@ -154,6 +163,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile.postgres
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aeriePostgres.outputs.tags }}
           labels: ${{ steps.aeriePostgres.outputs.labels }}
@@ -181,6 +191,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./scheduler-worker
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aerieSchedulerWorker.outputs.tags }}
           labels: ${{ steps.aerieSchedulerWorker.outputs.labels }}
@@ -208,6 +219,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./scheduler-server
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aerieScheduler.outputs.tags }}
           labels: ${{ steps.aerieScheduler.outputs.labels }}
@@ -235,6 +247,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./sequencing-server
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.aerieSequencing.outputs.tags }}
           labels: ${{ steps.aerieSequencing.outputs.labels }}


### PR DESCRIPTION
* **Tickets addressed:** resolves #555 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Adds `buildx` support to our `publish` pipeline to allow multi-arch (amd64, arm64, etc) images to be built. Uses QEMU to emulate architectures, since the built-in QEMU emulation in buildx fails otherwise. See #576 .

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Changes were applied to a [fork](https://github.com/skovati/testing/actions/runs/3877220045/jobs/6611978486) to make sure the action worked as intended.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A