### PR TITLE
Add Kubernetes manifests

### DIFF
--- a/deployment/kubernetes/aerie-file-store-persistentvolumeclaim.yaml
+++ b/deployment/kubernetes/aerie-file-store-persistentvolumeclaim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: aerie-dev
+  name: aerie-file-store
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Mi

--- a/deployment/kubernetes/aerie-gateway-deployment.yaml
+++ b/deployment/kubernetes/aerie-gateway-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: aerie-dev
+  name: aerie-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aerie-gateway
+  template:
+    metadata:
+      labels:
+        app: aerie-gateway
+    spec:
+      containers:
+        - name: aerie-gateway
+          image: ghcr.io/nasa-ammos/aerie-gateway:develop
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /app/files
+              name: aerie-file-store
+          env:
+            - name: AUTH_TYPE
+              value: none
+            - name: GQL_API_URL
+              value: http://localhost:8080/v1/graphql
+            - name: LOG_FILE
+              value: console
+            - name: LOG_LEVEL
+              value: warn
+            - name: PORT
+              value: "9000"
+            - name: POSTGRES_AERIE_MERLIN_DB
+              value: aerie_merlin
+            - name: POSTGRES_HOST
+              value: postgres
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dev-env
+                  key: AERIE_USERNAME
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dev-env
+                  key: AERIE_PASSWORD
+      volumes:
+        - name: aerie-file-store
+          persistentVolumeClaim:
+            claimName: aerie-file-store

--- a/deployment/kubernetes/aerie-gateway-service.yaml
+++ b/deployment/kubernetes/aerie-gateway-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aerie-dev
+  name: aerie-gateway
+spec:
+  ports:
+    - name: "9000"
+      port: 9000
+      targetPort: 9000
+      nodePort: 30000
+  type: NodePort
+  selector:
+    app: aerie-gateway

--- a/deployment/kubernetes/aerie-merlin-deployment.yaml
+++ b/deployment/kubernetes/aerie-merlin-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: aerie-dev
+  name: aerie-merlin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aerie-merlin
+  template:
+    metadata:
+      labels:
+        app: aerie-merlin
+    spec:
+      containers:
+        - name: aerie-merlin
+          image: ghcr.io/nasa-ammos/aerie-merlin:develop
+          ports:
+            - containerPort: 27183
+          volumeMounts:
+            - mountPath: /usr/src/app/merlin_file_store
+              name: aerie-file-store
+          env:
+            - name: JAVA_OPTS
+              value: |
+                -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN -Dorg.slf4j.simpleLogger.logFile=System.err
+            - name: MERLIN_DB
+              value: aerie_merlin
+            - name: MERLIN_DB_PORT
+              value: "5432"
+            - name: MERLIN_DB_SERVER
+              value: postgres
+            - name: MERLIN_LOCAL_STORE
+              value: /usr/src/app/merlin_file_store
+            - name: MERLIN_PORT
+              value: "27183"
+            - name: UNTRUE_PLAN_START
+              value: "2000-01-01T11:58:55.816Z"
+            - name: MERLIN_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dev-env
+                  key: AERIE_USERNAME
+            - name: MERLIN_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dev-env
+                  key: AERIE_PASSWORD
+      restartPolicy: Always
+      volumes:
+        - name: aerie-file-store
+          persistentVolumeClaim:
+            claimName: aerie-file-store

--- a/deployment/kubernetes/aerie-merlin-service.yaml
+++ b/deployment/kubernetes/aerie-merlin-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aerie-dev
+  name: aerie-merlin
+spec:
+  ports:
+    - name: "27183"
+      port: 27183
+      targetPort: 27183
+  selector:
+    app: aerie-merlin

