### PR TITLE
Fix Scheduling Dropping Daemons

### DIFF
--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/Mission.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/Mission.java
@@ -10,6 +10,7 @@ import gov.nasa.jpl.aerie.contrib.serialization.mappers.IntegerValueMapper;
 import gov.nasa.jpl.aerie.foomissionmodel.models.Imager;
 import gov.nasa.jpl.aerie.foomissionmodel.models.ImagerMode;
 import gov.nasa.jpl.aerie.foomissionmodel.models.SimpleData;
+import gov.nasa.jpl.aerie.foomissionmodel.models.TimeTrackerDaemon;
 import gov.nasa.jpl.aerie.merlin.framework.ModelActions;
 import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.resources.real.RealResource;
@@ -37,6 +38,8 @@ public final class Mission {
 
   public final Clock utcClock = new Clock(Instant.parse("2023-08-18T00:00:00.00Z"));
   private final Registrar cachedRegistrar; // Normally bad practice, only stored to demonstrate built/unbuilt check
+
+  public final TimeTrackerDaemon timeTrackerDaemon = new TimeTrackerDaemon();
 
   public Mission(final Registrar registrar, final Instant planStart, final Configuration config) {
     this.cachedRegistrar = registrar;
@@ -70,6 +73,8 @@ public final class Mission {
     registrar.real("/simple_data/b/volume", this.simpleData.b.volume);
     registrar.real("/simple_data/b/rate", this.simpleData.b.rate);
     registrar.real("/simple_data/total_volume", this.simpleData.totalVolume);
+
+    spawn(timeTrackerDaemon::run);
 
     spawn(() -> { // Register a never-ending daemon task
       while (true) {

--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/activities/DaemonCheckerActivity.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/activities/DaemonCheckerActivity.java
@@ -1,0 +1,20 @@
+package gov.nasa.jpl.aerie.foomissionmodel.activities;
+
+import gov.nasa.jpl.aerie.foomissionmodel.Mission;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
+
+/**
+ * An activity that checks that the TimeTrackerDaemon has run the correct number of times.
+ * @param minutesElapsed The expected number of minutes elapsed.
+ */
+@ActivityType("DaemonCheckerActivity")
+public record DaemonCheckerActivity(int minutesElapsed) {
+  @EffectModel
+  public void run(final Mission mission) {
+    if (mission.timeTrackerDaemon.getMinutesElapsed() != minutesElapsed) {
+      throw new RuntimeException("Minutes elapsed is incorrect. TimeTrackerDaemon may have stopped."
+                                 + "\n\tExpected: " +minutesElapsed+" Actual: "+mission.timeTrackerDaemon.getMinutesElapsed() );
+    }
+  }
+}

--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/models/TimeTrackerDaemon.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/models/TimeTrackerDaemon.java
@@ -1,0 +1,28 @@
+package gov.nasa.jpl.aerie.foomissionmodel.models;
+
+import gov.nasa.jpl.aerie.merlin.framework.ModelActions;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+/**
+ * A daemon task that tracks the number of minutes since plan start
+ */
+public class TimeTrackerDaemon {
+  private int minutesElapsed;
+
+  public int getMinutesElapsed() {
+    return minutesElapsed;
+  }
+
+  public TimeTrackerDaemon(){
+    minutesElapsed = 0;
+  }
+
+  public void run(){
+    minutesElapsed = 0;
+    while(true) {
+      ModelActions.delay(Duration.MINUTE);
+      minutesElapsed++;
+    }
+  }
+
+}

--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/package-info.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/package-info.java
@@ -14,6 +14,7 @@
 @WithActivityType(OtherControllableDurationActivity.class)
 @WithActivityType(BasicFooActivity.class)
 @WithActivityType(ZeroDurationUncontrollableActivity.class)
+@WithActivityType(DaemonCheckerActivity.class)
 
 @WithActivityType(DecompositionTestActivities.ParentActivity.class)
 @WithActivityType(DecompositionTestActivities.ChildActivity.class)
@@ -25,6 +26,7 @@ import gov.nasa.jpl.aerie.foomissionmodel.activities.BarActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.BasicActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.BasicFooActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.ControllableDurationActivity;
+import gov.nasa.jpl.aerie.foomissionmodel.activities.DaemonCheckerActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.DecompositionTestActivities;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.FooActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.OtherControllableDurationActivity;


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Prior to this PR, the last batch `ResumableSchedulerDriver` would grab before pausing would be dropped when the method variable `batch` went out of scope. This means that daemon tasks would be lost when the Driver resumed (for example, to simulate a later activity).

This PR promotes `batch` to a class variable so that if the Driver resumes, it starts with the correct batch.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Added `TimeTrackerDaemon` and `DaemonCheckerActivity` to `FooMissionModel`, which are used in a new Scheduling Integration Test. When this test is run against `develop`, it fails, as the `TimeTrackerDaemon` was dropped after the first activity. 
