### PR TITLE
Added handling for activities that stretch past a plans duration

### DIFF
--- a/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
+++ b/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
@@ -166,10 +166,10 @@ export interface SimulatedActivity<
     };
   };
   attributes: SimulatedActivityAttributes<ActivityArguments, ActivityComputedAttributes>;
-  duration: Temporal.Duration;
+  duration: Temporal.Duration | null;
   startOffset: Temporal.Duration;
   startTime: Temporal.Instant;
-  endTime: Temporal.Instant;
+  endTime: Temporal.Instant | null;
   activityTypeName: string;
 }
 
@@ -206,10 +206,10 @@ export function mapGraphQLActivityInstance(
       },
     },
     id: activityInstance.id,
-    duration: Temporal.Duration.from(parse(activityInstance.duration).toISOString()),
+    duration: activityInstance.duration ? Temporal.Duration.from(parse(activityInstance.duration).toISOString()) : null,
     startOffset: Temporal.Duration.from(parse(activityInstance.start_offset).toISOString()),
     startTime: Temporal.Instant.from(activityInstance.start_time),
-    endTime: Temporal.Instant.from(activityInstance.end_time),
+    endTime: activityInstance.end_time ? Temporal.Instant.from(activityInstance.end_time) : null,
     simulationDatasetId: activityInstance.simulation_dataset.id,
     activityTypeName: activityInstance.activity_type_name,
     attributes: {


### PR DESCRIPTION
* **Tickets addressed:** Closes #655
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Now if the user is trying to expand and we come across an activity type whose effect model goes past the end of the plan the expansion will have a duration error for that specific activity.

## Verification
I added a test for this scenario alongside our existing tests.

## Documentation
N/A

## Future work
N/A
