### PR TITLE
Make scheduler's backtracking configuration accessible to user

### DIFF
--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Goal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Goal.java
@@ -17,12 +17,26 @@ import java.util.List;
  * describes some criteria that is desired in the solution plans
  */
 public class Goal {
+  /**
+   * the human-legible identifier of the goal
+   * never null
+   */
+  protected String name;
 
+  /**
+   * the contiguous range of time over which the goal applies
+   */
+  protected Expression<Windows> temporalContext;
+
+  /**
+   * state constraints applying to the goal
+   */
+  protected Expression<Windows> resourceConstraints;
   /** Set to true if partial satisfaction is ok, the scheduler will try to do its best */
-  private boolean partialSatisfaction = false;
+  private boolean shouldRollbackIfUnsatisfied = false;
 
-  public boolean isPartiallySatisfiable() {
-    return partialSatisfaction;
+  public boolean shouldRollbackIfUnsatisfied() {
+    return shouldRollbackIfUnsatisfied;
   }
 
   /**
@@ -127,12 +141,12 @@ public class Goal {
 
     protected  final List<Expression<Windows>> resourceConstraints = new LinkedList<>();
 
-    public T partialSatisfaction() {
-      this.partialSatisfaction = true;
+    public T shouldRollbackIfUnsatisfied(final boolean shouldRollbackIfUnsatisfied) {
+      this.shouldRollbackIfUnsatisfied = shouldRollbackIfUnsatisfied;
       return getThis();
     }
 
-    boolean partialSatisfaction;
+    boolean shouldRollbackIfUnsatisfied;
 
     /**
      * uses all pending specifications to construct a matching new goal object
@@ -168,7 +182,7 @@ public class Goal {
     protected Goal fill(Goal goal) {
       goal.name = name;
 
-      goal.partialSatisfaction = true;
+      goal.shouldRollbackIfUnsatisfied = this.shouldRollbackIfUnsatisfied;
 
       goal.resourceConstraints = null;
       if (this.resourceConstraints.size() > 0) {
@@ -260,22 +274,4 @@ public class Goal {
     }
     this.name = name;
   }
-
-  /**
-   * the human-legible identifier of the goal
-   *
-   * never null
-   */
-  protected String name;
-
-  /**
-   * the contiguous range of time over which the goal applies
-   */
-  protected Expression<Windows> temporalContext;
-
-  /**
-   * state constraints applying to the goal
-   */
-  protected Expression<Windows> resourceConstraints;
-
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
@@ -24,7 +24,6 @@ import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Objects;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUnsatisfiableCompositeGoals.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUnsatisfiableCompositeGoals.java
@@ -1,0 +1,247 @@
+package gov.nasa.jpl.aerie.scheduler;
+
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.Segment;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate;
+import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
+import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.TimeAnchor;
+import gov.nasa.jpl.aerie.scheduler.goals.CardinalityGoal;
+import gov.nasa.jpl.aerie.scheduler.goals.ChildCustody;
+import gov.nasa.jpl.aerie.scheduler.goals.CoexistenceGoal;
+import gov.nasa.jpl.aerie.scheduler.goals.CompositeAndGoal;
+import gov.nasa.jpl.aerie.scheduler.goals.OptionGoal;
+import gov.nasa.jpl.aerie.scheduler.model.ActivityType;
+import gov.nasa.jpl.aerie.scheduler.model.PlanInMemory;
+import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
+import gov.nasa.jpl.aerie.scheduler.model.Problem;
+import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
+import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
+import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class TestUnsatisfiableCompositeGoals {
+
+  private final static PlanningHorizon h = new PlanningHorizon(
+      TimeUtility.fromDOY("2025-001T00:00:00.000"),
+      TimeUtility.fromDOY("2025-002T00:00:00.000")
+  );
+
+  private final static Duration t0 = h.getStartAerie();
+  private final static Duration d1min = Duration.of(1, Duration.MINUTE);
+  private final static Duration d1hr = Duration.of(1, Duration.HOUR);
+  private final static Duration t1hr = t0.plus(d1hr);
+  private final static Duration t2hr = t0.plus(d1hr.times(2));
+
+  //test mission with two primitive activity types
+  private static Problem makeTestMissionAB() {
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    return new Problem(fooMissionModel, h, new SimulationFacade(h, fooMissionModel), SimulationUtility.getFooSchedulerModel());
+  }
+
+  private static PlanInMemory makePlanA12(Problem problem) {
+    final var plan = new PlanInMemory();
+    final var actTypeA = problem.getActivityType("ControllableDurationActivity");
+    plan.add(SchedulingActivityDirective.of(actTypeA, t1hr, d1min, null, true));
+    plan.add(SchedulingActivityDirective.of(actTypeA, t2hr, d1min, null, true));
+    return plan;
+  }
+
+  //activities without parameters
+  public CoexistenceGoal BForEachAGoal(ActivityType A, ActivityType B){
+
+    return new CoexistenceGoal.Builder()
+        .named("g0")
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(h.getHor(), true)))
+        .forEach(new ActivityExpression.Builder()
+                     .ofType(A)
+                     .build())
+        .thereExistsOne(new ActivityCreationTemplate.Builder()
+                            .ofType(B)
+                            .build())
+        .startsAt(TimeAnchor.START)
+        .build();
+  }
+
+  @Test
+  public void testAndWithoutBackTrack(){
+    final var problem = makeTestMissionAB();
+    problem.setInitialPlan(makePlanA12(problem));
+    final var actTypeControllable = problem.getActivityType("ControllableDurationActivity");
+    final var actTypeBasic = problem.getActivityType("BasicActivity");
+    final var actTypeBar = problem.getActivityType("bar");
+    final var goal = BForEachAGoal(actTypeControllable, actTypeBasic);
+    final var goal2 = BForEachAGoal(actTypeControllable, actTypeBar);
+    final var compositeAndGoal = new CompositeAndGoal.Builder()
+        .and(goal2)
+        .and(goal)
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(h.getHor(), true)))
+        .build();
+    final var exclusionBasic = TestUtility.createExclusionSchedulingZone(actTypeBasic,
+                                                                         new Windows(
+                                                                             Segment.of(Interval.FOREVER, false),
+                                                                             Segment.of(Interval.between(t1hr.minus(d1min), t1hr.plus(d1min)), true)
+                                                                         ));
+    problem.add(exclusionBasic);
+    problem.setGoals(List.of(compositeAndGoal));
+    final var solver = new PrioritySolver(problem);
+    final var plan = solver.getNextSolution().orElseThrow();
+    //AND goal is unsatisfiable because of exclusion zone for the Basic activities
+    //by default, goals are not backtracking so the plan should show 2 BAR activities and 1 basic activity and the 2 controllable acts from the base plan
+    Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t1hr, actTypeControllable));
+    Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeControllable));
+    Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t1hr, actTypeBar));
+    Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeBar));
+    Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeBasic));
+    Assertions.assertEquals(plan.getActivities().size(), 5);
+    }
+
+  @Test
+  public void testAndWithBackTrack(){
+    final var problem = makeTestMissionAB();
+    problem.setInitialPlan(makePlanA12(problem));
+    final var actTypeControllable = problem.getActivityType("ControllableDurationActivity");
+    final var actTypeBasic = problem.getActivityType("BasicActivity");
+    final var actTypeBar = problem.getActivityType("bar");
+    final var goal = BForEachAGoal(actTypeControllable, actTypeBar);
+    final var goal2 = BForEachAGoal(actTypeControllable, actTypeBasic);
+    final var compositeAndGoal = new CompositeAndGoal.Builder()
+        .and(goal2)
+        .and(goal)
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(h.getHor(), true)))
+        .shouldRollbackIfUnsatisfied(true)
+        .build();
+    final var exclusionBasic = TestUtility.createExclusionSchedulingZone(actTypeBasic,
+                                                                         new Windows(
+                                                                             Segment.of(Interval.FOREVER, false),
+                                                                             Segment.of(Interval.between(t1hr.minus(d1min), t1hr.plus(d1min)), true)
+                                                                         ));
+    problem.add(exclusionBasic);
+    problem.setGoals(List.of(compositeAndGoal));
+    final var solver = new PrioritySolver(problem);
+    final var plan = solver.getNextSolution().orElseThrow();
+    //AND goal is unsatisfiable because of exclusion zone for the Basic activities
+    //and goal is backtracking here so the plan should show only the 2 controllable acts from the base plan
+    Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t1hr, actTypeControllable));
+    Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeControllable));
+    Assertions.assertEquals(plan.getActivities().size(), 2);
+  }
+
+  @Test
+  public void testOrWithoutBacktrack(){
+    final var problem = makeTestMissionAB();
+    problem.setInitialPlan(makePlanA12(problem));
+    final var actTypeControllable = problem.getActivityType("ControllableDurationActivity");
+    final var actTypeBasic = problem.getActivityType("BasicActivity");
+    final var actTypeBar = problem.getActivityType("bar");
+    final var goal = BForEachAGoal(actTypeControllable, actTypeBasic);
+    final var goal2 = BForEachAGoal(actTypeControllable, actTypeBar);
+    final var orGoal = new OptionGoal.Builder()
+        .or(goal2)
+        .or(goal)
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(h.getHor(), true)))
+        .build();
+    final var exclusionBasic = TestUtility.createExclusionSchedulingZone(actTypeBasic,
+                                                                         new Windows(
+                                                                             Segment.of(Interval.FOREVER, false),
+                                                                             Segment.of(Interval.between(t1hr.minus(d1min), t1hr.plus(d1min)), true)
+                                                                         ));
+    final var exclusionBar = TestUtility.createExclusionSchedulingZone(actTypeBar,
+                                                                       new Windows(
+                                                                           Segment.of(Interval.FOREVER, false),
+                                                                           Segment.of(Interval.between(t1hr.minus(d1min), t1hr.plus(d1min)), true)
+                                                                       ));
+    problem.add(exclusionBasic);
+    problem.add(exclusionBar);
+    problem.setGoals(List.of(orGoal));
+    final var solver = new PrioritySolver(problem);
+    final var plan = solver.getNextSolution().orElseThrow();
+    //OR goal is unsatisfiable because of exclusion zone for both the Basic and Bar activities
+    //goal is not configured to backtrack plan should show 2 controllable acts from the base plan + the two activities that could be scheduled out of the exclusion zone
+    Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t1hr, actTypeControllable));
+    Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeControllable));
+    Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeBar));
+    Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeBasic));
+    Assertions.assertEquals(plan.getActivities().size(), 4);
+  }
+
+  @Test
+  public void testOrWithBacktrack(){
+    final var problem = makeTestMissionAB();
+    problem.setInitialPlan(makePlanA12(problem));
+    final var actTypeControllable = problem.getActivityType("ControllableDurationActivity");
+    final var actTypeBasic = problem.getActivityType("BasicActivity");
+    final var actTypeBar = problem.getActivityType("bar");
+    final var goal = BForEachAGoal(actTypeControllable, actTypeBasic);
+    final var goal2 = BForEachAGoal(actTypeControllable, actTypeBar);
+    final var orGoal = new OptionGoal.Builder()
+        .or(goal2)
+        .or(goal)
+        .shouldRollbackIfUnsatisfied(true)
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(h.getHor(), true)))
+        .build();
+    final var exclusionBasic = TestUtility.createExclusionSchedulingZone(actTypeBasic,
+                                                                         new Windows(Interval.between(t1hr.minus(d1min), t1hr.plus(d1min)),
+                                                                                     true));
+    final var exclusionBar = TestUtility.createExclusionSchedulingZone(actTypeBar,
+                                                                         new Windows(Interval.between(t1hr.minus(d1min), t1hr.plus(d1min)),
+                                                                                     true));
+    problem.add(exclusionBasic);
+    problem.add(exclusionBar);
+    problem.setGoals(List.of(orGoal));
+    final var solver = new PrioritySolver(problem);
+    final var plan = solver.getNextSolution().orElseThrow();
+    //OR goal is unsatisfiable beacuse of exclusion zone for the Basic and Bar activities
+    //goals are backtracking so the plan should show only 2 controllable acts from the base plan
+    Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t1hr, actTypeControllable));
+    Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeControllable));
+    Assertions.assertEquals(plan.getActivities().size(), 2);
+  }
+
+  @Test
+  public void testCardinalityBacktrack() {
+    var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(20));
+
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
+        planningHorizon,
+        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var activityType = problem.getActivityType("ControllableDurationActivity");
+
+    final var goalWindow = new Windows(false).set(List.of(
+        Interval.between(Duration.of(1, Duration.SECONDS), Duration.of(1, Duration.SECONDS)),
+        Interval.between(Duration.of(7, Duration.SECONDS), Duration.of(8, Duration.SECONDS)), //exclusive
+        Interval.between(Duration.of(11, Duration.SECONDS), Duration.of(13, Duration.SECONDS))
+    ), true);
+
+    //unsatisfiable because 10 occurences asked when only one can be placed
+    CardinalityGoal unsatisfiableGoal = new CardinalityGoal.Builder()
+        .duration(Interval.between(Duration.of(16, Duration.SECONDS), Duration.of(21, Duration.SECONDS)))
+        .occurences(new Range<>(10, 10))
+        .thereExistsOne(new ActivityCreationTemplate.Builder()
+                            .ofType(problem.getActivityType("ControllableDurationActivity"))
+                            .duration(Duration.of(2, Duration.SECONDS))
+                            .build())
+        .named("TestCardGoal")
+        .forAllTimeIn(new WindowsWrapperExpression(goalWindow))
+        .owned(ChildCustody.Jointly)
+        .shouldRollbackIfUnsatisfied(true)
+        .build();
+
+
+    TestUtility.createAutoMutexGlobalSchedulingCondition(activityType).forEach(problem::add);
+    problem.setGoals(List.of(unsatisfiableGoal));
+
+    final var solver = new PrioritySolver(problem);
+
+    var plan = solver.getNextSolution().orElseThrow();
+    assertThat(plan.getActivities().size()).isEqualTo(0);
+  }
+}

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUtility.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUtility.java
@@ -7,6 +7,7 @@ import gov.nasa.jpl.aerie.constraints.tree.ForEachActivitySpans;
 import gov.nasa.jpl.aerie.constraints.tree.Not;
 import gov.nasa.jpl.aerie.constraints.tree.Or;
 import gov.nasa.jpl.aerie.constraints.tree.WindowsFromSpans;
