### PR TITLE
Timer stats

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,7 +203,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
-        -Dgov.nasa.jpl.aerie.timeTasks=ON
+        -Dgov.nasa.jpl.aerie.timeTasks=OFF
     ports: ["5010:5005", "27190:8080"]
     restart: always
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
-        -Dgov.nasa.jpl.aerie.timeTasks=ON
+        -Dgov.nasa.jpl.aerie.timeTasks=OFF
       UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
     ports: ["5007:5005", "27187:8080"]
     restart: always
@@ -150,7 +150,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
-        -Dgov.nasa.jpl.aerie.timeTasks=ON
+        -Dgov.nasa.jpl.aerie.timeTasks=OFF
       UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
     ports: ["5008:5005", "27188:8080"]
     restart: always
@@ -177,7 +177,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
-        -Dgov.nasa.jpl.aerie.timeTasks=ON
+        -Dgov.nasa.jpl.aerie.timeTasks=OFF
     ports: ["5009:5005", "27189:8080"]
     restart: always
     volumes:
@@ -229,10 +229,6 @@ services:
       - ./deployment/hasura/metadata:/hasura-metadata
   postgres:
     container_name: aerie_postgres
-#    # Make Postgres log to a file.
-#    # More on logging with Postgres: https://www.postgresql.org/docs/current/static/runtime-config-logging.html
-#    # command: postgres -c logging_collector=on -c log_destination=csvlog -c log_directory=/var/log -c log_rotation_age=1d -c log_statement=all -c log_filename=postgresql-%Y-%m-%d.log
-#    command: postgres -c logging_collector=on -c log_destination=stderr -c log_directory=/var/log -c log_statement=all
     environment:
       POSTGRES_DB: postgres
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
@@ -244,11 +240,9 @@ services:
     restart: always
     volumes:
       - postgres_data:/var/lib/postgresql/data
-#      - varlog:/var/log
       - ./deployment/postgres-init-db:/docker-entrypoint-initdb.d
 
 volumes:
   aerie_file_store:
   mission_file_store:
   postgres_data:
-#  varlog:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
+        -Dgov.nasa.jpl.aerie.timeTasks=ON
       UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
     ports: ["5007:5005", "27187:8080"]
     restart: always
@@ -149,6 +150,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
+        -Dgov.nasa.jpl.aerie.timeTasks=ON
       UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
     ports: ["5008:5005", "27188:8080"]
     restart: always
@@ -175,6 +177,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
+        -Dgov.nasa.jpl.aerie.timeTasks=ON
     ports: ["5009:5005", "27189:8080"]
     restart: always
     volumes:
@@ -200,6 +203,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
+        -Dgov.nasa.jpl.aerie.timeTasks=ON
     ports: ["5010:5005", "27190:8080"]
     restart: always
     volumes:
@@ -225,6 +229,10 @@ services:
       - ./deployment/hasura/metadata:/hasura-metadata
   postgres:
     container_name: aerie_postgres
+#    # Make Postgres log to a file.
+#    # More on logging with Postgres: https://www.postgresql.org/docs/current/static/runtime-config-logging.html
+#    # command: postgres -c logging_collector=on -c log_destination=csvlog -c log_directory=/var/log -c log_rotation_age=1d -c log_statement=all -c log_filename=postgresql-%Y-%m-%d.log
+#    command: postgres -c logging_collector=on -c log_destination=stderr -c log_directory=/var/log -c log_statement=all
     environment:
       POSTGRES_DB: postgres
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
@@ -236,9 +244,11 @@ services:
     restart: always
     volumes:
       - postgres_data:/var/lib/postgresql/data
+#      - varlog:/var/log
       - ./deployment/postgres-init-db:/docker-entrypoint-initdb.d
 
 volumes:
   aerie_file_store:
   mission_file_store:
   postgres_data:
+#  varlog:

--- a/examples/banananation/build.gradle
+++ b/examples/banananation/build.gradle
@@ -20,7 +20,7 @@ jar {
   from {
     configurations.runtimeClasspath.filter{ it.exists() }.collect{ it.isDirectory() ? it : zipTree(it) }
   } {
-    exclude 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt'
+    exclude 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt', 'META-INF/versions/**/*.class'
   }
 }
 

--- a/examples/config-with-defaults/build.gradle
+++ b/examples/config-with-defaults/build.gradle
@@ -12,7 +12,7 @@ jar {
   from {
     configurations.runtimeClasspath.filter{ it.exists() }.collect{ it.isDirectory() ? it : zipTree(it) }
   } {
-    exclude 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt'
+    exclude 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt', 'META-INF/versions/**/*.class'
   }
 }
 

--- a/examples/config-without-defaults/build.gradle
+++ b/examples/config-without-defaults/build.gradle
@@ -12,7 +12,7 @@ jar {
   from {
     configurations.runtimeClasspath.filter{ it.exists() }.collect{ it.isDirectory() ? it : zipTree(it) }
   } {
-    exclude 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt'
+    exclude 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt', 'META-INF/versions/**/*.class'
   }
 }
 

