### PR TITLE
Activity Presets DB

### DIFF
--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/AnchorTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/AnchorTests.java
@@ -292,11 +292,6 @@ public class AnchorTests {
   private record AnchorValidationStatus(int activityId, int planId, String reasonInvalid) {}
   //endregion
 
-  /*
-    Tests left to write:
-      Reanchor function updates the offset as expected
-  */
-
   @Nested
   class AnchorCreationAndExceptions {
     @Test
@@ -1207,13 +1202,4 @@ public class AnchorTests {
       assertActivityEquals(parentActivity, remainingActivities.get(1));
     }
   }
-
-
-
-
-
-
-
-
-
 }

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PresetTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PresetTests.java
@@ -1,0 +1,421 @@
+package gov.nasa.jpl.aerie.database;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class PresetTests {
+  private static final File initSqlScriptFile = new File("../merlin-server/sql/merlin/init.sql");
+  private DatabaseTestHelper helper;
+
+  private Connection connection;
+  int fileId;
+  int missionModelId;
+
+  void setConnection(DatabaseTestHelper helper) {
+    connection = helper.connection();
+  }
+
+  @BeforeEach
+  void beforeEach() throws SQLException {
+    fileId = insertFileUpload();
+    missionModelId = insertMissionModel(fileId);
+    // Insert the "test-activity" activity types to avoid a foreign key conflict
+    insertActivityType(missionModelId, "test-activity");
+  }
+
+  @AfterEach
+  void afterEach() throws SQLException {
+    helper.clearTable("uploaded_file");
+    helper.clearTable("mission_model");
+    helper.clearTable("plan");
+    helper.clearTable("activity_directive");
+    helper.clearTable("simulation_template");
+    helper.clearTable("simulation");
+    helper.clearTable("dataset");
+    helper.clearTable("plan_dataset");
+    helper.clearTable("simulation_dataset");
+    helper.clearTable("plan_snapshot");
+    helper.clearTable("plan_latest_snapshot");
+    helper.clearTable("plan_snapshot_activities");
+    helper.clearTable("plan_snapshot_parent");
+    helper.clearTable("anchor_validation_status");
+    helper.clearTable("activity_presets");
+    helper.clearTable("preset_to_directive");
+    helper.clearTable("preset_to_snapshot_directive");
+  }
+
+  @BeforeAll
+  void beforeAll() throws SQLException, IOException, InterruptedException {
+    helper = new DatabaseTestHelper(
+        "aerie_merlin_test",
+        "Merlin Database Tests",
+        initSqlScriptFile
+    );
+    helper.startDatabase();
+    setConnection(helper);
+  }
+
+  @AfterAll
+  void afterAll() throws SQLException, IOException, InterruptedException {
+    helper.stopDatabase();
+    connection = null;
+    helper = null;
+  }
+
+  //region Helper Methods from MerlinDatabaseTests
+  int insertFileUpload() throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement
+          .executeQuery(
+              """
+                  INSERT INTO uploaded_file (path, name)
+                  VALUES ('test-path', 'test-name-%s')
+                  RETURNING id;"""
+                  .formatted(UUID.randomUUID().toString())
+          );
+      res.next();
+      return res.getInt("id");
+    }
+  }
+
+  int insertMissionModel(final int fileId) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement
+          .executeQuery(
+              """
+                  INSERT INTO mission_model (name, mission, owner, version, jar_id)
+                  VALUES ('test-mission-model-%s', 'test-mission', 'tester', '0', %s)
+                  RETURNING id;"""
+                  .formatted(UUID.randomUUID().toString(), fileId)
+          );
+      res.next();
+      return res.getInt("id");
+    }
+  }
+
+  int insertPlan(final int missionModelId) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement
+          .executeQuery(
+              """
+                  INSERT INTO plan (name, model_id, duration, start_time)
+                  VALUES ('test-plan-%s', '%s', '0', '%s')
+                  RETURNING id;"""
+                  .formatted(UUID.randomUUID().toString(), missionModelId, "2020-1-1 00:00:00")
+          );
+      res.next();
+      return res.getInt("id");
+    }
+  }
+
+  int insertActivity(final int planId) throws SQLException {
+    return insertActivity(planId, "{}");
+  }
+
+  int insertActivity(final int planId, final String arguments) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement
+          .executeQuery(
+              """
+                  INSERT INTO activity_directive (type, plan_id, start_offset, arguments)
+                  VALUES ('test-activity', '%s', '00:00:00', '%s')
+                  RETURNING id;"""
+                  .formatted(planId, arguments)
+          );
+
+      res.next();
+      return res.getInt("id");
+    }
+  }
+
+  void insertActivityType(final int modelId, final String name) throws SQLException {
+    try(final var statement = connection.createStatement()) {
+      statement.execute(
+          """
+          INSERT INTO activity_type (model_id, name, parameters, required_parameters, computed_attributes_value_schema)
+          VALUES (%d, '%s', '{}', '[]', '{}');
+          """.formatted(modelId, name)
+      );
+    }
+  }
+  //endregion
+
+  //region Helper Methods
+  Activity assignPreset(int presetId, int activityId, int planId) throws SQLException {
+    try(final var statement = connection.createStatement()){
+      statement.execute("""
+         select hasura_functions.apply_preset_to_activity(%d, %d, %d);
+         """.formatted(presetId, activityId, planId));
+      return getActivity(planId, activityId);
+    }
+  }
+
+  Activity getActivity(final int planId, final int activityId) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement.executeQuery("""
+        SELECT *
+        FROM activity_directive
+        WHERE id = %d
+        AND plan_id = %d;
+      """.formatted(activityId, planId));
+      res.first();
+      return new Activity(
+          res.getInt("id"),
+          res.getInt("plan_id"),
+          res.getString("name"),
+          res.getString("type"),
+          res.getString("arguments")
+      );
+    }
+  }
+
+  ArrayList<Activity> getActivities(final int planId) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement.executeQuery("""
+        SELECT *
+        FROM activity_directive
+        WHERE plan_id = %d
+        ORDER BY id;
+      """.formatted(planId));
+
+      final var activities = new ArrayList<Activity>();
+      while (res.next()){
+        activities.add(new Activity(
+            res.getInt("id"),
+            res.getInt("plan_id"),
+            res.getString("name"),
+            res.getString("type"),
+            res.getString("arguments")
+        ));
+      }
+      return activities;
+    }
+  }
+
+  static void assertActivityEqualsAsideFromArgs(final Activity expected, final Activity actual) {
+    assertEquals(expected.activityId, actual.activityId);
+    assertEquals(expected.planId, actual.planId);
+    assertEquals(expected.name, actual.name);
+    assertEquals(expected.type, actual.type);
+  }
+
+  int insertPreset(int modelId, String name, String associatedActivityType) throws SQLException {
+    return insertPreset(modelId, name, associatedActivityType, "{}");
+  }
+
+  int insertPreset(int modelId, String name, String associatedActivityType, String arguments)
+  throws SQLException
+  {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement
+          .executeQuery(
+              """
+                  INSERT INTO activity_presets (model_id, name, associated_activity_type, arguments)
+                  VALUES (%d, '%s', '%s', '%s')
+                  RETURNING id;"""
+                  .formatted(modelId, name, associatedActivityType, arguments)
+          );
+      res.next();
+      return res.getInt("id");
+    }
+  }
+
+  void deletePreset(int presetId) throws SQLException {
+    try (final var statement = connection.createStatement()){
+      statement.execute(
+        """
+        DELETE FROM activity_presets
+        WHERE id = %d
+        """.formatted(presetId));
+    }
+  }
+
+  ArrayList<Activity> getActivitiesWithPreset(final int presetId) throws SQLException{
+    try (final var statement = connection.createStatement()) {
+      // Select from act dirs using the list of ids gotten from the join table preset to dirs
+      final var res = statement.executeQuery("""
+        SELECT ad.id, ad.plan_id, ad.name, ad.type, ad.arguments
+        FROM activity_directive ad,
+            (SELECT activity_id, plan_id
+             FROM preset_to_directive
+             WHERE preset_id = %d) presets
+        WHERE (ad.id, ad.plan_id) = (presets.activity_id, presets.plan_id);
+      """.formatted(presetId));
+
+      final var activities = new ArrayList<Activity>();
+      while (res.next()){
+        activities.add(new Activity(
+            res.getInt("id"),
+            res.getInt("plan_id"),
+            res.getString("name"),
+            res.getString("type"),
+            res.getString("arguments")
+        ));
+      }
+      return activities;
+    }
+  }
+
+  Preset getPresetAssignedToActivity(final int activityId, final int planId) throws SQLException{
+    try (final var statement = connection.createStatement()) {
+      final var res = statement.executeQuery("""
+      SELECT ap.id, ap.model_id, ap.name, ap.associated_activity_type, ap.arguments
+      FROM activity_presets ap, (SELECT preset_id from preset_to_directive WHERE (activity_id, plan_id) = (%d, %d)) o
+      WHERE ap.id = o.preset_id;
+      """.formatted(activityId, planId));
+      return res.first() ?
+       new Preset(
+          res.getInt("id"),
+          res.getInt("model_id"),
+          res.getString("name"),
+          res.getString("associated_activity_type"),
+          res.getString("arguments")
+      ) : null;
+    }
+  }
+  //endregion
+
+  //region Records
+  record Activity(int activityId, int planId, String name, String type, String arguments) {}
+  record Preset(int id, int modelId, String name, String associatedActivityType, String arguments) {}
+  //endregion
+
+  @Test
+  void presetAppliesCorrectly() throws SQLException {
+    final int planId = insertPlan(missionModelId);
+    final String activityArgs = "{\"fruitCount\": 40}";
+    final int activityId = insertActivity(planId, activityArgs);
+    final String simplePresetArgs = "{\"fruitCount\": 80}";
+    final int simplePresetId = insertPreset(missionModelId, "simple preset", "test-activity", simplePresetArgs);
+    final String extendedPresetArgs = "{\"coreCount\": 120, \"destination\": \"Mars\"}";
+    final int extendedPresetId = insertPreset(missionModelId, "extended preset", "test-activity", extendedPresetArgs);
+
+    var simplePresetActivities = getActivitiesWithPreset(simplePresetId);
+    var extendedPresetActivities = getActivitiesWithPreset(extendedPresetId);
+    assertTrue(simplePresetActivities.isEmpty());
+    assertTrue(extendedPresetActivities.isEmpty());
+
+    // Simple Update
+    final Activity originalActivity = getActivity(planId, activityId);
+    final Activity simpleActivity = assignPreset(simplePresetId, activityId, planId);
+    assertEquals(1, getActivities(planId).size());
+    assertActivityEqualsAsideFromArgs(originalActivity, simpleActivity);
+    assertNotEquals(originalActivity.arguments, simpleActivity.arguments);
+    assertEquals(simplePresetArgs, simpleActivity.arguments);
+
+    simplePresetActivities = getActivitiesWithPreset(simplePresetId);
+    extendedPresetActivities = getActivitiesWithPreset(extendedPresetId);
+    assertEquals(1, simplePresetActivities.size());
+    assertEquals(simpleActivity, simplePresetActivities.get(0));
+    assertTrue(extendedPresetActivities.isEmpty());
+
+    // Extended Update
+    final Activity extendedActivity = assignPreset(extendedPresetId, activityId, planId);
+    assertEquals(1, getActivities(planId).size());
+    assertActivityEqualsAsideFromArgs(originalActivity, extendedActivity);
+    assertNotEquals(originalActivity.arguments, extendedActivity.arguments);
+    assertEquals(extendedPresetArgs, extendedActivity.arguments);
+
+    simplePresetActivities = getActivitiesWithPreset(simplePresetId);
+    extendedPresetActivities = getActivitiesWithPreset(extendedPresetId);
+    assertTrue(simplePresetActivities.isEmpty());
+    assertEquals(1, extendedPresetActivities.size());
+    assertEquals(extendedActivity, extendedPresetActivities.get(0));
+  }
+
+
+  @Test
+  void cannotApplyPresetOfIncorrectType() throws SQLException {
+    // Insert 'fake-type' to avoid an FK conflict
+    insertActivityType(missionModelId, "fake-type");
+    final int planId = insertPlan(missionModelId);
+    final int activityId = insertActivity(planId);
+    final int presetId = insertPreset(missionModelId, "test preset", "fake-type");
+
+    final Activity activity = getActivity(planId, activityId);
+    assertEquals("test-activity", activity.type);
+
+    try{
+      assignPreset(presetId, activityId, planId);
+      fail();
+    } catch (SQLException ex){
+      if(!ex.getMessage().contains("Cannot apply preset for activity type \"fake-type\" onto an activity of type \"test-activity\".")){
+        throw ex;
+      }
+    }
+  }
+
+  @Test
+  void cannotApplyNonexistentPreset() throws SQLException {
+    final int planId = insertPlan(missionModelId);
+    final int activityId = insertActivity(planId);
+
+    try{
+      assignPreset(-1, activityId, planId);
+      fail();
+    } catch (SQLException ex){
+      if(!ex.getMessage().contains("Activity preset -1 does not exist")){
+        throw ex;
+      }
+    }
+  }
+
+  @Test
+  void cannotApplyPresetToNonexistentActivity() throws SQLException {
+    final int planId = insertPlan(missionModelId);
+    final int presetId = insertPreset(missionModelId, "test preset", "test-activity");
+
+    try{
+      assignPreset(presetId, -1, planId);
+      fail();
+    } catch (SQLException ex){
+      if(!ex.getMessage().contains("Activity directive -1 does not exist in plan "+planId)){
+        throw ex;
+      }
+    }
+  }
+
+  // Tests that two presets with the same name can be uploaded as long as the model or associated activity type differs
+  // and that two presets applied to the same activity type and model but with different names can be uploaded
+  // but that two presets with the same name, model, and associated activity type cannot be uploaded
+  @Test
+  void presetUniquenessConstraint() throws SQLException {
+    final int otherModelId = insertMissionModel(fileId);
+    // Insert the used activity types to avoid an FK conflict
+    insertActivityType(missionModelId, "Shared Type");
+    insertActivityType(missionModelId, "Different Type");
+    insertActivityType(otherModelId, "Shared Type");
+    insertActivityType(otherModelId, "Unique Type");
+
+    insertPreset(missionModelId, "Shared Name", "Shared Type");
+    insertPreset(missionModelId, "Shared Name", "Different Type");
+    insertPreset(otherModelId, "Shared Name", "Shared Type");
+    insertPreset(missionModelId, "Different Name", "Shared Type");
+    insertPreset(otherModelId, "Unique Name", "Unique Type");
+    try{
+      insertPreset(missionModelId, "Shared Name", "Shared Type");
+      fail();
+    } catch (SQLException ex){
+      if(!ex.getMessage().contains("duplicate key value violates unique constraint \"activity_presets_model_id_associated_activity_type_name_key\"")){
+        throw ex;
+      }
+    }
+  }
+}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
@@ -23,6 +23,15 @@ object_relationships:
       table:
         name: anchor_validation_status
         schema: public
