### PR TITLE
Move clearTable to DatabaseTestHelper

### DIFF
--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/CommandExpansionDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/CommandExpansionDatabaseTests.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.database;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,13 @@ class CommandExpansionDatabaseTests {
     helper.stopDatabase();
     connection = null;
     helper = null;
+  }
+
+  @AfterEach
+  void afterEach() throws SQLException {
+    helper.clearTable("expansion_rule");
+    helper.clearTable("sequence");
+    helper.clearTable("sequence_to_simulated_activity");
   }
 
   @Nested

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/DatabaseTestHelper.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/DatabaseTestHelper.java
@@ -111,4 +111,10 @@ public class DatabaseTestHelper {
   public Connection connection() {
     return connection;
   }
+
+  public void clearTable(String table) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      statement.executeUpdate("TRUNCATE " + table + " CASCADE;");
+    }
+  }
 }

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MerlinDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MerlinDatabaseTests.java
@@ -202,12 +202,6 @@ class MerlinDatabaseTests {
     }
   }
 
-  void clearTable(String table) throws SQLException {
-    try (final var statement = connection.createStatement()) {
-      statement.executeUpdate("TRUNCATE " + table + " CASCADE;");
-    }
-  }
-
   int fileId;
   int missionModelId;
   int planId;
@@ -235,15 +229,15 @@ class MerlinDatabaseTests {
 
   @AfterEach
   void afterEach() throws SQLException {
-    clearTable("uploaded_file");
-    clearTable("mission_model");
-    clearTable("plan");
-    clearTable("activity_directive");
-    clearTable("simulation_template");
-    clearTable("simulation");
-    clearTable("dataset");
-    clearTable("plan_dataset");
-    clearTable("simulation_dataset");
+    helper.clearTable("uploaded_file");
+    helper.clearTable("mission_model");
+    helper.clearTable("plan");
+    helper.clearTable("activity_directive");
+    helper.clearTable("simulation_template");
+    helper.clearTable("simulation");
+    helper.clearTable("dataset");
+    helper.clearTable("plan_dataset");
+    helper.clearTable("simulation_dataset");
   }
 
   @Nested

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PlanCollaborationTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PlanCollaborationTests.java
@@ -56,22 +56,22 @@ public class PlanCollaborationTests {
 
   @AfterEach
   void afterEach() throws SQLException {
-    clearTable("uploaded_file");
-    clearTable("mission_model");
-    clearTable("plan");
-    clearTable("activity_directive");
-    clearTable("simulation_template");
-    clearTable("simulation");
-    clearTable("dataset");
-    clearTable("plan_dataset");
-    clearTable("simulation_dataset");
-    clearTable("plan_snapshot");
-    clearTable("plan_latest_snapshot");
-    clearTable("plan_snapshot_activities");
-    clearTable("plan_snapshot_parent");
-    clearTable("merge_request");
-    clearTable("merge_staging_area");
-    clearTable("conflicting_activities");
+    helper.clearTable("uploaded_file");
+    helper.clearTable("mission_model");
+    helper.clearTable("plan");
+    helper.clearTable("activity_directive");
+    helper.clearTable("simulation_template");
+    helper.clearTable("simulation");
+    helper.clearTable("dataset");
+    helper.clearTable("plan_dataset");
+    helper.clearTable("simulation_dataset");
+    helper.clearTable("plan_snapshot");
+    helper.clearTable("plan_latest_snapshot");
+    helper.clearTable("plan_snapshot_activities");
+    helper.clearTable("plan_snapshot_parent");
+    helper.clearTable("merge_request");
+    helper.clearTable("merge_staging_area");
+    helper.clearTable("conflicting_activities");
   }
 
   @BeforeAll
@@ -250,12 +250,6 @@ public class PlanCollaborationTests {
       return new gov.nasa.jpl.aerie.database.SimulationDatasetRecord(
           res.getInt("simulation_id"),
           res.getInt("dataset_id"));
-    }
-  }
-
-  void clearTable(String table) throws SQLException {
-    try (final var statement = connection.createStatement()) {
-      statement.executeUpdate("TRUNCATE " + table + " CASCADE;");
     }
   }
   //endregion

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
@@ -77,11 +77,6 @@ class SchedulerDatabaseTests {
     }
   }
 
-  void clearTable(String table) throws SQLException {
-    try (final var statement = connection.createStatement()) {
-      statement.executeUpdate("TRUNCATE " + table + " CASCADE;");
-    }
-  }
 
   @Nested
   class TestSpecificationAndTemplateGoalTriggers {
@@ -98,11 +93,11 @@ class SchedulerDatabaseTests {
 
     @AfterEach
     void afterEach() throws SQLException {
-      clearTable("scheduling_specification");
-      clearTable("scheduling_template");
-      clearTable("scheduling_goal");
-      clearTable("scheduling_specification_goals");
-      clearTable("scheduling_template_goals");
+      helper.clearTable("scheduling_specification");
+      helper.clearTable("scheduling_template");
+      helper.clearTable("scheduling_goal");
+      helper.clearTable("scheduling_specification_goals");
+      helper.clearTable("scheduling_template_goals");
     }
 
     void insertGoalPriorities(String tableStem, int specOrTemplateIndex, int[] priorities) throws SQLException {


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
I noticed in our DBTests that every Test file reimplemented `clearTable` in the same way, so I moved it up to the `DatabaseTestHelper`.

Additionally, I modified `CommandExpansionDatabaseTests` to clear the tables it writes through between each test.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Tests still pass.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
If we make more DB tests that operate against the Merlin database after Anchors, we ought to split some of the repeated methods (ie `insertMissionModel`, `insertPlan`) into something like a `MerlinDBTestHelper`.