### PR TITLE
Implement `negate` as wrapper of `times(-1)`

### DIFF
--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -551,6 +551,17 @@ export class Real {
   }
 
   /**
+   * Create a real profile where all segments are negated.
+   */
+  public negate(): Real {
+    return new Real({
+      kind: AST.NodeKind.RealProfileTimes,
+      profile: this.__astNode,
+      multiplier: -1
+    });
+  }
+
+  /**
    * Produce a window whenever this profile is less than another real profile.
    * @param other
    */
@@ -1222,6 +1233,11 @@ declare global {
      * @param other
      */
     public plus(other: Real | number): Real;
+
+    /**
+     * Create a real profile where all segments are negated.
+     */
+    public negate(): Real;
 
     /**
      * Produce a window whenever this profile is less than another real profile.

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -1,10 +1,8 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.constraints.time.AbsoluteInterval;
-import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.tree.AccumulatedDuration;
-import gov.nasa.jpl.aerie.constraints.time.Spans;
 import gov.nasa.jpl.aerie.constraints.tree.ActivitySpan;
 import gov.nasa.jpl.aerie.constraints.tree.ActivityWindow;
 import gov.nasa.jpl.aerie.constraints.tree.And;
@@ -523,6 +521,18 @@ class ConstraintsDSLCompilationServiceTests {
             }
         """,
         new ViolationsOfWindows(new Equal<>(new Plus(new RealResource("state of charge"), new RealValue(2.0)), new RealValue(4.0)))
+    );
+  }
+
+  @Test
+  void testNegate() {
+    checkSuccessfulCompilation(
+        """
+            export default() => {
+              return Real.Resource("state of charge").negate().equal(Real.Value(4.0))
+            }
+        """,
+        new ViolationsOfWindows(new Equal<>(new Times(new RealResource("state of charge"), -1.0), new RealValue(4.0)))
     );
   }
 


### PR DESCRIPTION
* **Tickets addressed:** closes #601 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
It occurred to me that we actually already can do subtraction, I just forgot how math works! This PR just adds an edsl function `negate` that delegates to `times(-1)` for ease of use.

## Verification
eDSL compilation test added.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
eDSL method is doc-commented

