### PR TITLE
Add JSON Spec to sequencing server

### DIFF
--- a/sequencing-server/package-lock.json
+++ b/sequencing-server/package-lock.json
@@ -12,6 +12,7 @@
         "@js-temporal/polyfill": "^0.4.3",
         "@nasa-jpl/aerie-ampcs": "^1.0.0",
         "@nasa-jpl/aerie-ts-user-code-runner": "^0.5.0",
+        "@nasa-jpl/seq-json-schema": "^1.0.9",
         "body-parser": "^1.20.1",
         "dataloader": "^2.1.0",
         "express": "^5.0.0-beta.1",
@@ -1111,6 +1112,11 @@
       "peerDependencies": {
         "typescript": "4.x"
       }
+    },
+    "node_modules/@nasa-jpl/seq-json-schema": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/seq-json-schema/-/seq-json-schema-1.0.9.tgz",
+      "integrity": "sha512-HamW5Lr/7IinWWnM0T2WsigKRk+we5kMvC2sezfv5/MTAtt1KWsgt9FRu8y3T5ZrAa6HJRAAqFvJi3qzw2EvMw=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.47",
@@ -2675,9 +2681,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -6417,6 +6423,11 @@
         "stack-trace": "^1.0.0-pre1"
       }
     },
+    "@nasa-jpl/seq-json-schema": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/seq-json-schema/-/seq-json-schema-1.0.9.tgz",
+      "integrity": "sha512-HamW5Lr/7IinWWnM0T2WsigKRk+we5kMvC2sezfv5/MTAtt1KWsgt9FRu8y3T5ZrAa6HJRAAqFvJi3qzw2EvMw=="
+    },
     "@sinclair/typebox": {
       "version": "0.24.47",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.47.tgz",
@@ -6866,7 +6877,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.9.7",
+        "qs": "6.11.0",
         "raw-body": "2.5.1",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -7654,9 +7665,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -9032,7 +9043,8 @@
       }
     },
     "qs": {
-      "version": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
       "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "requires": {
         "side-channel": "^1.0.4"

--- a/sequencing-server/package.json
+++ b/sequencing-server/package.json
@@ -22,6 +22,7 @@
     "@js-temporal/polyfill": "^0.4.3",
     "@nasa-jpl/aerie-ampcs": "^1.0.0",
     "@nasa-jpl/aerie-ts-user-code-runner": "^0.5.0",
+    "@nasa-jpl/seq-json-schema": "^1.0.9",
     "body-parser": "^1.20.1",
     "dataloader": "^2.1.0",
     "express": "^5.0.0-beta.1",

--- a/sequencing-server/src/app.ts
+++ b/sequencing-server/src/app.ts
@@ -22,7 +22,7 @@ import {
   simulatedActivityInstanceBySimulatedActivityIdBatchLoader,
 } from './lib/batchLoaders/simulatedActivityBatchLoader.js';
 import { generateTypescriptForGraphQLActivitySchema } from './lib/codegen/ActivityTypescriptCodegen.js';
-import { Command, CommandSeqJson, Sequence, SequenceSeqJson } from './lib/codegen/CommandEDSLPreface.js';
+import { CommandStem, CommandSeqJson, Sequence, SequenceSeqJson } from './lib/codegen/CommandEDSLPreface.js';
 import { processDictionary } from './lib/codegen/CommandTypeCodegen.js';
 import './polyfills.js';
 import { FallibleStatus } from './types.js';
@@ -682,7 +682,7 @@ app.post('/get-seqjson-for-seqid-and-simulation-dataset', async (req, res, next)
     }
     return {
       ...ai,
-      commands: row.commands?.map(Command.fromSeqJson) ?? null,
+      commands: row.commands?.map(CommandStem.fromSeqJson) ?? null,
       errors: row.errors,
     };
   });
@@ -841,7 +841,7 @@ app.post('/bulk-get-seqjson-for-seqid-and-simulation-dataset', async (req, res, 
         }
         return {
           ...ai,
-          commands: row.commands?.map(Command.fromSeqJson) ?? null,
+          commands: row.commands?.map(CommandStem.fromSeqJson) ?? null,
           errors: row.errors,
         };
       });