--- a/examples/foo-missionmodel/build.gradle
+++ b/examples/foo-missionmodel/build.gradle
@@ -12,7 +12,7 @@ jar {
   from {
     configurations.runtimeClasspath.filter{ it.exists() }.collect{ it.isDirectory() ? it : zipTree(it) }
   } {
-    exclude 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt'
+    exclude 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt', 'META-INF/versions/**/*.class'
   }
 }
 

--- a/merlin-framework/build.gradle
+++ b/merlin-framework/build.gradle
@@ -26,6 +26,7 @@ javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 
 dependencies {
   compileOnlyApi project(':merlin-sdk')
+  implementation project(':parsing-utilities')
   implementation 'org.apache.commons:commons-lang3:3.12.0'
 
   testImplementation project(':merlin-sdk')

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingTask.java
@@ -29,8 +29,14 @@ public final class ReplayingTask<Return> implements Task<Return> {
     final var context = new ReplayingReactionContext(this.rootContext, this.memory, scheduler, handle);
 
     try (final var restore = this.rootContext.set(context)){
-      // This is where the adaptation is invoked.
-      final var returnValue = Timer.run("adaptation", this.task);
+      final Return returnValue;
+      // The Timer.timeTasks flag is controlled by a Java property to determine whether to attempt to collect
+      // performance stats around user adaptation.  It is turned off by default since it could slow down simulation.
+      if (Timer.timeTasks) {
+        returnValue = Timer.run("adaptation", this.task);  // This is where the adaptation is invoked.
+      } else {
+        returnValue = this.task.get();  // This is where the adaptation is invoked.
+      }
 
       // If we get here, the activity has completed normally.
       return TaskStatus.completed(returnValue);

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingTask.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.framework;
 
+import gov.nasa.jpl.aerie.stats.Timer;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
@@ -28,7 +29,8 @@ public final class ReplayingTask<Return> implements Task<Return> {
     final var context = new ReplayingReactionContext(this.rootContext, this.memory, scheduler, handle);
 
     try (final var restore = this.rootContext.set(context)){
-      final var returnValue = this.task.get();
+      // This is where the adaptation is invoked.
+      final var returnValue = Timer.run("adaptation", this.task);
 
       // If we get here, the activity has completed normally.
       return TaskStatus.completed(returnValue);

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTask.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.framework;
 
+import gov.nasa.jpl.aerie.stats.Timer;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
@@ -87,7 +88,7 @@ public final class ThreadedTask<Return> implements Task<Return> {
   private void beginAsync() {
     final var handle = new ThreadedTaskHandle();
 
-    this.executor.execute(() -> {
+    this.executor.execute(() -> {  // This is where thread is created
       final TaskRequest request;
       try {
         request = ThreadedTask.this.hostToTask.take();
@@ -138,7 +139,8 @@ public final class ThreadedTask<Return> implements Task<Return> {
         final var context = new ThreadedReactionContext(ThreadedTask.this.rootContext, scheduler, this);
 
         try (final var restore = ThreadedTask.this.rootContext.set(context)) {
-          return new TaskResponse.Success<>(TaskStatus.completed(ThreadedTask.this.task.get()));
+          // This is where the adaptation is invoked.
+          return new TaskResponse.Success<>(TaskStatus.completed(Timer.run("adaptation", ThreadedTask.this.task)));
         } catch (final TaskAbort ex) {
           return new TaskResponse.Success<>(TaskStatus.completed(null));
         } catch (final Throwable ex) {

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTask.java
@@ -139,8 +139,12 @@ public final class ThreadedTask<Return> implements Task<Return> {
         final var context = new ThreadedReactionContext(ThreadedTask.this.rootContext, scheduler, this);
 
         try (final var restore = ThreadedTask.this.rootContext.set(context)) {
-          // This is where the adaptation is invoked.
-          return new TaskResponse.Success<>(TaskStatus.completed(Timer.run("adaptation", ThreadedTask.this.task)));
+          // The Timer.timeTasks flag is controlled by a Java property to determine whether to attempt to collect
+          // performance stats around user adaptation.  It is turned off by default since it could slow down simulation.
+          if (Timer.timeTasks) {
+            return new TaskResponse.Success<>(TaskStatus.completed(Timer.run("adaptation", ThreadedTask.this.task)));  // This is where the adaptation is invoked.
+          }
+          return new TaskResponse.Success<>(TaskStatus.completed(ThreadedTask.this.task.get()));  // This is where the adaptation is invoked.
         } catch (final TaskAbort ex) {
           return new TaskResponse.Success<>(TaskStatus.completed(null));
         } catch (final Throwable ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -9,6 +9,7 @@ import gov.nasa.jpl.aerie.merlin.server.services.GenerateConstraintsLibAction;
 import gov.nasa.jpl.aerie.merlin.server.services.GetSimulationResultsAction;
 import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService;
 import gov.nasa.jpl.aerie.merlin.server.services.PlanService;
+import gov.nasa.jpl.aerie.stats.Timer;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 import io.javalin.plugin.Plugin;
@@ -192,6 +193,8 @@ public final class MerlinBindings implements Plugin {
   }
 
   private void getSimulationResults(final Context ctx) {
+    Timer.reset(); // erase static memory of past stats
+    Timer timer = new Timer("server getSimulationResults()", true);
     try {
       final var body = parseJson(ctx.body(), hasuraPlanActionP);
       final var planId = body.input().planId();
@@ -207,6 +210,9 @@ public final class MerlinBindings implements Plugin {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchPlanException(ex).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
+    } finally {
+      timer.stop(true);
+      Timer.logStats();
     }
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -16,6 +16,7 @@ import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.remotes.ResultsCellRepository;
+import gov.nasa.jpl.aerie.stats.Timer;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.slf4j.Logger;
@@ -614,6 +615,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
 
     @Override
     public void succeedWith(final SimulationResults results) {
+      Timer writeTimer = new Timer("write sim to DB");
       try (final var connection = dataSource.getConnection();
            final var transactionContext = new TransactionContext(connection)) {
         postSimulationResults(connection, datasetId, results);
@@ -624,6 +626,8 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
         // A cell should only be created for a valid, existing dataset
         // A dataset should only be deleted by its cell
         throw new Error("Cell references nonexistent simulation dataset");
+      } finally {
+        writeTimer.stop();
       }
     }
 

--- a/parsing-utilities/build.gradle
+++ b/parsing-utilities/build.gradle
@@ -17,6 +17,8 @@ dependencies {
   api 'org.glassfish:javax.json:1.1.4'
   api 'org.apache.commons:commons-lang3:3.12.0'
 
+  implementation 'org.slf4j:slf4j-simple:2.0.3'
+
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 

--- a/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/stats/Timer.java
+++ b/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/stats/Timer.java
@@ -82,9 +82,9 @@ public class Timer {
       t2 = Instant.now();
     }
     avgTimeOfSystemCall = (instantToNanos(t2) - instantToNanos(t1)) / 10;  // divide by 10, not 11
-    logger.info("timeTasksProperty = " + timeTasksProperty);
-    logger.info("timeTasks = " + timeTasks);
-    logger.info("avgTimeOfSystemCall = " + avgTimeOfSystemCall);
+    logger.info("property gov.nasa.jpl.aerie.timeTasks = " + timeTasksProperty);
+    logger.info("Timer.timeTasks = " + timeTasks);
+    logger.info("average time of system call = " + avgTimeOfSystemCall + " nanoseconds");
   }
 
   /**

--- a/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/stats/Timer.java
+++ b/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/stats/Timer.java
@@ -82,6 +82,9 @@ public class Timer {
       t2 = Instant.now();
     }
     avgTimeOfSystemCall = (instantToNanos(t2) - instantToNanos(t1)) / 10;  // divide by 10, not 11
+    logger.info("timeTasksProperty = " + timeTasksProperty);
+    logger.info("timeTasks = " + timeTasks);
+    logger.info("avgTimeOfSystemCall = " + avgTimeOfSystemCall);
   }
 
   /**
@@ -286,8 +289,40 @@ public class Timer {
   public static void logStats() {
     logger.info(timestampNow() + " %% REPORTING TIMER STATS %%");
     String stats = summarizeStats();
-    final String[] lines = stats.split("\n");
+    String[] lines = stats.split("\n");
     List.of(lines).forEach(x -> logger.info(" %% " + x ));
+
+    String csvRows = csvStats();
+    lines = csvRows.split("\n");
+    List.of(lines).forEach(x -> logger.info(" %% " + x ));
+  }
+
+  public static String csvStats() {
+    StringBuilder sb = new StringBuilder();
+    // print header row
+    final List<String> headers = new ArrayList<>();
+    for (String label : stats.keySet()) {
+      final ConcurrentSkipListMap<StatType, Long> innerMap = getInnerMap(label);
+      for (StatType stat : innerMap.keySet()) {
+        headers.add(stat + " " + label);
+      }
+    }
+    String headerString = String.join(",", headers);
+    sb.append(headerString + "\n");
+
+    // print data row
+    final List<String> data = new ArrayList<>();
+    for (String label : stats.keySet()) {
+      final ConcurrentSkipListMap<StatType, Long> innerMap = getInnerMap(label);
+      for (StatType stat : innerMap.keySet()) {
+        data.add("" + innerMap.get(stat));
+      }
+    }
+    String dataString = String.join(",", data);
+    sb.append(dataString + "\n");
+
+    String twoRows = sb.toString();
+    return twoRows;
   }
 
   // It would be nice to use one of the two Timestamp classes below.  They are maybe

--- a/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/stats/Timer.java
+++ b/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/stats/Timer.java
@@ -247,7 +247,7 @@ public class Timer {
           labels.add(label);
           long duration = end - start;
           sb.append(label + ": duration = " + formatDuration(duration) + "\n");
-          count = statsForLabel.get("count");
+          count = statsForLabel.get(StatType.count);
           if (count == null) count = 1L;
           if (count > 1) {
             sb.append(label + ": " + count + " occurrences\n");

--- a/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/stats/Timer.java
+++ b/parsing-utilities/src/main/java/gov/nasa/jpl/aerie/stats/Timer.java
@@ -1,0 +1,380 @@
+package gov.nasa.jpl.aerie.stats;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Timer measures both wall clock, CPU time, and counting.
+ * Individual instances of Timer capture a single time interval.
+ * A resettable static map keeps statistics across multiple Timers,
+ * which could be in separate threads.
+ * Users of Timer should be careful about threads.  A Timer instance
+ * only measures time for the existing thread, excluding the CPU time
+ * of spawned threads.  Timers must be instantiated separately for
+ * each thread.
+ */
+public class Timer {
+
+  // STATIC MEMBERS
+
+  private static final Logger logger = LoggerFactory.getLogger(Timer.class);
+
+  /**
+   * The stats recorded for multiple occurrences (Timer instantiations) -- since it's static and could be accessed
+   * by multiple threads, we use a ConcurrentMap for thread safety.
+   */
+  protected static ConcurrentSkipListMap<String, ConcurrentSkipListMap<String, Long>> stats = new ConcurrentSkipListMap<>();
+
+  /**
+   *  A map from the start time so that we can write stats out in time order.
+   */
+  protected static ConcurrentSkipListMap<Long, ConcurrentSkipListSet<String>> labelsByStartTime = new ConcurrentSkipListMap<>();
+
+  /**
+   *
+   *  @return the stats map for custom use
+   */
+  public static ConcurrentSkipListMap<String, ConcurrentSkipListMap<String, Long>> getStats() {
+    return stats;
+  }
+
+  /**
+   * Clear the existing statically recorded stats maps to start collect stats
+   */
+  public static void reset() {
+    stats.clear();
+    labelsByStartTime.clear();
+  }
+
+  /**
+   * Utility for getting or creating a map nested in another map.
+   * @param label key of the outer map
+   * @param stat key of the inner map
+   * @return
+   */
+  protected static ConcurrentSkipListMap<String, Long> getInnerMap(String label, String stat) {
+    ConcurrentSkipListMap<String, Long> innerMap;
+    if (stats.keySet().contains(label)) {
+      innerMap = stats.get(label);
+    } else {
+      innerMap = new ConcurrentSkipListMap<>();
+      stats.put(label, innerMap);
+    }
+    return innerMap;
+  }
+
+  /**
+   * Add the value to the existing one for the stat and label.
+   * @param label the thing for which the stat applies
+   * @param stat the kind of stat (e.g. "cpu time")
+   * @param value the increase in the stat value
+   */
+  public static void addStat(String label, String stat, long value) {
+    // Don't add start or end time values.  Call putStat() to overwrite instead of add.
+    if (stat.startsWith("start") || stat.startsWith("end")) {
+      putStat(label, stat, value);
+      return;
+    }
+    // Make sure map entries exist before adding.
+    final ConcurrentSkipListMap<String, Long> innerMap = getInnerMap(label, stat);
+    if (!innerMap.containsKey(stat)) {
+      innerMap.put(stat, value);
+    } else {
+      innerMap.put(stat, innerMap.get(stat) + value);
+    }
+  }
+
+  /**
+   * Insert or overwrite the value of the stat for the label.
+   * @param label the thing for which the stat applies
+   * @param stat the kind of stat (e.g. "start")
+   * @param value the increase in the stat value
+   */
+  public static void putStat(String label, String stat, long value) {
+    // Make sure map entries exist before adding.
+    final ConcurrentSkipListMap<String, Long> innerMap = getInnerMap(label, stat);
+    innerMap.put(stat, value);
+
+    // If this is the start time, add to the labelsByStart map.
+    if (stat.startsWith("start")) {
+      final ConcurrentSkipListSet<String> timeList;
+      if (labelsByStartTime.containsKey(value)) {
+        timeList = labelsByStartTime.get(value);
+      } else {
+        timeList = new ConcurrentSkipListSet<>();
+        labelsByStartTime.put(value, timeList);
+      }
+      timeList.add(label);
+    }
+  }
+
+
+  public static <T> T run(String label, Supplier<T> r) {
+    Timer timer = new Timer(label);
+    T t = r.get();
+    timer.stop();
+    return t;
+  }
+
+  public static String formatDuration(Long nanoseconds) {
+    return (nanoseconds / 1.0e9) + " seconds";
+  }
+
+  // Stole this from Duration.  Consider moving Duration to a different package
+  public static String formatDurationFancy(long nanoseconds) {
+    var rest = nanoseconds;
+
+    var sign = "";
+    if (rest < 0L) {
+      sign = "-";
+      rest  = -rest;
+    }
+
+    final long hours;
+    hours = rest / (3600L * 1_000_000_000L);
+    rest = rest % (3600L * 1_000_000_000L);
+
+    final long minutes = rest / (60L * 1_000_000_000L);
+    rest = rest % (60L * 1_000_000_000L);
+
+    final long seconds = rest / 1_000_000_000L;
+    rest = rest % 1_000_000_000L;
+
+    final long microseconds = rest / 1000L;
+
+    return String.format("%s%02d:%02d:%02d.%06d", sign, hours, minutes, seconds, microseconds);
+  }
+
+  /**
+   * These stats are written out differently.
+   */
+  protected static TreeSet<String> timeAndCountStats =
+      new TreeSet<>(Arrays.asList( "start", "end", "count"));
+
+  /**
+   * Write out the stats for each label ordered by time.
+   * @return a string with each stat written on a different line
+   */
+  public static String summarizeStats() {
+    StringBuilder sb = new StringBuilder();
+    TreeMap<Long, List<String>> labelsByEnd = new TreeMap<>();
+    TreeSet<Long> endTimesCopy;
+
+    // Loop through labels in order of start time.
+    for (Long start : labelsByStartTime.keySet()) {  // nanoseconds
+      // Write any passed end times before this start
+      endTimesCopy = new TreeSet<>(labelsByEnd.keySet()); // copy so that we can remove entries--consider priority queue
+      for (Long end : endTimesCopy) {  // nanoseconds
+        if ( end > start + 1000000 ) break;  // only end times before or roughly at the same time the start
+        for (String label: labelsByEnd.get(end)) {
+          sb.append(label + ": end = " + formatTimestamp(end) + "\n");
+        }
+        labelsByEnd.remove(end);
+      }
+
+      // Write start, duration, and number of occurrences.
+      for (String label: labelsByStartTime.get(start)) {
+        final ConcurrentSkipListMap<String, Long> statsForLabel = stats.get(label);
+        Long end = statsForLabel.get("end");
+        sb.append( label + ": start = " + formatTimestamp(start) + "\n");
+        if ( end != null ) {
+          var labels = labelsByEnd.get(end);
+          if (labels == null) {
+            labels = new ArrayList<>();
+            labelsByEnd.put(end, labels);
+          }
+          labels.add(label);
+          long duration = end - start;
+          sb.append(label + ": duration = " + formatDuration(duration) + "\n");
+          Long count = statsForLabel.get("count");
+          if (count != null && count > 1) {
+            sb.append(label + ": " + count + " occurrences\n");
+            // Averaging the duration above doesn't make sense since the occurrences may have been sporadic.
+            // The "other duration stats" below could be averaged but aren't just to keep output simple.
+            // But, maybe a total, min, max, avg column justified would be nice.
+          }
+        }
+
+        // Write all other duration stats for the label.  (Note that the stats are assumed to all be nanoseconds!)
+        for (String stat : statsForLabel.keySet()) {
+          if (!timeAndCountStats.contains(stat)) {
+            sb.append(label + ": " + stat + " = " + formatDuration(statsForLabel.get(stat)) + "\n");
+          }
+        }
+      }
+    }
+
+    // Write remaining end times now that we're done looping through start times.
+    endTimesCopy = new TreeSet<>(labelsByEnd.keySet());
+    for (Long end : endTimesCopy) {  // nanoseconds
+      for (String label: labelsByEnd.get(end)) {
+        sb.append(label + ": end = " + formatTimestamp(end) + "\n");
+      }
+      labelsByEnd.remove(end);
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Get the string with lines of stats from summarizeStats() and log each line with a little decoration.
+   */
+  public static void logStats() {
+    logger.info(timestampNow() + " %% REPORTING TIMER STATS %%");
+    String stats = summarizeStats();
+    final String[] lines = stats.split("\n");
+    List.of(lines).forEach(x -> logger.info(" %% " + x ));
+  }
+
+  // It would be nice to use the Timestamp class here.  Consider moving Timestamp to a more general package.
+  /**
+   * ISO timestamp format
+   */
+  public static final DateTimeFormatter format =
+      new DateTimeFormatterBuilder()
+          .appendPattern("uuuu-DDD'T'HH:mm:ss")
+          .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+          .toFormatter();
+
+  /**
+   * Format nanoseconds from Instant into a date-timestamp.
+    * @param nanoseconds
+   * @return formatted string
+   */
+  protected static String formatTimestamp(long nanoseconds) {
+    return formatTimestamp(Instant.ofEpochSecond(0L, nanoseconds));
+  }
+
+  /**
+   * Format Instant into a date-timestamp.
+   * @param instant
+   * @return formatted string
+   */
+  protected static String formatTimestamp(Instant instant) {
+    return format.format(instant.atZone(ZoneOffset.UTC));
+  }
+
+  /**
+   * Format the current system time into a date-timestamp
+    * @return
+   */
+  protected static String timestampNow() {
+    return formatTimestamp(Instant.now());
+  }
+
+
+  // NON-STATIC MEMBERS
+
+  protected String label;  // The name of the thing for which the stats are recorded,
+  protected long initialWallClockTime; // nanoseconds
+  protected long accumulatedWallClockTime = 0;  // nanoseconds
+  protected long initialCpuTime;  // nanoseconds
+  protected long accumulatedCpuTime = 0;  // nanoseconds
+
+  protected long threadId;  // TODO - consider getting rid of one or both of these
+  protected Thread thread;  // TODO - consider getting rid of one or both of these
+
+
+
+  /**
+   * Start a timer with a label and optionally log the start event.
+   * @param label a name for a category in which stats are collected and summed
+   * @param t the Thread from which stats are collected
+   * @param writeToLog if true, logs the start of the timer if the first occurrence of this label since the last reset
+   */
+  public Timer(String label, Thread t, boolean writeToLog) {
+    this.label = label;
+    this.thread = t;
+    this.threadId = t.threadId();
+
+    // Get the wall clock time in nanoseconds
+    Instant start = Instant.now();   // Some say that System.nanoTime() is more accurate.
+    initialWallClockTime = start.getEpochSecond() * 1_000_000_000L + start.getNano();  // 64-bit long is good until year 2262
+
+    // Only record the start time stat the first time for the label to mark the start of all occurrences.
+    if (!stats.containsKey(label) || !stats.get(label).containsKey("start")) {
+      putStat(label, "start", initialWallClockTime);
+      if (writeToLog) {
+        logger.info(formatTimestamp(initialWallClockTime) + " -- " + label + " -- start");
+      }
+    }
+
+    ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+    initialCpuTime = threadMXBean.getThreadCpuTime(threadId);
+  }
+
+  /**
+   * Start a timer with a label and optionally log the start event.
+   * @param label
+   * @param writeToLog
+   */
+  public Timer(String label, boolean writeToLog) {
+    this(label, Thread.currentThread(), writeToLog);
+  }
+
+  /**
+   * Start a timer with a label.
+   * @param label
+   */
+  public Timer(String label) {
+    this(label, false);  // default - don't log start time
+  }
+
+  /**
+   * Stop the timer, get stats, combine with static stats (for multiple Timers), and optionally log the end time.
+   * @param writeToLog
+   */
+  public void stop(boolean writeToLog) {
+    Instant end = Instant.now();
+    long endWallClockTime = end.getEpochSecond() * 1_000_000_000L + end.getNano();    // This is good until 2262-04-11
+    accumulatedWallClockTime = endWallClockTime - initialWallClockTime;
+
+    ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+    accumulatedCpuTime = threadMXBean.getThreadCpuTime(threadId) - initialCpuTime;
+
+    addStat(label, "wall clock time", accumulatedWallClockTime);
+    addStat(label, "cpu time", accumulatedCpuTime);
+    addStat(label, "count", 1);
+    putStat(label, "end", endWallClockTime);
+    if (writeToLog) {
+      logger.info(formatTimestamp(end) + " -- " + label + " -- end");
+    }
+  }
+
+  /**
+   * Stop the timer, get stats, and combine with static stats (for multiple Timers).
+   */
+  public void stop() {
+    stop(false);  // don't log end time
+  }
+
+  /**
+   * @return a string reporting the cpu and wall clock time so far this Timer
+   * This is not being used -- consider removing
+   */
+  public String status() {
+    Instant now = Instant.now();
+    accumulatedWallClockTime = now.getEpochSecond() * 1_000_000_000L + now.getNano() - initialWallClockTime;    // 64-bit long is good until 2262-04-11
+
+    ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+    accumulatedCpuTime = threadMXBean.getThreadCpuTime(threadId) - initialCpuTime;
+    String status = "Thread " + this.thread + " -- cpu time = " + formatDuration(accumulatedCpuTime) +
+                    "; wall clock time = " + formatDuration(accumulatedWallClockTime);
+    return status;
+  }
+
+}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
@@ -15,6 +15,7 @@ import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchSpecificationExcepti
 import gov.nasa.jpl.aerie.scheduler.server.services.GenerateSchedulingLibAction;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleAction;
 import gov.nasa.jpl.aerie.scheduler.server.services.SchedulerService;
+import gov.nasa.jpl.aerie.stats.Timer;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 import io.javalin.plugin.Plugin;
@@ -62,6 +63,8 @@ public record SchedulerBindings(
    * @param ctx the http context of the request from which to read input or post results
    */
   private void schedule(final Context ctx) {
+    Timer.reset();
+    Timer timer = new Timer("server schedule()", true);
     try {
       //TODO: is plan enough to locate goal set to use, or need more args in body?
       final var body = parseJson(ctx.body(), hasuraSpecificationActionP);
@@ -78,6 +81,9 @@ public record SchedulerBindings(
       ctx.status(400).result(serializeInvalidJsonException(ex).toString());
     } catch (final NoSuchSpecificationException ex) {
       ctx.status(404).result(serializeException(ex).toString());
+    } finally {
+      timer.stop(true);
+      //Timer.logStats();
     }
   }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -16,6 +16,7 @@ import gov.nasa.jpl.aerie.scheduler.server.remotes.ResultsCellRepository;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleFailure;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleResults;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleResults.GoalResult;
+import gov.nasa.jpl.aerie.stats.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -324,10 +325,13 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
 
     @Override
     public void succeedWith(final ScheduleResults results) {
+      Timer dbWriteTimer = new Timer("write schedule to DB");
       try (final var connection = dataSource.getConnection()) {
         succeedRequest(connection, specId, specRevision, analysisId, results);
       } catch (final SQLException ex) {
         throw new DatabaseException("Failed to update scheduling request state", ex);
+      } finally {
+        dbWriteTimer.stop();
       }
     }
 


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Logs wall clock time and CPU time performance of simulation, scheduling, separating out database writing and, optionally via Java property, calls to the adaptation.   Here is an example of what appears in the combined logs for simulation and scheduling when grepping with `egrep '([|] Request: POST)|Timer'`:

```
aerie_merlin              | [qtp1764996806-48] INFO gov.nasa.jpl.aerie.stats.Timer - property gov.nasa.jpl.aerie.timeTasks = null
aerie_merlin              | [qtp1764996806-48] INFO gov.nasa.jpl.aerie.stats.Timer - Timer.timeTasks = false
aerie_merlin              | [qtp1764996806-48] INFO gov.nasa.jpl.aerie.stats.Timer - average time of system call = 674 nanoseconds
aerie_merlin              | [qtp1764996806-48] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:14.014562 -- server getSimulationResults() -- start
aerie_merlin              | [qtp1764996806-48] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:14.082387 -- server getSimulationResults() -- end
aerie_merlin              | [qtp1764996806-48] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:14.084937 %% REPORTING TIMER STATS %%
aerie_merlin              | [qtp1764996806-48] INFO gov.nasa.jpl.aerie.stats.Timer -  %% server getSimulationResults(): start = 2023-030T20:12:14.014562
aerie_merlin              | [qtp1764996806-48] INFO gov.nasa.jpl.aerie.stats.Timer -  %% server getSimulationResults(): duration = 0.067824208 seconds
aerie_merlin              | [qtp1764996806-48] INFO gov.nasa.jpl.aerie.stats.Timer -  %% server getSimulationResults(): cpu time = 0.021897811 seconds
aerie_merlin              | [qtp1764996806-48] INFO gov.nasa.jpl.aerie.stats.Timer -  %% server getSimulationResults(): end = 2023-030T20:12:14.082387
aerie_merlin              | [qtp1764996806-48] INFO gov.nasa.jpl.aerie.stats.Timer -  %% start server getSimulationResults(),end server getSimulationResults(),cpu time server getSimulationResults(),wall clock time server getSimulationResults(),count server getSimulationResults()
aerie_merlin              | [qtp1764996806-48] INFO gov.nasa.jpl.aerie.stats.Timer -  %% 1675109534014562996,1675109534082387204,21897811,64218208,1
aerie_merlin              | Request: POST [/getSimulationResults]
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer - property gov.nasa.jpl.aerie.timeTasks = null
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer - Timer.timeTasks = false
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer - average time of system call = 743 nanoseconds
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:14.262433 -- worker simulation -- start
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:14.686763 -- worker simulation -- end
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:14.68708 %% REPORTING TIMER STATS %%
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% worker simulation: start = 2023-030T20:12:14.262433
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% worker simulation: duration = 0.424330046 seconds
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% worker simulation: cpu time = 0.342728728 seconds
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% sim without writing: start = 2023-030T20:12:14.327363
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% sim without writing: duration = 0.149750657 seconds
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% sim without writing: cpu time = 0.138953591 seconds
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% sim without writing: end = 2023-030T20:12:14.477113
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% write sim to DB: start = 2023-030T20:12:14.477189
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% write sim to DB: duration = 0.209505256 seconds
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% write sim to DB: cpu time = 0.152690132 seconds
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% write sim to DB: end = 2023-030T20:12:14.686694
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% worker simulation: end = 2023-030T20:12:14.686763
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% start sim without writing,end sim without writing,cpu time sim without writing,wall clock time sim without writing,count sim without writing,start worker simulation,end worker simulation,cpu time worker simulation,wall clock time worker simulation,count worker simulation,start write sim to DB,end write sim to DB,cpu time write sim to DB,wall clock time write sim to DB,count write sim to DB
aerie_merlin_worker_2     | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% 1675109534327363245,1675109534477113902,138953591,149625681,1,1675109534262433159,1675109534686763205,342728728,420952393,1,1675109534477189559,1675109534686694815,152690132,209477743,1
aerie_scheduler           | [qtp231202600-39] INFO gov.nasa.jpl.aerie.stats.Timer - property gov.nasa.jpl.aerie.timeTasks = null
aerie_scheduler           | [qtp231202600-39] INFO gov.nasa.jpl.aerie.stats.Timer - Timer. timeTasks = false
aerie_scheduler           | [qtp231202600-39] INFO gov.nasa.jpl.aerie.stats.Timer - average time of system call = 735 nanoseconds
aerie_scheduler           | [qtp231202600-39] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:24.888831 -- server schedule() -- start
aerie_scheduler           | [qtp231202600-39] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:25.033334 -- server schedule() -- end
aerie_scheduler           | Request: POST [/schedule]
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer - property gov.nasa.jpl.aerie.timeTasks = null
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer - Timer.timeTasks = false
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer - average time of system call = 763 nanoseconds
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:25.121622 -- worker scheduling -- start
aerie_scheduler           | [qtp231202600-34] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:25.602738 -- server schedule() -- start
aerie_scheduler           | [qtp231202600-34] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:25.634673 -- server schedule() -- end
aerie_scheduler           | Request: POST [/schedule]
aerie_merlin              | Request: POST [/resourceTypes]
aerie_scheduler           | [qtp231202600-36] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:26.16047 -- server schedule() -- start
aerie_scheduler           | [qtp231202600-36] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:26.202649 -- server schedule() -- end
aerie_scheduler           | Request: POST [/schedule]
aerie_scheduler           | [qtp231202600-38] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:26.727154 -- server schedule() -- start
aerie_scheduler           | [qtp231202600-38] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:26.747124 -- server schedule() -- end
aerie_scheduler           | Request: POST [/schedule]
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:27.10201 -- worker scheduling -- end
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:27.102381 %% REPORTING TIMER STATS %%
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% worker scheduling: start = 2023-030T20:12:25.121622
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% worker scheduling: duration = 1.980388138 seconds
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% worker scheduling: cpu time = 0.553469331 seconds
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% collect scheduling results: start = 2023-030T20:12:27.074642
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% collect scheduling results: duration = 0.003475532 seconds
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% collect scheduling results: cpu time = 0.002367103 seconds
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% collect scheduling results: end = 2023-030T20:12:27.078118
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% write scheduling results: start = 2023-030T20:12:27.078362
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% write scheduling results: duration = 0.023618686 seconds
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% write scheduling results: cpu time = 0.009277075 seconds
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% write schedule to DB: start = 2023-030T20:12:27.078578
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% write schedule to DB: duration = 0.0233293 seconds
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% write schedule to DB: cpu time = 0.008996446 seconds
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% write schedule to DB: end = 2023-030T20:12:27.101907
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% write scheduling results: end = 2023-030T20:12:27.10198
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% worker scheduling: end = 2023-030T20:12:27.10201
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% start collect scheduling results,end collect scheduling results,cpu time collect scheduling results,wall clock time collect scheduling results,count collect scheduling results,start worker scheduling,end worker scheduling,cpu time worker scheduling,wall clock time worker scheduling,count worker scheduling,start write schedule to DB,end write schedule to DB,cpu time write schedule to DB,wall clock time write schedule to DB,count write schedule to DB,start write scheduling results,end write scheduling results,cpu time write scheduling results,wall clock time write scheduling results,count write scheduling results
aerie_scheduler_worker_2  | [main] INFO gov.nasa.jpl.aerie.stats.Timer -  %% 1675109547074642504,1675109547078118036,2367103,3291900,1,1675109545121622682,1675109547102010820,553469331,1974841029,1,1675109547078578101,1675109547101907401,8996446,23107624,1,1675109547078362054,1675109547101980740,9277075,23456883,1
aerie_merlin              | Request: POST [/validateActivityArguments]
aerie_merlin              | Request: POST [/getActivityEffectiveArguments]
aerie_scheduler           | [qtp231202600-36] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:27.267125 -- server schedule() -- start
aerie_scheduler           | [qtp231202600-36] INFO gov.nasa.jpl.aerie.stats.Timer - 2023-030T20:12:27.320005 -- server schedule() -- end
aerie_scheduler           | Request: POST [/schedule]
```

The basic structure of logging stats for simulation and scheduling is roughly the same.  This is the structure for simulation:

- timestamp when sim request on the server starts
- timestamp when sim request on the server ends
- list of stats for the server request
- csv header for server stats
- csv row for server stats   -- for  pasting in a spreadsheet, for example, to more easily visualize and compare the stats 
- timestamp when worker simulation starts
- timestamp when worker simulation ends
- list of stats for the worker simulation
   - ordered start and end times of different parts of the simulation (sim before DB, writing to DB, and adaptation)
   - end times of parts are followed by their list of stats
- CSV header for worker sim stats
- CSV row for worker sim stats

This list is logged each time simulation is invoked.

Logged once during static initialization of the TImer class are the java property value and the overhead of the system time call to get nanoseconds since 1/1/1970.  This overhead is used to correct the wall clock time.  In the case above, the Java property was left out.

## Verification
Build tests passed.  I verified logging with the adaptation part turned on and off and left out.

The wall clock time for the adaptation was inconsistent.  The adaptation calls each take 1 ms on average, so there appears to be error at the level of a millisecond, possibly due to the timer code skewing results.  Since this level of timing appears to be too invasive, it is turned off by default.  More testing is planned to verify suspicions.

## Documentation
I didn't update documentation, but if there is an appropriate place for it, please let me know, and I'll add it.  We probably don't document how to look at the log files, but the Java property to turn on the timing adaptation calls could be discussed.

## Future work
None planned, but kind of wanted to write out html to visualize results; did the CSV instead based on user feedback.
