### PR TITLE
Fixed the ordered of repeat args in sequence generation

### DIFF
--- a/sequencing-server/package-lock.json
+++ b/sequencing-server/package-lock.json
@@ -1639,17 +1639,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1741,6 +1730,18 @@
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2653,8 +2654,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -2672,6 +2672,19 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-package-type": {
@@ -2770,7 +2783,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -2785,6 +2797,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hdr-histogram-js": {
@@ -4064,6 +4087,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -4491,6 +4522,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4788,6 +4833,19 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
       "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
       "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6812,13 +6870,6 @@
         "raw-body": "2.5.1",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.9.7",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
-          "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
-        }
       }
     },
     "brace-expansion": {
@@ -6885,6 +6936,15 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
     },
     "callsites": {
       "version": "3.1.0",
@@ -7579,8 +7639,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -7593,6 +7652,16 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -7665,7 +7734,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -7675,6 +7743,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "hdr-histogram-js": {
       "version": "2.0.3",
@@ -8646,6 +8719,11 @@
         "path-key": "^3.0.0"
       }
     },
+    "object-inspect": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
+    },
     "on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -8953,6 +9031,13 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "qs": {
+      "version": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -9183,6 +9268,16 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
       "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
       "dev": true
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
     },
     "signal-exit": {
       "version": "3.0.7",

--- a/sequencing-server/src/utils/InheritedError.ts
+++ b/sequencing-server/src/utils/InheritedError.ts
@@ -6,7 +6,7 @@ export type ErrorLike = {
 };
 
 export class InheritedError extends Error {
-  public readonly cause: ErrorLike | ErrorLike[];
+  public override readonly cause: ErrorLike | ErrorLike[];
 
   constructor(message: string, cause: ErrorLike | ErrorLike[]) {
     let inheritedMessage =

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -172,7 +172,7 @@ export class Command<
 
   public toSeqJson(): CommandSeqJson {
     return {
-      args: typeof this.arguments == 'object' ? Object.values(this.arguments) : this.arguments,
+      args: flatten(this.arguments),
       stem: this.stem,
       time:
         this.absoluteTime !== null
@@ -486,30 +486,30 @@ function commandsWithTimeValue<T extends TimingTypes>(
   }, {} as typeof Commands);
 }
 
-// @ts-ignore
-function orderCommandArguments(args: { [argName: string]: any }, order: string[]): any {
-  return order.map(key => args[key]);
-}
+function flatten(input: { [argName: string]: any }): any {
+  let flatList: any[] = [];
 
-// @ts-ignore: Used in generated code
-function findAndOrderCommandArguments(
-  commandName: string,
-  args: { [argName: string]: any },
-  argumentOrders: string[][],
-): any {
-  for (const argumentOrder of argumentOrders) {
-    if (argumentOrder.length === Object.keys(args).length) {
-      let difference = argumentOrder
-        .filter((value: string) => !Object.keys(args).includes(value))
-        .concat(Object.keys(args).filter((value: string) => !argumentOrder.includes(value))).length;
+  for (const element of Object.values(input)) {
+    // If our input was already flattened, don't try and flatten it again.
+    if (typeof element !== 'object') {
+      return input;
+    }
 
-      // found correct argument order to apply
-      if (difference === 0) {
-        return orderCommandArguments(args, argumentOrder);
+    const values = Object.values(element);
+
+    for (const value of values) {
+      if (Array.isArray(value)) {
+        // We've come across a repeat arg so we need to extract its values.
+        for (const repeat of value) {
+          flatList = flatList.concat([...Object.values(repeat)]);
+        }
+      } else {
+        flatList.push(value);
       }
     }
   }
-  throw new Error(\`Could not find correct argument order for command: \${commandName}\`);
+
+  return flatList;
 }
 
 function indent(text: string, numTimes: number = 1, char: string = '  '): string {
@@ -523,92 +523,49 @@ function indent(text: string, numTimes: number = 1, char: string = '  '): string
 
 declare global {
 
-  
-	/**This command will echo back a string*/
-	interface ECHO extends Command<[
-		VarString<8, 1024>,
-	] | {
-		'echo_string': VarString<8, 1024>,
-	}> {}
+	interface ECHO extends Command<[ [{ 'echo_string': VarString<8, 1024> }] ]> {}
 
-  
-	/**This command will turn on the oven*/
-	interface PREHEAT_OVEN extends Command<[
-		U8,
-	] | {
-		'temperature': U8,
-	}> {}
+	interface PREHEAT_OVEN extends Command<[ [{ 'temperature': U8 }] ]> {}
 
-  
-	/**This command will throw a banana*/
-	interface THROW_BANANA extends Command<[
-		U8,
-	] | {
-		'distance': U8,
-	}> {}
+	interface THROW_BANANA extends Command<[ [{ 'distance': U8 }] ]> {}
 
-  
-	/**This command will grow bananas*/
-	interface GROW_BANANA extends Command<[
-		U8,
-		U8,
-	] | {
-		'quantity': U8,
-		'durationSecs': U8,
-	}> {}
+	interface GROW_BANANA extends Command<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
 
-  
-	/**This command make the banana bread dough*/
-	interface PREPARE_LOAF extends Command<[
-		U8,
-		boolean,
-	] | {
-		'tb_sugar': U8,
-		'gluten_free': boolean,
-	}> {}
+	interface PREPARE_LOAF extends Command<[ [{ 'tb_sugar': U8,'gluten_free': boolean }] ]> {}
 
-  
-	/**This command peels a single banana*/
-	interface PEEL_BANANA extends Command<[
-		('fromStem' | 'fromTip'),
-	] | {
-		'peelDirection': ('fromStem' | 'fromTip'),
-	}> {}
+	interface PEEL_BANANA extends Command<[ [{ 'peelDirection': ('fromStem' | 'fromTip') }] ]> {}
 
 
-	/**This command bakes a banana bread*/
+/**
+* This command bakes a banana bread
+*
+*/
 	interface BAKE_BREAD extends Command<[]> {}
 
 
 
-	/**This command waters the banana tree*/
+/**
+* This command waters the banana tree
+*
+*/
 	interface ADD_WATER extends Command<[]> {}
 
 
-	interface PACKAGE_BANANA extends Command<[
-[U16] 
-|[{	'lot_number': U16}]
-|[VarString<8, 1024>, U8, U16] 
-|[{	'bundle_name_1': VarString<8, 1024>, 	'number_of_bananas_1': U8, 	'lot_number': U16}]
-|[VarString<8, 1024>, U8, VarString<8, 1024>, U8, U16] 
-|[{	'bundle_name_1': VarString<8, 1024>, 	'number_of_bananas_1': U8, 	'bundle_name_2': VarString<8, 1024>, 	'number_of_bananas_2': U8, 	'lot_number': U16}]
-|[VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, U16] 
-|[{	'bundle_name_1': VarString<8, 1024>, 	'number_of_bananas_1': U8, 	'bundle_name_2': VarString<8, 1024>, 	'number_of_bananas_2': U8, 	'bundle_name_3': VarString<8, 1024>, 	'number_of_bananas_3': U8, 	'lot_number': U16}]
-|[VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, U16] 
-|[{	'bundle_name_1': VarString<8, 1024>, 	'number_of_bananas_1': U8, 	'bundle_name_2': VarString<8, 1024>, 	'number_of_bananas_2': U8, 	'bundle_name_3': VarString<8, 1024>, 	'number_of_bananas_3': U8, 	'bundle_name_4': VarString<8, 1024>, 	'number_of_bananas_4': U8, 	'lot_number': U16}]
-|[VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, U16] 
-|[{	'bundle_name_1': VarString<8, 1024>, 	'number_of_bananas_1': U8, 	'bundle_name_2': VarString<8, 1024>, 	'number_of_bananas_2': U8, 	'bundle_name_3': VarString<8, 1024>, 	'number_of_bananas_3': U8, 	'bundle_name_4': VarString<8, 1024>, 	'number_of_bananas_4': U8, 	'bundle_name_5': VarString<8, 1024>, 	'number_of_bananas_5': U8, 	'lot_number': U16}]
-|[VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, U16] 
-|[{	'bundle_name_1': VarString<8, 1024>, 	'number_of_bananas_1': U8, 	'bundle_name_2': VarString<8, 1024>, 	'number_of_bananas_2': U8, 	'bundle_name_3': VarString<8, 1024>, 	'number_of_bananas_3': U8, 	'bundle_name_4': VarString<8, 1024>, 	'number_of_bananas_4': U8, 	'bundle_name_5': VarString<8, 1024>, 	'number_of_bananas_5': U8, 	'bundle_name_6': VarString<8, 1024>, 	'number_of_bananas_6': U8, 	'lot_number': U16}]
-]> {}
+	interface PACKAGE_BANANA extends Command<[ [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }] ]> {}
 
 
-	/**Pick a banana*/
+/**
+* Pick a banana
+*
+*/
 	interface PICK_BANANA extends Command<[]> {}
 
 
 
-	/**Eat a banana*/
+/**
+* Eat a banana
+*
+*/
 	interface EAT_BANANA extends Command<[]> {}
 
 	const Commands: {
@@ -626,142 +583,128 @@ declare global {
 	};
 }
 
-const ECHO_ARGS_ORDER = ['echo_string'];
 
-	/**This command will echo back a string*/
-function ECHO(...args: [
-	VarString<8, 1024>,
-] | [{
-	'echo_string': VarString<8, 1024>,
-}]): ECHO {
+/**
+* This command will echo back a string
+* @param echo_string String to echo back
+*/
+function ECHO(...args: [{ 'echo_string': VarString<8, 1024> }]) {
   return Command.new({
     stem: 'ECHO',
-    arguments: typeof args[0] === 'object' ? orderCommandArguments(args[0],ECHO_ARGS_ORDER) : args,
+    arguments: args
   }) as ECHO;
 }
 
-const PREHEAT_OVEN_ARGS_ORDER = ['temperature'];
 
-	/**This command will turn on the oven*/
-function PREHEAT_OVEN(...args: [
-	U8,
-] | [{
-	'temperature': U8,
-}]): PREHEAT_OVEN {
+/**
+* This command will turn on the oven
+* @param temperature Set the oven temperature
+*/
+function PREHEAT_OVEN(...args: [{ 'temperature': U8 }]) {
   return Command.new({
     stem: 'PREHEAT_OVEN',
-    arguments: typeof args[0] === 'object' ? orderCommandArguments(args[0],PREHEAT_OVEN_ARGS_ORDER) : args,
+    arguments: args
   }) as PREHEAT_OVEN;
 }
 
-const THROW_BANANA_ARGS_ORDER = ['distance'];
 
-	/**This command will throw a banana*/
-function THROW_BANANA(...args: [
-	U8,
-] | [{
-	'distance': U8,
-}]): THROW_BANANA {
+/**
+* This command will throw a banana
+* @param distance The distance you throw the bananan
+*/
+function THROW_BANANA(...args: [{ 'distance': U8 }]) {
   return Command.new({
     stem: 'THROW_BANANA',
-    arguments: typeof args[0] === 'object' ? orderCommandArguments(args[0],THROW_BANANA_ARGS_ORDER) : args,
+    arguments: args
   }) as THROW_BANANA;
 }
 
-const GROW_BANANA_ARGS_ORDER = ['quantity', 'durationSecs'];
 
-	/**This command will grow bananas*/
-function GROW_BANANA(...args: [
-	U8,
-	U8,
-] | [{
-	'quantity': U8,
-	'durationSecs': U8,
-}]): GROW_BANANA {
+/**
+* This command will grow bananas
+* @param quantity Number of bananas to grow
+* @param durationSecs How many seconds will it take to grow
+*/
+function GROW_BANANA(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
   return Command.new({
     stem: 'GROW_BANANA',
-    arguments: typeof args[0] === 'object' ? orderCommandArguments(args[0],GROW_BANANA_ARGS_ORDER) : args,
+    arguments: args
   }) as GROW_BANANA;
 }
 
-const PREPARE_LOAF_ARGS_ORDER = ['tb_sugar', 'gluten_free'];
 
-	/**This command make the banana bread dough*/
-function PREPARE_LOAF(...args: [
-	U8,
-	boolean,
-] | [{
-	'tb_sugar': U8,
-	'gluten_free': boolean,
-}]): PREPARE_LOAF {
+/**
+* This command make the banana bread dough
+* @param tb_sugar How much sugar is needed
+* @param gluten_free Do you hate flavor
+*/
+function PREPARE_LOAF(...args: [{ 'tb_sugar': U8,'gluten_free': boolean }]) {
   return Command.new({
     stem: 'PREPARE_LOAF',
-    arguments: typeof args[0] === 'object' ? orderCommandArguments(args[0],PREPARE_LOAF_ARGS_ORDER) : args,
+    arguments: args
   }) as PREPARE_LOAF;
 }
 
-const PEEL_BANANA_ARGS_ORDER = ['peelDirection'];
 
-	/**This command peels a single banana*/
-function PEEL_BANANA(...args: [
-	('fromStem' | 'fromTip'),
-] | [{
-	'peelDirection': ('fromStem' | 'fromTip'),
-}]): PEEL_BANANA {
+/**
+* This command peels a single banana
+* @param peelDirection Which way do you peel the banana
+*/
+function PEEL_BANANA(...args: [{ 'peelDirection': ('fromStem' | 'fromTip') }]) {
   return Command.new({
     stem: 'PEEL_BANANA',
-    arguments: typeof args[0] === 'object' ? orderCommandArguments(args[0],PEEL_BANANA_ARGS_ORDER) : args,
+    arguments: args
   }) as PEEL_BANANA;
 }
 
 
-	/**This command bakes a banana bread*/
+/**
+* This command bakes a banana bread
+*
+*/
 const BAKE_BREAD: BAKE_BREAD = Command.new({
 	stem: 'BAKE_BREAD',
 	arguments: [],
 })
 
 
-	/**This command waters the banana tree*/
+/**
+* This command waters the banana tree
+*
+*/
 const ADD_WATER: ADD_WATER = Command.new({
 	stem: 'ADD_WATER',
 	arguments: [],
 })
 
-const PACKAGE_BANANA_ARGS_ORDERS = [['lot_number'],['bundle_name_1','number_of_bananas_1','lot_number'],['bundle_name_1','number_of_bananas_1','bundle_name_2','number_of_bananas_2','lot_number'],['bundle_name_1','number_of_bananas_1','bundle_name_2','number_of_bananas_2','bundle_name_3','number_of_bananas_3','lot_number'],['bundle_name_1','number_of_bananas_1','bundle_name_2','number_of_bananas_2','bundle_name_3','number_of_bananas_3','bundle_name_4','number_of_bananas_4','lot_number'],['bundle_name_1','number_of_bananas_1','bundle_name_2','number_of_bananas_2','bundle_name_3','number_of_bananas_3','bundle_name_4','number_of_bananas_4','bundle_name_5','number_of_bananas_5','lot_number'],['bundle_name_1','number_of_bananas_1','bundle_name_2','number_of_bananas_2','bundle_name_3','number_of_bananas_3','bundle_name_4','number_of_bananas_4','bundle_name_5','number_of_bananas_5','bundle_name_6','number_of_bananas_6','lot_number']];
 
-	/**Dynamically bundle bananas into lots*/
-function PACKAGE_BANANA(...args:
- [U16] 
-|[{	'lot_number': U16}]
-|[VarString<8, 1024>, U8, U16] 
-|[{	'bundle_name_1': VarString<8, 1024>, 	'number_of_bananas_1': U8, 	'lot_number': U16}]
-|[VarString<8, 1024>, U8, VarString<8, 1024>, U8, U16] 
-|[{	'bundle_name_1': VarString<8, 1024>, 	'number_of_bananas_1': U8, 	'bundle_name_2': VarString<8, 1024>, 	'number_of_bananas_2': U8, 	'lot_number': U16}]
-|[VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, U16] 
-|[{	'bundle_name_1': VarString<8, 1024>, 	'number_of_bananas_1': U8, 	'bundle_name_2': VarString<8, 1024>, 	'number_of_bananas_2': U8, 	'bundle_name_3': VarString<8, 1024>, 	'number_of_bananas_3': U8, 	'lot_number': U16}]
-|[VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, U16] 
-|[{	'bundle_name_1': VarString<8, 1024>, 	'number_of_bananas_1': U8, 	'bundle_name_2': VarString<8, 1024>, 	'number_of_bananas_2': U8, 	'bundle_name_3': VarString<8, 1024>, 	'number_of_bananas_3': U8, 	'bundle_name_4': VarString<8, 1024>, 	'number_of_bananas_4': U8, 	'lot_number': U16}]
-|[VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, U16] 
-|[{	'bundle_name_1': VarString<8, 1024>, 	'number_of_bananas_1': U8, 	'bundle_name_2': VarString<8, 1024>, 	'number_of_bananas_2': U8, 	'bundle_name_3': VarString<8, 1024>, 	'number_of_bananas_3': U8, 	'bundle_name_4': VarString<8, 1024>, 	'number_of_bananas_4': U8, 	'bundle_name_5': VarString<8, 1024>, 	'number_of_bananas_5': U8, 	'lot_number': U16}]
-|[VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, VarString<8, 1024>, U8, U16] 
-|[{	'bundle_name_1': VarString<8, 1024>, 	'number_of_bananas_1': U8, 	'bundle_name_2': VarString<8, 1024>, 	'number_of_bananas_2': U8, 	'bundle_name_3': VarString<8, 1024>, 	'number_of_bananas_3': U8, 	'bundle_name_4': VarString<8, 1024>, 	'number_of_bananas_4': U8, 	'bundle_name_5': VarString<8, 1024>, 	'number_of_bananas_5': U8, 	'bundle_name_6': VarString<8, 1024>, 	'number_of_bananas_6': U8, 	'lot_number': U16}]
-) {
+/**
+* Dynamically bundle bananas into lots
+* @param lot_number Identification number assigned to a particular quantity
+* @param bundle A repeated set of strings and integer containing the arguments to the lot
+*/
+function PACKAGE_BANANA(...args: [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]) {
   return Command.new({
     stem: 'PACKAGE_BANANA',
-    arguments: typeof args[0] === 'object' ? findAndOrderCommandArguments("PACKAGE_BANANA",args[0],PACKAGE_BANANA_ARGS_ORDERS) : args,
+    arguments: args
   }) as PACKAGE_BANANA;
 }
 
 
-	/**Pick a banana*/
+/**
+* Pick a banana
+*
+*/
 const PICK_BANANA: PICK_BANANA = Command.new({
 	stem: 'PICK_BANANA',
 	arguments: [],
 })
 
 
-	/**Eat a banana*/
+/**
+* Eat a banana
+*
+*/
 const EAT_BANANA: EAT_BANANA = Command.new({
 	stem: 'EAT_BANANA',
 	arguments: [],

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -58,8 +58,8 @@ describe('sequence generation', () => {
       `
     export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
       return [
-        C.PREHEAT_OVEN({temperature: 70}),
-        C.PREPARE_LOAF(50, false),
+        C.PREHEAT_OVEN({ temperature: 70 }),
+        C.PREPARE_LOAF({ tb_sugar: 50, gluten_free: false }),
         C.BAKE_BREAD,
       ];
     }
@@ -71,9 +71,9 @@ describe('sequence generation', () => {
       `
     export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
       return [
-        C.PREHEAT_OVEN({temperature: 70}),
+        C.PREHEAT_OVEN({ temperature: 70 }),
         C.BAKE_BREAD,
-        C.PREPARE_LOAF(50, false),
+        C.PREPARE_LOAF({ tb_sugar: 50, gluten_free: false }),
       ];
     }
     `,
@@ -85,26 +85,37 @@ describe('sequence generation', () => {
     export default function TimeDynamicCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
       return [
         A\`2020-060T03:45:19\`.ADD_WATER,
-        A(Temporal.Instant.from("2025-12-24T12:01:59Z")).PREHEAT_OVEN({temperature: 360}),
-        R\`00:15:30\`.PREHEAT_OVEN({temperature: 425}),
+        A(Temporal.Instant.from("2025-12-24T12:01:59Z")).PREHEAT_OVEN({ temperature: 360 }),
+        R\`00:15:30\`.PREHEAT_OVEN({ temperature: 425 }),
         R(Temporal.Duration.from({ hours: 1, minutes: 15, seconds: 30 })).EAT_BANANA,
-        E(Temporal.Duration.from({ hours: 12, minutes: 6, seconds: 54 })).PREPARE_LOAF(50, false),
+        E(Temporal.Duration.from({ hours: 12, minutes: 6, seconds: 54 })).PREPARE_LOAF({ tb_sugar: 50, gluten_free: false }),
         E\`04:56:54\`.EAT_BANANA,
         C.PACKAGE_BANANA({
-          bundle_name_1: "Chiquita",
-          number_of_bananas_1: 43,
-          bundle_name_2: "Dole",
-          number_of_bananas_2: 12,
           lot_number: 1093,
+          bundle: [
+            {
+              bundle_name: "Chiquita",
+              number_of_bananas: 43
+            },
+            {
+              bundle_name: "Dole",
+              number_of_bananas: 12 
+            }
+          ]
         }),
         C.PACKAGE_BANANA({
-          bundle_name_2: "Dole",
-          number_of_bananas_1: 43,
-          bundle_name_1: "Chiquita",
           lot_number: 1093,
-          number_of_bananas_2: 12
-        }),
-        C.PACKAGE_BANANA("Chiquita",43,"Dole",12,"Blue",1,1093)
+          bundle: [
+            {
+              bundle_name: "Chiquita",
+              number_of_bananas: 43
+            },
+            {
+              bundle_name: "Blue",
+              number_of_bananas: 12 
+            }
+          ]
+        })
       ];
     }
     `,
@@ -295,21 +306,14 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
+        args: [1093, 'Chiquita', 43, 'Dole', 12],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
       {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
-        metadata: { simulatedActivityId: simulatedActivityId3 },
-      },
-      {
-        type: 'command',
-        stem: 'PACKAGE_BANANA',
-        time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 'Blue', 1, 1093],
+        args: [1093, 'Chiquita', 43, 'Blue', 12],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
     ]);
@@ -547,21 +551,14 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
+        args: [1093, 'Chiquita', 43, 'Dole', 12],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
       {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
-        metadata: { simulatedActivityId: simulatedActivityId3 },
-      },
-      {
-        type: 'command',
-        stem: 'PACKAGE_BANANA',
-        time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 'Blue', 1, 1093],
+        args: [1093, 'Chiquita', 43, 'Blue', 12],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
     ]);
@@ -687,21 +684,14 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
+        args: [1093, 'Chiquita', 43, 'Dole', 12],
         metadata: { simulatedActivityId: simulatedActivityId6 },
       },
       {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
-        metadata: { simulatedActivityId: simulatedActivityId6 },
-      },
-      {
-        type: 'command',
-        stem: 'PACKAGE_BANANA',
-        time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 'Blue', 1, 1093],
+        args: [1093, 'Chiquita', 43, 'Blue', 12],
         metadata: { simulatedActivityId: simulatedActivityId6 },
       },
     ]);
@@ -920,21 +910,14 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
+        args: [1093, 'Chiquita', 43, 'Dole', 12],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
       {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
-        metadata: { simulatedActivityId: simulatedActivityId3 },
-      },
-      {
-        type: 'command',
-        stem: 'PACKAGE_BANANA',
-        time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 'Blue', 1, 1093],
+        args: [1093, 'Chiquita', 43, 'Blue', 12],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
       {
@@ -1203,21 +1186,14 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
+        args: [1093, 'Chiquita', 43, 'Dole', 12],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
       {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
-        metadata: { simulatedActivityId: simulatedActivityId3 },
-      },
-      {
-        type: 'command',
-        stem: 'PACKAGE_BANANA',
-        time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 'Blue', 1, 1093],
+        args: [1093, 'Chiquita', 43, 'Blue', 12],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
       {
@@ -1346,21 +1322,14 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
+        args: [1093, 'Chiquita', 43, 'Dole', 12],
         metadata: { simulatedActivityId: simulatedActivityId7 },
       },
       {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
-        metadata: { simulatedActivityId: simulatedActivityId7 },
-      },
-      {
-        type: 'command',
-        stem: 'PACKAGE_BANANA',
-        time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 'Blue', 1, 1093],
+        args: [1093, 'Chiquita', 43, 'Blue', 12],
         metadata: { simulatedActivityId: simulatedActivityId7 },
       },
       {
@@ -1582,21 +1551,14 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
+        args: [1093, 'Chiquita', 43, 'Dole', 12],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
       {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
-        metadata: { simulatedActivityId: simulatedActivityId3 },
-      },
-      {
-        type: 'command',
-        stem: 'PACKAGE_BANANA',
-        time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 'Blue', 1, 1093],
+        args: [1093, 'Chiquita', 43, 'Blue', 12],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
     ]);
@@ -1845,21 +1807,14 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
+        args: [1093, 'Chiquita', 43, 'Dole', 12],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
       {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
-        metadata: { simulatedActivityId: simulatedActivityId3 },
-      },
-      {
-        type: 'command',
-        stem: 'PACKAGE_BANANA',
-        time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 'Blue', 1, 1093],
+        args: [1093, 'Chiquita', 43, 'Blue', 12],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
     ]);
@@ -1985,21 +1940,14 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
+        args: [1093, 'Chiquita', 43, 'Dole', 12],
         metadata: { simulatedActivityId: simulatedActivityId7 },
       },
       {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
-        metadata: { simulatedActivityId: simulatedActivityId7 },
-      },
-      {
-        type: 'command',
-        stem: 'PACKAGE_BANANA',
-        time: { type: TimingTypes.COMMAND_COMPLETE },
-        args: ['Chiquita', 43, 'Dole', 12, 'Blue', 1, 1093],
+        args: [1093, 'Chiquita', 43, 'Blue', 12],
         metadata: { simulatedActivityId: simulatedActivityId7 },
       },
     ]);