+import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
 import gov.nasa.jpl.aerie.scheduler.model.ActivityType;
@@ -65,6 +66,14 @@ public class TestUtility {
       }
     }
     return false;
+  }
+
+  public static SchedulingCondition createExclusionSchedulingZone(final ActivityType activityType, final Windows exclusionZone){
+    return new SchedulingCondition(
+        new Not(
+            new WindowsWrapperExpression(exclusionZone)
+        ),
+        List.of(activityType));
   }
 
   public static List<SchedulingCondition> createAutoMutexGlobalSchedulingCondition(final ActivityType activityType) {

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GoalBuilder.java
@@ -43,6 +43,7 @@ public class GoalBuilder {
       return new RecurrenceGoal.Builder()
           .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(hor, true)))
           .repeatingEvery(g.interval())
+          .shouldRollbackIfUnsatisfied(g.shouldRollbackIfUnsatisfied())
           .thereExistsOne(makeActivityTemplate(g.activityTemplate(), lookupActivityType))
           .build();
     } else if (goalSpecifier instanceof SchedulingDSL.GoalSpecifier.CoexistenceGoalDefinition g) {
@@ -51,6 +52,7 @@ public class GoalBuilder {
           .forEach(spansOfConstraintExpression(
               g.forEach()))
           .thereExistsOne(makeActivityTemplate(g.activityTemplate(), lookupActivityType))
+          .shouldRollbackIfUnsatisfied(g.shouldRollbackIfUnsatisfied())
           .aliasForAnchors(g.alias());
       if (g.startConstraint().isPresent()) {
         final var startConstraint = g.startConstraint().get();
@@ -83,6 +85,7 @@ public class GoalBuilder {
                                                   lookupActivityType));
       }
       builder.forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(hor, true)));