--- a/deployment/kubernetes/aerie-merlin-worker-deployment.yaml
+++ b/deployment/kubernetes/aerie-merlin-worker-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: aerie-dev
+  name: aerie-merlin-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aerie-merlin-worker
+  template:
+    metadata:
+      labels:
+        app: aerie-merlin-worker
+    spec:
+      containers:
+        - name: aerie-merlin-worker
+          image: ghcr.io/nasa-ammos/aerie-merlin-worker:develop
+          ports:
+            - containerPort: 8080
+          resources: {}
+          volumeMounts:
+            - mountPath: /usr/src/app/merlin_file_store
+              name: aerie-file-store
+              readOnly: true
+          env:
+            - name: JAVA_OPTS
+              value: |
+                -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=WARN -Dorg.slf4j.simpleLogger.logFile=System.err
+            - name: MERLIN_WORKER_DB
+              value: aerie_merlin
+            - name: MERLIN_WORKER_DB_PORT
+              value: "5432"
+            - name: MERLIN_WORKER_DB_SERVER
+              value: postgres
+            - name: MERLIN_WORKER_LOCAL_STORE
+              value: /usr/src/app/merlin_file_store
+            - name: UNTRUE_PLAN_START
+              value: "2000-01-01T11:58:55.816Z"
+            - name: MERLIN_WORKER_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dev-env
+                  key: AERIE_USERNAME
+            - name: MERLIN_WORKER_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dev-env
+                  key: AERIE_PASSWORD
+      restartPolicy: Always
+      volumes:
+        - name: aerie-file-store
+          persistentVolumeClaim:
+            claimName: aerie-file-store
+            readOnly: true

--- a/deployment/kubernetes/aerie-merlin-worker-service.yaml
+++ b/deployment/kubernetes/aerie-merlin-worker-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aerie-dev
+  name: aerie-merlin-worker
+spec:
+  ports:
+    - name: "27187"
+      port: 27187
+      targetPort: 8080
+  selector:
+    app: aerie-merlin-worker

--- a/deployment/kubernetes/aerie-scheduler-deployment.yaml
+++ b/deployment/kubernetes/aerie-scheduler-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: aerie-dev
+  name: aerie-scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aerie-scheduler
+  template:
+    metadata:
+      labels:
+        app: aerie-scheduler
+    spec:
+      containers:
+        - name: aerie-scheduler
+          image: ghcr.io/nasa-ammos/aerie-scheduler:develop
+          ports:
+            - containerPort: 27185
+          volumeMounts:
+            - mountPath: /usr/src/app/merlin_file_store
+              name: aerie-file-store
+          env:
+            - name: JAVA_OPTS
+              value: |
+                -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN -Dorg.slf4j.simpleLogger.logFile=System.err
+            - name: MERLIN_GRAPHQL_URL
+              value: http://hasura:8080/v1/graphql
+            - name: SCHEDULER_DB
+              value: aerie_scheduler
+            - name: SCHEDULER_DB_PORT
+              value: "5432"
+            - name: SCHEDULER_DB_SERVER
+              value: postgres
+            - name: SCHEDULER_PORT
+              value: "27185"
+            - name: SCHEDULER_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dev-env
+                  key: AERIE_USERNAME
+            - name: SCHEDULER_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dev-env
+                  key: AERIE_PASSWORD
+      restartPolicy: Always
+      volumes:
+        - name: aerie-file-store
+          persistentVolumeClaim:
+            claimName: aerie-file-store

--- a/deployment/kubernetes/aerie-scheduler-service.yaml
+++ b/deployment/kubernetes/aerie-scheduler-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aerie-dev
+  name: aerie-scheduler
+spec:
+  ports:
+    - name: "27185"
+      port: 27185
+      targetPort: 27185
+  selector:
+    app: aerie-scheduler

--- a/deployment/kubernetes/aerie-scheduler-worker-deployment.yaml
+++ b/deployment/kubernetes/aerie-scheduler-worker-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: aerie-dev
+  name: aerie-scheduler-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aerie-scheduler-worker
+  template:
+    metadata:
+      labels:
+        app: aerie-scheduler-worker
+    spec:
+      containers:
+        - name: aerie-scheduler-worker
+          image: ghcr.io/nasa-ammos/aerie-scheduler-worker:develop
+          ports:
+            - containerPort: 8080
+          resources: {}
+          volumeMounts:
+            - mountPath: /usr/src/app/merlin_file_store
+              name: aerie-file-store
+              readOnly: true
+          env:
+            - name: JAVA_OPTS
+              value: |
+                -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO -Dorg.slf4j.simpleLogger.logFile=System.err
+            - name: MERLIN_GRAPHQL_URL
+              value: http://hasura:8080/v1/graphql
+            - name: MERLIN_LOCAL_STORE
+              value: /usr/src/app/merlin_file_store
+            - name: SCHEDULER_OUTPUT_MODE
+              value: UpdateInputPlanWithNewActivities
+            - name: SCHEDULER_RULES_JAR
+              value: /usr/src/app/merlin_file_store/scheduler_rules.jar
+            - name: SCHEDULER_WORKER_DB
+              value: aerie_scheduler
+            - name: SCHEDULER_WORKER_DB_PORT
+              value: "5432"
+            - name: SCHEDULER_WORKER_DB_SERVER
+              value: postgres
+            - name: SCHEDULER_WORKER_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dev-env
+                  key: AERIE_USERNAME
+            - name: SCHEDULER_WORKER_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dev-env
+                  key: AERIE_PASSWORD
+      restartPolicy: Always
+      volumes:
+        - name: aerie-file-store
+          persistentVolumeClaim:
+            claimName: aerie-file-store
+            readOnly: true