@@ -2118,7 +2066,7 @@ it('should provide start, end, and computed attributes on activities', async () 
       return [
         A(props.activityInstance.startTime).BAKE_BREAD,
         A(props.activityInstance.endTime).BAKE_BREAD,
-        C.ECHO("Computed attributes: " + props.activityInstance.attributes.computed),
+        C.ECHO({ echo_string: "Computed attributes: " + props.activityInstance.attributes.computed }),
       ];
     }
     `,
@@ -2195,13 +2143,19 @@ describe('user sequence to seqjson', () => {
         metadata: {},
         commands: [
             C.BAKE_BREAD,
-            A\`2020-060T03:45:19\`.PREHEAT_OVEN(100),
+            A\`2020-060T03:45:19\`.PREHEAT_OVEN({ temperature: 100 }),
             E(Temporal.Duration.from({ hours: 12, minutes: 6, seconds: 54 })).PACKAGE_BANANA({
-              bundle_name_2: "Dole",
-              number_of_bananas_1: 43,
-              bundle_name_1: "Chiquita",
               lot_number: 1093,
-              number_of_bananas_2: 12
+              bundle: [
+                {
+                  bundle_name: "Chiquita",
+                  number_of_bananas: 43
+                },
+                {
+                  bundle_name: "Dole",
+                  number_of_bananas: 12 
+                }
+              ]
             }),
         ],
       });
@@ -2235,7 +2189,7 @@ describe('user sequence to seqjson', () => {
           tag: '12:06:54.000',
           type: 'EPOCH_RELATIVE',
         },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
+        args: [1093, 'Chiquita', 43, 'Dole', 12],
         metadata: {},
       },
     ]);
@@ -2252,14 +2206,20 @@ describe('user sequence to seqjson', () => {
               metadata: {},
               commands: [
                   C.BAKE_BREAD,
-                  A\`2020-060T03:45:19\`.PREHEAT_OVEN(100),
+                  A\`2020-060T03:45:19\`.PREHEAT_OVEN({ temperature: 100 }),
                   E(Temporal.Duration.from({ hours: 12, minutes: 6, seconds: 54 })).PACKAGE_BANANA({
-                    bundle_name_2: "Dole",
-                    number_of_bananas_1: 43,
-                    bundle_name_1: "Chiquita",
                     lot_number: 1093,
-                    number_of_bananas_2: 12
-                  }),
+                    bundle: [
+                      {
+                        bundle_name: "Chiquita",
+                        number_of_bananas: 43
+                      },
+                      {
+                        bundle_name: "Dole",
+                        number_of_bananas: 12 
+                      }
+                    ]
+                }),
               ],
             });
           `,
