### PR TITLE
Cannot read field "durationInMicroseconds" because "right" is null

### DIFF
--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/ActivityInstance.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/ActivityInstance.java
@@ -101,6 +101,24 @@ public record ActivityInstance(
                                 parameters, topParent);
   }
 
+  private static ActivityInstance of(SchedulingActivityInstanceId id, ActivityType type, Duration start, Duration duration, Map<String, SerializedValue> parameters, SchedulingActivityInstanceId topParent) {
+    return new ActivityInstance(id,
+                                type,
+                                start,
+                                duration,
+                                parameters,
+                                topParent);
+  }
+
+  public static ActivityInstance copyOf(ActivityInstance activityInstance, Duration duration){
+    return ActivityInstance.of(activityInstance.id,
+            activityInstance.type,
+            activityInstance.startTime,
+            duration,
+            new HashMap<>(activityInstance.arguments),
+            activityInstance.topParent);
+  }
+
   /**
    * create an activity instance based on the provided one (but adifferent id)
    *

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -130,6 +130,28 @@ public class SimulationFacade {
     }
   }
 
+  /**
+   * Replaces an activity instance with another, strictly when they have the same id
+   * @param toBeReplaced the activity to be replaced
+   * @param replacement the replacement activity
+   */
+  public void replaceActivityFromSimulation(final ActivityInstance toBeReplaced, final ActivityInstance replacement){
+    if(toBeReplaced.type() != replacement.type()||
+       toBeReplaced.startTime() != replacement.startTime()||
+       !(toBeReplaced.arguments().equals(replacement.arguments()))) {
+      throw new IllegalArgumentException("When replacing an activity, you can only update the duration");
+    }
+    if(!insertedActivities.containsKey(toBeReplaced)){
+      throw new IllegalArgumentException("Trying to replace an activity that has not been previously simulated");
+    }
+    final var associated = insertedActivities.get(toBeReplaced);
+    insertedActivities.remove(toBeReplaced);
+    insertedActivities.put(replacement, associated);
+    final var simulationId = this.planActInstanceIdToSimulationActInstanceId.get(toBeReplaced.id());
+    this.planActInstanceIdToSimulationActInstanceId.remove(toBeReplaced.id());
+    this.planActInstanceIdToSimulationActInstanceId.put(replacement.id(), simulationId);
+  }
+
   public void simulateActivities(final Collection<ActivityInstance> activities)
   throws SimulationException {
     final var activitiesSortedByStartTime =

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
@@ -1348,6 +1348,35 @@ public class SchedulingIntegrationTests {
     assertEquals(96, results.updatedPlan().size());
   }
 
+  /**
+   * If you passed activities without duration to the scheduler in an initial plan, it would fail
+   */
+  @Test
+  public void testBugDurationInMicroseconds(){
+    final var results = runScheduler(
+        BANANANATION,
+        List.of(),
+        List.of(new SchedulingGoal(new GoalId(0L), """
+            export default (): Goal =>
+              Goal.ActivityRecurrenceGoal({
+                activityTemplate: ActivityTemplates.BakeBananaBread({ temperature: 325.0, tbSugar: 2, glutenFree: false }),
+                interval: Temporal.Duration.from({ hours: 12 }),
+              });
+            """, true)),
+        PLANNING_HORIZON);
+    final var results2 = runScheduler(
+        BANANANATION,
+        results.updatedPlan.stream().toList(),
+        List.of(new SchedulingGoal(new GoalId(0L), """
+            export default (): Goal =>
+              Goal.ActivityRecurrenceGoal({
+                activityTemplate: ActivityTemplates.BakeBananaBread({ temperature: 325.0, tbSugar: 2, glutenFree: false }),
+                interval: Temporal.Duration.from({ hours: 12 }),
+              });
+            """, true)),
+        PLANNING_HORIZON);
+    assertEquals(8, results.updatedPlan().size());
+  }
 
   @Test
   void test_inf_loop(){


### PR DESCRIPTION
* **Tickets addressed:** Fixes #633 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Durations of activities were not pulled from the simulation. When using the activities, we assumed the durations were present. We pull them now and replace activities. I think this bug was introduced with the forEach PR #546 but I am not sure. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I reproduced the bug with a test and it is now passing. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None