### PR TITLE
Enable jacocoTestReport task for all java subprojects

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,6 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-      - name: Build Classes
-        run: ./gradlew classes
       - name: Assemble
         run: ./gradlew assemble
       - name: Validate Docker Configurations
@@ -52,32 +50,37 @@ jobs:
           AERIE_PASSWORD: "${{secrets.AERIE_PASSWORD}}"
           POSTGRES_USER: "${{secrets.POSTGRES_USER}}"
           POSTGRES_PASSWORD: "${{secrets.POSTGRES_PASSWORD}}"
-      - name: Sleep for 30 Seconds
-        run: sleep 30s
+      - name: Sleep for 15 Seconds
+        run: sleep 15s
         shell: bash
       - name: Run Unit Tests
         run: ./gradlew test
       - name: Run E2E Tests
         run: ./gradlew e2eTest
-      - name: Report JUnit Test Results
-        uses: dorny/test-reporter@v1
-        if: always()
-        with:
-          name: ☕ JUnit Results
-          path: "**/build/test-results/**/TEST-*.xml"
-          reporter: java-junit
-      - name: Upload JUnit Test Results
+      - name: Upload Test Results as XML
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ☕ JUnit Results
-          path: "**/build/test-results/**/TEST-*.xml"
-      - name: Upload Playwright Test Results
+          name: Test Results
+          path: "**/build/test-results/test"
+      - name: Upload Test Results as HTML
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: 🎭 Playwright Results
-          path: ./e2e-tests/test-results
+          name: Test Results
+          path: "**/build/reports/tests/test"
+      - name: Upload E2E Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test Results
+          path: "**/e2e-tests/test-results"
+      - name: Upload Sequencing Server Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test Results
+          path: "**/sequencing-server/test-report.html"
       - name: Print Logs for Services
         run: docker compose -f ./e2e-tests/docker-compose-test.yml logs -t
       - name: Stop Services