+- name: applied_preset
+  using:
+    foreign_key_constraint_on:
+      columns:
+        - activity_id
+        - plan_id
+      table:
+        name: preset_to_directive
+        schema: public
 array_relationships:
 - name: simulated_activities
   using:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_presets.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_presets.yaml
@@ -1,0 +1,3 @@
+table:
+  name: activity_presets
+  schema: public

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_type.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_type.yaml
@@ -1,6 +1,17 @@
 table:
   name: activity_type
   schema: public
+array_relationships:
+  - name: presets
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: activity_presets
+        insertion_order: null
+        column_mapping:
+          model_id: model_id
+          name: associated_activity_type
 remote_relationships:
 - name: expansion_rules
   definition:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_preset_to_directive.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_preset_to_directive.yaml
@@ -1,0 +1,17 @@
+table:
+  name: preset_to_directive
+  schema: public
+object_relationships:
+  - name: directives_applied_to
+    using:
+      manual_configuration:
+        column_mapping:
+          activity_id: id
+          plan_id: plan_id
+        insertion_order: null
+        remote_table:
+          name: activity_directive
+          schema: public
+  - name: presets_applied
+    using:
+      foreign_key_constraint_on: preset_id

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
@@ -28,6 +28,8 @@
 - "!include public_conflicting_activities.yaml"
 - "!include public_plan_snapshot.yaml"
 - "!include public_anchor_validation_status.yaml"