+      builder.shouldRollbackIfUnsatisfied(g.shouldRollbackIfUnsatisfied());
       return builder.build();
     } else if (goalSpecifier instanceof SchedulingDSL.GoalSpecifier.GoalOr g) {
       var builder = new OptionGoal.Builder();
@@ -93,6 +96,7 @@ public class GoalBuilder {
                                                  lookupActivityType));
       }
       builder.forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(hor, true)));
+      builder.shouldRollbackIfUnsatisfied(g.shouldRollbackIfUnsatisfied());
       return builder.build();
     }
 
@@ -105,7 +109,8 @@ public class GoalBuilder {
     else if(goalSpecifier instanceof SchedulingDSL.GoalSpecifier.CardinalityGoalDefinition g){
       final var builder = new CardinalityGoal.Builder()
           .thereExistsOne(makeActivityTemplate(g.activityTemplate(), lookupActivityType))
-           .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(hor, true)));
+           .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(hor, true)))
+          .shouldRollbackIfUnsatisfied(g.shouldRollbackIfUnsatisfied());
       if(g.specification().duration().isPresent()){
         builder.duration(Interval.between(g.specification().duration().get(), Duration.MAX_VALUE));
       }

--- a/scheduler-worker/scheduling-dsl-compiler/src/libs/scheduler-ast.ts
+++ b/scheduler-worker/scheduling-dsl-compiler/src/libs/scheduler-ast.ts
@@ -58,12 +58,14 @@ export interface ActivityRecurrenceGoal {
   kind: NodeKind.ActivityRecurrenceGoal,
   activityTemplate: ActivityTemplate<any>,
   interval: Temporal.Duration,
+  shouldRollbackIfUnsatisfied: boolean
 }
 
 export interface ActivityCardinalityGoal {
   kind: NodeKind.ActivityCardinalityGoal,
   activityTemplate: ActivityTemplate<any>,
-  specification: CardinalityGoalArguments
+  specification: CardinalityGoalArguments,
+  shouldRollbackIfUnsatisfied: boolean
 }
 
 export interface ActivityCoexistenceGoal {
@@ -73,6 +75,7 @@ export interface ActivityCoexistenceGoal {
   forEach: WindowsExpressions.WindowsExpression | ActivityExpression,
   startConstraint: ActivityTimingConstraintSingleton | ActivityTimingConstraintRange | undefined,
   endConstraint: ActivityTimingConstraintSingleton | ActivityTimingConstraintRange | undefined,
+  shouldRollbackIfUnsatisfied: boolean
 }
 
 export interface ActivityExpression {
@@ -151,11 +154,13 @@ export type GoalComposition =
 export interface GoalAnd {
   kind: NodeKind.GoalAnd,
   goals: GoalSpecifier[],
+  shouldRollbackIfUnsatisfied: boolean
 }
 
 export interface GoalOr {
   kind: NodeKind.GoalOr,
   goals: GoalSpecifier[],
+  shouldRollbackIfUnsatisfied: boolean
 }
 
 /**

--- a/scheduler-worker/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
+++ b/scheduler-worker/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
@@ -136,6 +136,7 @@ export class Goal {
         this.__astNode,
         ...others.map(other => other.__astNode),
       ],
+      shouldRollbackIfUnsatisfied: false
     });
   }
 
@@ -182,6 +183,7 @@ export class Goal {
         this.__astNode,
         ...others.map(other => other.__astNode),
       ],
+      shouldRollbackIfUnsatisfied: false
     });
   }
 
@@ -270,7 +272,20 @@ export class Goal {
       kind: AST.NodeKind.ActivityRecurrenceGoal,
       activityTemplate: opts.activityTemplate,
       interval: opts.interval,
+      shouldRollbackIfUnsatisfied: false
     });
+  }
+
+  /**
+   * Specifies whether the scheduler should rollback or not if the goal is only partially satisfied.
+   * Rolling back is removing all inserted activities to satisfy the goal as well as removing associations to existing activities
+   * @param shouldRollbackIfUnsatisfied boolean specifying the behavior of the scheduler in terms of rollback
+   */
+  public shouldRollbackIfUnsatisfied(shouldRollbackIfUnsatisfied: boolean): Goal{
+    if('shouldRollbackIfUnsatisfied' in this.__astNode){
+      this.__astNode['shouldRollbackIfUnsatisfied'] = shouldRollbackIfUnsatisfied
+    }
+    return this
   }
 
   /**
@@ -345,6 +360,7 @@ export class Goal {
       forEach: opts.forEach.__astNode,
       startConstraint: (("startsAt" in opts) ? opts.startsAt.__astNode : ("startsWithin" in opts) ? opts.startsWithin.__astNode : undefined),
       endConstraint: (("endsAt" in opts) ? opts.endsAt.__astNode : ("endsWithin" in opts) ? opts.endsWithin.__astNode : undefined),
+      shouldRollbackIfUnsatisfied: false
     });
   }
 
@@ -410,7 +426,8 @@ export class Goal {
     return Goal.new({
       kind: AST.NodeKind.ActivityCardinalityGoal,
       activityTemplate: opts.activityTemplate,
-      specification: opts.specification
+      specification: opts.specification,
+      shouldRollbackIfUnsatisfied: false
     });
   }
 }
@@ -596,7 +613,9 @@ declare global {
   class Goal {
     public readonly __astNode: AST.GoalSpecifier;
 
-    /**
+    public shouldRollbackIfUnsatisfied(shouldRollbackIfUnsatisfied: boolean): Goal;
+
+      /**
      * Aggregates the goal with another list of goals to form a conjunction of goals
      *
      * All goals in the conjunction must be satisfied in order for the conjunction to be satisfied

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingDSLCompilationServiceTests.java
@@ -153,7 +153,39 @@ class SchedulingDSLCompilationServiceTests {
             "SampleActivity1",
             getSampleActivity1Parameters()
         ),
-        HOUR);
+        HOUR,
+        false);
+    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success<SchedulingDSL.GoalSpecifier> r) {
+      assertEquals(expectedGoalDefinition, r.value());
+    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
+      fail(r.toString());
+    }
+  }
+
+  @Test
+  void  testSchedulingDSL_partial()
+  {
+    final var result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+        missionModelService,
+        PLAN_ID, """
+                export default function myGoal() {
+                  return Goal.ActivityRecurrenceGoal({
+                    activityTemplate: ActivityTemplates.SampleActivity1({
+                      variant: 'option2',
+                      fancy: { subfield1: 'value1', subfield2: [{subsubfield1: 2.0}]},
+                      duration: Temporal.Duration.from({ hours: 1 })
+                    }),
+                    interval: Temporal.Duration.from({ hours: 1 })
+                  }).shouldRollbackIfUnsatisfied(true)
+                }
+            """);
+    final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
+        new SchedulingDSL.ActivityTemplate(
+            "SampleActivity1",
+            getSampleActivity1Parameters()
+        ),
+        HOUR,
+        true);
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success<SchedulingDSL.GoalSpecifier> r) {
       assertEquals(expectedGoalDefinition, r.value());
     } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
@@ -186,7 +218,8 @@ class SchedulingDSLCompilationServiceTests {
             "SampleActivity1",
             getSampleActivity1Parameters()
         ),
-        HOUR);
+        HOUR,
+        false);
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
       assertEquals(expectedGoalDefinition, r.value());
     } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
@@ -245,7 +278,8 @@ class SchedulingDSLCompilationServiceTests {
                 "SampleActivity1",
                 getSampleActivity1Parameters()
             ),
-            HOUR
+            HOUR,
+            false
         ),
         new GreaterThan(
             new RealResource("/sample/resource/1"),
@@ -297,7 +331,8 @@ class SchedulingDSLCompilationServiceTests {
             "SampleActivity1",
             getSampleActivity1Parameters()
         ),
-        Duration.HOURS.times(24)
+        Duration.HOURS.times(24),
+        false
     );
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
       assertEquals(expectedGoalDefinition, r.value());
@@ -329,7 +364,8 @@ class SchedulingDSLCompilationServiceTests {
             "SampleActivity1",
             getSampleActivity1Parameters()
         ),
-        HOUR
+        HOUR,
+        false
     );
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
       assertEquals(expectedGoalDefinition, r.value());
@@ -365,7 +401,8 @@ class SchedulingDSLCompilationServiceTests {
               "coexistence activity alias 0",
               new SchedulingDSL.ConstraintExpression.ActivityExpression("SampleActivity2"),
               Optional.of(new SchedulingDSL.ActivityTimingConstraint(TimeAnchor.START, TimeUtility.Operator.PLUS, SECOND, true)),
-              Optional.empty()
+              Optional.empty(),
+              false
           ),
           r.value()
       );
@@ -410,7 +447,8 @@ class SchedulingDSLCompilationServiceTests {
               "coexistence activity alias 0",
               new SchedulingDSL.ConstraintExpression.ActivityExpression("SampleActivity2"),
               Optional.of(new SchedulingDSL.ActivityTimingConstraint(TimeAnchor.START, TimeUtility.Operator.PLUS, SECOND, true)),
-              Optional.empty()
+              Optional.empty(),
+              false
           ),
           r.value()
       );
@@ -455,7 +493,8 @@ class SchedulingDSLCompilationServiceTests {
               "coexistence activity alias 0",
               new SchedulingDSL.ConstraintExpression.ActivityExpression("SampleActivity2"),
               Optional.of(new SchedulingDSL.ActivityTimingConstraint(TimeAnchor.START, TimeUtility.Operator.PLUS, SECOND, true)),
-              Optional.empty()
+              Optional.empty(),
+              false
           ),
           r.value()
       );
@@ -543,7 +582,8 @@ class SchedulingDSLCompilationServiceTests {
             "SampleActivityEmpty",
             new StructExpressionAt(Map.of())
         ),
-        HOUR
+        HOUR,
+        false
     );
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
       assertEquals(expectedGoalDefinition, r.value());
@@ -606,7 +646,8 @@ class SchedulingDSLCompilationServiceTests {
               "coexistence activity alias 0",
               new SchedulingDSL.ConstraintExpression.WindowsExpression(new LongerThan(new GreaterThan(new RealResource("/sample/resource/1"), new RealValue(50.0)), Duration.of(10, Duration.MICROSECOND))),
               Optional.of(new SchedulingDSL.ActivityTimingConstraint(TimeAnchor.END, TimeUtility.Operator.PLUS, Duration.ZERO, true)),
-              Optional.empty()
+              Optional.empty(),
+              false
           ),
           r.value()
       );
@@ -661,14 +702,16 @@ class SchedulingDSLCompilationServiceTests {
               "SampleActivityEmpty",
               new StructExpressionAt(Map.of())
           ),
-          HOUR
+          HOUR,
+          false
     ), new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
             new SchedulingDSL.ActivityTemplate(
                 "SampleActivityEmpty",
                 new StructExpressionAt(Map.of())
             ),
-            HOUR.times(2)
-        )));
+            HOUR.times(2),
+            false
+        )),false);
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success r) {
       assertEquals(
           expectedGoalDefinition,
@@ -702,14 +745,16 @@ class SchedulingDSLCompilationServiceTests {
                 "SampleActivityEmpty",
                 new StructExpressionAt(Map.of())
             ),
-            HOUR
+            HOUR,
+            false
         ), new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
             new SchedulingDSL.ActivityTemplate(
                 "SampleActivityEmpty",
                 new StructExpressionAt(Map.of())
             ),
-            HOUR.times(2)
-        )));
+            HOUR.times(2),
+            false
+        )),false);
     if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success<SchedulingDSL.GoalSpecifier> r) {
       assertEquals(
           expectedGoalDefinition,


### PR DESCRIPTION
* **Tickets addressed:** Closes #624 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
See the ticket #624 for info on what this is. 

In the eDSL, we allow the user to set the parameter for each goal. 

In the backend, checked and updated the backtrack policy as well as making the name of the configuration parameter much clearer (`partialSatisfaction` -> `shouldRollbackIfUnsatisfied`).

By default, nothing has changed, as the default behavior is not to backtrack. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I have written several tests that demonstrate the behavior. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
I need to write documentation for this PR as well as the previous one. 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Nothing regarding this particular aspect. 