--- a/constraints/build.gradle
+++ b/constraints/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'java-library'
+  id 'jacoco'
 }
 
 java {
@@ -10,6 +11,13 @@ java {
 
 test {
   useJUnitPlatform()
+}
+
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
 }
 
 repositories {

--- a/contrib/build.gradle
+++ b/contrib/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id 'java-library'
   id 'maven-publish'
+  id 'jacoco'
 }
 
 java {
@@ -14,6 +15,13 @@ java {
 
 test {
   useJUnitPlatform()
+}
+
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
 }
 
 // Link references to standard Java classes to the official Java 11 documentation.

--- a/db-tests/build.gradle
+++ b/db-tests/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'java-library'
+  id 'jacoco'
 }
 
 java {
@@ -10,6 +11,13 @@ java {
 
 test {
   useJUnitPlatform()
+}
+
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
 }
 
 task e2eTest(type: Test) {

--- a/examples/banananation/build.gradle
+++ b/examples/banananation/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id 'java-library'
   id 'maven-publish'
+  id 'jacoco'
 }
 
 java {
@@ -11,6 +12,13 @@ java {
 
 test {
   useJUnitPlatform()
+}
+
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
 }
 
 // The runtime environment this JAR will be deployed to doesn't know what this model depends on.

--- a/examples/config-with-defaults/build.gradle
+++ b/examples/config-with-defaults/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'java-library'
+  id 'jacoco'
 }
 
 java {
@@ -18,6 +19,13 @@ jar {
 
 test {
   useJUnitPlatform()
+}
+
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
 }
 
 dependencies {

--- a/examples/config-without-defaults/build.gradle
+++ b/examples/config-without-defaults/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'java-library'
+  id 'jacoco'
 }
 
 java {
@@ -18,6 +19,13 @@ jar {
 
 test {
   useJUnitPlatform()
+}
+
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
 }
 
 dependencies {

--- a/examples/foo-missionmodel/build.gradle
+++ b/examples/foo-missionmodel/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'java-library'
+  id 'jacoco'
 }
 
 java {
@@ -18,6 +19,13 @@ jar {
 
 test {
   useJUnitPlatform()
+}
+
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
 }
 
 dependencies {

--- a/merlin-driver/build.gradle
+++ b/merlin-driver/build.gradle
@@ -19,7 +19,12 @@ test {
   }
 }
 
-jacocoTestReport.dependsOn test
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
+}
 
 // Link references to standard Java classes to the official Java 11 documentation.
 javadoc.options.links 'https://docs.oracle.com/en/java/javase/11/docs/api/'

--- a/merlin-framework/build.gradle
+++ b/merlin-framework/build.gradle
@@ -17,7 +17,12 @@ test {
   useJUnitPlatform()
 }
 
-jacocoTestReport.dependsOn test
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
+}
 
 // Link references to standard Java classes to the official Java 11 documentation.
 javadoc.options.links 'https://docs.oracle.com/en/java/javase/11/docs/api/'

--- a/merlin-sdk/build.gradle
+++ b/merlin-sdk/build.gradle
@@ -17,7 +17,12 @@ test {
   useJUnitPlatform()
 }
 
-jacocoTestReport.dependsOn test
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
+}
 
 javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 

--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -2,6 +2,7 @@ plugins {
   id 'java'
   id 'application'
   id 'com.github.node-gradle.node' version '3.5.0'
+  id 'jacoco'
 }
 
 java {
@@ -73,6 +74,13 @@ test {
 
   environment "CONSTRAINTS_DSL_COMPILER_ROOT", projectDir.toPath().resolve('constraints-dsl-compiler')
   environment "CONSTRAINTS_DSL_COMPILER_COMMAND", './build/main.js'
+}
+
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
 }
 
 application {

--- a/parsing-utilities/build.gradle
+++ b/parsing-utilities/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id 'java-library'
   id 'maven-publish'
+  id 'jacoco'
 }
 
 java {
@@ -11,6 +12,13 @@ java {
 
 test {
   useJUnitPlatform()
+}
+
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
 }
 
 dependencies {

--- a/scheduler-driver/build.gradle
+++ b/scheduler-driver/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'java-library'
+  id 'jacoco'
 }
 
 java {
@@ -10,6 +11,13 @@ java {
 
 test {
   useJUnitPlatform()
+}
+
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
 }
 
 dependencies {

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -4,6 +4,7 @@ plugins {
   id 'java'
   id 'java-test-fixtures'
   id 'application'
+  id 'jacoco'
 }
 
 java {
@@ -54,5 +55,12 @@ test {
   testLogging {
       events 'passed', 'skipped', 'failed'
       exceptionFormat 'full'
+  }
+}
+
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
   }
 }

--- a/scheduler-worker/build.gradle
+++ b/scheduler-worker/build.gradle
@@ -2,6 +2,7 @@ plugins {
   id 'java'
   id 'application'
   id 'com.github.node-gradle.node' version '3.5.0'
+  id 'jacoco'
 }
 
 java {
@@ -98,6 +99,13 @@ test {
 
   dependsOn ":examples:banananation:assemble"
   environment 'AERIE_ROOT', rootDir.toString()
+}
+
+jacocoTestReport {
+  dependsOn test
+  reports {
+    xml.required = true
+  }
 }
 
 application {


### PR DESCRIPTION
* **Tickets addressed:** Closes https://github.com/NASA-AMMOS/aerie/issues/583
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
To help with putting together resources for our MGSS Test Readiness Review, this PR adds the `jacocoTestReport` task to every java subproject.

The html report will be placed in `<SUBPROJECT>/build/reports/jacoco/test/html`

This coverage report is generated per subproject in isolation - so tests in one subproject that exercise code in another subproject won't be counted. We decided that this is actually desirable for the purposes of this test package.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Manually verified that running `./gradlew jacocoTestReport` triggers the `test` task for any subprojects for which that task is out of date, and then produces reports in the directory described above.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs in this PR, though perhaps this could be worth mentioning in developer-facing docs

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Incorporate this into workflows for test report generation.
