### PR TITLE
Add extendExternalDataset hasura action

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -21,6 +21,13 @@ type Mutation {
 }
 
 type Mutation {
+  extendExternalDataset(
+    datasetId: Int!
+    profileSet: ProfileSet!
+  ): AddExternalDatasetResponse
+}
+
+type Mutation {
   uploadDictionary(dictionary: String!): CommandDictionaryResponse
 }
 

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -3,6 +3,10 @@ actions:
     definition:
       kind: synchronous
       handler: http://aerie_merlin:27183/addExternalDataset
+  - name: extendExternalDataset
+    definition:
+      kind: synchronous
+      handler: http://aerie_merlin:27183/extendExternalDataset
   - name: uploadDictionary
     definition:
       kind: synchronous

--- a/e2e-tests/src/tests/external-datasets.test.ts
+++ b/e2e-tests/src/tests/external-datasets.test.ts
@@ -22,7 +22,48 @@ test.describe('External Datasets', () => {
       ]
     }
   };
-  const profile_set_result = {
+
+  const profile_set_extension_1 = {
+    "/my_boolean": {
+      type: "discrete",
+      schema: {
+        type: "boolean"
+      },
+      segments: [
+        {duration: 1800000000, "dynamics": false},
+        {duration: 1800000000, "dynamics": true},
+      ]
+    },
+    "/new_profile": {
+      type: "discrete",
+      schema: {
+        type: "boolean"
+      },
+      segments: [
+        {duration: 1800000000, "dynamics": true},
+        {duration: 1800000000, "dynamics": false},
+        {duration: 1800000000},
+        {duration: 1800000000, "dynamics": true}
+      ]
+    }
+  };
+
+  const profile_set_extension_2 = {
+    "/newer_profile": {
+      type: "discrete",
+      schema: {
+        type: "boolean"
+      },
+      segments: [
+        {duration: 1800000000, "dynamics": true},
+        {duration: 1800000000, "dynamics": false},
+        {duration: 1800000000},
+        {duration: 1800000000, "dynamics": true}
+      ]
+    }
+  };
+
+  const profile_set_result_1 = {
     plan_dataset_by_pk: {
       offset_from_plan_start: "06:00:00",
       dataset: {
@@ -48,6 +89,150 @@ test.describe('External Datasets', () => {
               {
                 start_offset: "04:00:00",
                 dynamics: false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  };
+
+  const profile_set_result_2 = {
+    plan_dataset_by_pk: {
+      offset_from_plan_start: "06:00:00",
+      dataset: {
+        profiles: [
+          {
+            profile_segments: [
+              {
+                start_offset: "00:00:00",
+                dynamics: false
+              },
+              {
+                start_offset: "01:00:00",
+                dynamics: null
+              },
+              {
+                start_offset: "02:00:00",
+                dynamics: true
+              },
+              {
+                start_offset: "03:00:00",
+                dynamics: null
+              },
+              {
+                start_offset: "04:00:00",
+                dynamics: false
+              },
+              {
+                start_offset: "05:00:00",
+                dynamics: false
+              },
+              {
+                start_offset: "05:30:00",
+                dynamics: true
+              }
+            ]
+          },
+          {
+            profile_segments: [
+              {
+                start_offset: "00:00:00",
+                dynamics: true
+              },
+              {
+                start_offset: "00:30:00",
+                dynamics: false
+              },
+              {
+                start_offset: "01:00:00",
+                dynamics: null
+              },
+              {
+                start_offset: "01:30:00",
+                dynamics: true
+              }
+            ]
+          }
+        ]
+      }
+    }
+  };
+
+  const profile_set_result_3 = {
+    plan_dataset_by_pk: {
+      offset_from_plan_start: "06:00:00",
+      dataset: {
+        profiles: [
+          {
+            profile_segments: [
+              {
+                start_offset: "00:00:00",
+                dynamics: false
+              },
+              {
+                start_offset: "01:00:00",
+                dynamics: null
+              },
+              {
+                start_offset: "02:00:00",
+                dynamics: true
+              },
+              {
+                start_offset: "03:00:00",
+                dynamics: null
+              },
+              {
+                start_offset: "04:00:00",
+                dynamics: false
+              },
+              {
+                start_offset: "05:00:00",
+                dynamics: false
+              },
+              {
+                start_offset: "05:30:00",
+                dynamics: true
+              }
+            ]
+          },
+          {
+            profile_segments: [
+              {
+                start_offset: "00:00:00",
+                dynamics: true
+              },
+              {
+                start_offset: "00:30:00",
+                dynamics: false
+              },
+              {
+                start_offset: "01:00:00",
+                dynamics: null
+              },
+              {
+                start_offset: "01:30:00",
+                dynamics: true
+              }
+            ]
+          },
+          {
+            profile_segments: [
+              {
+                start_offset: "00:00:00",
+                dynamics: true
+              },
+              {
+                start_offset: "00:30:00",
+                dynamics: false
+              },
+              {
+                start_offset: "01:00:00",
+                dynamics: null
+              },
+              {
+                start_offset: "01:30:00",
+                dynamics: true
               }
             ]
           }
@@ -101,12 +286,52 @@ test.describe('External Datasets', () => {
     expect(typeof dataset_id).toEqual("number");
   });
 
-  test('Query External Dataset', async ({ request }) => {
+  test('Query External Dataset 1', async ({ request }) => {
     const getExternalDatasetInput: ExternalDatasetQueryInput = { plan_id, dataset_id };
 
     const result = await req.getExternalDataset(request, getExternalDatasetInput);
 
-    expect(result).toEqual(profile_set_result);
+    expect(result).toEqual(profile_set_result_1);
+  });
+
+  test('Extend External Dataset 1', async ({ request }) => {
+    const externalDatasetInput: ExternalDatasetExtendInput = {
+      dataset_id,
+      profile_set: profile_set_extension_1
+    };
+
+    dataset_id = await req.extendExternalDataset(request, externalDatasetInput);
+    expect(dataset_id).not.toBeNull();
+    expect(dataset_id).toBeDefined();
+    expect(typeof dataset_id).toEqual("number");
+  });
+
+  test('Query External Dataset 2', async ({ request }) => {
+    const getExternalDatasetInput: ExternalDatasetQueryInput = { plan_id, dataset_id };
+
+    const result = await req.getExternalDataset(request, getExternalDatasetInput);
+
+    expect(result).toEqual(profile_set_result_2);
+  });
+
+  test('Extend External Dataset 2', async ({ request }) => {
+    const externalDatasetInput: ExternalDatasetExtendInput = {
+      dataset_id,
+      profile_set: profile_set_extension_2
+    };
+
+    dataset_id = await req.extendExternalDataset(request, externalDatasetInput);
+    expect(dataset_id).not.toBeNull();
+    expect(dataset_id).toBeDefined();
+    expect(typeof dataset_id).toEqual("number");
+  });
+
+  test('Query External Dataset 3', async ({ request }) => {
+    const getExternalDatasetInput: ExternalDatasetQueryInput = { plan_id, dataset_id };
+
+    const result = await req.getExternalDataset(request, getExternalDatasetInput);
+
+    expect(result).toEqual(profile_set_result_3);
   });
 
   test('Delete External Dataset', async ({ request }) => {

--- a/e2e-tests/src/types/external-dataset.d.ts
+++ b/e2e-tests/src/types/external-dataset.d.ts
@@ -10,6 +10,17 @@ type ExternalDatasetInsertInput = {
   }
 };
 
+type ExternalDatasetExtendInput = {
+  dataset_id: number,
+  profile_set: {
+    [key: string]: {
+      type: string,
+      schema: any,
+      segments: { duration: number, dynamics?: any }[]
+    }
+  }
+};
+
 type ExternalDatasetQueryInput = {
   dataset_id: number,
   plan_id: number

--- a/e2e-tests/src/utilities/gql.ts
+++ b/e2e-tests/src/utilities/gql.ts
@@ -204,12 +204,23 @@ const gql = {
     }
   `,
 
+  EXTEND_EXTERNAL_DATASET: `#graphql
+  mutation extendExternalDataset($dataset_id: Int!, $profile_set: ProfileSet!) {
+    extendExternalDataset(
+      datasetId: $dataset_id
+      profileSet: $profile_set
+    ) {
+      datasetId
+    }
+  }
+  `,
+
   GET_EXTERNAL_DATASET: `#graphql
     query getExtProfile($plan_id: Int!, $dataset_id: Int!) {
       plan_dataset_by_pk(plan_id:$plan_id, dataset_id:$dataset_id) {
         offset_from_plan_start
         dataset {
-          profiles(distinct_on:[]) {
+          profiles(distinct_on:[], order_by: { name: asc }) {
             profile_segments(distinct_on: []) {
               start_offset
               dynamics

--- a/e2e-tests/src/utilities/requests.ts
+++ b/e2e-tests/src/utilities/requests.ts
@@ -220,6 +220,14 @@ const req = {
     return datasetId;
   },
 
+  async extendExternalDataset(request: APIRequestContext, input: ExternalDatasetExtendInput): Promise<number> {
+    const data = await req.hasura(request, gql.EXTEND_EXTERNAL_DATASET, input);
+    const { extendExternalDataset } = data;
+    const { datasetId } = extendExternalDataset;
+
+    return datasetId;
+  },
+
   async getExternalDataset(request: APIRequestContext, input: ExternalDatasetQueryInput) {
     return await req.hasura(request, gql.GET_EXTERNAL_DATASET, input);
   },

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/NoSuchPlanDatasetException.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/NoSuchPlanDatasetException.java
@@ -1,0 +1,12 @@
+package gov.nasa.jpl.aerie.merlin.server.exceptions;
+
+import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
+
+public final class NoSuchPlanDatasetException extends Exception {
+  public final DatasetId id;
+
+  public NoSuchPlanDatasetException(final DatasetId id) {
+    super("No plan dataset exists with id `" + id + "`");
+    this.id = id;
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
@@ -17,6 +17,7 @@ import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
 import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
 import static gov.nasa.jpl.aerie.merlin.driver.json.SerializedValueJsonParser.serializedValueP;
+import static gov.nasa.jpl.aerie.merlin.server.http.MerlinParsers.datasetIdP;
 import static gov.nasa.jpl.aerie.merlin.server.http.MerlinParsers.planIdP;
 import static gov.nasa.jpl.aerie.merlin.server.http.MerlinParsers.timestampP;
 import static gov.nasa.jpl.aerie.merlin.server.http.ProfileParsers.profileSetP;
@@ -130,4 +131,13 @@ public abstract class HasuraParsers {
             .map(
                 untuple(HasuraAction.UploadExternalDatasetInput::new),
                 $ -> tuple($.planId(), $.datasetStart(), $.profileSet())));
+
+  public static final JsonParser<HasuraAction<HasuraAction.ExtendExternalDatasetInput>> hasuraExtendExternalDatasetActionP
+      = hasuraActionF(
+          productP
+            .field("datasetId", datasetIdP)
+            .field("profileSet", profileSetP)
+            .map(
+                untuple(HasuraAction.ExtendExternalDatasetInput::new),
+                $ -> tuple($.datasetId(), $.profileSet())));
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
@@ -6,7 +6,6 @@ import gov.nasa.jpl.aerie.merlin.server.models.HasuraAction;
 import gov.nasa.jpl.aerie.merlin.server.models.HasuraActivityDirectiveEvent;
 import gov.nasa.jpl.aerie.merlin.server.models.HasuraMissionModelEvent;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Optional;
 
@@ -34,28 +33,29 @@ public abstract class HasuraParsers {
           untuple((role, userId) -> new HasuraAction.Session(role, userId.orElse(""))),
           $ -> tuple($.hasuraRole(), Optional.ofNullable($.hasuraUserId())));
 
-  private static <I> JsonParser<Pair<Pair<Pair<String, I>, HasuraAction.Session>, String>> hasuraActionP(final JsonParser<I> inputP) {
+  private static <I extends HasuraAction.Input> JsonParser<HasuraAction<I>> hasuraActionF(final JsonParser<I> inputP) {
     return productP
         .field("action", productP.field("name", stringP))
         .field("input", inputP)
         .field("session_variables", hasuraActionSessionP)
-        .field("request_query", stringP);
+        .field("request_query", stringP)
+        .map(
+            untuple((name, input, session, requestQuery) -> new HasuraAction<>(name, input, session)),
+            $ -> tuple($.name(), $.input(), $.session(), ""));
   }
 
   public static final JsonParser<HasuraAction<HasuraAction.MissionModelInput>> hasuraMissionModelActionP
-      = hasuraActionP(productP.field("missionModelId", stringP))
-      .map(
-          untuple((name, missionModelId, session, requestQuery) -> new HasuraAction<>(name, new HasuraAction.MissionModelInput(missionModelId), session)),
-          $ -> tuple($.name(), $.input().missionModelId(), $.session(), ""));
+      = hasuraActionF(productP
+                          .field("missionModelId", stringP)
+                          .map(HasuraAction.MissionModelInput::new, HasuraAction.MissionModelInput::missionModelId));
 
   public static final JsonParser<HasuraAction<HasuraAction.PlanInput>> hasuraPlanActionP
-      = hasuraActionP(productP.field("planId", planIdP))
-      .map(
-          untuple((name, planId, session, requestQuery) -> new HasuraAction<>(name, new HasuraAction.PlanInput(planId), session)),
-          $ -> tuple($.name(), $.input().planId(), $.session(), ""));
+      = hasuraActionF(productP
+                          .field("planId", planIdP)
+                          .map(HasuraAction.PlanInput::new, HasuraAction.PlanInput::planId));
 
   public static final JsonParser<HasuraAction<HasuraAction.ConstraintsInput>> hasuraConstraintsCodeAction
-      = hasuraActionP(
+      = hasuraActionF(
           productP
               .field("missionModelId", stringP)
               .optionalField("planId", nullableP(planIdP))
@@ -63,10 +63,6 @@ public abstract class HasuraParsers {
                   untuple((modelId, planId) -> new HasuraAction.ConstraintsInput(modelId, planId.flatMap($ -> $))),
                   $ -> tuple($.missionModelId(), Optional.of($.planId()))
               )
-      )
-      .map(
-          untuple((name, input, session, requestQuery) -> new HasuraAction<>(name, input, session)),
-          $ -> tuple($.name(), $.input(), $.session(), "")
       );
 
   public static final JsonParser<HasuraMissionModelEvent> hasuraMissionModelEventTriggerP
@@ -111,10 +107,7 @@ public abstract class HasuraParsers {
           $ -> tuple($.missionModelId(), $.arguments()));
 
   public static final JsonParser<HasuraAction<HasuraAction.MissionModelArgumentsInput>> hasuraMissionModelArgumentsActionP
-      = hasuraActionP(hasuraMissionModelArgumentsInputP)
-      .map(
-          untuple((name, input, session, requestQuery) -> new HasuraAction<>(name, input, session)),
-          $ -> tuple($.name(), $.input(), $.session(), ""));
+      = hasuraActionF(hasuraMissionModelArgumentsInputP);
 
   private static final JsonParser<HasuraAction.ActivityInput> hasuraActivityInputP
       = productP
@@ -126,23 +119,15 @@ public abstract class HasuraParsers {
           $ -> tuple($.missionModelId(), $.activityTypeName(), $.arguments()));
 
   public static final JsonParser<HasuraAction<HasuraAction.ActivityInput>> hasuraActivityActionP
-      = hasuraActionP(hasuraActivityInputP)
-      .map(
-          untuple((name, input, session, requestQuery) -> new HasuraAction<>(name, input, session)),
-          $ -> tuple($.name(), $.input(), $.session(), ""));
+      = hasuraActionF(hasuraActivityInputP);
 
-  public static final JsonParser<HasuraAction.UploadExternalDatasetInput> hasuraUploadExternalDatasetActionP
-      = productP
-      .field("planId", planIdP)
-      .field("datasetStart", timestampP)
-      .field("profileSet", profileSetP)
-      .map(
-          untuple(HasuraAction.UploadExternalDatasetInput::new),
-          $ -> tuple($.planId(), $.datasetStart(), $.profileSet()));
-
-  public static final JsonParser<HasuraAction<HasuraAction.UploadExternalDatasetInput>> hasuraExternalDatasetActionP
-      = hasuraActionP(hasuraUploadExternalDatasetActionP)
-      .map(
-          untuple((name, input, session, requestQuery) -> new HasuraAction<>(name, input, session)),
-          $ -> tuple($.name(), $.input(), $.session(), ""));
+  public static final JsonParser<HasuraAction<HasuraAction.UploadExternalDatasetInput>> hasuraUploadExternalDatasetActionP
+      = hasuraActionF(
+          productP
+            .field("planId", planIdP)
+            .field("datasetStart", timestampP)
+            .field("profileSet", profileSetP)
+            .map(
+                untuple(HasuraAction.UploadExternalDatasetInput::new),
+                $ -> tuple($.planId(), $.datasetStart(), $.profileSet())));
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraActivityActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraActivityDirectiveEventTriggerP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraConstraintsCodeAction;
-import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraExternalDatasetActionP;
+import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraUploadExternalDatasetActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelArgumentsActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelEventTriggerP;
@@ -359,7 +359,7 @@ public final class MerlinBindings implements Plugin {
 
   private void addExternalDataset(final Context ctx) {
     try {
-      final var input = parseJson(ctx.body(), hasuraExternalDatasetActionP).input();
+      final var input = parseJson(ctx.body(), hasuraUploadExternalDatasetActionP).input();
 
       final var planId = input.planId();
       final var datasetStart = input.datasetStart();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.server.http;
 import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveForValidation;
 import gov.nasa.jpl.aerie.merlin.server.services.GenerateConstraintsLibAction;
@@ -28,6 +29,7 @@ import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionM
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelArgumentsActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelEventTriggerP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraPlanActionP;
+import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraExtendExternalDatasetActionP;
 import static io.javalin.apibuilder.ApiBuilder.before;
 import static io.javalin.apibuilder.ApiBuilder.path;
 import static io.javalin.apibuilder.ApiBuilder.post;
@@ -107,6 +109,9 @@ public final class MerlinBindings implements Plugin {
       });
       path("addExternalDataset", () -> {
         post(this::addExternalDataset);
+      });
+      path("extendExternalDataset", () -> {
+        post(this::extendExternalDataset);
       });
       path("constraintsDslTypescript", () -> {
         post(this::getConstraintsDslTypescript);
@@ -370,6 +375,29 @@ public final class MerlinBindings implements Plugin {
       ctx.status(201).result(ResponseSerializers.serializeCreatedDatasetId(datasetId).toString());
     } catch (final NoSuchPlanException ex) {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchPlanException(ex).toString());
+    } catch (final InvalidJsonException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
+    } catch (final InvalidEntityException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
+    }
+  }
+
+  private void extendExternalDataset(final Context ctx) {
+    try {
+      final var input = parseJson(ctx.body(), hasuraExtendExternalDatasetActionP).input();
+
+      final var datasetId = input.datasetId();
+      final var profileSet = input.profileSet();
+
+      this.planService.extendExternalDataset(datasetId, profileSet);
+
+      ctx.status(200).result(
+          Json
+              .createObjectBuilder()
+              .add("datasetId", datasetId.id())
+              .build().toString());
+    } catch (final NoSuchPlanDatasetException ex) {
+      ctx.status(404).result(ResponseSerializers.serializeNoSuchPlanDatasetException(ex).toString());
     } catch (final InvalidJsonException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     } catch (final InvalidEntityException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
@@ -6,6 +6,7 @@ import gov.nasa.jpl.aerie.json.SchemaCache;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationFailure;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.services.UnexpectedSubtypeError;
@@ -71,6 +72,12 @@ public abstract class MerlinParsers {
       . map(
           PlanId::new,
           PlanId::id);
+
+  public static final JsonParser<DatasetId> datasetIdP
+      = longP
+      . map(
+          DatasetId::new,
+          DatasetId::id);
 
   public static final JsonParser<SimulationFailure> simulationFailureP = productP
       .field("type", stringP)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -12,6 +12,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.remotes.MissionModelAccessException;
 import gov.nasa.jpl.aerie.merlin.server.services.GetSimulationResultsAction;
@@ -399,6 +400,13 @@ public final class ResponseSerializers {
         .add("message", "no such plan")
         .add("plan_id", ex.id.id())
         .build();
+  }
+
+  public static JsonValue serializeNoSuchPlanDatasetException(final NoSuchPlanDatasetException ex) {
+    return Json.createObjectBuilder()
+               .add("message", "no such plan dataset")
+               .add("plan_id", ex.id.id())
+               .build();
   }
 
   public static JsonValue serializeNoSuchMissionModelException(final MissionModelService.NoSuchMissionModelException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
@@ -7,6 +7,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityDirective;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
+import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.NewPlan;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
@@ -151,6 +152,11 @@ public final class InMemoryPlanRepository implements PlanRepository {
   throws NoSuchPlanException
   {
     return 0;
+  }
+
+  @Override
+  public void extendExternalDataset(final DatasetId datasetId, final ProfileSet profileSet) {
+    throw new UnsupportedOperationException("InMemoryPlanRepository does not store external datasets, so they cannot be extended");
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/DatasetId.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/DatasetId.java
@@ -1,2 +1,3 @@
-package gov.nasa.jpl.aerie.merlin.server.models;public record DatasetId() {
-}
+package gov.nasa.jpl.aerie.merlin.server.models;
+
+public record DatasetId(long id) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/DatasetId.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/DatasetId.java
@@ -1,0 +1,2 @@
+package gov.nasa.jpl.aerie.merlin.server.models;public record DatasetId() {
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
@@ -21,6 +21,8 @@ public record HasuraAction<I extends HasuraAction.Input>(String name, I input, S
   public record UploadExternalDatasetInput(PlanId planId,
                                            Timestamp datasetStart,
                                            ProfileSet profileSet) implements Input {}
+  public record ExtendExternalDatasetInput(DatasetId datasetId,
+                                           ProfileSet profileSet) implements Input {}
 
   public record ConstraintsInput(String missionModelId, Optional<PlanId> planId) implements Input {}
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
@@ -5,9 +5,11 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchActivityInstanceException;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityDirective;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
+import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
@@ -37,6 +39,7 @@ public interface PlanRepository {
   Map<String, Constraint> getAllConstraintsInPlan(PlanId planId) throws NoSuchPlanException;
 
   long addExternalDataset(PlanId planId, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
+  void extendExternalDataset(DatasetId datasetId, ProfileSet profileSet) throws NoSuchPlanDatasetException;
   List<Pair<Duration, ProfileSet>> getExternalDatasets(PlanId planId) throws NoSuchPlanException;
   Map<String, ValueSchema> getExternalResourceSchemas(PlanId planId) throws NoSuchPlanException;
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/AppendProfileSegmentsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/AppendProfileSegmentsAction.java
@@ -1,0 +1,69 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.jpl.aerie.json.JsonParser;
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Optional;
+
+public final class AppendProfileSegmentsAction implements AutoCloseable {
+  private final @Language("SQL") String sql = """
+      insert into profile_segment (dataset_id, profile_id, start_offset, dynamics, is_gap)
+      values (?, ?, ?::interval, ?::json, ?)
+    """;
+  private final PreparedStatement statement;
+
+  public AppendProfileSegmentsAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public <Dynamics> Duration apply(
+      final long datasetId,
+      final ProfileRecord profileRecord,
+      final List<ProfileSegment<Optional<Dynamics>>> segments,
+      final JsonParser<Dynamics> dynamicsP
+      ) throws SQLException {
+    var accumulatedOffset = profileRecord.duration();
+    for (final var pair : segments) {
+      final var duration = pair.extent();
+      final var dynamics = pair.dynamics();
+
+      this.statement.setLong(1, datasetId);
+      this.statement.setLong(2, profileRecord.id());
+      PreparedStatements.setDuration(this.statement, 3, accumulatedOffset);
+      if (dynamics.isPresent()) {
+        this.statement.setString(4, serializeDynamics(dynamics.get(), dynamicsP));
+        this.statement.setBoolean(5, false);
+      } else {
+        this.statement.setString(4, "null");
+        this.statement.setBoolean(5, true);
+      }
+
+      this.statement.addBatch();
+
+      accumulatedOffset = Duration.add(accumulatedOffset, duration);
+    }
+
+    final var results = this.statement.executeBatch();
+    for (final var result : results) {
+      if (result == Statement.EXECUTE_FAILED) throw new FailedInsertException("profile_segment");
+    }
+
+    return accumulatedOffset;
+  }
+
+  private <Dynamics> String serializeDynamics(final Dynamics dynamics, final JsonParser<Dynamics> dynamicsP) {
+    return dynamicsP.unparse(dynamics).toString();
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CheckPlanDatasetExistsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CheckPlanDatasetExistsAction.java
@@ -1,0 +1,34 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/*package-local*/ final class CheckPlanDatasetExistsAction implements AutoCloseable {
+    private final @Language("SQL") String sql = """
+      select 1
+      from plan_dataset as p
+      where
+        p.dataset_id = ?
+    """;
+
+    private final PreparedStatement statement;
+
+    public CheckPlanDatasetExistsAction(final Connection connection) throws SQLException {
+        this.statement = connection.prepareStatement(sql);
+    }
+
+    public boolean get(final DatasetId datasetId) throws SQLException {
+        this.statement.setLong(1, datasetId.id());
+        final var resultSet = statement.executeQuery();
+        return resultSet.next();
+    }
+
+    @Override
+    public void close() throws SQLException {
+        this.statement.close();
+    }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateProfileDurationAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateProfileDurationAction.java
@@ -1,0 +1,38 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/*package-local*/ final class UpdateProfileDurationAction implements AutoCloseable {
+  private final @Language("SQL") String sql = """
+      update profile
+      set duration = ?
+      where dataset_id=? and id=?;
+    """;
+  private final PreparedStatement statement;
+
+  public UpdateProfileDurationAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+  }
+
+  public void apply(
+      final long datasetId,
+      final long profileId,
+      final Duration newDuration
+  ) throws SQLException {
+    PreparedStatements.setDuration(this.statement, 1, newDuration);
+    this.statement.setLong(2, datasetId);
+    this.statement.setLong(3, profileId);
+    this.statement.executeUpdate();
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
@@ -2,8 +2,10 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
+import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
@@ -43,6 +45,13 @@ public final class LocalPlanService implements PlanService {
   throws NoSuchPlanException
   {
     return this.planRepository.addExternalDataset(planId, datasetStart, profileSet);
+  }
+
+  @Override
+  public void extendExternalDataset(final DatasetId datasetId, final ProfileSet profileSet)
+  throws NoSuchPlanDatasetException
+  {
+    this.planRepository.extendExternalDataset(datasetId, profileSet);
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
@@ -2,8 +2,10 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
+import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
@@ -20,6 +22,7 @@ public interface PlanService {
   Map<String, Constraint> getConstraintsForPlan(PlanId planId) throws NoSuchPlanException;
 
   long addExternalDataset(PlanId planId, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
+  void extendExternalDataset(DatasetId datasetId, ProfileSet profileSet) throws NoSuchPlanDatasetException;
   List<Pair<Duration, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException;
   Map<String, ValueSchema> getExternalResourceSchemas(final PlanId planId) throws NoSuchPlanException;
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
@@ -1,12 +1,13 @@
 package gov.nasa.jpl.aerie.merlin.server.mocks;
 
+import gov.nasa.jpl.aerie.merlin.driver.ActivityDirective;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
-import gov.nasa.jpl.aerie.merlin.driver.ActivityDirective;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
+import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
@@ -78,6 +79,11 @@ public final class StubPlanService implements PlanService {
   throws NoSuchPlanException
   {
     return 0;
+  }
+
+  @Override
+  public void extendExternalDataset(final DatasetId datasetId, final ProfileSet profileSet) {
+    throw new UnsupportedOperationException("StubPlanService does not store external datasets, so they cannot be extended");
   }
 
   @Override


### PR DESCRIPTION
* **Tickets addressed:** Closes #593
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR adds a `extendExternalDataset` hasura action that can be used to extend a dataset that was previously added using `addExternalDataset`.

The semantics are as follows:
- Any profiles provided to `extendExternalDataset` that match in name profiles that already exist in the dataset will be appended to the end. This means we use the existing profile duration as the start offset for the first new segment.
- Any profiles that do not correspond in name with existing profiles will be added as new profiles, starting with a start_offset of zero.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I've updated the e2e test for external datasets to also exercise `extendExternalDataset`.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
https://github.com/NASA-AMMOS/aerie-docs/pull/16

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Explore further options to reduce the payload size, so that a large dataset can be uploaded more quickly.