--- a/sequencing-server/src/defaultSeqBuilder.ts
+++ b/sequencing-server/src/defaultSeqBuilder.ts
@@ -1,4 +1,4 @@
-import { Command, Sequence } from './lib/codegen/CommandEDSLPreface.js';
+import { CommandStem, Sequence } from './lib/codegen/CommandEDSLPreface.js';
 import type { SeqBuilder } from './types/seqBuilder';
 
 export const defaultSeqBuilder: SeqBuilder = (
@@ -19,7 +19,7 @@ export const defaultSeqBuilder: SeqBuilder = (
 
     if (ai.errors.length > 0) {
       return ai.errors.map(e =>
-        Command.new({
+        CommandStem.new({
           stem: '$$ERROR$$',
           arguments: [e.message],
           metadata: {

--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
@@ -1,5 +1,5 @@
 import {
-  Command,
+  CommandStem,
   doyToInstant,
   DOY_STRING,
   hmsToDuration,
@@ -11,7 +11,7 @@ import {
 describe('Command', () => {
   describe('fromSeqJson', () => {
     it('should parse a command seqjson', () => {
-      const command = Command.fromSeqJson({
+      const command = CommandStem.fromSeqJson({
         type: 'command',
         stem: 'test',
         metadata: {},
@@ -19,7 +19,7 @@ describe('Command', () => {
         time: { type: TimingTypes.COMMAND_COMPLETE },
       });
 
-      expect(command).toBeInstanceOf(Command);
+      expect(command).toBeInstanceOf(CommandStem);
       expect(command.stem).toBe('test');
       expect(command.metadata).toEqual({});
       expect(command.arguments).toEqual([]);
@@ -28,7 +28,7 @@ describe('Command', () => {
 
   describe('toEDSLString()', () => {
     it('should handle absolute time tagged commands', () => {
-      const command = Command.new({
+      const command = CommandStem.new({
         stem: 'TEST',
         arguments: ['string', 0, true],
         absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
@@ -38,7 +38,7 @@ describe('Command', () => {
     });
 
     it('should handle relative time tagged commands', () => {
-      const command = Command.new({
+      const command = CommandStem.new({
         stem: 'TEST',
         arguments: ['string', 0, true],
         relativeTime: hmsToDuration('00:00:00.000' as HMS_STRING),
@@ -48,7 +48,7 @@ describe('Command', () => {
     });
 
     it('should handle epoch relative time tagged commands', () => {
-      const command = Command.new({
+      const command = CommandStem.new({
         stem: 'TEST',
         arguments: ['string', 0, true],
         epochTime: hmsToDuration('00:00:00.000' as HMS_STRING),
@@ -58,7 +58,7 @@ describe('Command', () => {
     });
 
     it('should handle command complete commands', () => {
-      const command = Command.new({
+      const command = CommandStem.new({
         stem: 'TEST',
         arguments: ['string', 0, true],
       });
@@ -67,14 +67,14 @@ describe('Command', () => {
     });
 
     it('should handle commands without arguments', () => {
-      const command = Command.new({
+      const command = CommandStem.new({
         stem: 'TEST',
         arguments: [],
       });
 
       expect(command.toEDSLString()).toEqual('C.TEST');
 
-      const command2 = Command.new({
+      const command2 = CommandStem.new({
         stem: 'TEST',
         arguments: {},
       });
@@ -83,7 +83,7 @@ describe('Command', () => {
     });
 
     it('should convert to EDSL string with array arguments', () => {
-      const command = Command.new({
+      const command = CommandStem.new({
         stem: 'TEST',
         arguments: ['string', 0, true],
         absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
@@ -93,7 +93,7 @@ describe('Command', () => {
     });
 
     it('should convert to EDSL string with named arguments', () => {
-      const command = Command.new({
+      const command = CommandStem.new({
         stem: 'TEST',
         arguments: {
           string: 'string',
@@ -139,12 +139,12 @@ describe('Sequence', () => {
       expect(sequence.metadata).toEqual({});
       expect(sequence.commands.length).toEqual(2);
 
-      expect(sequence.commands[0]!).toBeInstanceOf(Command);
+      expect(sequence.commands[0]!).toBeInstanceOf(CommandStem);
       expect(sequence.commands[0]!.stem).toBe('test');
       expect(sequence.commands[0]!.metadata).toEqual({});
       expect(sequence.commands[0]!.arguments).toEqual([]);
 
-      expect(sequence.commands[1]!).toBeInstanceOf(Command);
+      expect(sequence.commands[1]!).toBeInstanceOf(CommandStem);
       expect(sequence.commands[1]!.stem).toBe('test2');
       expect(sequence.commands[1]!.metadata).toEqual({});
       expect(sequence.commands[1]!.arguments).toEqual(['string', 0, true]);
@@ -173,12 +173,12 @@ describe('Sequence', () => {
         seqId: 'test',
         metadata: {},
         commands: [
-          Command.new({
+          CommandStem.new({
             stem: 'TEST',
             arguments: ['string', 0, true],
             absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
           }),
-          Command.new({
+          CommandStem.new({
             stem: 'TEST',
             arguments: {
               string: 'string',

--- a/sequencing-server/src/lib/codegen/CommandTypeCodegen.ts
+++ b/sequencing-server/src/lib/codegen/CommandTypeCodegen.ts
@@ -60,14 +60,14 @@ function generateFswCommandCode(
     // language=TypeScript
     const value = `
 ${doc}
-const ${fswCommandName}: ${fswCommandName} = Command.new({
+const ${fswCommandName}: ${fswCommandName} = CommandStem.new({
 \tstem: '${fswCommand.stem}',
 \targuments: [],
 })`;
 
     const interfaces = `
 ${doc}
-\tinterface ${fswCommandName} extends Command<[]> {}
+\tinterface ${fswCommandName} extends CommandStem<[]> {}
 `;
     return {
       value,
@@ -104,14 +104,14 @@ ${doc}
   const value = `
 ${doc}
 function ${fswCommandName}(...args: [{ ${argsWithType.map(arg => arg.name + ': ' + arg.type).join(',')} }]) {
-  return Command.new({
+  return CommandStem.new({
     stem: '${fswCommandName}',
     arguments: args
   }) as ${fswCommandName};
 }`;
 
   const interfaces = `
-\tinterface ${fswCommandName} extends Command<[ [{ ${argsWithType
+\tinterface ${fswCommandName} extends CommandStem<[ [{ ${argsWithType
     .map(arg => arg.name + ': ' + arg.type)
     .join(',')} }] ]> {}`;
 
@@ -176,14 +176,19 @@ function mapArgumentType(argument: ampcs.FswCommandArgument, enumMap: ampcs.Enum
 
 export async function processDictionary(dictionary: ampcs.CommandDictionary) {
   const prefaceUrl = new URL('./CommandEDSLPreface.ts', import.meta.url);
+  const jsonSpecUrl = new URL('../../../node_modules/@nasa-jpl/seq-json-schema/types.ts', import.meta.url);
   const folder = `${getEnv().STORAGE}/${dictionary.header.mission_name.toLowerCase()}/`;
   const fileName = `command_lib.${dictionary.header.version}.ts`;
   const prefaceString = await fs.promises.readFile(prefaceUrl.pathname, 'utf8');
+  const jsonSpecString = `/** START Sequence JSON Spec */
+  //https://github.com/NASA-AMMOS/seq-json-schema/blob/develop/types.ts\n
+  ${await fs.promises.readFile(jsonSpecUrl.pathname, 'utf8')}
+  \n/** END Sequence JSON Spec */`;
 
   const { values, declarations } = generateTypescriptCode(dictionary); //update sql table store seprate
 
   await fs.promises.mkdir(folder, { recursive: true });
 
-  await fs.promises.writeFile(folder + fileName, prefaceString + declarations + values, { flag: 'w' });
+  await fs.promises.writeFile(folder + fileName, prefaceString + jsonSpecString + declarations + values, { flag: 'w' });
   return folder + fileName;
 }

--- a/sequencing-server/src/types/seqBuilder.ts
+++ b/sequencing-server/src/types/seqBuilder.ts
@@ -1,12 +1,12 @@
 import type { UserCodeError } from '@nasa-jpl/aerie-ts-user-code-runner';
 
-import type { Command, Sequence } from '../lib/codegen/CommandEDSLPreface.js';
+import type { CommandStem, Sequence } from '../lib/codegen/CommandEDSLPreface.js';
 import type { SimulatedActivity } from '../lib/batchLoaders/simulatedActivityBatchLoader';
 
 export interface SeqBuilder {
   (
     sortedActivityInstancesWithCommands: (SimulatedActivity & {
-      commands: Command[] | null;
+      commands: CommandStem[] | null;
       errors: ReturnType<UserCodeError['toJSON']>[] | null;
     })[],
     seqId: string,

--- a/sequencing-server/src/worker.ts
+++ b/sequencing-server/src/worker.ts
@@ -7,7 +7,7 @@ import ts from 'typescript';
 import { CacheItem, UserCodeError, UserCodeRunner } from '@nasa-jpl/aerie-ts-user-code-runner';
 
 import type { SimulatedActivity } from './lib/batchLoaders/simulatedActivityBatchLoader.js';
-import type { Command, SequenceSeqJson } from './lib/codegen/CommandEDSLPreface.js';
+import type { CommandStem, SequenceSeqJson } from './lib/codegen/CommandEDSLPreface.js';
 import type { Mutable } from './lib/codegen/CodegenHelpers';
 import { deserializeWithTemporal } from './utils/temporalSerializers.js';
 import { Result, SerializedResult } from '@nasa-jpl/aerie-ts-user-code-runner/build/utils/monads.js';
@@ -74,7 +74,7 @@ export async function executeEDSL(opts: {
 export async function executeExpansionFromBuildArtifacts(opts: {
   buildArtifacts: CacheItem;
   serializedActivityInstance: SimulatedActivity;
-}): Promise<SerializedResult<ReturnType<Command['toSeqJson']>[], ReturnType<UserCodeError['toJSON']>[]>> {
+}): Promise<SerializedResult<ReturnType<CommandStem['toSeqJson']>[], ReturnType<UserCodeError['toJSON']>[]>> {
   const activityInstance = deserializeWithTemporal(opts.serializedActivityInstance) as SimulatedActivity;
   const result = await codeRunner.executeUserCodeFromArtifacts<
     [
@@ -102,9 +102,9 @@ export async function executeExpansionFromBuildArtifacts(opts: {
     if (!Array.isArray(commands)) {
       commands = [commands];
     }
-    const commandsFlat = commands.flat() as Command[];
+    const commandsFlat = commands.flat() as CommandStem[];
     for (const command of commandsFlat) {
-      (command as Mutable<Command>).metadata = {
+      (command as Mutable<CommandStem>).metadata = {
         ...command.metadata,
         simulatedActivityId: activityInstance.id,
       };

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -62,11 +62,11 @@ export interface SequenceSeqJson {
 }
 
 declare global {
-  class Command<
+  class CommandStem<
     A extends ArgType[] | { [argName: string]: any } = [] | {},
     M extends Record<string, any> = Record<string, any>,
   > {
-    public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): Command<A>;
+    public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): CommandStem<A>;
 
     public toSeqJson(): CommandSeqJson;
   }
@@ -74,15 +74,15 @@ declare global {
   class Sequence {
     public readonly seqId: string;
     public readonly metadata: Record<string, any>;
-    public readonly commands: Command[];
+    public readonly commands: CommandStem[];
 
-    public static new(opts: { seqId: string; metadata: Record<string, any>; commands: Command[] }): Sequence;
+    public static new(opts: { seqId: string; metadata: Record<string, any>; commands: CommandStem[] }): Sequence;
 
     public toSeqJson(): SequenceSeqJson;
   }
 
   type Context = {};
-  type ExpansionReturn = Arrayable<Command>;
+  type ExpansionReturn = Arrayable<CommandStem>;
 
   type U<BitLength extends 8 | 16 | 32 | 64> = number;
   type U8 = U<8>;
@@ -125,7 +125,7 @@ declare global {
   const C: typeof Commands;
 }
 
-export class Command<
+export class CommandStem<
   A extends ArgType[] | { [argName: string]: any } = [] | {},
   M extends Record<string, any> = Record<string, any>,
 > {
@@ -149,24 +149,24 @@ export class Command<
     }
   }
 
-  public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): Command<A> {
+  public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): CommandStem<A> {
     if ('absoluteTime' in opts) {
-      return new Command<A>({
+      return new CommandStem<A>({
         ...opts,
         absoluteTime: opts.absoluteTime,
       });
     } else if ('epochTime' in opts) {
-      return new Command<A>({
+      return new CommandStem<A>({
         ...opts,
         epochTime: opts.epochTime,
       });
     } else if ('relativeTime' in opts) {
-      return new Command<A>({
+      return new CommandStem<A>({
         ...opts,
         relativeTime: opts.relativeTime,
       });
     } else {
-      return new Command<A>(opts);
+      return new CommandStem<A>(opts);
     }
   }
 
@@ -187,7 +187,7 @@ export class Command<
     };
   }
 
-  public static fromSeqJson<A extends ArgType[]>(json: CommandSeqJson<A>): Command<A> {
+  public static fromSeqJson<A extends ArgType[]>(json: CommandSeqJson<A>): CommandStem<A> {
     const timeValue =
       json.time.type === TimingTypes.ABSOLUTE
         ? { absoluteTime: doyToInstant(json.time.tag) }
@@ -197,7 +197,7 @@ export class Command<
         ? { epochTime: hmsToDuration(json.time.tag) }
         : {};
 
-    return Command.new<A>({
+    return CommandStem.new<A>({
       stem: json.stem,
       arguments: json.args as A,
       metadata: json.metadata,
@@ -205,24 +205,24 @@ export class Command<
     });
   }
 
-  public absoluteTiming(absoluteTime: Temporal.Instant): Command<A> {
-    return Command.new({
+  public absoluteTiming(absoluteTime: Temporal.Instant): CommandStem<A> {
+    return CommandStem.new({
       stem: this.stem,
       arguments: this.arguments,
       absoluteTime: absoluteTime,
     });
   }
 
-  public epochTiming(epochTime: Temporal.Duration): Command<A> {
-    return Command.new({
+  public epochTiming(epochTime: Temporal.Duration): CommandStem<A> {
+    return CommandStem.new({
       stem: this.stem,
       arguments: this.arguments,
       epochTime: epochTime,
     });
   }
 
-  public relativeTiming(relativeTime: Temporal.Duration): Command<A> {
-    return Command.new({
+  public relativeTiming(relativeTime: Temporal.Duration): CommandStem<A> {
+    return CommandStem.new({
       stem: this.stem,
       arguments: this.arguments,
       relativeTime: relativeTime,
@@ -238,7 +238,8 @@ export class Command<
       ? \`R\\\`\${durationToHms(this.relativeTime)}\\\`\`
       : 'C';
 
-    const argsString = Object.keys(this.arguments).length === 0 ? '' : \`(\${Command.argumentsToString(this.arguments)})\`;
+    const argsString =
+      Object.keys(this.arguments).length === 0 ? '' : \`(\${CommandStem.argumentsToString(this.arguments)})\`;
 
     return \`\${timeString}.\${this.stem}\${argsString}\`;
   }
@@ -270,13 +271,13 @@ export class Command<
 export interface SequenceOptions {
   seqId: string;
   metadata: Record<string, any>;
-  commands: Command[];
+  commands: CommandStem[];
 }
 
 export class Sequence {
   public readonly seqId: string;
   public readonly metadata: Record<string, any>;
-  public readonly commands: Command[];
+  public readonly commands: CommandStem[];
 
   private constructor(opts: SequenceOptions) {
     this.seqId = opts.seqId;
@@ -313,7 +314,7 @@ export class Sequence {
     return Sequence.new({
       seqId: json.id,
       metadata: json.metadata,
-      commands: json.steps.map(c => Command.fromSeqJson(c)),
+      commands: json.steps.map(c => CommandStem.fromSeqJson(c)),
     });
   }
 }
@@ -520,27 +521,341 @@ function indent(text: string, numTimes: number = 1, char: string = '  '): string
 }
 
 /** END Preface */
+/** START Sequence JSON Spec */
+  //https://github.com/NASA-AMMOS/seq-json-schema/blob/develop/types.ts
 
+  /* eslint-disable */
+/**
+ * This file was automatically generated by json-schema-to-typescript.
+ * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+ * and run json-schema-to-typescript to regenerate this file.
+ */
+
+export type VariableDeclaration = {
+  /**
+   * Variable type. Allowed types: FLOAT, INT, STRING, UINT, ENUM.
+   */
+  type: 'FLOAT' | 'INT' | 'STRING' | 'UINT' | 'ENUM';
+  /**
+   * User-friendly variable names that will be mapped to FSW variable names. Must begin with a letter and contain only letters, numbers, and underscores.
+   */
+  name: string;
+  /**
+   * For enumerated type variables, the name of the corresponding FSW-defined ENUM.
+   */
+  enum_name?: string;
+  /**
+   * A list of allowable values for this variable.
+   */
+  allowable_values?: unknown[];
+  /**
+   * One or more allowable ranges of values, for FLOAT, INT, or UINT variable types.
+   */
+  allowable_ranges?: VariableRange[];
+  /**
+   * The FSW-specified name for this variable that should be used in the translated sequence, in case this must be specified. Used for variables which are specially-handled onboard such as LCS (Last Command Status)
+   */
+  sc_name?: string;
+} & {
+  [k: string]: unknown;
+} & {
+  [k: string]: unknown;
+};
+/**
+ * Sequence steps can be grouped into a request, which can then be shifted or adjusted altogether as part of the request.
+ */
+export type Request = {
+  description?: Description;
+  ground_epoch?: GroundEpoch;
+  metadata?: Metadata;
+  /**
+   * Request Name, used for tracking commands back to the original request after ground expansion. Must be unique.
+   */
+  name: string;
+  /**
+   * Sequence steps that are part of this request.
+   *
+   * @minItems 1
+   */
+  steps: [Step, ...Step[]];
+  time?: Time;
+  type: 'request';
+} & Request1;
+/**
+ * Description. Can be attached to any sequence step.
+ */
+export type Description = string;
+export type Step = Activate | Command | GroundBlock | GroundEvent | Load;
+/**
+ * Array of command arguments
+ */
+export type Args = (string | number | boolean | SymbolArgument | HexArgument)[];
+export type Request1 =
+  | {
+      [k: string]: unknown;
+    }
+  | {
+      [k: string]: unknown;
+    };
+
+export interface SeqJson {
+  /**
+   * Unique identifier
+   */
+  id: string;
+  /**
+   * Local variable declarations.
+   *
+   * @minItems 1
+   */
+  locals?: [VariableDeclaration, ...VariableDeclaration[]];
+  metadata: Metadata;
+  /**
+   * Parameter variable declarations.
+   *
+   * @minItems 1
+   */
+  parameters?: [VariableDeclaration, ...VariableDeclaration[]];
+  /**
+   * Commands groups into requests
+   */
+  requests?: Request[];
+  /**
+   * Sequence steps
+   */
+  steps?: Step[];
+  /**
+   * Immediate commands which are interpreted by FSW and not part of any sequence.
+   */
+  immediate_commands?: ImmediateCommand[];
+  /**
+   * Hardware commands which are not interpreted by FSW and not part of any sequence.
+   */
+  hardware_commands?: HardwareCommand[];
+  [k: string]: unknown;
+}
+/**
+ * A range of allowable variable values between a defined min and max, inclusive. min and max must be numbers
+ */
+export interface VariableRange {
+  /**
+   * Minimum value of the variable, inclusive
+   */
+  min: number;
+  /**
+   * Maximum value of the variable, inclusive
+   */
+  max: number;
+}
+/**
+ * Flexible sequence metadata for any key-value pairs.
+ */
+export interface Metadata {
+  [k: string]: unknown;
+}
+/**
+ * Ground epoch object
+ */
+export interface GroundEpoch {
+  /**
+   * Epoch delta given as a duration, start time will be epoch+delta.
+   */
+  delta?: string;
+  /**
+   * Name of ground-defined epoch.
+   */
+  name?: string;
+  [k: string]: unknown;
+}
+/**
+ * Activate object
+ */
+export interface Activate {
+  args?: Args;
+  description?: Description;
+  /**
+   * Sequence target engine.
+   */
+  engine?: number;
+  /**
+   * Onboard epoch to pass to the sequence for derivation of epoch-relative timetags
+   */
+  epoch?: string;
+  metadata?: Metadata;
+  models?: Model[];
+  /**
+   * Onboard path and filename of sequence to be loaded.
+   */
+  sequence: string;
+  time: Time;
+  type: 'activate';
+}
+/**
+ * A step argument referencing a local or global variable, or some other symbolic name known to downstream modeling software (such as CONDITION in SEQGEN)
+ */
+export interface SymbolArgument {
+  /**
+   * The symbolic name being referenced.
+   */
+  symbol: string;
+}
+/**
+ * A step argument containing an unsigned integer in hexadecimal format.
+ */
+export interface HexArgument {
+  /**
+   * The hexadecimal integer, as a string prefixed with 0x. Digits A-F must be uppercase.
+   */
+  hex: string;
+}
+/**
+ * Model object that be included with commands to set variables for modeling purposes only, usually to direct sequence execution down a particular branch during modeling.
+ */
+export interface Model {
+  /**
+   * Duration to wait after step time to trigger model change
+   */
+  offset: string;
+  /**
+   * Value to set in variable.
+   */
+  value: string | number | boolean;
+  /**
+   * Variable to be set in the model
+   */
+  variable: string;
+}
+/**
+ * Time object
+ */
+export interface Time {
+  /**
+   * Relative or absolute time. Required for ABSOLUTE, COMMAND_RELATIVE, and EPOCH_RELATIVE time tags but not COMMAND_COMPLETE.
+   */
+  tag?: string;
+  /**
+   * Allowed time types: ABSOLUTE, COMMAND_RELATIVE, EPOCH_RELATIVE, or COMMAND_COMPLETE.
+   */
+  type: 'ABSOLUTE' | 'COMMAND_RELATIVE' | 'EPOCH_RELATIVE' | 'COMMAND_COMPLETE';
+}
+/**
+ * Command object
+ */
+export interface Command {
+  args: Args;
+  description?: Description;
+  metadata?: Metadata;
+  models?: Model[];
+  /**
+   * Command stem
+   */
+  stem: string;
+  time: Time;
+  type: 'command';
+  /**
+   * Name of a defined local variable to which the exit status of this command should be written to. For this to work, that local variable must have been defined with the 'SC_Name' property set to LCS
+   */
+  return_assign_to?: string;
+}
+/**
+ * Ground blocks
+ */
+export interface GroundBlock {
+  args?: Args;
+  description?: Description;
+  metadata?: Metadata;
+  models?: Model[];
+  /**
+   * Ground block name
+   */
+  name: string;
+  time: Time;
+  type: 'ground_block';
+}
+/**
+ * Ground events
+ */
+export interface GroundEvent {
+  args?: Args;
+  description?: Description;
+  metadata?: Metadata;
+  models?: Model[];
+  /**
+   * Ground event name
+   */
+  name: string;
+  time: Time;
+  type: 'ground_event';
+}
+/**
+ * Load object
+ */
+export interface Load {
+  args?: Args;
+  description?: Description;
+  /**
+   * Sequence target engine.
+   */
+  engine?: number;
+  /**
+   * Onboard epoch to pass to the sequence for derivation of epoch-relative timetags
+   */
+  epoch?: string;
+  metadata?: Metadata;
+  models?: Model[];
+  /**
+   * Onboard path and filename of sequence to be loaded.
+   */
+  sequence: string;
+  time: Time;
+  type: 'load';
+}
+/**
+ * Object representing a single Immediate Command
+ */
+export interface ImmediateCommand {
+  args: Args;
+  description?: Description;
+  metadata?: Metadata;
+  /**
+   * Command stem
+   */
+  stem: string;
+}
+/**
+ * Object representing a single Hardware Command
+ */
+export interface HardwareCommand {
+  description?: Description;
+  metadata?: Metadata;
+  /**
+   * Command stem
+   */
+  stem: string;
+}
+
+  
+/** END Sequence JSON Spec */
 declare global {
 
-	interface ECHO extends Command<[ [{ 'echo_string': VarString<8, 1024> }] ]> {}
+	interface ECHO extends CommandStem<[ [{ 'echo_string': VarString<8, 1024> }] ]> {}
 
-	interface PREHEAT_OVEN extends Command<[ [{ 'temperature': U8 }] ]> {}
+	interface PREHEAT_OVEN extends CommandStem<[ [{ 'temperature': U8 }] ]> {}
 
-	interface THROW_BANANA extends Command<[ [{ 'distance': U8 }] ]> {}
+	interface THROW_BANANA extends CommandStem<[ [{ 'distance': U8 }] ]> {}
 
-	interface GROW_BANANA extends Command<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
+	interface GROW_BANANA extends CommandStem<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
 
-	interface PREPARE_LOAF extends Command<[ [{ 'tb_sugar': U8,'gluten_free': boolean }] ]> {}
+	interface PREPARE_LOAF extends CommandStem<[ [{ 'tb_sugar': U8,'gluten_free': boolean }] ]> {}
 
-	interface PEEL_BANANA extends Command<[ [{ 'peelDirection': ('fromStem' | 'fromTip') }] ]> {}
+	interface PEEL_BANANA extends CommandStem<[ [{ 'peelDirection': ('fromStem' | 'fromTip') }] ]> {}
 
 
 /**
 * This command bakes a banana bread
 *
 */
-	interface BAKE_BREAD extends Command<[]> {}
+	interface BAKE_BREAD extends CommandStem<[]> {}
 
 
 
@@ -548,17 +863,17 @@ declare global {
 * This command waters the banana tree
 *
 */
-	interface ADD_WATER extends Command<[]> {}
+	interface ADD_WATER extends CommandStem<[]> {}
 
 
-	interface PACKAGE_BANANA extends Command<[ [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }] ]> {}
+	interface PACKAGE_BANANA extends CommandStem<[ [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }] ]> {}
 
 
 /**
 * Pick a banana
 *
 */
-	interface PICK_BANANA extends Command<[]> {}
+	interface PICK_BANANA extends CommandStem<[]> {}
 
 
 
@@ -566,7 +881,7 @@ declare global {
 * Eat a banana
 *
 */
-	interface EAT_BANANA extends Command<[]> {}
+	interface EAT_BANANA extends CommandStem<[]> {}
 
 	const Commands: {
 		ECHO: typeof ECHO,
@@ -589,7 +904,7 @@ declare global {
 * @param echo_string String to echo back
 */
 function ECHO(...args: [{ 'echo_string': VarString<8, 1024> }]) {
-  return Command.new({
+  return CommandStem.new({
     stem: 'ECHO',
     arguments: args
   }) as ECHO;
@@ -601,7 +916,7 @@ function ECHO(...args: [{ 'echo_string': VarString<8, 1024> }]) {
 * @param temperature Set the oven temperature
 */
 function PREHEAT_OVEN(...args: [{ 'temperature': U8 }]) {
-  return Command.new({
+  return CommandStem.new({
     stem: 'PREHEAT_OVEN',
     arguments: args
   }) as PREHEAT_OVEN;
@@ -613,7 +928,7 @@ function PREHEAT_OVEN(...args: [{ 'temperature': U8 }]) {
 * @param distance The distance you throw the bananan
 */
 function THROW_BANANA(...args: [{ 'distance': U8 }]) {
-  return Command.new({
+  return CommandStem.new({
     stem: 'THROW_BANANA',
     arguments: args
   }) as THROW_BANANA;
@@ -626,7 +941,7 @@ function THROW_BANANA(...args: [{ 'distance': U8 }]) {
 * @param durationSecs How many seconds will it take to grow
 */
 function GROW_BANANA(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
-  return Command.new({
+  return CommandStem.new({
     stem: 'GROW_BANANA',
     arguments: args
   }) as GROW_BANANA;
@@ -639,7 +954,7 @@ function GROW_BANANA(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
 * @param gluten_free Do you hate flavor
 */
 function PREPARE_LOAF(...args: [{ 'tb_sugar': U8,'gluten_free': boolean }]) {
-  return Command.new({
+  return CommandStem.new({
     stem: 'PREPARE_LOAF',
     arguments: args
   }) as PREPARE_LOAF;
@@ -651,7 +966,7 @@ function PREPARE_LOAF(...args: [{ 'tb_sugar': U8,'gluten_free': boolean }]) {
 * @param peelDirection Which way do you peel the banana
 */
 function PEEL_BANANA(...args: [{ 'peelDirection': ('fromStem' | 'fromTip') }]) {
-  return Command.new({
+  return CommandStem.new({
     stem: 'PEEL_BANANA',
     arguments: args
   }) as PEEL_BANANA;
@@ -662,7 +977,7 @@ function PEEL_BANANA(...args: [{ 'peelDirection': ('fromStem' | 'fromTip') }]) {
 * This command bakes a banana bread
 *
 */
-const BAKE_BREAD: BAKE_BREAD = Command.new({
+const BAKE_BREAD: BAKE_BREAD = CommandStem.new({
 	stem: 'BAKE_BREAD',
 	arguments: [],
 })
@@ -672,7 +987,7 @@ const BAKE_BREAD: BAKE_BREAD = Command.new({
 * This command waters the banana tree
 *
 */
-const ADD_WATER: ADD_WATER = Command.new({
+const ADD_WATER: ADD_WATER = CommandStem.new({
 	stem: 'ADD_WATER',
 	arguments: [],
 })
@@ -684,7 +999,7 @@ const ADD_WATER: ADD_WATER = Command.new({
 * @param bundle A repeated set of strings and integer containing the arguments to the lot
 */
 function PACKAGE_BANANA(...args: [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]) {
-  return Command.new({
+  return CommandStem.new({
     stem: 'PACKAGE_BANANA',
     arguments: args
   }) as PACKAGE_BANANA;
@@ -695,7 +1010,7 @@ function PACKAGE_BANANA(...args: [{ 'lot_number': U16,'bundle': Array<{ 'bundle_
 * Pick a banana
 *
 */
-const PICK_BANANA: PICK_BANANA = Command.new({
+const PICK_BANANA: PICK_BANANA = CommandStem.new({
 	stem: 'PICK_BANANA',
 	arguments: [],
 })
@@ -705,7 +1020,7 @@ const PICK_BANANA: PICK_BANANA = Command.new({
 * Eat a banana
 *
 */
-const EAT_BANANA: EAT_BANANA = Command.new({
+const EAT_BANANA: EAT_BANANA = CommandStem.new({
 	stem: 'EAT_BANANA',
 	arguments: [],
 })

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -1999,7 +1999,7 @@ describe('expansion regressions', () => {
     /** End Setup*/
 
     const { activity_instance_commands } = await graphqlClient.request<{
-      activity_instance_commands: { commands: ReturnType<Command['toSeqJson']>; errors: string[] }[];
+      activity_instance_commands: { commands: ReturnType<CommandStem['toSeqJson']>; errors: string[] }[];
     }>(
       gql`
         query getExpandedCommands($expansionRunId: Int!, $simulatedActivityId: Int!) {


### PR DESCRIPTION
* **Tickets addressed:** Resolves https://github.com/NASA-AMMOS/aerie/issues/609
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The overall goal is to incorporate the JSON spec into the Aerie Repo and give eDSL access to the full JSON Spec while wrapping the current EDSL into the 4 command types. The goal is to clean up the code and merge more of the spec and EDSL API together to create a tighter coupling, and to look at how to write custom eDSL to make the process easier.

This is the first part of the development process, which will be to add the JSON spec to the Aerie Repo and combine it with the EDSL.

## Verification
I ran through the e2e tests without any issues.

## Documentation
None

## Future work
Rework the Sequence eDSL class with this new spec file. 