@@ -2273,13 +2233,19 @@ describe('user sequence to seqjson', () => {
               metadata: {},
               commands: [
                   C.BAKE_BREAD,
-                  A\`2020-061T03:45:19\`.PREHEAT_OVEN(100),
+                  A\`2020-061T03:45:19\`.PREHEAT_OVEN({ temperature: 100 }),
                   E(Temporal.Duration.from({ hours: 12, minutes: 6, seconds: 54 })).PACKAGE_BANANA({
-                    bundle_name_2: "Dole",
-                    number_of_bananas_1: 43,
-                    bundle_name_1: "Chiquita",
                     lot_number: 1093,
-                    number_of_bananas_2: 12
+                    bundle: [
+                      {
+                        bundle_name: "Chiquita",
+                        number_of_bananas: 43
+                      },
+                      {
+                        bundle_name: "Dole",
+                        number_of_bananas: 12 
+                      }
+                    ]
                   }),
               ],
             });
@@ -2314,7 +2280,7 @@ describe('user sequence to seqjson', () => {
           tag: '12:06:54.000',
           type: 'EPOCH_RELATIVE',
         },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
+        args: [1093, 'Chiquita', 43, 'Dole', 12],
         metadata: {},
       },
     ]);
@@ -2346,7 +2312,7 @@ describe('user sequence to seqjson', () => {
           tag: '12:06:54.000',
           type: 'EPOCH_RELATIVE',
         },
-        args: ['Chiquita', 43, 'Dole', 12, 1093],
+        args: [1093, 'Chiquita', 43, 'Dole', 12],
         metadata: {},
       },
     ]);


### PR DESCRIPTION
Closes #542.

This fixes the order of repeat args in the generated seqjson, it also removes support for the existing list notation and moves to using object notation for adding command arguments.

* **Tickets addressed:** #542 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This started as a small fix for the repeat arg ordering, but expanded into quite a large change.

## Verification
Tests were slightly modified to use the new notation.

## Documentation

## Future work
We need to readdress this issue once we know what changes are going to be made to seqjson to support repeat args. Right now there's a case where we could have side-by-side repeat args that are the same type and we'd never be able to know which one the user is intending to use unless they're using the named object notation.