--- a/deployment/kubernetes/aerie-scheduler-worker-service.yaml
+++ b/deployment/kubernetes/aerie-scheduler-worker-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aerie-dev
+  name: aerie-scheduler-worker
+spec:
+  ports:
+    - name: "27189"
+      port: 27189
+      targetPort: 8080
+  selector:
+    app: aerie-scheduler-worker

--- a/deployment/kubernetes/aerie-sequencing-deployment.yaml
+++ b/deployment/kubernetes/aerie-sequencing-deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: aerie-dev
+  name: aerie-sequencing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aerie-sequencing
+  template:
+    metadata:
+      labels:
+        app: aerie-sequencing
+    spec:
+      containers:
+        - name: aerie-sequencing
+          image: ghcr.io/nasa-ammos/aerie-sequencing:develop
+          ports:
+            - containerPort: 27184
+          resources: {}
+          volumeMounts:
+            - mountPath: /usr/src/app/sequencing_file_store
+              name: aerie-file-store
+          env:
+            - name: LOG_FILE
+              value: console
+            - name: LOG_LEVEL
+              value: warn
+            - name: MERLIN_GRAPHQL_URL
+              value: http://hasura:8080/v1/graphql
+            - name: SEQUENCING_DB
+              value: aerie_sequencing
+            - name: SEQUENCING_DB_PORT
+              value: "5432"
+            - name: SEQUENCING_DB_SERVER
+              value: postgres
+            - name: SEQUENCING_LOCAL_STORE
+              value: /usr/src/app/sequencing_file_store
+            - name: SEQUENCING_SERVER_PORT
+              value: "27184"
+            - name: SEQUENCING_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dev-env
+                  key: AERIE_USERNAME
+            - name: SEQUENCING_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dev-env
+                  key: AERIE_PASSWORD
+      restartPolicy: Always
+      volumes:
+        - name: aerie-file-store
+          persistentVolumeClaim:
+            claimName: aerie-file-store

--- a/deployment/kubernetes/aerie-sequencing-service.yaml
+++ b/deployment/kubernetes/aerie-sequencing-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aerie-dev
+  name: aerie-sequencing
+spec:
+  ports:
+    - name: "27184"
+      port: 27184
+      targetPort: 27184
+  selector:
+    app: aerie-sequencing

--- a/deployment/kubernetes/aerie-ui-deployment.yaml
+++ b/deployment/kubernetes/aerie-ui-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: aerie-dev
+  name: aerie-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aerie-ui
+  template:
+    metadata:
+      labels:
+        app: aerie-ui
+    spec:
+      containers:
+        - env:
+            - name: ORIGIN
+              value: http://127.0.0.1
+            - name: PUBLIC_AUTH_TYPE
+              value: none
+            - name: PUBLIC_GATEWAY_CLIENT_URL
+              value: http://localhost:9000
+            - name: PUBLIC_GATEWAY_SERVER_URL
+              value: http://aerie-gateway:9000
+            - name: PUBLIC_HASURA_CLIENT_URL
+              value: http://localhost:8080/v1/graphql
+            - name: PUBLIC_HASURA_SERVER_URL
+              value: http://hasura:8080/v1/graphql
+            - name: PUBLIC_HASURA_WEB_SOCKET_URL
+              value: ws://localhost:8080/v1/graphql
+          image: ghcr.io/nasa-ammos/aerie-ui:develop
+          name: aerie-ui
+          ports:
+            - containerPort: 80