+- "!include public_activity_presets.yaml"
+- "!include public_preset_to_directive.yaml"
 # Function return values:
 - table:
     name: create_merge_request_return_value

--- a/deployment/hasura/migrations/AerieMerlin/3_activity_presets/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/3_activity_presets/down.sql
@@ -1,0 +1,223 @@
+-- Plan Merge
+create or replace procedure commit_merge(request_id integer)
+  language plpgsql as $$
+  declare
+    validate_noConflicts integer;
+    plan_id_R integer;
+    snapshot_id_S integer;
+begin
+  if(select id from merge_request where id = request_id) is null then
+    raise exception 'Invalid merge request id %.', request_id;
+  end if;
+
+  -- Stop if this merge is not 'in-progress'
+  if (select status from merge_request where id = request_id) != 'in-progress' then
+    raise exception 'Cannot commit a merge request that is not in-progress.';
+  end if;
+
+  -- Stop if any conflicts have not been resolved
+  select * from conflicting_activities
+  where merge_request_id = request_id and resolution = 'none'
+  limit 1
+  into validate_noConflicts;
+
+  if(validate_noConflicts is not null) then
+    raise exception 'There are unresolved conflicts in merge request %. Cannot commit merge.', request_id;
+  end if;
+
+  select plan_id_receiving_changes from merge_request mr where mr.id = request_id into plan_id_R;
+  select snapshot_id_supplying_changes from merge_request mr where mr.id = request_id into snapshot_id_S;
+
+  insert into merge_staging_area(
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type)
+    -- gather delete data from the opposite tables
+    select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+            start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'delete'::activity_change_type
+      from  conflicting_activities ca
+      join  activity_directive ad
+        on  ca.activity_id = ad.id
+      where ca.resolution = 'supplying'
+        and ca.merge_request_id = commit_merge.request_id
+        and plan_id = plan_id_R
+        and ca.change_type_supplying = 'delete'
+    union
+    select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'delete'::activity_change_type
+      from  conflicting_activities ca
+      join  plan_snapshot_activities psa
+        on  ca.activity_id = psa.id
+      where ca.resolution = 'receiving'
+        and ca.merge_request_id = commit_merge.request_id
+        and snapshot_id = snapshot_id_S
+        and ca.change_type_receiving = 'delete'
+    union
+    select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+            start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'::activity_change_type
+      from  conflicting_activities ca
+      join  activity_directive ad
+        on  ca.activity_id = ad.id
+      where ca.resolution = 'receiving'
+        and ca.merge_request_id = commit_merge.request_id
+        and plan_id = plan_id_R
+        and ca.change_type_receiving = 'modify'
+    union
+    select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'modify'::activity_change_type
+      from  conflicting_activities ca
+      join  plan_snapshot_activities psa
+        on  ca.activity_id = psa.id
+      where ca.resolution = 'supplying'
+        and ca.merge_request_id = commit_merge.request_id
+        and snapshot_id = snapshot_id_S
+        and ca.change_type_supplying = 'modify';
+
+  -- Unlock so that updates can be written
+  update plan
+  set is_locked = false
+  where id = plan_id_R;
+
+  -- Update the plan's activities to match merge-staging-area's activities
+  -- Add
+  insert into activity_directive(
+                id, plan_id, name, tags, source_scheduling_goal_id, created_at,
+                start_offset, type, arguments, metadata, anchor_id, anchored_to_start )
+  select  activity_id, plan_id_R, name, tags, source_scheduling_goal_id, created_at,
+            start_offset, type, arguments, metadata, anchor_id, anchored_to_start
+   from merge_staging_area
+  where merge_staging_area.merge_request_id = commit_merge.request_id
+    and change_type = 'add';
+
+  -- Modify
+  insert into activity_directive(
+    id, plan_id, "name", tags, source_scheduling_goal_id, created_at,
+    start_offset, "type", arguments, metadata, anchor_id, anchored_to_start )
+  select  activity_id, plan_id_R, "name", tags, source_scheduling_goal_id, created_at,
+          start_offset, "type", arguments, metadata, anchor_id, anchored_to_start
+  from merge_staging_area
+  where merge_staging_area.merge_request_id = commit_merge.request_id
+    and change_type = 'modify'
+  on conflict (id, plan_id)
+  do update
+  set name = excluded.name,
+      tags = excluded.tags,
+      source_scheduling_goal_id = excluded.source_scheduling_goal_id,
+      created_at = excluded.created_at,
+      start_offset = excluded.start_offset,
+      type = excluded.type,
+      arguments = excluded.arguments,
+      metadata = excluded.metadata,
+      anchor_id = excluded.anchor_id,
+      anchored_to_start = excluded.anchored_to_start;
+
+  -- Delete
+  delete from activity_directive ad
+  using merge_staging_area msa
+  where ad.id = msa.activity_id
+    and ad.plan_id = plan_id_R
+    and msa.merge_request_id = commit_merge.request_id
+    and msa.change_type = 'delete';
+
+  -- Clean up
+  delete from conflicting_activities where merge_request_id = request_id;
+  delete from merge_staging_area where merge_staging_area.merge_request_id = commit_merge.request_id;
+
+  update merge_request
+  set status = 'accepted'
+  where id = request_id;
+
+  -- Attach snapshot history
+  insert into plan_latest_snapshot(plan_id, snapshot_id)
+  select plan_id_receiving_changes, snapshot_id_supplying_changes
+  from merge_request
+  where id = request_id;
+end
+$$;
+
+-- Snapshots
+create or replace function create_snapshot(plan_id integer)
+  returns integer -- snapshot id inserted into the table
+  language plpgsql as $$
+  declare
+    validate_planid integer;
+    inserted_snapshot_id integer;
+begin
+  select id from plan where plan.id = plan_id into validate_planid;
+  if validate_planid is null then
+    raise exception 'Plan % does not exist.', plan_id;
+  end if;
+
+  insert into plan_snapshot(plan_id, revision, name, duration, start_time)
+    select id, revision, name, duration, start_time
+    from plan where id = plan_id
+    returning snapshot_id into inserted_snapshot_id;
+  insert into plan_snapshot_activities(
+                snapshot_id, id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
+                arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+                )
+    select
+      inserted_snapshot_id,                                   -- this is the snapshot id
+      id, name, tags,source_scheduling_goal_id, created_at,   -- these are the rest of the data for an activity row
+      last_modified_at, start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+    from activity_directive where activity_directive.plan_id = create_snapshot.plan_id;
+
+  --all snapshots in plan_latest_snapshot for plan plan_id become the parent of the current snapshot
+  insert into plan_snapshot_parent(snapshot_id, parent_snapshot_id)
+    select inserted_snapshot_id, snapshot_id
+    from plan_latest_snapshot where plan_latest_snapshot.plan_id = create_snapshot.plan_id;
+
+  --remove all of those entries from plan_latest_snapshot and add this new snapshot.
+  delete from plan_latest_snapshot where plan_latest_snapshot.plan_id = create_snapshot.plan_id;
+  insert into plan_latest_snapshot(plan_id, snapshot_id) values (create_snapshot.plan_id, inserted_snapshot_id);
+
+  return inserted_snapshot_id;
+  end;
+$$;
+
+create or replace function duplicate_plan(plan_id integer, new_plan_name text)
+  returns integer -- plan_id of the new plan
+  security definer
+  language plpgsql as $$
+  declare
+    validate_plan_id integer;
+    new_plan_id integer;
+    created_snapshot_id integer;
+begin
+  select id from plan where plan.id = duplicate_plan.plan_id into validate_plan_id;
+  if(validate_plan_id is null) then
+    raise exception 'Plan % does not exist.', plan_id;
+  end if;
+
+  select create_snapshot(plan_id) into created_snapshot_id;
+
+  insert into plan(revision, name, model_id, duration, start_time, parent_id)
+    select
+        0, new_plan_name, model_id, duration, start_time, plan_id
+    from plan where id = plan_id
+    returning id into new_plan_id;
+  insert into activity_directive(
+      id, plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+      last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+    )
+    select
+      id, new_plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+      last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+    from activity_directive where activity_directive.plan_id = duplicate_plan.plan_id;
+  insert into simulation (revision, simulation_template_id, plan_id, arguments)
+    select 0, simulation_template_id, new_plan_id, arguments
+    from simulation
+    where simulation.plan_id = duplicate_plan.plan_id;
+
+  insert into plan_latest_snapshot(plan_id, snapshot_id) values(new_plan_id, created_snapshot_id);
+  return new_plan_id;
+end;
+$$;
+
+-- Drop Presets
+drop function hasura_functions.apply_preset_to_activity(_preset_id int, _activity_id int, _plan_id int);
+
+drop table preset_to_snapshot_directive;
+drop table preset_to_directive;
+drop table activity_presets;
+
+call migrations.mark_migration_rolled_back('3');

