### PR TITLE
Added a fix for when an activity type has the same name as a command

### DIFF
--- a/sequencing-server/cdict/command_banananation.xml
+++ b/sequencing-server/cdict/command_banananation.xml
@@ -106,6 +106,32 @@
                 <prime_string_restriction prime_string_only="No" />
             </restricted_modes>
         </fsw_command>
+        <fsw_command opcode="0xFFFF" stem="GrowBanana" class="FSW">
+            <arguments>
+                <unsigned_arg name="quantity" bit_length="8" units="none">
+                    <range_of_values>
+                        <include min="0" max="100" />
+                    </range_of_values>
+                    <description>Number of bananas to grow</description>
+                </unsigned_arg>
+                <unsigned_arg name="durationSecs" bit_length="8" units="none">
+                    <range_of_values>
+                        <include min="0" max="100" />
+                    </range_of_values>
+                    <description>How many seconds will it take to grow</description>
+                </unsigned_arg>
+            </arguments>
+            <categories>
+                <module>shell_ctl</module>
+                <ops_category>FSW</ops_category>
+            </categories>
+            <description>This command will grow bananas, it's a duplicate to clash with an activity type of the same name</description>
+            <completion>Bananas are grown</completion>
+            <fsw_specification custom_validation_required="No" command_priority="Nominal" />
+            <restricted_modes>
+                <prime_string_restriction prime_string_only="No" />
+            </restricted_modes>
+        </fsw_command>
         <fsw_command opcode="0xFFFF" stem="PREPARE_LOAF" class="FSW">
             <arguments>
                 <unsigned_arg name="tb_sugar" bit_length="8" units="priority">

--- a/sequencing-server/src/lib/codegen/ActivityTypescriptCodegen.ts
+++ b/sequencing-server/src/lib/codegen/ActivityTypescriptCodegen.ts
@@ -7,7 +7,7 @@ readonly startTime: Temporal.Instant;
 readonly endTime: Temporal.Instant;`;
 
 export function generateTypescriptForGraphQLActivitySchema(activitySchema: GraphQLActivitySchema): string {
-  const activityTypeAlias = `type ActivityType = ${activitySchema.name};`;
+  const activityTypeAlias = `type ActivityType = ActivityTypes.${activitySchema.name};`;
 
   const activityTypeDeclaration = `readonly type: '${activitySchema.name}';`;
 
@@ -27,8 +27,12 @@ export function generateTypescriptForGraphQLActivitySchema(activitySchema: Graph
   const propertyDeclarations = [activityTypeDeclaration, commonProperties, attributesDeclaration].join('\n');
 
   return (
-    globalDeclaration(`${interfaceDeclaration(activitySchema.name, propertyDeclarations)}\n${activityTypeAlias}`) +
-    '\n\nexport {};'
+    globalDeclaration(
+      `namespace ActivityTypes {\n${interfaceDeclaration(
+        activitySchema.name,
+        propertyDeclarations,
+      )}\n}\n${activityTypeAlias}`,
+    ) + '\n\nexport {};'
   );
 }
 

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -1054,6 +1054,8 @@ declare global {
 
 	interface GROW_BANANA extends CommandStem<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
 
+	interface GrowBanana extends CommandStem<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
+
 	interface PREPARE_LOAF extends CommandStem<[ [{ 'tb_sugar': U8,'gluten_free': boolean }] ]> {}
 
 	interface PEEL_BANANA extends CommandStem<[ [{ 'peelDirection': ('fromStem' | 'fromTip') }] ]> {}
@@ -1096,6 +1098,7 @@ declare global {
 		PREHEAT_OVEN: typeof PREHEAT_OVEN,
 		THROW_BANANA: typeof THROW_BANANA,
 		GROW_BANANA: typeof GROW_BANANA,
+		GrowBanana: typeof GrowBanana,
 		PREPARE_LOAF: typeof PREPARE_LOAF,
 		PEEL_BANANA: typeof PEEL_BANANA,
 		BAKE_BREAD: typeof BAKE_BREAD,
@@ -1153,6 +1156,19 @@ function GROW_BANANA(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
     stem: 'GROW_BANANA',
     arguments: args
   }) as GROW_BANANA;
+}
+
+
+/**
+* This command will grow bananas, it's a duplicate to clash with an activity type of the same name
+* @param quantity Number of bananas to grow
+* @param durationSecs How many seconds will it take to grow
+*/
+function GrowBanana(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
+  return CommandStem.new({
+    stem: 'GrowBanana',
+    arguments: args
+  }) as GrowBanana;
 }
 
 
@@ -1236,6 +1252,7 @@ export const Commands = {		ECHO: ECHO,
 		PREHEAT_OVEN: PREHEAT_OVEN,
 		THROW_BANANA: THROW_BANANA,
 		GROW_BANANA: GROW_BANANA,
+		GrowBanana: GrowBanana,
 		PREPARE_LOAF: PREPARE_LOAF,
 		PEEL_BANANA: PEEL_BANANA,
 		BAKE_BREAD: BAKE_BREAD,


### PR DESCRIPTION
* **Tickets addressed:** Closes #635.
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
There was an issue when creating an expansion set that had an activity type with the exact same name as a command in the command dictionary. I created a duplicate `GrowBanana` command so the name would match the activity type in the bananation model and confirmed that creating an expansion set was broken as well as a type error was being thrown in the editor.

To fix this I added a namespace for `ActivityTypes` so there is no longer a conflict.

## Verification
I tested manually in the UI and added a new unit test to double check this behavior against the updated command dictionary.

## Documentation
N/A

## Future work
N/A