--- a/deployment/kubernetes/aerie-ui-ingress.yaml
+++ b/deployment/kubernetes/aerie-ui-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: aerie-ui-ingress
+  namespace: aerie-dev
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: aerie-ui
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/deployment/kubernetes/aerie-ui-service.yaml
+++ b/deployment/kubernetes/aerie-ui-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aerie-dev
+  name: aerie-ui
+spec:
+  ports:
+    - name: "80"
+      port: 80
+      targetPort: 80
+  selector:
+    app: aerie-ui

--- a/deployment/kubernetes/hasura-deployment.yaml
+++ b/deployment/kubernetes/hasura-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: aerie-dev
+  name: hasura
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hasura
+  template:
+    metadata:
+      labels:
+        app: hasura
+    spec:
+      containers:
+        - name: hasura
+          image: ghcr.io/nasa-ammos/aerie-hasura
+          ports:
+            - containerPort: 8080
+          env:
+            - name: AERIE_MERLIN_DATABASE_URL
+              value: postgres://aerie:aerie@postgres:5432/aerie_merlin
+            - name: AERIE_SCHEDULER_DATABASE_URL
+              value: postgres://aerie:aerie@postgres:5432/aerie_scheduler
+            - name: AERIE_SEQUENCING_DATABASE_URL
+              value: postgres://aerie:aerie@postgres:5432/aerie_sequencing
+            - name: AERIE_UI_DATABASE_URL
+              value: postgres://aerie:aerie@postgres:5432/aerie_ui
+            - name: HASURA_GRAPHQL_METADATA_DATABASE_URL
+              value: postgres://aerie:aerie@postgres:5432/aerie_hasura
+            - name: HASURA_GRAPHQL_DEV_MODE
+              value: "true"
+            - name: HASURA_GRAPHQL_ENABLED_LOG_TYPES
+              value: startup, http-log, webhook-log, websocket-log, query-log
+            - name: HASURA_GRAPHQL_ENABLE_CONSOLE
+              value: "true"
+            - name: HASURA_GRAPHQL_LOG_LEVEL
+              value: warn
+            - name: HASURA_GRAPHQL_METADATA_DIR
+              value: /hasura-metadata

--- a/deployment/kubernetes/hasura-service.yaml
+++ b/deployment/kubernetes/hasura-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aerie-dev
+  name: hasura
+spec:
+  ports:
+    - name: "8080"
+      port: 8080
+      targetPort: 8080
+      nodePort: 30080
+  type: NodePort
+  selector:
+    app: hasura

--- a/deployment/kubernetes/postgres-data-persistentvolumeclaim.yaml
+++ b/deployment/kubernetes/postgres-data-persistentvolumeclaim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: aerie-dev
+  name: postgres-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Mi

--- a/deployment/kubernetes/postgres-deployment.yaml
+++ b/deployment/kubernetes/postgres-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: aerie-dev
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: ghcr.io/nasa-ammos/aerie-postgres:develop
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: postgres-data
+          env:
+            - name: POSTGRES_DB
+              value: postgres
+          envFrom:
+            - secretRef:
+                name: dev-env
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-data

--- a/deployment/kubernetes/postgres-service.yaml
+++ b/deployment/kubernetes/postgres-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aerie-dev
+  name: postgres
+spec:
+  ports:
+    - name: "5432"
+      port: 5432
+      targetPort: 5432
+  selector:
+    app: postgres


### PR DESCRIPTION
* **Tickets addressed:** close #572 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This initial prototype of kubernetes manifests is essentially a one-for-one port of our `deployment/docker-compose.yml`, so it uses all pre-built images from `ghcr.io`.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Kubernetes successfully deployed using a local [k3s](https://k3s.io) cluster, running in `docker` containers with the help of [k3d](https://k3d.io). 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No documentation invalidated, but new Kubernetes specific documentation regarding local deployment and AWS deployment will be added to [aerie-docs](https://github.com/NASA-AMMOS/aerie-docs).

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- A small but important quirk of Kubernetes is that it doesn't support underscores in pod names, since DNS records need to be compliant with [RFC1123](https://tools.ietf.org/html/rfc1123). This means we will need to change the naming scheme of our docker-compose files and hasura metadata, which will be completed in a follow-up PR.
- Secrets management should be handled using a templating scheme like the built-in [kustomize](https://kustomize.io/).
- Proper ingress support should be added, e.g. having http://gateway.localhost redirect to the gateway service or using `LoadBalancer` objects instead of relying on `NodePorts`
- Use environment file to hold all env vars instead of hardcoding into manifests.