--- a/deployment/hasura/migrations/AerieMerlin/3_activity_presets/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/3_activity_presets/up.sql
@@ -1,0 +1,354 @@
+/*
+  This migration adds in the concept of activity presets.
+  Presets are a collection of arguments that can be applied to an activity directive.
+ */
+
+-- Add Presets
+create table activity_presets(
+  id integer generated always as identity primary key,
+  model_id integer not null,
+  name text not null,
+  associated_activity_type text not null,
+  arguments merlin_argument_set not null,
+
+  foreign key (model_id, associated_activity_type)
+    references activity_type
+    on delete cascade,
+  unique (model_id, associated_activity_type, name)
+);
+
+comment on table activity_presets is e''
+  'A set of arguments that can be applied to an activity of a given type.';
+
+comment on column activity_presets.id is e''
+  'The unique identifier for this activity preset';
+comment on column activity_presets.model_id is e''
+  'The model defining this activity preset is associated with.';
+comment on column activity_presets.name is e''
+  'The name of this activity preset, unique for an activity type within a mission model.';
+comment on column activity_presets.associated_activity_type is e''
+  'The activity type with which this activity preset is associated.';
+comment on column activity_presets.arguments is e''
+  'The set of arguments to be applied when this preset is applied.';
+
+create table preset_to_directive(
+  preset_id integer
+    references activity_presets
+    on update cascade
+    on delete cascade,
+
+  activity_id integer,
+  plan_id integer,
+  foreign key (activity_id, plan_id)
+    references activity_directive
+    on update cascade
+    on delete cascade,
+
+  constraint one_preset_per_activity_directive
+    unique (activity_id, plan_id),
+
+  primary key (preset_id, activity_id, plan_id)
+);
+
+comment on table preset_to_directive is e''
+  'Associates presets with activity directives that have been assigned presets.';
+
+create table preset_to_snapshot_directive(
+  preset_id integer
+    references activity_presets
+    on update cascade
+    on delete cascade,
+
+  activity_id integer,
+  snapshot_id integer,
+
+  foreign key (activity_id, snapshot_id)
+    references plan_snapshot_activities
+    on update cascade
+    on delete cascade,
+
+  constraint one_preset_per_snapshot_directive
+    unique (activity_id, snapshot_id),
+
+  primary key (preset_id, activity_id, snapshot_id)
+);
+
+comment on table preset_to_snapshot_directive is e''
+  'Associates presets with snapshot activity directives that have been assigned presets.';
+
+-- Add Hasura Function
+create function hasura_functions.apply_preset_to_activity(_preset_id int, _activity_id int, _plan_id int)
+returns activity_directive
+strict
+language plpgsql as $$
+  declare
+    returning_directive activity_directive;
+    ad_activity_type text;
+    preset_activity_type text;
+begin
+    if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+      raise exception 'Activity directive % does not exist in plan %', _activity_id, _plan_id;
+    end if;
+    if not exists(select id from public.activity_presets where id = _preset_id) then
+      raise exception 'Activity preset % does not exist', _preset_id;
+    end if;
+
+    select type from activity_directive where (id, plan_id) = (_activity_id, _plan_id) into ad_activity_type;
+    select associated_activity_type from activity_presets where id = _preset_id into preset_activity_type;
+
+    if (ad_activity_type != preset_activity_type) then
+      raise exception 'Cannot apply preset for activity type "%" onto an activity of type "%".', preset_activity_type, ad_activity_type;
+    end if;
+
+    update activity_directive
+    set arguments = (select arguments from activity_presets where id = _preset_id)
+    where (id, plan_id) = (_activity_id, _plan_id);
+
+    insert into preset_to_directive(preset_id, activity_id, plan_id)
+    select _preset_id, _activity_id, _plan_id
+    on conflict (activity_id, plan_id) do update
+    set preset_id = _preset_id;
+
+    select * from activity_directive
+    where (id, plan_id) = (_activity_id, _plan_id)
+    into returning_directive;
+
+    return returning_directive;
+end
+$$;
+
+-- Update snapshots
+create or replace function create_snapshot(plan_id integer)
+  returns integer -- snapshot id inserted into the table
+  language plpgsql as $$
+  declare
+    validate_planid integer;
+    inserted_snapshot_id integer;
+begin
+  select id from plan where plan.id = plan_id into validate_planid;
+  if validate_planid is null then
+    raise exception 'Plan % does not exist.', plan_id;
+  end if;
+
+  insert into plan_snapshot(plan_id, revision, name, duration, start_time)
+    select id, revision, name, duration, start_time
+    from plan where id = plan_id
+    returning snapshot_id into inserted_snapshot_id;
+  insert into plan_snapshot_activities(
+                snapshot_id, id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
+                arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+                )
+    select
+      inserted_snapshot_id,                                   -- this is the snapshot id
+      id, name, tags,source_scheduling_goal_id, created_at,   -- these are the rest of the data for an activity row
+      last_modified_at, start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+    from activity_directive where activity_directive.plan_id = create_snapshot.plan_id;
+  insert into preset_to_snapshot_directive(preset_id, activity_id, snapshot_id)
+  select ptd.preset_id, ptd.activity_id, inserted_snapshot_id
+    from preset_to_directive ptd
+    where ptd.plan_id = create_snapshot.plan_id;
+
+  --all snapshots in plan_latest_snapshot for plan plan_id become the parent of the current snapshot
+  insert into plan_snapshot_parent(snapshot_id, parent_snapshot_id)
+    select inserted_snapshot_id, snapshot_id
+    from plan_latest_snapshot where plan_latest_snapshot.plan_id = create_snapshot.plan_id;
+
+  --remove all of those entries from plan_latest_snapshot and add this new snapshot.
+  delete from plan_latest_snapshot where plan_latest_snapshot.plan_id = create_snapshot.plan_id;
+  insert into plan_latest_snapshot(plan_id, snapshot_id) values (create_snapshot.plan_id, inserted_snapshot_id);
+
+  return inserted_snapshot_id;
+  end;
+$$;
+
+create or replace function duplicate_plan(plan_id integer, new_plan_name text)
+  returns integer -- plan_id of the new plan
+  security definer
+  language plpgsql as $$
+  declare
+    validate_plan_id integer;
+    new_plan_id integer;
+    created_snapshot_id integer;
+begin
+  select id from plan where plan.id = duplicate_plan.plan_id into validate_plan_id;
+  if(validate_plan_id is null) then
+    raise exception 'Plan % does not exist.', plan_id;
+  end if;
+
+  select create_snapshot(plan_id) into created_snapshot_id;
+
+  insert into plan(revision, name, model_id, duration, start_time, parent_id)
+    select
+        0, new_plan_name, model_id, duration, start_time, plan_id
+    from plan where id = plan_id
+    returning id into new_plan_id;
+  insert into activity_directive(
+      id, plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+      last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+    )
+    select
+      id, new_plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+      last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+    from activity_directive where activity_directive.plan_id = duplicate_plan.plan_id;
+  insert into simulation (revision, simulation_template_id, plan_id, arguments)
+    select 0, simulation_template_id, new_plan_id, arguments
+    from simulation
+    where simulation.plan_id = duplicate_plan.plan_id;
+
+  insert into preset_to_directive(preset_id, activity_id, plan_id)
+  select preset_id, activity_id, new_plan_id
+  from preset_to_directive ptd where ptd.plan_id = duplicate_plan.plan_id;
+
+  insert into plan_latest_snapshot(plan_id, snapshot_id) values(new_plan_id, created_snapshot_id);
+  return new_plan_id;
+end;
+$$;
+
+-- Plan Merge
+create or replace procedure commit_merge(request_id integer)
+  language plpgsql as $$
+  declare
+    validate_noConflicts integer;
+    plan_id_R integer;
+    snapshot_id_S integer;
+begin
+  if(select id from merge_request where id = request_id) is null then
+    raise exception 'Invalid merge request id %.', request_id;
+  end if;
+
+  -- Stop if this merge is not 'in-progress'
+  if (select status from merge_request where id = request_id) != 'in-progress' then
+    raise exception 'Cannot commit a merge request that is not in-progress.';
+  end if;
+
+  -- Stop if any conflicts have not been resolved
+  select * from conflicting_activities
+  where merge_request_id = request_id and resolution = 'none'
+  limit 1
+  into validate_noConflicts;
+
+  if(validate_noConflicts is not null) then
+    raise exception 'There are unresolved conflicts in merge request %. Cannot commit merge.', request_id;
+  end if;
+
+  select plan_id_receiving_changes from merge_request mr where mr.id = request_id into plan_id_R;
+  select snapshot_id_supplying_changes from merge_request mr where mr.id = request_id into snapshot_id_S;
+
+  insert into merge_staging_area(
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type)
+    -- gather delete data from the opposite tables
+    select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+            start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'delete'::activity_change_type
+      from  conflicting_activities ca
+      join  activity_directive ad
+        on  ca.activity_id = ad.id
+      where ca.resolution = 'supplying'
+        and ca.merge_request_id = commit_merge.request_id
+        and plan_id = plan_id_R
+        and ca.change_type_supplying = 'delete'
+    union
+    select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'delete'::activity_change_type
+      from  conflicting_activities ca
+      join  plan_snapshot_activities psa
+        on  ca.activity_id = psa.id
+      where ca.resolution = 'receiving'
+        and ca.merge_request_id = commit_merge.request_id
+        and snapshot_id = snapshot_id_S
+        and ca.change_type_receiving = 'delete'
+    union
+    select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+            start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'::activity_change_type
+      from  conflicting_activities ca
+      join  activity_directive ad
+        on  ca.activity_id = ad.id
+      where ca.resolution = 'receiving'
+        and ca.merge_request_id = commit_merge.request_id
+        and plan_id = plan_id_R
+        and ca.change_type_receiving = 'modify'
+    union
+    select  commit_merge.request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+          start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'modify'::activity_change_type
+      from  conflicting_activities ca
+      join  plan_snapshot_activities psa
+        on  ca.activity_id = psa.id
+      where ca.resolution = 'supplying'
+        and ca.merge_request_id = commit_merge.request_id
+        and snapshot_id = snapshot_id_S
+        and ca.change_type_supplying = 'modify';
+
+  -- Unlock so that updates can be written
+  update plan
+  set is_locked = false
+  where id = plan_id_R;
+
+  -- Update the plan's activities to match merge-staging-area's activities
+  -- Add
+  insert into activity_directive(
+                id, plan_id, name, tags, source_scheduling_goal_id, created_at,
+                start_offset, type, arguments, metadata, anchor_id, anchored_to_start )
+  select  activity_id, plan_id_R, name, tags, source_scheduling_goal_id, created_at,
+            start_offset, type, arguments, metadata, anchor_id, anchored_to_start
+   from merge_staging_area
+  where merge_staging_area.merge_request_id = commit_merge.request_id
+    and change_type = 'add';
+
+  -- Modify
+  insert into activity_directive(
+    id, plan_id, "name", tags, source_scheduling_goal_id, created_at,
+    start_offset, "type", arguments, metadata, anchor_id, anchored_to_start )
+  select  activity_id, plan_id_R, "name", tags, source_scheduling_goal_id, created_at,
+          start_offset, "type", arguments, metadata, anchor_id, anchored_to_start
+  from merge_staging_area
+  where merge_staging_area.merge_request_id = commit_merge.request_id
+    and change_type = 'modify'
+  on conflict (id, plan_id)
+  do update
+  set name = excluded.name,
+      tags = excluded.tags,
+      source_scheduling_goal_id = excluded.source_scheduling_goal_id,
+      created_at = excluded.created_at,
+      start_offset = excluded.start_offset,
+      type = excluded.type,
+      arguments = excluded.arguments,
+      metadata = excluded.metadata,
+      anchor_id = excluded.anchor_id,
+      anchored_to_start = excluded.anchored_to_start;
+
+  -- Presets
+  insert into preset_to_directive(preset_id, activity_id, plan_id)
+  select pts.preset_id, pts.activity_id, plan_id_R
+  from merge_staging_area msa, preset_to_snapshot_directive pts
+  where msa.activity_id = pts.activity_id
+    and msa.change_type = 'add'
+     or msa.change_type = 'modify'
+  on conflict (activity_id, plan_id)
+    do update
+    set preset_id = excluded.preset_id;
+
+  -- Delete
+  delete from activity_directive ad
+  using merge_staging_area msa
+  where ad.id = msa.activity_id
+    and ad.plan_id = plan_id_R
+    and msa.merge_request_id = commit_merge.request_id
+    and msa.change_type = 'delete';
+
+  -- Clean up
+  delete from conflicting_activities where merge_request_id = request_id;
+  delete from merge_staging_area where merge_staging_area.merge_request_id = commit_merge.request_id;
+
+  update merge_request
+  set status = 'accepted'
+  where id = request_id;
+
+  -- Attach snapshot history
+  insert into plan_latest_snapshot(plan_id, snapshot_id)
+  select plan_id_receiving_changes, snapshot_id_supplying_changes
+  from merge_request
+  where id = request_id;
+end
+$$;
+
+call migrations.mark_migration_applied('3');

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -5,3 +5,4 @@ This file denotes which migrations occur "before" this version of the schema.
 call migrations.mark_migration_applied('0');
 call migrations.mark_migration_applied('1');
 call migrations.mark_migration_applied('2');
