### PR TITLE
Catch long overflows when looking for intersection

### DIFF
--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/LinearProfileTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/model/LinearProfileTest.java
@@ -144,7 +144,7 @@ public class LinearProfileTest {
         Segment.of(Interval.between( 4, Inclusive,  6, Exclusive, SECONDS), new LinearEquation(Duration.of( 4, SECONDS),  2,  1)),
         Segment.of(Interval.between( 6, Inclusive, 12, Exclusive, SECONDS), new LinearEquation(Duration.of( 6, SECONDS),  4,  0)),
         Segment.of(Interval.between(12, Inclusive, 16, Exclusive, SECONDS), new LinearEquation(Duration.of(12, SECONDS),  4, -1)),
-        Segment.of(Interval.between(16, Inclusive, 20, Inclusive, SECONDS), new LinearEquation(Duration.of(16, SECONDS),  0,  0))
+        Segment.of(Interval.between(16, Inclusive, 20, Inclusive, SECONDS), new LinearEquation(Duration.of(16, SECONDS),  -20,  1e-20))
     );
 
     final var result = profile.lessThan(other);


### PR DESCRIPTION
* **Tickets addressed:**
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Due to floating point math, it is possible for subtracting a number from itself to not result in 0. (i.e. `0.1+0.2-0.1-0.2`)

I personally don't like declaring an arbitrary cutoff like `|x| < 1e-15` means `x = 0`, because well, how do you decide?

So when finding intersections between two lines where the difference in slopes is `1e-20`, our options are:
1. use hand-written non-standard saturating math routines which are slow just to avoid using exceptions in the happy path
2. use exceptions in the happy path

2 is a lot easier.

## Verification
I updated the lessThan test to cause this exception.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
