### PR TITLE
Add command interface to steps

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -291,20 +291,22 @@ type ExpandedActivityInstance {
 type SequenceSeqJson {
   id: String!
   metadata: Any!
-  steps: [CommandSeqJson!]!
+  steps: [CommandSeqJson!]
 }
 
 input SequenceSeqJsonInput {
   id: String!
   metadata: Any!
-  steps: [CommandSeqJsonInput!]!
+  steps: [CommandSeqJsonInput!]
 }
 
 type CommandSeqJson {
   stem: String!,
   time: CommandSeqJsonTime!,
   type: CommandSeqJsonType!,
-  metadata: Any!
+  metadata: Any,
+  description : String,
+  models: [Any!],
   args: [Any!]!
 }
 
@@ -312,8 +314,10 @@ input CommandSeqJsonInput {
   stem: String!,
   time: CommandSeqJsonTimeInput!,
   type: CommandSeqJsonType!,
-  metadata: Any!
-  args: [Any!]!
+  metadata: Any,
+  description : String,
+  models: [Any!],
+  args: [Any!]
 }
 
 type CommandSeqJsonTime {

--- a/sequencing-server/src/app.ts
+++ b/sequencing-server/src/app.ts
@@ -22,7 +22,9 @@ import {
   simulatedActivityInstanceBySimulatedActivityIdBatchLoader,
 } from './lib/batchLoaders/simulatedActivityBatchLoader.js';
 import { generateTypescriptForGraphQLActivitySchema } from './lib/codegen/ActivityTypescriptCodegen.js';
-import { CommandStem, CommandSeqJson, Sequence, SequenceSeqJson } from './lib/codegen/CommandEDSLPreface.js';
+import { CommandStem, Sequence } from './lib/codegen/CommandEDSLPreface.js';
+import type { Command, SeqJson } from '@nasa-jpl/seq-json-schema/types';
+
 import { processDictionary } from './lib/codegen/CommandTypeCodegen.js';
 import './polyfills.js';
 import { FallibleStatus } from './types.js';
@@ -605,7 +607,7 @@ app.post('/get-seqjson-for-seqid-and-simulation-dataset', async (req, res, next)
   const [{ rows: activityInstanceCommandRows }, { rows: seqRows }] = await Promise.all([
     db.query<{
       metadata: Record<string, unknown>;
-      commands: CommandSeqJson[];
+      commands: Command[];
       activity_instance_id: number;
       errors: ReturnType<UserCodeError['toJSON']>[] | null;
     }>(
@@ -735,7 +737,7 @@ app.post('/bulk-get-seqjson-for-seqid-and-simulation-dataset', async (req, res, 
   const [{ rows: activityInstanceCommandRows }, { rows: seqRows }] = await Promise.all([
     db.query<{
       metadata: Record<string, unknown>;
-      commands: CommandSeqJson[];
+      commands: Command[];
       activity_instance_id: number;
       errors: ReturnType<UserCodeError['toJSON']>[] | null;
       seq_id: string;
@@ -899,7 +901,7 @@ app.post('/bulk-get-seqjson-for-seqid-and-simulation-dataset', async (req, res, 
  * @deprecated Use `/bulk-get-edsl-for-seqjson` instead
  */
 app.post('/get-edsl-for-seqjson', async (req, res, next) => {
-  const seqJson = req.body.input.seqJson as SequenceSeqJson;
+  const seqJson = req.body.input.seqJson as SeqJson;
 
   res.json(Sequence.fromSeqJson(seqJson).toEDSLString());
   return next();
@@ -907,7 +909,7 @@ app.post('/get-edsl-for-seqjson', async (req, res, next) => {
 
 // Generate Sequence EDSL from many sequence JSONs
 app.post('/bulk-get-edsl-for-seqjson', async (req, res, next) => {
-  const seqJsons = req.body.input.seqJsons as SequenceSeqJson[];
+  const seqJsons = req.body.input.seqJsons as SeqJson[];
 
   res.json(seqJsons.map(seqJson => Sequence.fromSeqJson(seqJson).toEDSLString()));
   return next();

--- a/sequencing-server/src/defaultSeqBuilder.ts
+++ b/sequencing-server/src/defaultSeqBuilder.ts
@@ -22,10 +22,7 @@ export const defaultSeqBuilder: SeqBuilder = (
         CommandStem.new({
           stem: '$$ERROR$$',
           arguments: [e.message],
-          metadata: {
-            simulatedActivityId: ai.id,
-          },
-        }),
+        }).METADATA({ simulatedActivityId: ai.id }),
       );
     }
     // Typeguard only
@@ -42,6 +39,6 @@ export const defaultSeqBuilder: SeqBuilder = (
       planId,
       simulationDatasetId,
     },
-    commands,
+    steps: commands,
   });
 };

--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
@@ -21,7 +21,7 @@ describe('Command', () => {
 
       expect(command).toBeInstanceOf(CommandStem);
       expect(command.stem).toBe('test');
-      expect(command.metadata).toEqual({});
+      expect(command.GET_METADATA()).toEqual({});
       expect(command.arguments).toEqual([]);
     });
   });
@@ -127,7 +127,9 @@ describe('Sequence', () => {
           {
             type: 'command',
             stem: 'test2',
-            metadata: {},
+            metadata: {
+              author: 'Mission Operation Engineer',
+            },
             args: ['string', 0, true],
             time: { type: TimingTypes.ABSOLUTE, tag: '2020-001T00:00:00.000' as DOY_STRING },
           },
@@ -137,17 +139,22 @@ describe('Sequence', () => {
       expect(sequence).toBeInstanceOf(Sequence);
       expect(sequence.id).toBe('test00000');
       expect(sequence.metadata).toEqual({});
-      expect(sequence.commands.length).toEqual(2);
 
-      expect(sequence.commands[0]!).toBeInstanceOf(CommandStem);
-      expect(sequence.commands[0]!.stem).toBe('test');
-      expect(sequence.commands[0]!.metadata).toEqual({});
-      expect(sequence.commands[0]!.arguments).toEqual([]);
+      expect(sequence.steps?.length).toEqual(2);
 
-      expect(sequence.commands[1]!).toBeInstanceOf(CommandStem);
-      expect(sequence.commands[1]!.stem).toBe('test2');
-      expect(sequence.commands[1]!.metadata).toEqual({});
-      expect(sequence.commands[1]!.arguments).toEqual(['string', 0, true]);
+      if (sequence.steps) {
+        expect(sequence.steps[0]! as CommandStem).toBeInstanceOf(CommandStem);
+        expect(sequence.steps[0]!.stem).toBe('test');
+        expect(sequence.steps[0]!.GET_METADATA()).toEqual({});
+        expect(sequence.steps[0]!.arguments).toEqual([]);
+
+        expect(sequence.steps[1]!).toBeInstanceOf(CommandStem);
+        expect(sequence.steps[1]!.stem).toBe('test2');
+        expect(sequence.steps[1]!.GET_METADATA()).toEqual({
+          author: 'Mission Operation Engineer',
+        });
+        expect(sequence.steps[1]!.arguments).toEqual(['string', 0, true]);
+      }
     });
   });
 
@@ -156,15 +163,13 @@ describe('Sequence', () => {
       const sequence = Sequence.new({
         seqId: 'test',
         metadata: {},
-        commands: [],
+        steps: [],
       });
 
       expect(sequence.toEDSLString()).toEqual(`export default () =>
   Sequence.new({
     seqId: 'test',
     metadata: {},
-    commands: [
-    ],
   });`);
     });
 
@@ -172,7 +177,7 @@ describe('Sequence', () => {
       const sequence = Sequence.new({
         seqId: 'test',
         metadata: {},
-        commands: [
+        steps: [
           CommandStem.new({
             stem: 'TEST',
             arguments: ['string', 0, true],
@@ -186,6 +191,8 @@ describe('Sequence', () => {
               boolean: true,
             },
             absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
+          }).METADATA({
+            author: 'XXXXXXXXXXXXXXXXXXXXXXXXXX',
           }),
         ],
       });
@@ -194,12 +201,15 @@ describe('Sequence', () => {
   Sequence.new({
     seqId: 'test',
     metadata: {},
-    commands: [
+    steps: [
       A\`2020-001T00:00:00.000\`.TEST('string', 0, true),
       A\`2020-001T00:00:00.000\`.TEST({
         string: 'string',
         number: 0,
         boolean: true,
+      })
+      .METADATA({
+        author: 'XXXXXXXXXXXXXXXXXXXXXXXXXX',
       }),
     ],
   });`);

--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -7,27 +7,17 @@ export enum TimingTypes {
   COMMAND_COMPLETE = 'COMMAND_COMPLETE',
 }
 
-type SeqJsonTimeType =
-  | {
-      type: TimingTypes.ABSOLUTE;
-      tag: DOY_STRING;
-    }
-  | {
-      type: TimingTypes.COMMAND_RELATIVE;
-      tag: HMS_STRING;
-    }
-  | {
-      type: TimingTypes.EPOCH_RELATIVE;
-      tag: HMS_STRING;
-    }
-  | {
-      type: TimingTypes.COMMAND_COMPLETE;
-    };
-
-export type CommandOptions<
-  A extends ArgType[] | { [argName: string]: any } = [] | {},
-  M extends Record<string, any> = Record<string, any>,
-> = { stem: string; arguments: A; metadata?: M } & (
+// @ts-ignore : 'Args' found in JSON Spec
+export type CommandOptions<A extends Args[] | { [argName: string]: any } = [] | {}> = {
+  stem: string;
+  arguments: A;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  metadata?: Metadata | undefined;
+  // @ts-ignore : 'Description' found in JSON Spec
+  description?: Description | undefined;
+  // @ts-ignore : 'Model' found in JSON Spec
+  models?: Model[] | undefined;
+} & (
   | {
       absoluteTime: Temporal.Instant;
     }
@@ -41,23 +31,15 @@ export type CommandOptions<
   | {}
 );
 
-export interface CommandSeqJson<A extends ArgType[] = ArgType[]> {
-  args: A;
-  stem: string;
-  time: SeqJsonTimeType;
-  type: 'command';
-  metadata: Record<string, unknown>;
-}
-
-export type ArgType = boolean | string | number;
 export type Arrayable<T> = T | Arrayable<T>[];
 
 export interface SequenceOptions {
   seqId: string;
-  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-  locals?: [VariableDeclaration, ...VariableDeclaration[]];
   // @ts-ignore : 'Metadata' found in JSON Spec
   metadata: Metadata;
+
+  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+  locals?: [VariableDeclaration, ...VariableDeclaration[]];
   // @ts-ignore : 'VariableDeclaration' found in JSON Spec
   parameters?: [VariableDeclaration, ...VariableDeclaration[]];
   // @ts-ignore : 'Step' found in JSON Spec
@@ -68,32 +50,46 @@ export interface SequenceOptions {
   immediate_commands?: ImmediateCommand[];
   // @ts-ignore : 'HardwareCommand' found in JSON Spec
   hardware_commands?: HardwareCommand[];
-  commands: CommandStem[];
-}
-
-//TODO : Remove this interface and use SeqJson from the spec
-export interface SequenceSeqJson {
-  id: string;
-  metadata: Record<string, any>;
-  steps: CommandSeqJson[];
 }
 
 declare global {
-  class CommandStem<
-    A extends ArgType[] | { [argName: string]: any } = [] | {},
-    M extends Record<string, any> = Record<string, any>,
-  > {
+  // @ts-ignore : 'Args' found in JSON Spec
+  class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
+    // @ts-ignore : 'Args' found in JSON Spec
+    args: Args;
+    stem: string;
+    // @ts-ignore : 'TIME' found in JSON Spec
+    time: Time;
+    type: 'command';
+
     public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): CommandStem<A>;
 
-    public toSeqJson(): CommandSeqJson;
+    // @ts-ignore : 'Command' found in JSON Spec
+    public toSeqJson(): Command;
+
+    // @ts-ignore : 'Model' found in JSON Spec
+    public MODELS(models: Model[]): CommandStem<A>;
+    // @ts-ignore : 'Model' found in JSON Spec
+    public GET_MODELS(): Model[] | undefined;
+
+    // @ts-ignore : 'Metadata' found in JSON Spec
+    public METADATA(metadata: Metadata): CommandStem<A>;
+    // @ts-ignore : 'Metadata' found in JSON Spec
+    public GET_METADATA(): Metadata | undefined;
+
+    // @ts-ignore : 'Description' found in JSON Spec
+    public DESCRIPTION(description: Description): CommandStem<A>;
+    // @ts-ignore : 'Description' found in JSON Spec
+    public GET_DESCRIPTION(): Description | undefined;
   }
   // @ts-ignore : 'SeqJson' found in JSON Spec
   class Sequence implements SeqJson {
     public readonly id: string;
-    // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-    public readonly locals?: [VariableDeclaration, ...VariableDeclaration[]];
     // @ts-ignore : 'Metadata' found in JSON Spec
     public readonly metadata: Metadata;
+
+    // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+    public readonly locals?: [VariableDeclaration, ...VariableDeclaration[]];
     // @ts-ignore : 'VariableDeclaration' found in JSON Spec
     public readonly parameters?: [VariableDeclaration, ...VariableDeclaration[]];
     // @ts-ignore : 'Step' found in JSON Spec
@@ -106,26 +102,28 @@ declare global {
     public readonly hardware_commands?: HardwareCommand[];
     [k: string]: unknown;
 
-    public readonly commands: CommandStem[]; //  TODO: remove later for Step[]
-
-    public static new(opts: {
-      seqId: string;
-      // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-      locals?: [VariableDeclaration, ...VariableDeclaration[]];
-      // @ts-ignore : 'Metadata' found in JSON Spec
-      metadata: Metadata;
-      // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-      parameters?: [VariableDeclaration, ...VariableDeclaration[]];
-      // @ts-ignore : 'Step' found in JSON Spec
-      steps?: Step[];
-      // @ts-ignore : 'Request' found in JSON Spec
-      requests?: Request[];
-      // @ts-ignore : 'ImmediateCommand' found in JSON Spec
-      immediate_commands?: ImmediateCommand[];
-      // @ts-ignore : 'HardwareCommand' found in JSON Spec
-      hardware_commands?: HardwareCommand[];
-      commands: CommandStem[];
-    }): Sequence;
+    public static new(
+      opts:
+        | {
+            seqId: string;
+            // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+            locals?: [VariableDeclaration, ...VariableDeclaration[]];
+            // @ts-ignore : 'Metadata' found in JSON Spec
+            metadata: Metadata;
+            // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+            parameters?: [VariableDeclaration, ...VariableDeclaration[]];
+            // @ts-ignore : 'Step' found in JSON Spec
+            steps?: Step[];
+            // @ts-ignore : 'Request' found in JSON Spec
+            requests?: Request[];
+            // @ts-ignore : 'ImmediateCommand' found in JSON Spec
+            immediate_commands?: ImmediateCommand[];
+            // @ts-ignore : 'HardwareCommand' found in JSON Spec
+            hardware_commands?: HardwareCommand[];
+          }
+        // @ts-ignore : 'SeqJson' found in JSON Spec
+        | SeqJson,
+    ): Sequence;
 
     // @ts-ignore : 'SeqJson' found in JSON Spec
     public toSeqJson(): SeqJson;
@@ -175,21 +173,30 @@ declare global {
   const C: typeof Commands;
 }
 
-export class CommandStem<
-  A extends ArgType[] | { [argName: string]: any } = [] | {},
-  M extends Record<string, any> = Record<string, any>,
-> {
-  public readonly stem: string;
-  public readonly metadata: M;
+// @ts-ignore : 'Args' found in JSON Spec
+export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
   public readonly arguments: A;
   public readonly absoluteTime: Temporal.Instant | null = null;
   public readonly epochTime: Temporal.Duration | null = null;
   public readonly relativeTime: Temporal.Duration | null = null;
 
-  private constructor(opts: CommandOptions<A, M>) {
+  public readonly stem: string;
+  // @ts-ignore : 'Args' found in JSON Spec
+  public readonly args!: Args;
+  // @ts-ignore : 'Time' found in JSON Spec
+  public readonly time!: Time;
+  // @ts-ignore : 'Model' found in JSON Spec
+  private readonly _models?: Model[] | undefined;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  private readonly _metadata?: Metadata | undefined;
+  // @ts-ignore : 'Description' found in JSON Spec
+  private readonly _description?: Description | undefined;
+  public readonly type: 'command' = 'command';
+
+  private constructor(opts: CommandOptions<A>) {
     this.stem = opts.stem;
     this.arguments = opts.arguments;
-    this.metadata = opts.metadata ?? ({} as M);
+
     if ('absoluteTime' in opts) {
       this.absoluteTime = opts.absoluteTime;
     } else if ('epochTime' in opts) {
@@ -197,6 +204,9 @@ export class CommandStem<
     } else if ('relativeTime' in opts) {
       this.relativeTime = opts.relativeTime;
     }
+    this._metadata = opts.metadata;
+    this._description = opts.description;
+    this._models = opts.models;
   }
 
   public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): CommandStem<A> {
@@ -220,7 +230,64 @@ export class CommandStem<
     }
   }
 
-  public toSeqJson(): CommandSeqJson {
+  // @ts-ignore : 'Model' found in JSON Spec
+  public MODELS(models: Model[]): CommandStem {
+    return CommandStem.new({
+      stem: this.stem,
+      arguments: this.arguments,
+      models: models,
+      metadata: this._metadata,
+      description: this._description,
+      ...(this.absoluteTime && { absoluteTime: this.absoluteTime }),
+      ...(this.epochTime && { epochTime: this.epochTime }),
+      ...(this.relativeTime && { relativeTime: this.relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public GET_MODELS(): Model[] | undefined {
+    return this._models;
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public METADATA(metadata: Metadata): CommandStem {
+    return CommandStem.new({
+      stem: this.stem,
+      arguments: this.arguments,
+      models: this._models,
+      metadata: metadata,
+      description: this._description,
+      ...(this.absoluteTime && { absoluteTime: this.absoluteTime }),
+      ...(this.epochTime && { epochTime: this.epochTime }),
+      ...(this.relativeTime && { relativeTime: this.relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public GET_METADATA(): Metadata | undefined {
+    return this._metadata;
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public DESCRIPTION(description: Description): CommandStem {
+    return CommandStem.new({
+      stem: this.stem,
+      arguments: this.arguments,
+      models: this._models,
+      metadata: this._metadata,
+      description: description,
+      ...(this.absoluteTime && { absoluteTime: this.absoluteTime }),
+      ...(this.epochTime && { epochTime: this.epochTime }),
+      ...(this.relativeTime && { relativeTime: this.relativeTime }),
+    });
+  }
+  // @ts-ignore : 'Description' found in JSON Spec
+  public GET_DESCRIPTION(): Description | undefined {
+    return this._description;
+  }
+
+  // @ts-ignore : 'Command' found in JSON Spec
+  public toSeqJson(): Command {
     return {
       args: flatten(this.arguments),
       stem: this.stem,
@@ -232,25 +299,30 @@ export class CommandStem<
           : this.relativeTime !== null
           ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this.relativeTime) }
           : { type: TimingTypes.COMMAND_COMPLETE },
-      type: 'command',
-      metadata: this.metadata,
+      type: this.type,
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { models: this._models } : {}),
+      ...(this._description ? { description: this._description } : {}),
     };
   }
 
-  public static fromSeqJson<A extends ArgType[]>(json: CommandSeqJson<A>): CommandStem<A> {
+  // @ts-ignore : 'Command' found in JSON Spec
+  public static fromSeqJson(json: Command): CommandStem {
     const timeValue =
       json.time.type === TimingTypes.ABSOLUTE
-        ? { absoluteTime: doyToInstant(json.time.tag) }
+        ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
         : json.time.type === TimingTypes.COMMAND_RELATIVE
-        ? { relativeTime: hmsToDuration(json.time.tag) }
+        ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : json.time.type === TimingTypes.EPOCH_RELATIVE
-        ? { epochTime: hmsToDuration(json.time.tag) }
+        ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : {};
 
-    return CommandStem.new<A>({
+    return CommandStem.new({
       stem: json.stem,
-      arguments: json.args as A,
+      arguments: json.args,
       metadata: json.metadata,
+      models: json.models,
+      description: json.description,
       ...timeValue,
     });
   }
@@ -291,10 +363,21 @@ export class CommandStem<
     const argsString =
       Object.keys(this.arguments).length === 0 ? '' : `(${CommandStem.argumentsToString(this.arguments)})`;
 
-    return `${timeString}.${this.stem}${argsString}`;
+    const metadata =
+      this._metadata && Object.keys(this._metadata).length !== 0
+        ? `\n.METADATA(${objectToString(this._metadata)})`
+        : '';
+    const description =
+      this._description && this._description.length !== 0 ? `\n.DESCRIPTION('${this._description}')` : '';
+    const models =
+      this._models && Object.keys(this._models).length !== 0
+        ? `\n.MODELS([${this._models.map(m => objectToString(m))}])`
+        : '';
+    return `${timeString}.${this.stem}${argsString}${description}${metadata}${models}`;
   }
 
-  private static argumentsToString<A extends ArgType[] | { [argName: string]: any } = [] | {}>(args: A): string {
+  // @ts-ignore : 'Args' found in JSON Spec
+  private static argumentsToString<A extends Args[] | { [argName: string]: any } = [] | {}>(args: A): string {
     if (Array.isArray(args)) {
       const argStrings = args.map(arg => {
         if (typeof arg === 'string') {
@@ -321,10 +404,11 @@ export class CommandStem<
 // @ts-ignore : 'SeqJson' found in JSON Spec
 export class Sequence implements SeqJson {
   public readonly id: string;
-  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-  public readonly locals?: [VariableDeclaration, ...VariableDeclaration[]];
   // @ts-ignore : 'Metadata' found in JSON Spec
   public readonly metadata: Metadata;
+
+  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+  public readonly locals?: [VariableDeclaration, ...VariableDeclaration[]];
   // @ts-ignore : 'VariableDeclaration' found in JSON Spec
   public readonly parameters?: [VariableDeclaration, ...VariableDeclaration[]];
   // @ts-ignore : 'Step' found in JSON Spec
@@ -336,31 +420,22 @@ export class Sequence implements SeqJson {
   // @ts-ignore : 'HardwareCommand' found in JSON Spec
   public readonly hardware_commands?: HardwareCommand[];
   [k: string]: unknown;
-  public readonly commands: CommandStem[]; //  TODO: remove later for Stepp[]
 
-  private constructor(opts: SequenceOptions) {
-    this.id = opts.seqId;
+  // @ts-ignore : 'SeqJson' found in JSON Spec
+  private constructor(opts: SequenceOptions | SeqJson) {
+    if ('id' in opts) {
+      this.id = opts.id;
+    } else {
+      this.id = opts.seqId;
+    }
     this.metadata = opts.metadata;
-    this.commands = opts.commands;
 
-    if (opts.locals) {
-      this.locals = opts.locals;
-    }
-    if (opts.parameters) {
-      this.parameters = opts.parameters;
-    }
-    if (opts.steps) {
-      this.steps = opts.steps;
-    }
-    if (opts.requests) {
-      this.requests = opts.requests;
-    }
-    if (opts.immediate_commands) {
-      this.immediate_commands = opts.immediate_commands;
-    }
-    if (opts.hardware_commands) {
-      this.hardware_commands = opts.hardware_commands;
-    }
+    this.locals = opts.locals ?? undefined;
+    this.parameters = opts.parameters ?? undefined;
+    this.steps = opts.steps ?? undefined;
+    this.requests = opts.requests ?? undefined;
+    this.immediate_commands = opts.immediate_commands ?? undefined;
+    this.hardware_commands = opts.hardware_commands ?? undefined;
   }
   public static new(opts: SequenceOptions): Sequence {
     return new Sequence(opts);
@@ -371,28 +446,52 @@ export class Sequence implements SeqJson {
     return {
       id: this.id,
       metadata: this.metadata,
-      steps: this.commands.map(c => c.toSeqJson()),
+      ...(this.steps
+        ? {
+            steps: this.steps.map(step => {
+              if (step instanceof CommandStem) return step.toSeqJson();
+              return step;
+            }),
+          }
+        : {}),
     };
   }
 
   public toEDSLString(): string {
     const commandsString =
-      this.commands.length === 0 ? '' : '\n' + indent(this.commands.map(c => c.toEDSLString() + ',').join('\n'), 3);
+      this.steps && this.steps.length > 0
+        ? '\n' +
+          indent(
+            this.steps
+              .map(step => {
+                return (step as CommandStem).toEDSLString() + ',';
+              })
+              .join('\n'),
+            2,
+          )
+        : '';
 
     return `export default () =>
   Sequence.new({
     seqId: '${this.id}',
-    metadata: ${JSON.stringify(this.metadata)},
-    commands: [${commandsString}
-    ],
+    metadata: ${JSON.stringify(this.metadata)},${
+      commandsString.length > 0 ? `\n${indent(`  steps: [${commandsString}`)}\n${indent('],', 2)}` : ''
+    }
   });`;
   }
 
-  public static fromSeqJson(json: SequenceSeqJson): Sequence {
+  // @ts-ignore : 'Args' found in JSON Spec
+  public static fromSeqJson(json: SeqJson): Sequence {
     return Sequence.new({
       seqId: json.id,
       metadata: json.metadata,
-      commands: json.steps.map(c => CommandStem.fromSeqJson(c)),
+      // @ts-ignore : 'Step' found in JSON Spec
+      ...(json.steps ? { steps: json.steps.map((c: Step) => CommandStem.fromSeqJson(c as CommandStem)) } : {}),
+      ...(json.locals ? { locals: json.locals } : {}),
+      ...(json.parameters ? { parameters: json.parameters } : {}),
+      ...(json.requests ? { requests: json.requests } : {}),
+      ...(json.immediate_commands ? { immediate_commands: json.immediate_commands } : {}),
+      ...(json.hardware_commands ? { hardware_commands: json.hardware_commands } : {}),
     });
   }
 }
@@ -596,6 +695,34 @@ function indent(text: string, numTimes: number = 1, char: string = '  '): string
     .split('\n')
     .map(line => char.repeat(numTimes) + line)
     .join('\n');
+}
+// @ts-ignore : 'Metadata' found in JSON Spec
+function objectToString(obj: any): string {
+  let output = '';
+  let indentLevel = 1;
+
+  const print = (obj: any) => {
+    Object.keys(obj).forEach(key => {
+      const value = obj[key];
+      const indent = '  '.repeat(indentLevel);
+
+      if (typeof value === 'object') {
+        output += `${indent}${key}:{\n`;
+        indentLevel++;
+        print(value);
+        indentLevel--;
+        output += `${indent}},\n`;
+      } else {
+        output += `${indent}${key}: ${typeof value === 'string' ? `'${value}'` : value},\n`;
+      }
+    });
+  };
+
+  output += '{\n';
+  print(obj);
+  output += '}';
+
+  return output;
 }
 
 /** END Preface */

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -10,27 +10,17 @@ export enum TimingTypes {
   COMMAND_COMPLETE = 'COMMAND_COMPLETE',
 }
 
-type SeqJsonTimeType =
-  | {
-      type: TimingTypes.ABSOLUTE;
-      tag: DOY_STRING;
-    }
-  | {
-      type: TimingTypes.COMMAND_RELATIVE;
-      tag: HMS_STRING;
-    }
-  | {
-      type: TimingTypes.EPOCH_RELATIVE;
-      tag: HMS_STRING;
-    }
-  | {
-      type: TimingTypes.COMMAND_COMPLETE;
-    };
-
-export type CommandOptions<
-  A extends ArgType[] | { [argName: string]: any } = [] | {},
-  M extends Record<string, any> = Record<string, any>,
-> = { stem: string; arguments: A; metadata?: M } & (
+// @ts-ignore : 'Args' found in JSON Spec
+export type CommandOptions<A extends Args[] | { [argName: string]: any } = [] | {}> = {
+  stem: string;
+  arguments: A;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  metadata?: Metadata | undefined;
+  // @ts-ignore : 'Description' found in JSON Spec
+  description?: Description | undefined;
+  // @ts-ignore : 'Model' found in JSON Spec
+  models?: Model[] | undefined;
+} & (
   | {
       absoluteTime: Temporal.Instant;
     }
@@ -44,23 +34,15 @@ export type CommandOptions<
   | {}
 );
 
-export interface CommandSeqJson<A extends ArgType[] = ArgType[]> {
-  args: A;
-  stem: string;
-  time: SeqJsonTimeType;
-  type: 'command';
-  metadata: Record<string, unknown>;
-}
-
-export type ArgType = boolean | string | number;
 export type Arrayable<T> = T | Arrayable<T>[];
 
 export interface SequenceOptions {
   seqId: string;
-  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-  locals?: [VariableDeclaration, ...VariableDeclaration[]];
   // @ts-ignore : 'Metadata' found in JSON Spec
   metadata: Metadata;
+
+  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+  locals?: [VariableDeclaration, ...VariableDeclaration[]];
   // @ts-ignore : 'VariableDeclaration' found in JSON Spec
   parameters?: [VariableDeclaration, ...VariableDeclaration[]];
   // @ts-ignore : 'Step' found in JSON Spec
@@ -71,32 +53,46 @@ export interface SequenceOptions {
   immediate_commands?: ImmediateCommand[];
   // @ts-ignore : 'HardwareCommand' found in JSON Spec
   hardware_commands?: HardwareCommand[];
-  commands: CommandStem[];
-}
-
-//TODO : Remove this interface and use SeqJson from the spec
-export interface SequenceSeqJson {
-  id: string;
-  metadata: Record<string, any>;
-  steps: CommandSeqJson[];
 }
 
 declare global {
-  class CommandStem<
-    A extends ArgType[] | { [argName: string]: any } = [] | {},
-    M extends Record<string, any> = Record<string, any>,
-  > {
+  // @ts-ignore : 'Args' found in JSON Spec
+  class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
+    // @ts-ignore : 'Args' found in JSON Spec
+    args: Args;
+    stem: string;
+    // @ts-ignore : 'TIME' found in JSON Spec
+    time: Time;
+    type: 'command';
+
     public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): CommandStem<A>;
 
-    public toSeqJson(): CommandSeqJson;
+    // @ts-ignore : 'Command' found in JSON Spec
+    public toSeqJson(): Command;
+
+    // @ts-ignore : 'Model' found in JSON Spec
+    public MODELS(models: Model[]): CommandStem<A>;
+    // @ts-ignore : 'Model' found in JSON Spec
+    public GET_MODELS(): Model[] | undefined;
+
+    // @ts-ignore : 'Metadata' found in JSON Spec
+    public METADATA(metadata: Metadata): CommandStem<A>;
+    // @ts-ignore : 'Metadata' found in JSON Spec
+    public GET_METADATA(): Metadata | undefined;
+
+    // @ts-ignore : 'Description' found in JSON Spec
+    public DESCRIPTION(description: Description): CommandStem<A>;
+    // @ts-ignore : 'Description' found in JSON Spec
+    public GET_DESCRIPTION(): Description | undefined;
   }
   // @ts-ignore : 'SeqJson' found in JSON Spec
   class Sequence implements SeqJson {
     public readonly id: string;
-    // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-    public readonly locals?: [VariableDeclaration, ...VariableDeclaration[]];
     // @ts-ignore : 'Metadata' found in JSON Spec
     public readonly metadata: Metadata;
+
+    // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+    public readonly locals?: [VariableDeclaration, ...VariableDeclaration[]];
     // @ts-ignore : 'VariableDeclaration' found in JSON Spec
     public readonly parameters?: [VariableDeclaration, ...VariableDeclaration[]];
     // @ts-ignore : 'Step' found in JSON Spec
@@ -109,26 +105,28 @@ declare global {
     public readonly hardware_commands?: HardwareCommand[];
     [k: string]: unknown;
 
-    public readonly commands: CommandStem[]; //  TODO: remove later for Step[]
-
-    public static new(opts: {
-      seqId: string;
-      // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-      locals?: [VariableDeclaration, ...VariableDeclaration[]];
-      // @ts-ignore : 'Metadata' found in JSON Spec
-      metadata: Metadata;
-      // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-      parameters?: [VariableDeclaration, ...VariableDeclaration[]];
-      // @ts-ignore : 'Step' found in JSON Spec
-      steps?: Step[];
-      // @ts-ignore : 'Request' found in JSON Spec
-      requests?: Request[];
-      // @ts-ignore : 'ImmediateCommand' found in JSON Spec
-      immediate_commands?: ImmediateCommand[];
-      // @ts-ignore : 'HardwareCommand' found in JSON Spec
-      hardware_commands?: HardwareCommand[];
-      commands: CommandStem[];
-    }): Sequence;
+    public static new(
+      opts:
+        | {
+            seqId: string;
+            // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+            locals?: [VariableDeclaration, ...VariableDeclaration[]];
+            // @ts-ignore : 'Metadata' found in JSON Spec
+            metadata: Metadata;
+            // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+            parameters?: [VariableDeclaration, ...VariableDeclaration[]];
+            // @ts-ignore : 'Step' found in JSON Spec
+            steps?: Step[];
+            // @ts-ignore : 'Request' found in JSON Spec
+            requests?: Request[];
+            // @ts-ignore : 'ImmediateCommand' found in JSON Spec
+            immediate_commands?: ImmediateCommand[];
+            // @ts-ignore : 'HardwareCommand' found in JSON Spec
+            hardware_commands?: HardwareCommand[];
+          }
+        // @ts-ignore : 'SeqJson' found in JSON Spec
+        | SeqJson,
+    ): Sequence;
 
     // @ts-ignore : 'SeqJson' found in JSON Spec
     public toSeqJson(): SeqJson;
@@ -178,21 +176,30 @@ declare global {
   const C: typeof Commands;
 }
 
-export class CommandStem<
-  A extends ArgType[] | { [argName: string]: any } = [] | {},
-  M extends Record<string, any> = Record<string, any>,
-> {
-  public readonly stem: string;
-  public readonly metadata: M;
+// @ts-ignore : 'Args' found in JSON Spec
+export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
   public readonly arguments: A;
   public readonly absoluteTime: Temporal.Instant | null = null;
   public readonly epochTime: Temporal.Duration | null = null;
   public readonly relativeTime: Temporal.Duration | null = null;
 
-  private constructor(opts: CommandOptions<A, M>) {
+  public readonly stem: string;
+  // @ts-ignore : 'Args' found in JSON Spec
+  public readonly args!: Args;
+  // @ts-ignore : 'Time' found in JSON Spec
+  public readonly time!: Time;
+  // @ts-ignore : 'Model' found in JSON Spec
+  private readonly _models?: Model[] | undefined;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  private readonly _metadata?: Metadata | undefined;
+  // @ts-ignore : 'Description' found in JSON Spec
+  private readonly _description?: Description | undefined;
+  public readonly type: 'command' = 'command';
+
+  private constructor(opts: CommandOptions<A>) {
     this.stem = opts.stem;
     this.arguments = opts.arguments;
-    this.metadata = opts.metadata ?? ({} as M);
+
     if ('absoluteTime' in opts) {
       this.absoluteTime = opts.absoluteTime;
     } else if ('epochTime' in opts) {
@@ -200,6 +207,9 @@ export class CommandStem<
     } else if ('relativeTime' in opts) {
       this.relativeTime = opts.relativeTime;
     }
+    this._metadata = opts.metadata;
+    this._description = opts.description;
+    this._models = opts.models;
   }
 
   public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): CommandStem<A> {
@@ -223,7 +233,64 @@ export class CommandStem<
     }
   }
 
-  public toSeqJson(): CommandSeqJson {
+  // @ts-ignore : 'Model' found in JSON Spec
+  public MODELS(models: Model[]): CommandStem {
+    return CommandStem.new({
+      stem: this.stem,
+      arguments: this.arguments,
+      models: models,
+      metadata: this._metadata,
+      description: this._description,
+      ...(this.absoluteTime && { absoluteTime: this.absoluteTime }),
+      ...(this.epochTime && { epochTime: this.epochTime }),
+      ...(this.relativeTime && { relativeTime: this.relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public GET_MODELS(): Model[] | undefined {
+    return this._models;
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public METADATA(metadata: Metadata): CommandStem {
+    return CommandStem.new({
+      stem: this.stem,
+      arguments: this.arguments,
+      models: this._models,
+      metadata: metadata,
+      description: this._description,
+      ...(this.absoluteTime && { absoluteTime: this.absoluteTime }),
+      ...(this.epochTime && { epochTime: this.epochTime }),
+      ...(this.relativeTime && { relativeTime: this.relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public GET_METADATA(): Metadata | undefined {
+    return this._metadata;
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public DESCRIPTION(description: Description): CommandStem {
+    return CommandStem.new({
+      stem: this.stem,
+      arguments: this.arguments,
+      models: this._models,
+      metadata: this._metadata,
+      description: description,
+      ...(this.absoluteTime && { absoluteTime: this.absoluteTime }),
+      ...(this.epochTime && { epochTime: this.epochTime }),
+      ...(this.relativeTime && { relativeTime: this.relativeTime }),
+    });
+  }
+  // @ts-ignore : 'Description' found in JSON Spec
+  public GET_DESCRIPTION(): Description | undefined {
+    return this._description;
+  }
+
+  // @ts-ignore : 'Command' found in JSON Spec
+  public toSeqJson(): Command {
     return {
       args: flatten(this.arguments),
       stem: this.stem,
@@ -235,25 +302,30 @@ export class CommandStem<
           : this.relativeTime !== null
           ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this.relativeTime) }
           : { type: TimingTypes.COMMAND_COMPLETE },
-      type: 'command',
-      metadata: this.metadata,
+      type: this.type,
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { models: this._models } : {}),
+      ...(this._description ? { description: this._description } : {}),
     };
   }
 
-  public static fromSeqJson<A extends ArgType[]>(json: CommandSeqJson<A>): CommandStem<A> {
+  // @ts-ignore : 'Command' found in JSON Spec
+  public static fromSeqJson(json: Command): CommandStem {
     const timeValue =
       json.time.type === TimingTypes.ABSOLUTE
-        ? { absoluteTime: doyToInstant(json.time.tag) }
+        ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
         : json.time.type === TimingTypes.COMMAND_RELATIVE
-        ? { relativeTime: hmsToDuration(json.time.tag) }
+        ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : json.time.type === TimingTypes.EPOCH_RELATIVE
-        ? { epochTime: hmsToDuration(json.time.tag) }
+        ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : {};
 
-    return CommandStem.new<A>({
+    return CommandStem.new({
       stem: json.stem,
-      arguments: json.args as A,
+      arguments: json.args,
       metadata: json.metadata,
+      models: json.models,
+      description: json.description,
       ...timeValue,
     });
   }
@@ -294,10 +366,21 @@ export class CommandStem<
     const argsString =
       Object.keys(this.arguments).length === 0 ? '' : \`(\${CommandStem.argumentsToString(this.arguments)})\`;
 
-    return \`\${timeString}.\${this.stem}\${argsString}\`;
+    const metadata =
+      this._metadata && Object.keys(this._metadata).length !== 0
+        ? \`\\n.METADATA(\${objectToString(this._metadata)})\`
+        : '';
+    const description =
+      this._description && this._description.length !== 0 ? \`\\n.DESCRIPTION('\${this._description}')\` : '';
+    const models =
+      this._models && Object.keys(this._models).length !== 0
+        ? \`\\n.MODELS([\${this._models.map(m => objectToString(m))}])\`
+        : '';
+    return \`\${timeString}.\${this.stem}\${argsString}\${description}\${metadata}\${models}\`;
   }
 
-  private static argumentsToString<A extends ArgType[] | { [argName: string]: any } = [] | {}>(args: A): string {
+  // @ts-ignore : 'Args' found in JSON Spec
+  private static argumentsToString<A extends Args[] | { [argName: string]: any } = [] | {}>(args: A): string {
     if (Array.isArray(args)) {
       const argStrings = args.map(arg => {
         if (typeof arg === 'string') {
@@ -324,10 +407,11 @@ export class CommandStem<
 // @ts-ignore : 'SeqJson' found in JSON Spec
 export class Sequence implements SeqJson {
   public readonly id: string;
-  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-  public readonly locals?: [VariableDeclaration, ...VariableDeclaration[]];
   // @ts-ignore : 'Metadata' found in JSON Spec
   public readonly metadata: Metadata;
+
+  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+  public readonly locals?: [VariableDeclaration, ...VariableDeclaration[]];
   // @ts-ignore : 'VariableDeclaration' found in JSON Spec
   public readonly parameters?: [VariableDeclaration, ...VariableDeclaration[]];
   // @ts-ignore : 'Step' found in JSON Spec
@@ -339,31 +423,22 @@ export class Sequence implements SeqJson {
   // @ts-ignore : 'HardwareCommand' found in JSON Spec
   public readonly hardware_commands?: HardwareCommand[];
   [k: string]: unknown;
-  public readonly commands: CommandStem[]; //  TODO: remove later for Stepp[]
 
-  private constructor(opts: SequenceOptions) {
-    this.id = opts.seqId;
+  // @ts-ignore : 'SeqJson' found in JSON Spec
+  private constructor(opts: SequenceOptions | SeqJson) {
+    if ('id' in opts) {
+      this.id = opts.id;
+    } else {
+      this.id = opts.seqId;
+    }
     this.metadata = opts.metadata;
-    this.commands = opts.commands;
 
-    if (opts.locals) {
-      this.locals = opts.locals;
-    }
-    if (opts.parameters) {
-      this.parameters = opts.parameters;
-    }
-    if (opts.steps) {
-      this.steps = opts.steps;
-    }
-    if (opts.requests) {
-      this.requests = opts.requests;
-    }
-    if (opts.immediate_commands) {
-      this.immediate_commands = opts.immediate_commands;
-    }
-    if (opts.hardware_commands) {
-      this.hardware_commands = opts.hardware_commands;
-    }
+    this.locals = opts.locals ?? undefined;
+    this.parameters = opts.parameters ?? undefined;
+    this.steps = opts.steps ?? undefined;
+    this.requests = opts.requests ?? undefined;
+    this.immediate_commands = opts.immediate_commands ?? undefined;
+    this.hardware_commands = opts.hardware_commands ?? undefined;
   }
   public static new(opts: SequenceOptions): Sequence {
     return new Sequence(opts);
@@ -374,28 +449,52 @@ export class Sequence implements SeqJson {
     return {
       id: this.id,
       metadata: this.metadata,
-      steps: this.commands.map(c => c.toSeqJson()),
+      ...(this.steps
+        ? {
+            steps: this.steps.map(step => {
+              if (step instanceof CommandStem) return step.toSeqJson();
+              return step;
+            }),
+          }
+        : {}),
     };
   }
 
   public toEDSLString(): string {
     const commandsString =
-      this.commands.length === 0 ? '' : '\\n' + indent(this.commands.map(c => c.toEDSLString() + ',').join('\\n'), 3);
+      this.steps && this.steps.length > 0
+        ? '\\n' +
+          indent(
+            this.steps
+              .map(step => {
+                return (step as CommandStem).toEDSLString() + ',';
+              })
+              .join('\\n'),
+            2,
+          )
+        : '';
 
     return \`export default () =>
   Sequence.new({
     seqId: '\${this.id}',
-    metadata: \${JSON.stringify(this.metadata)},
-    commands: [\${commandsString}
-    ],
+    metadata: \${JSON.stringify(this.metadata)},\${
+      commandsString.length > 0 ? \`\\n\${indent(\`  steps: [\${commandsString}\`)}\\n\${indent('],', 2)}\` : ''
+    }
   });\`;
   }
 
-  public static fromSeqJson(json: SequenceSeqJson): Sequence {
+  // @ts-ignore : 'Args' found in JSON Spec
+  public static fromSeqJson(json: SeqJson): Sequence {
     return Sequence.new({
       seqId: json.id,
       metadata: json.metadata,
-      commands: json.steps.map(c => CommandStem.fromSeqJson(c)),
+      // @ts-ignore : 'Step' found in JSON Spec
+      ...(json.steps ? { steps: json.steps.map((c: Step) => CommandStem.fromSeqJson(c as CommandStem)) } : {}),
+      ...(json.locals ? { locals: json.locals } : {}),
+      ...(json.parameters ? { parameters: json.parameters } : {}),
+      ...(json.requests ? { requests: json.requests } : {}),
+      ...(json.immediate_commands ? { immediate_commands: json.immediate_commands } : {}),
+      ...(json.hardware_commands ? { hardware_commands: json.hardware_commands } : {}),
     });
   }
 }
@@ -599,6 +698,34 @@ function indent(text: string, numTimes: number = 1, char: string = '  '): string
     .split('\\n')
     .map(line => char.repeat(numTimes) + line)
     .join('\\n');
+}
+// @ts-ignore : 'Metadata' found in JSON Spec
+function objectToString(obj: any): string {
+  let output = '';
+  let indentLevel = 1;
+
+  const print = (obj: any) => {
+    Object.keys(obj).forEach(key => {
+      const value = obj[key];
+      const indent = '  '.repeat(indentLevel);
+
+      if (typeof value === 'object') {
+        output += \`\${indent}\${key}:{\\n\`;
+        indentLevel++;
+        print(value);
+        indentLevel--;
+        output += \`\${indent}},\\n\`;
+      } else {
+        output += \`\${indent}\${key}: \${typeof value === 'string' ? \`'\${value}'\` : value},\\n\`;
+      }
+    });
+  };
+
+  output += '{\\n';
+  print(obj);
+  output += '}';
+
+  return output;
 }
 
 /** END Preface */

--- a/sequencing-server/test/seqjson-to-edsl.spec.ts
+++ b/sequencing-server/test/seqjson-to-edsl.spec.ts
@@ -47,7 +47,7 @@ describe('getEdslForSeqJson', () => {
   Sequence.new({
     seqId: 'test_00001',
     metadata: {},
-    commands: [
+    steps: [
       C.BAKE_BREAD,
       A\`2020-060T03:45:19.000\`.PREHEAT_OVEN(100),
     ],
@@ -119,7 +119,7 @@ describe('getEdslForSeqJsonBulk', () => {
   Sequence.new({
     seqId: 'test_00001',
     metadata: {},
-    commands: [
+    steps: [
       C.BAKE_BREAD,
       A\`2020-060T03:45:19.000\`.PREHEAT_OVEN(100),
     ],
@@ -128,7 +128,7 @@ describe('getEdslForSeqJsonBulk', () => {
   Sequence.new({
     seqId: 'test_00002',
     metadata: {},
-    commands: [
+    steps: [
       C.BAKE_BREAD,
       A\`2020-060T03:45:19.000\`.PREHEAT_OVEN(100),
     ],

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -99,7 +99,7 @@ describe('sequence generation', () => {
             },
             {
               bundle_name: "Dole",
-              number_of_bananas: 12 
+              number_of_bananas: 12
             }
           ]
         }),
@@ -112,7 +112,7 @@ describe('sequence generation', () => {
             },
             {
               bundle_name: "Blue",
-              number_of_bananas: 12 
+              number_of_bananas: 12
             }
           ]
         })
@@ -2141,7 +2141,7 @@ describe('user sequence to seqjson', () => {
       Sequence.new({
         seqId: "test00001",
         metadata: {},
-        commands: [
+        steps: [
             C.BAKE_BREAD,
             A\`2020-060T03:45:19\`.PREHEAT_OVEN({ temperature: 100 }),
             E(Temporal.Duration.from({ hours: 12, minutes: 6, seconds: 54 })).PACKAGE_BANANA({
@@ -2153,7 +2153,7 @@ describe('user sequence to seqjson', () => {
                 },
                 {
                   bundle_name: "Dole",
-                  number_of_bananas: 12 
+                  number_of_bananas: 12
                 }
               ]
             }),
@@ -2170,7 +2170,6 @@ describe('user sequence to seqjson', () => {
         stem: 'BAKE_BREAD',
         time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [],
-        metadata: {},
       },
       {
         type: 'command',
@@ -2180,7 +2179,6 @@ describe('user sequence to seqjson', () => {
           type: 'ABSOLUTE',
         },
         args: [100],
-        metadata: {},
       },
       {
         type: 'command',
@@ -2190,7 +2188,6 @@ describe('user sequence to seqjson', () => {
           type: 'EPOCH_RELATIVE',
         },
         args: [1093, 'Chiquita', 43, 'Dole', 12],
-        metadata: {},
       },
     ]);
   }, 30000);
@@ -2204,8 +2201,8 @@ describe('user sequence to seqjson', () => {
             Sequence.new({
               seqId: "test00001",
               metadata: {},
-              commands: [
-                  C.BAKE_BREAD,
+              steps: [
+                  C.BAKE_BREAD.DESCRIPTION("Bake bread"),
                   A\`2020-060T03:45:19\`.PREHEAT_OVEN({ temperature: 100 }),
                   E(Temporal.Duration.from({ hours: 12, minutes: 6, seconds: 54 })).PACKAGE_BANANA({
                     lot_number: 1093,
@@ -2216,7 +2213,7 @@ describe('user sequence to seqjson', () => {
                       },
                       {
                         bundle_name: "Dole",
-                        number_of_bananas: 12 
+                        number_of_bananas: 12
                       }
                     ]
                 }),
@@ -2231,7 +2228,7 @@ describe('user sequence to seqjson', () => {
             Sequence.new({
               seqId: "test00002",
               metadata: {},
-              commands: [
+              steps: [
                   C.BAKE_BREAD,
                   A\`2020-061T03:45:19\`.PREHEAT_OVEN({ temperature: 100 }),
                   E(Temporal.Duration.from({ hours: 12, minutes: 6, seconds: 54 })).PACKAGE_BANANA({
@@ -2243,10 +2240,22 @@ describe('user sequence to seqjson', () => {
                       },
                       {
                         bundle_name: "Dole",
-                        number_of_bananas: 12 
+                        number_of_bananas: 12
                       }
                     ]
-                  }),
+                  }).MODELS([{
+                    offset: '00:00:00.000',
+                    value: 1.234,
+                    variable: 'model_var_float',
+                  },{
+                    offset: '00:00:00.001',
+                    value: '-1234',
+                    variable: 'model_var_int',
+                  },{
+                    offset: '00:10:00.001',
+                    value: true,
+                    variable: 'model_var_boolean',
+                  }]),
               ],
             });
           `,
@@ -2259,9 +2268,9 @@ describe('user sequence to seqjson', () => {
       {
         type: 'command',
         stem: 'BAKE_BREAD',
+        description: 'Bake bread',
         time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [],
-        metadata: {},
       },
       {
         type: 'command',
@@ -2271,7 +2280,6 @@ describe('user sequence to seqjson', () => {
           type: 'ABSOLUTE',
         },
         args: [100],
-        metadata: {},
       },
       {
         type: 'command',
@@ -2281,7 +2289,6 @@ describe('user sequence to seqjson', () => {
           type: 'EPOCH_RELATIVE',
         },
         args: [1093, 'Chiquita', 43, 'Dole', 12],
-        metadata: {},
       },
     ]);
 
@@ -2293,7 +2300,6 @@ describe('user sequence to seqjson', () => {
         stem: 'BAKE_BREAD',
         time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [],
-        metadata: {},
       },
       {
         type: 'command',
@@ -2303,7 +2309,6 @@ describe('user sequence to seqjson', () => {
           type: 'ABSOLUTE',
         },
         args: [100],
-        metadata: {},
       },
       {
         type: 'command',
@@ -2313,7 +2318,23 @@ describe('user sequence to seqjson', () => {
           type: 'EPOCH_RELATIVE',
         },
         args: [1093, 'Chiquita', 43, 'Dole', 12],
-        metadata: {},
+        models: [
+          {
+            offset: '00:00:00.000',
+            value: 1.234,
+            variable: 'model_var_float',
+          },
+          {
+            offset: '00:00:00.001',
+            value: '-1234',
+            variable: 'model_var_int',
+          },
+          {
+            offset: '00:10:00.001',
+            value: true,
+            variable: 'model_var_boolean',
+          },
+        ],
       },
     ]);
   }, 30000);

--- a/sequencing-server/test/testUtils/Sequence.ts
+++ b/sequencing-server/test/testUtils/Sequence.ts
@@ -1,5 +1,5 @@
 import { gql, GraphQLClient } from 'graphql-request';
-import type { SequenceSeqJson } from '../../src/lib/codegen/CommandEDSLPreface.js';
+import type { SeqJson } from '@nasa-jpl/seq-json-schema/types';
 import { FallibleStatus } from '../../src/types.js';
 import { convertActivityDirectiveIdToSimulatedActivityId } from './ActivityDirective.js';
 
@@ -37,12 +37,12 @@ export async function getSequenceSeqJson(graphqlClient: GraphQLClient, seqId: st
     getSequenceSeqJson:
       | {
           status: FallibleStatus.FAILURE;
-          seqJson?: SequenceSeqJson;
+          seqJson?: SeqJson;
           errors: { message: string; stack: string }[];
         }
       | {
           status: FallibleStatus.SUCCESS;
-          seqJson: SequenceSeqJson;
+          seqJson: SeqJson;
           errors: { message: string; stack: string }[];
         };
   }>(
@@ -91,12 +91,12 @@ export async function getSequenceSeqJsonBulk(
     getSequenceSeqJsonBulk: (
       | {
           status: FallibleStatus.FAILURE;
-          seqJson?: SequenceSeqJson;
+          seqJson?: SeqJson;
           errors: { message: string; stack: string }[];
         }
       | {
           status: FallibleStatus.SUCCESS;
-          seqJson: SequenceSeqJson;
+          seqJson: SeqJson;
           errors: { message: string; stack: string }[];
         }
     )[];
@@ -138,17 +138,17 @@ export async function generateSequenceEDSL(
   graphqlClient: GraphQLClient,
   commandDictionaryID: number,
   edslBody: string,
-): Promise<SequenceSeqJson> {
+): Promise<SeqJson> {
   const res = await graphqlClient.request<{
     getUserSequenceSeqJson:
       | {
           status: FallibleStatus.FAILURE;
-          seqJson?: SequenceSeqJson;
+          seqJson?: SeqJson;
           errors: { message: string; stack: string }[];
         }
       | {
           status: FallibleStatus.SUCCESS;
-          seqJson: SequenceSeqJson;
+          seqJson: SeqJson;
           errors: { message: string; stack: string }[];
         };
   }>(
@@ -196,17 +196,17 @@ export async function generateSequenceEDSLBulk(
     commandDictionaryId: number;
     edslBody: string;
   }[],
-): Promise<SequenceSeqJson[]> {
+): Promise<SeqJson[]> {
   const res = await graphqlClient.request<{
     getUserSequenceSeqJsonBulk: (
       | {
           status: FallibleStatus.FAILURE;
-          seqJson?: SequenceSeqJson;
+          seqJson?: SeqJson;
           errors: { message: string; stack: string }[];
         }
       | {
           status: FallibleStatus.SUCCESS;
-          seqJson: SequenceSeqJson;
+          seqJson: SeqJson;
           errors: { message: string; stack: string }[];
         }
     )[];

--- a/sequencing-server/test/testUtils/Sequence.ts
+++ b/sequencing-server/test/testUtils/Sequence.ts
@@ -225,6 +225,8 @@ export async function generateSequenceEDSLBulk(
             steps {
               args
               metadata
+              models
+              description
               stem
               time {
                 tag


### PR DESCRIPTION
* **Tickets addressed:** Closes https://github.com/NASA-AMMOS/aerie/issues/640
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

The `CommandEDSLPreface` file underwent a significant refactor. Interfaces that were no longer necessary were removed and replaced with those defined within the Seq JSON Spec. The CommandStem class now implements the Command interface, making it compatible with the Step object in the Sequence Class. To make the code clear and easier to understand, certain variables were limited in scope so the content assist will only show relevant items to the user. 

The eDSL now supports chaining in no particular order.

```ts
C.BAKE_BREAD.METADATA({}).DESCRIPTION("")
A`2024-033T20:00:32.000.ECHO('').DESCRIPTION("").MODELS({})
```

There is also a client-side code change that links these backend changes to the frontend. 



## Verification
I modify the e2e test to include these new chaining ability and all test pass.

## Documentation
I will have to look over the documentation to see what I need to edit for Command Expansion

## Future work
I need to update the code because the seqJSON spec changed with these merges:
https://github.com/NASA-AMMOS/seq-json-schema/pull/4
https://github.com/NASA-AMMOS/seq-json-schema/pull/3