+call migrations.mark_migration_applied('3');

--- a/merlin-server/sql/merlin/hasura_functions.sql
+++ b/merlin-server/sql/merlin/hasura_functions.sql
@@ -319,3 +319,43 @@ begin
               deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
 end
 $$;
+
+create function hasura_functions.apply_preset_to_activity(_preset_id int, _activity_id int, _plan_id int)
+returns activity_directive
+strict
+language plpgsql as $$
+  declare
+    returning_directive activity_directive;
+    ad_activity_type text;
+    preset_activity_type text;
+begin
+    if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+      raise exception 'Activity directive % does not exist in plan %', _activity_id, _plan_id;
+    end if;
+    if not exists(select id from public.activity_presets where id = _preset_id) then
+      raise exception 'Activity preset % does not exist', _preset_id;
+    end if;
+
+    select type from activity_directive where (id, plan_id) = (_activity_id, _plan_id) into ad_activity_type;
+    select associated_activity_type from activity_presets where id = _preset_id into preset_activity_type;
+
+    if (ad_activity_type != preset_activity_type) then
+      raise exception 'Cannot apply preset for activity type "%" onto an activity of type "%".', preset_activity_type, ad_activity_type;
+    end if;
+
+    update activity_directive
+    set arguments = (select arguments from activity_presets where id = _preset_id)
+    where (id, plan_id) = (_activity_id, _plan_id);
+
+    insert into preset_to_directive(preset_id, activity_id, plan_id)
+    select _preset_id, _activity_id, _plan_id
+    on conflict (activity_id, plan_id) do update
+    set preset_id = _preset_id;
+
+    select * from activity_directive
+    where (id, plan_id) = (_activity_id, _plan_id)
+    into returning_directive;
+
+    return returning_directive;
+end
+$$;

--- a/merlin-server/sql/merlin/init.sql
+++ b/merlin-server/sql/merlin/init.sql
@@ -52,4 +52,7 @@ begin;
   \ir merge_comments.sql
   \ir plan_merge.sql
   \ir hasura_functions.sql
+
+  -- Presets
+  \ir tables/activity_presets.sql
 end;

--- a/merlin-server/sql/merlin/plan_merge.sql
+++ b/merlin-server/sql/merlin/plan_merge.sql
@@ -567,6 +567,17 @@ begin
       anchor_id = excluded.anchor_id,
       anchored_to_start = excluded.anchored_to_start;
 
+  -- Presets
+  insert into preset_to_directive(preset_id, activity_id, plan_id)
+  select pts.preset_id, pts.activity_id, plan_id_R
+  from merge_staging_area msa, preset_to_snapshot_directive pts
+  where msa.activity_id = pts.activity_id
+    and msa.change_type = 'add'
+     or msa.change_type = 'modify'
+  on conflict (activity_id, plan_id)
+    do update
+    set preset_id = excluded.preset_id;
+
   -- Delete
   delete from activity_directive ad
   using merge_staging_area msa

--- a/merlin-server/sql/merlin/tables/activity_presets.sql
+++ b/merlin-server/sql/merlin/tables/activity_presets.sql
@@ -1,0 +1,71 @@
+create table activity_presets(
+  id integer generated always as identity primary key,
+  model_id integer not null,
+  name text not null,
+  associated_activity_type text not null,
+  arguments merlin_argument_set not null,
+
+  foreign key (model_id, associated_activity_type)
+    references activity_type
+    on delete cascade,
+  unique (model_id, associated_activity_type, name)
+);
+
+comment on table activity_presets is e''
+  'A set of arguments that can be applied to an activity of a given type.';
+
+comment on column activity_presets.id is e''
+  'The unique identifier for this activity preset';
+comment on column activity_presets.model_id is e''
+  'The model defining this activity preset is associated with.';
+comment on column activity_presets.name is e''
+  'The name of this activity preset, unique for an activity type within a mission model.';
+comment on column activity_presets.associated_activity_type is e''
+  'The activity type with which this activity preset is associated.';
+comment on column activity_presets.arguments is e''
+  'The set of arguments to be applied when this preset is applied.';
+
+create table preset_to_directive(
+  preset_id integer
+    references activity_presets
+    on update cascade
+    on delete cascade,
+
+  activity_id integer,
+  plan_id integer,
+  foreign key (activity_id, plan_id)
+    references activity_directive
+    on update cascade
+    on delete cascade,
+
+  constraint one_preset_per_activity_directive
+    unique (activity_id, plan_id),
+
+  primary key (preset_id, activity_id, plan_id)
+);
+
+comment on table preset_to_directive is e''
+  'Associates presets with activity directives that have been assigned presets.';
+
+create table preset_to_snapshot_directive(
+  preset_id integer
+    references activity_presets
+    on update cascade
+    on delete cascade,
+
+  activity_id integer,
+  snapshot_id integer,
+
+  foreign key (activity_id, snapshot_id)
+    references plan_snapshot_activities
+    on update cascade
+    on delete cascade,
+
+  constraint one_preset_per_snapshot_directive
+    unique (activity_id, snapshot_id),
+
+  primary key (preset_id, activity_id, snapshot_id)
+);
+
+comment on table preset_to_snapshot_directive is e''
+  'Associates presets with snapshot activity directives that have been assigned presets.';


### PR DESCRIPTION
* **Tickets addressed:** Closes #677 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Creates the following tables:
- `activity_presets`: Stores an activity preset
- `preset_to_directive`: Association table between Presets and Activity Directives (One to Many)
- `preset_to_snapshot_directive`: Association table between Presets and Snapshot Directives (One to Many)

Creates a Hasura Function `apply_preset_to_activity`, which will check that the preset is for the correct activity type before updating the activity directive and upserting into `preset_to_directive`.

I chose to use association tables instead of adding a column to `activity_directive` because:
- It's a cleaner migration
- Presets are not really part of the definition of an activity. They are optional and ignored in merging, unlike the other metadata columns, which _are_ compared for equality.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

- Added tests to PlanMerge
- Added unit tests in PresetTests

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

Opened https://github.com/NASA-AMMOS/aerie-docs/issues/17