### PR TITLE
Added Ground_Block and Ground_Event to eDSL

### DIFF
--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
@@ -6,6 +6,8 @@ import {
   HMS_STRING,
   Sequence,
   TimingTypes,
+  Ground_Event,
+  Ground_Block,
 } from './CommandEDSLPreface';
 
 describe('Command', () => {
@@ -107,6 +109,55 @@ describe('Command', () => {
         "A`2020-001T00:00:00.000`.TEST({\n  string: 'string',\n  number: 0,\n  boolean: true,\n})",
       );
     });
+
+    it('should convert to EDSL string from ground event', () => {
+      const groundEvent = Ground_Event.new({
+        name: 'Ground Event Name',
+        args: [{ name: 'name', type: 'string', value: 'hello' }],
+        absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
+        description: 'ground event description',
+        metadata: { author: 'Emery' },
+      });
+
+      expect(groundEvent.toEDSLString()).toEqual(
+        "A`2020-001T00:00:00.000`.GROUND_EVENT('Ground Event Name')\n" +
+          '.ARGUMENTS([\n' +
+          '  {\n' +
+          "    name: 'name',\n" +
+          "    type: 'string',\n" +
+          "    value: 'hello',\n" +
+          '  }\n' +
+          '])\n' +
+          ".DESCRIPTION('ground event description')\n" +
+          '.METADATA({\n' +
+          "  author: 'Emery',\n" +
+          '})',
+      );
+    });
+
+    it('should convert to EDSL string from ground block', () => {
+      const groundBlock = Ground_Block.new({
+        name: 'Ground Block Name',
+        args: [{ name: 'turnOff', type: 'boolean', value: false }],
+        description: 'ground block description',
+        metadata: { author: 'Jasmine' },
+      });
+
+      expect(groundBlock.toEDSLString()).toEqual(
+        "C.GROUND_BLOCK('Ground Block Name')\n" +
+          '.ARGUMENTS([\n' +
+          '  {\n' +
+          "    name: 'turnOff',\n" +
+          "    type: 'boolean',\n" +
+          '    value: false,\n' +
+          '  }\n' +
+          '])\n' +
+          ".DESCRIPTION('ground block description')\n" +
+          '.METADATA({\n' +
+          "  author: 'Jasmine',\n" +
+          '})',
+      );
+    });
   });
 });
 
@@ -172,8 +223,8 @@ describe('Sequence', () => {
 
       expect(sequence.toEDSLString()).toEqual(`export default () =>
   Sequence.new({
-\t  seqId: 'test',
-\t  metadata: {},
+    seqId: 'test',
+    metadata: {},
   });`);
     });
 
@@ -203,8 +254,8 @@ describe('Sequence', () => {
 
       expect(sequence.toEDSLString()).toEqual(`export default () =>
   Sequence.new({
-\t  seqId: 'test',
-\t  metadata: {},
+    seqId: 'test',
+    metadata: {},
     steps: [
       A\`2020-001T00:00:00.000\`.TEST('string', 0, true),
       A\`2020-001T00:00:00.000\`.TEST({

--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -31,6 +31,30 @@ export type CommandOptions<A extends Args[] | { [argName: string]: any } = [] | 
   | {}
 );
 
+export type GroundOptions = {
+  name: string;
+  // @ts-ignore : 'Args' found in JSON Spec
+  args?: Args;
+  // @ts-ignore : 'Description' found in JSON Spec
+  description?: Description;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  metadata?: Metadata;
+  // @ts-ignore : 'Model' found in JSON Spec
+  models?: Model[];
+} & (
+  | {
+      absoluteTime: Temporal.Instant;
+    }
+  | {
+      epochTime: Temporal.Duration;
+    }
+  | {
+      relativeTime: Temporal.Duration;
+    }
+  // CommandComplete
+  | {}
+);
+
 export type Arrayable<T> = T | Arrayable<T>[];
 
 export interface SequenceOptions {
@@ -53,35 +77,6 @@ export interface SequenceOptions {
 }
 
 declare global {
-  // @ts-ignore : 'Args' found in JSON Spec
-  class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
-    // @ts-ignore : 'Args' found in JSON Spec
-    args: Args;
-    stem: string;
-    // @ts-ignore : 'TIME' found in JSON Spec
-    time: Time;
-    type: 'command';
-
-    public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): CommandStem<A>;
-
-    // @ts-ignore : 'Command' found in JSON Spec
-    public toSeqJson(): Command;
-
-    // @ts-ignore : 'Model' found in JSON Spec
-    public MODELS(models: Model[]): CommandStem<A>;
-    // @ts-ignore : 'Model' found in JSON Spec
-    public GET_MODELS(): Model[] | undefined;
-
-    // @ts-ignore : 'Metadata' found in JSON Spec
-    public METADATA(metadata: Metadata): CommandStem<A>;
-    // @ts-ignore : 'Metadata' found in JSON Spec
-    public GET_METADATA(): Metadata | undefined;
-
-    // @ts-ignore : 'Description' found in JSON Spec
-    public DESCRIPTION(description: Description): CommandStem<A>;
-    // @ts-ignore : 'Description' found in JSON Spec
-    public GET_DESCRIPTION(): Description | undefined;
-  }
   // @ts-ignore : 'SeqJson' found in JSON Spec
   class Sequence implements SeqJson {
     public readonly id: string;
@@ -129,6 +124,41 @@ declare global {
     public toSeqJson(): SeqJson;
   }
 
+  // @ts-ignore : 'Args' found in JSON Spec
+  class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
+    // @ts-ignore : 'Args' found in JSON Spec
+    args: Args;
+    stem: string;
+    // @ts-ignore : 'TIME' found in JSON Spec
+    time: Time;
+    type: 'command';
+
+    public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): CommandStem<A>;
+
+    // @ts-ignore : 'Command' found in JSON Spec
+    public toSeqJson(): Command;
+
+    // @ts-ignore : 'Model' found in JSON Spec
+    public MODELS(models: Model[]): CommandStem<A>;
+    // @ts-ignore : 'Model' found in JSON Spec
+    public GET_MODELS(): Model[] | undefined;
+
+    // @ts-ignore : 'Metadata' found in JSON Spec
+    public METADATA(metadata: Metadata): CommandStem<A>;
+    // @ts-ignore : 'Metadata' found in JSON Spec
+    public GET_METADATA(): Metadata | undefined;
+
+    // @ts-ignore : 'Description' found in JSON Spec
+    public DESCRIPTION(description: Description): CommandStem<A>;
+    // @ts-ignore : 'Description' found in JSON Spec
+    public GET_DESCRIPTION(): Description | undefined;
+  }
+
+  const STEPS: {
+    GROUND_BLOCK: typeof GROUND_BLOCK;
+    GROUND_EVENT: typeof GROUND_EVENT;
+  };
+
   type Context = {};
   type ExpansionReturn = Arrayable<CommandStem>;
 
@@ -149,29 +179,147 @@ declare global {
   type F64 = F<64>;
 
   // @ts-ignore : 'Commands' found in generated code
-  function A(...args: [TemplateStringsArray, ...string[]]): typeof Commands;
+  function A(...args: [TemplateStringsArray, ...string[]]): typeof Commands & typeof STEPS;
   // @ts-ignore : 'Commands' found in generated code
-  function A(absoluteTime: Temporal.Instant): typeof Commands;
+  function A(absoluteTime: Temporal.Instant): typeof Commands & typeof STEPS;
   // @ts-ignore : 'Commands' found in generated code
   function A(timeDOYString: string): typeof Commands;
 
   // @ts-ignore : 'Commands' found in generated code
-  function R(...args: [TemplateStringsArray, ...string[]]): typeof Commands;
+  function R(...args: [TemplateStringsArray, ...string[]]): typeof Commands & typeof STEPS;
   // @ts-ignore : 'Commands' found in generated code
-  function R(duration: Temporal.Duration): typeof Commands;
+  function R(duration: Temporal.Duration): typeof Commands & typeof STEPS;
   // @ts-ignore : 'Commands' found in generated code
-  function R(timeHMSString: string): typeof Commands;
+  function R(timeHMSString: string): typeof Commands & typeof STEPS;
 
   // @ts-ignore : 'Commands' found in generated code
-  function E(...args: [TemplateStringsArray, ...string[]]): typeof Commands;
+  function E(...args: [TemplateStringsArray, ...string[]]): typeof Commands & typeof STEPS;
   // @ts-ignore : 'Commands' found in generated code
-  function E(duration: Temporal.Duration): typeof Commands;
+  function E(duration: Temporal.Duration): typeof Commands & typeof STEPS;
   // @ts-ignore : 'Commands' found in generated code
-  function E(timeHMSString: string): typeof Commands;
+  function E(timeHMSString: string): typeof Commands & typeof STEPS;
 
   // @ts-ignore : 'Commands' found in generated code
-  const C: typeof Commands;
+  const C: typeof Commands & typeof STEPS;
 }
+
+/*
+  ---------------------------------
+			  Sequence eDSL
+  ---------------------------------
+  */
+// @ts-ignore : 'SeqJson' found in JSON Spec
+export class Sequence implements SeqJson {
+  public readonly id: string;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public readonly metadata: Metadata;
+
+  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+  public readonly locals?: [VariableDeclaration, ...VariableDeclaration[]];
+  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+  public readonly parameters?: [VariableDeclaration, ...VariableDeclaration[]];
+  // @ts-ignore : 'Step' found in JSON Spec
+  public readonly steps?: Step[];
+  // @ts-ignore : 'Request' found in JSON Spec
+  public readonly requests?: Request[];
+  // @ts-ignore : 'ImmediateCommand' found in JSON Spec
+  public readonly immediate_commands?: ImmediateCommand[];
+  // @ts-ignore : 'HardwareCommand' found in JSON Spec
+  public readonly hardware_commands?: HardwareCommand[];
+  [k: string]: unknown;
+
+  // @ts-ignore : 'SeqJson' found in JSON Spec
+  private constructor(opts: SequenceOptions | SeqJson) {
+    if ('id' in opts) {
+      this.id = opts.id;
+    } else {
+      this.id = opts.seqId;
+    }
+    this.metadata = opts.metadata;
+
+    this.locals = opts.locals ?? undefined;
+    this.parameters = opts.parameters ?? undefined;
+    this.steps = opts.steps ?? undefined;
+    this.requests = opts.requests ?? undefined;
+    this.immediate_commands = opts.immediate_commands ?? undefined;
+    this.hardware_commands = opts.hardware_commands ?? undefined;
+  }
+  public static new(opts: SequenceOptions): Sequence {
+    return new Sequence(opts);
+  }
+
+  // @ts-ignore : 'SeqJson' found in JSON Spec
+  public toSeqJson(): SeqJson {
+    return {
+      id: this.id,
+      metadata: this.metadata,
+      ...(this.steps
+        ? {
+            steps: this.steps.map(step => {
+              if (step instanceof CommandStem || step instanceof Ground_Block || step instanceof Ground_Event)
+                return step.toSeqJson();
+              return step;
+            }),
+          }
+        : {}),
+    };
+  }
+
+  public toEDSLString(): string {
+    const commandsString =
+      this.steps && this.steps.length > 0
+        ? '\n' +
+          indent(
+            this.steps
+              .map(step => {
+                if (step instanceof CommandStem || step instanceof Ground_Block) {
+                  return step.toEDSLString() + ',';
+                }
+                return step;
+              })
+              .join('\n'),
+            1,
+          )
+        : '';
+    // prettier-ignore
+    return `export default () =>
+${indent(`Sequence.new({`, 1)}
+${indent(`seqId: '${this.id}',`, 2)}
+${indent(`metadata: ${JSON.stringify(this.metadata)},`, 2)}${commandsString.length > 0 ? `\n${indent(`steps: [${commandsString}`, 2)}\n${indent('],', 2)}` : ''}
+${indent(`});`, 1)}`;
+  }
+
+  // @ts-ignore : 'Args' found in JSON Spec
+  public static fromSeqJson(json: SeqJson): Sequence {
+    return Sequence.new({
+      seqId: json.id,
+      metadata: json.metadata,
+      // @ts-ignore : 'Step' found in JSON Spec
+      ...(json.steps
+        ? {
+            // @ts-ignore : 'Step' found in JSON Spec
+            steps: json.steps.map((c: Step) => {
+              if (c.type === 'command') return CommandStem.fromSeqJson(c as CommandStem);
+              else if (c.type === 'ground_block') return Ground_Block.fromSeqJson(c as Ground_Block);
+              else if (c.type === 'ground_event') return Ground_Event.fromSeqJson(c as Ground_Event);
+              return c;
+            }),
+          }
+        : {}),
+      ...(json.locals ? { locals: json.locals } : {}),
+      ...(json.parameters ? { parameters: json.parameters } : {}),
+      ...(json.requests ? { requests: json.requests } : {}),
+      ...(json.immediate_commands ? { immediate_commands: json.immediate_commands } : {}),
+      ...(json.hardware_commands ? { hardware_commands: json.hardware_commands } : {}),
+    });
+  }
+}
+
+/*
+  ---------------------------------
+			  STEPS eDSL
+  ---------------------------------
+  */
 
 // @ts-ignore : 'Args' found in JSON Spec
 export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
@@ -470,6 +618,7 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
   // the function returns the result array of argument types -
   // StringArgument, NumberArgument, BooleanArgument, SymbolArgument, HexArgument, and RepeatArgument.
   // @ts-ignore : 'Args' found in JSON Spec
+  // @ts-ignore : 'Args' found in JSON Spec
   private static convertArgsToInterfaces(args: { [argName: string]: any }): Args {
     // @ts-ignore : 'Args' found in JSON Spec
     let result: Args = [];
@@ -522,103 +671,476 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
     return result;
   }
 }
+// @ts-ignore : 'GroundBlock' found in JSON Spec
+export class Ground_Block implements GroundBlock {
+  name: string;
+  // @ts-ignore : 'Time' found in JSON Spec
+  time!: Time;
+  type: 'ground_block' = 'ground_block';
 
-// @ts-ignore : 'SeqJson' found in JSON Spec
-export class Sequence implements SeqJson {
-  public readonly id: string;
+  private readonly _absoluteTime: Temporal.Instant | null = null;
+  private readonly _epochTime: Temporal.Duration | null = null;
+  private readonly _relativeTime: Temporal.Duration | null = null;
+
+  // @ts-ignore : 'Args' found in JSON Spec
+  private readonly _args: Args | undefined;
+  // @ts-ignore : 'Description' found in JSON Spec
+  private readonly _description: Description | undefined;
   // @ts-ignore : 'Metadata' found in JSON Spec
-  public readonly metadata: Metadata;
+  private readonly _metadata: Metadata | undefined;
+  // @ts-ignore : 'Model' found in JSON Spec
+  private readonly _models: Model[] | undefined;
 
-  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-  public readonly locals?: [VariableDeclaration, ...VariableDeclaration[]];
-  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-  public readonly parameters?: [VariableDeclaration, ...VariableDeclaration[]];
-  // @ts-ignore : 'Step' found in JSON Spec
-  public readonly steps?: Step[];
-  // @ts-ignore : 'Request' found in JSON Spec
-  public readonly requests?: Request[];
-  // @ts-ignore : 'ImmediateCommand' found in JSON Spec
-  public readonly immediate_commands?: ImmediateCommand[];
-  // @ts-ignore : 'HardwareCommand' found in JSON Spec
-  public readonly hardware_commands?: HardwareCommand[];
-  [k: string]: unknown;
+  constructor(opts: GroundOptions) {
+    this.name = opts.name;
 
-  // @ts-ignore : 'SeqJson' found in JSON Spec
-  private constructor(opts: SequenceOptions | SeqJson) {
-    if ('id' in opts) {
-      this.id = opts.id;
-    } else {
-      this.id = opts.seqId;
+    this._args = opts.args ?? undefined;
+    this._description = opts.description ?? undefined;
+    this._metadata = opts.metadata ?? undefined;
+    this._models = opts.models ?? undefined;
+
+    if ('absoluteTime' in opts) {
+      this._absoluteTime = opts.absoluteTime;
+    } else if ('epochTime' in opts) {
+      this._epochTime = opts.epochTime;
+    } else if ('relativeTime' in opts) {
+      this._relativeTime = opts.relativeTime;
     }
-    this.metadata = opts.metadata;
-
-    this.locals = opts.locals ?? undefined;
-    this.parameters = opts.parameters ?? undefined;
-    this.steps = opts.steps ?? undefined;
-    this.requests = opts.requests ?? undefined;
-    this.immediate_commands = opts.immediate_commands ?? undefined;
-    this.hardware_commands = opts.hardware_commands ?? undefined;
-  }
-  public static new(opts: SequenceOptions): Sequence {
-    return new Sequence(opts);
   }
 
-  // @ts-ignore : 'SeqJson' found in JSON Spec
-  public toSeqJson(): SeqJson {
+  public static new(opts: GroundOptions): Ground_Block {
+    return new Ground_Block(opts);
+  }
+
+  public absoluteTiming(absoluteTime: Temporal.Instant): Ground_Block {
+    return new Ground_Block({
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      name: this.name,
+      absoluteTime: absoluteTime,
+    });
+  }
+
+  public epochTiming(epochTime: Temporal.Duration): Ground_Block {
+    return new Ground_Block({
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      name: this.name,
+      epochTime: epochTime,
+    });
+  }
+
+  public relativeTiming(relativeTime: Temporal.Duration): Ground_Block {
+    return new Ground_Block({
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      name: this.name,
+      relativeTime: relativeTime,
+    });
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public MODELS(models: Model[]): Ground_Block {
+    return Ground_Block.new({
+      name: this.name,
+      models: models,
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public GET_MODELS(): Model[] | undefined {
+    return this._models;
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public METADATA(metadata: Metadata): Ground_Block {
+    return Ground_Block.new({
+      name: this.name,
+      ...(this._models && { models: this._models }),
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      metadata: metadata,
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public GET_METADATA(): Metadata | undefined {
+    return this._metadata;
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public DESCRIPTION(description: Description): Ground_Block {
+    return Ground_Block.new({
+      name: this.name,
+      ...(this._models && { models: this._models }),
+      ...(this._args && { args: this._args }),
+      description: description,
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+  // @ts-ignore : 'Description' found in JSON Spec
+  public GET_DESCRIPTION(): Description | undefined {
+    return this._description;
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public ARGUMENTS(args: Args): Ground_Block {
+    return Ground_Block.new({
+      name: this.name,
+      ...(this._models && { models: this._models }),
+      args: args,
+      ...(this._description && { description: this._description }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public GET_ARGUMENTS(): Args | undefined {
+    return this._args;
+  }
+
+  // @ts-ignore : 'GroundBlock' found in JSON Spec
+  public toSeqJson(): GroundBlock {
     return {
-      id: this.id,
-      metadata: this.metadata,
-      ...(this.steps
-        ? {
-            steps: this.steps.map(step => {
-              if (step instanceof CommandStem) return step.toSeqJson();
-              return step;
-            }),
-          }
-        : {}),
+      name: this.name,
+      time:
+        this._absoluteTime !== null
+          ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
+          : this._epochTime !== null
+          ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
+          : this._relativeTime !== null
+          ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
+          : { type: TimingTypes.COMMAND_COMPLETE },
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { models: this._models } : {}),
+      type: this.type,
     };
   }
 
-  public toEDSLString(): string {
-    const commandsString =
-      this.steps && this.steps.length > 0
-        ? '\n' +
-          indent(
-            this.steps
-              .map(step => {
-                return (step as CommandStem).toEDSLString() + ',';
-              })
-              .join('\n'),
-            1,
-          )
-        : '';
+  // @ts-ignore : 'GroundBlock' found in JSON Spec
+  public static fromSeqJson(json: GroundBlock): Ground_Block {
+    const timeValue =
+      json.time.type === TimingTypes.ABSOLUTE
+        ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
+        : json.time.type === TimingTypes.COMMAND_RELATIVE
+        ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
+        : json.time.type === TimingTypes.EPOCH_RELATIVE
+        ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+        : {};
 
-    return `export default () =>
-  Sequence.new({
-	  seqId: '${this.id}',
-	  metadata: ${JSON.stringify(this.metadata)},${
-      commandsString.length > 0 ? `\n${indent(`steps: [${commandsString}`, 2)}\n${indent('],', 2)}` : ''
-    }
-  });`;
+    return Ground_Block.new({
+      name: json.name,
+      ...(json.args ? { args: json.args } : {}),
+      ...(json.description ? { description: json.description } : {}),
+      ...(json.metadata ? { metadata: json.metadata } : {}),
+      ...(json.models ? { models: json.models } : {}),
+      ...timeValue,
+    });
   }
 
-  // @ts-ignore : 'Args' found in JSON Spec
-  public static fromSeqJson(json: SeqJson): Sequence {
-    return Sequence.new({
-      seqId: json.id,
-      metadata: json.metadata,
-      // @ts-ignore : 'Step' found in JSON Spec
-      ...(json.steps ? { steps: json.steps.map((c: Step) => CommandStem.fromSeqJson(c as CommandStem)) } : {}),
-      ...(json.locals ? { locals: json.locals } : {}),
-      ...(json.parameters ? { parameters: json.parameters } : {}),
-      ...(json.requests ? { requests: json.requests } : {}),
-      ...(json.immediate_commands ? { immediate_commands: json.immediate_commands } : {}),
-      ...(json.hardware_commands ? { hardware_commands: json.hardware_commands } : {}),
-    });
+  public toEDSLString(): string {
+    const timeString = this._absoluteTime
+      ? `A\`${instantToDoy(this._absoluteTime)}\``
+      : this._epochTime
+      ? `E\`${durationToHms(this._epochTime)}\``
+      : this._relativeTime
+      ? `R\`${durationToHms(this._relativeTime)}\``
+      : 'C';
+
+    const args =
+      this._args && Object.keys(this._args).length !== 0
+        ? // @ts-ignore : 'A : Args' found in JSON Spec
+          `\n.ARGUMENTS([\n${this._args.map(a => indent(objectToString(a))).join(',\n')}\n])`
+        : '';
+
+    const metadata =
+      this._metadata && Object.keys(this._metadata).length !== 0
+        ? `\n.METADATA(${objectToString(this._metadata)})`
+        : '';
+
+    const description =
+      this._description && this._description.length !== 0 ? `\n.DESCRIPTION('${this._description}')` : '';
+
+    const models =
+      this._models && Object.keys(this._models).length !== 0
+        ? `\n.MODELS([\n${this._models.map(m => indent(objectToString(m))).join(',\n')}\n])`
+        : '';
+
+    return `${timeString}.GROUND_BLOCK('${this.name}')${args}${description}${metadata}${models}`;
   }
 }
 
-/** Time utilities */
+/**
+ * This is a Ground Block step
+ *
+ */
+function GROUND_BLOCK(name: string) {
+  return new Ground_Block({ name: name });
+}
+
+// @ts-ignore : 'GroundBlock' found in JSON Spec
+export class Ground_Event implements GroundEvent {
+  name: string;
+  // @ts-ignore : 'Time' found in JSON Spec
+  time!: Time;
+  type: 'ground_event' = 'ground_event';
+
+  private readonly _absoluteTime: Temporal.Instant | null = null;
+  private readonly _epochTime: Temporal.Duration | null = null;
+  private readonly _relativeTime: Temporal.Duration | null = null;
+
+  // @ts-ignore : 'Args' found in JSON Spec
+  private readonly _args: Args | undefined;
+  // @ts-ignore : 'Description' found in JSON Spec
+  private readonly _description: Description | undefined;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  private readonly _metadata: Metadata | undefined;
+  // @ts-ignore : 'Model' found in JSON Spec
+  private readonly _models: Model[] | undefined;
+
+  constructor(opts: GroundOptions) {
+    this.name = opts.name;
+
+    this._args = opts.args ?? undefined;
+    this._description = opts.description ?? undefined;
+    this._metadata = opts.metadata ?? undefined;
+    this._models = opts.models ?? undefined;
+
+    if ('absoluteTime' in opts) {
+      this._absoluteTime = opts.absoluteTime;
+    } else if ('epochTime' in opts) {
+      this._epochTime = opts.epochTime;
+    } else if ('relativeTime' in opts) {
+      this._relativeTime = opts.relativeTime;
+    }
+  }
+
+  public static new(opts: GroundOptions): Ground_Event {
+    return new Ground_Event(opts);
+  }
+
+  public absoluteTiming(absoluteTime: Temporal.Instant): Ground_Event {
+    return new Ground_Event({
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      name: this.name,
+      absoluteTime: absoluteTime,
+    });
+  }
+
+  public epochTiming(epochTime: Temporal.Duration): Ground_Event {
+    return new Ground_Event({
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      name: this.name,
+      epochTime: epochTime,
+    });
+  }
+
+  public relativeTiming(relativeTime: Temporal.Duration): Ground_Event {
+    return new Ground_Event({
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      name: this.name,
+      relativeTime: relativeTime,
+    });
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public MODELS(models: Model[]): Ground_Event {
+    return Ground_Event.new({
+      name: this.name,
+      models: models,
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public GET_MODELS(): Model[] | undefined {
+    return this._models;
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public METADATA(metadata: Metadata): Ground_Event {
+    return Ground_Event.new({
+      name: this.name,
+      ...(this._models && { models: this._models }),
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      metadata: metadata,
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public GET_METADATA(): Metadata | undefined {
+    return this._metadata;
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public DESCRIPTION(description: Description): Ground_Event {
+    return Ground_Event.new({
+      name: this.name,
+      ...(this._models && { models: this._models }),
+      ...(this._args && { args: this._args }),
+      description: description,
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+  // @ts-ignore : 'Description' found in JSON Spec
+  public GET_DESCRIPTION(): Description | undefined {
+    return this._description;
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public ARGUMENTS(args: Args): Ground_Event {
+    return Ground_Event.new({
+      name: this.name,
+      ...(this._models && { models: this._models }),
+      args: args,
+      ...(this._description && { description: this._description }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public GET_ARGUMENTS(): Args | undefined {
+    return this._args;
+  }
+
+  // @ts-ignore : 'Ground_Event' found in JSON Spec
+  public toSeqJson(): GroundEvent {
+    return {
+      name: this.name,
+      time:
+        this._absoluteTime !== null
+          ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
+          : this._epochTime !== null
+          ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
+          : this._relativeTime !== null
+          ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
+          : { type: TimingTypes.COMMAND_COMPLETE },
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { models: this._models } : {}),
+      type: this.type,
+    };
+  }
+
+  // @ts-ignore : 'GroundEvent' found in JSON Spec
+  public static fromSeqJson(json: GroundEvent): Ground_Event {
+    const timeValue =
+      json.time.type === TimingTypes.ABSOLUTE
+        ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
+        : json.time.type === TimingTypes.COMMAND_RELATIVE
+        ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
+        : json.time.type === TimingTypes.EPOCH_RELATIVE
+        ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+        : {};
+
+    return Ground_Event.new({
+      name: json.name,
+      ...(json.args ? { args: json.args } : {}),
+      ...(json.description ? { description: json.description } : {}),
+      ...(json.metadata ? { metadata: json.metadata } : {}),
+      ...(json.models ? { models: json.models } : {}),
+      ...timeValue,
+    });
+  }
+
+  public toEDSLString(): string {
+    const timeString = this._absoluteTime
+      ? `A\`${instantToDoy(this._absoluteTime)}\``
+      : this._epochTime
+      ? `E\`${durationToHms(this._epochTime)}\``
+      : this._relativeTime
+      ? `R\`${durationToHms(this._relativeTime)}\``
+      : 'C';
+
+    const args =
+      this._args && Object.keys(this._args).length !== 0
+        ? // @ts-ignore : 'A : Args' found in JSON Spec
+          `\n.ARGUMENTS([\n${this._args.map(a => indent(objectToString(a))).join(',\n')}\n])`
+        : '';
+
+    const metadata =
+      this._metadata && Object.keys(this._metadata).length !== 0
+        ? `\n.METADATA(${objectToString(this._metadata)})`
+        : '';
+
+    const description =
+      this._description && this._description.length !== 0 ? `\n.DESCRIPTION('${this._description}')` : '';
+
+    const models =
+      this._models && Object.keys(this._models).length !== 0
+        ? `\n.MODELS([\n${this._models.map(m => indent(objectToString(m))).join(',\n')}\n])`
+        : '';
+
+    return `${timeString}.GROUND_EVENT('${this.name}')${args}${description}${metadata}${models}`;
+  }
+}
+
+/**
+ * This is a Ground Event step
+ *
+ */
+function GROUND_EVENT(name: string) {
+  return new Ground_Event({ name: name });
+}
+
+export const STEPS = {
+  GROUND_BLOCK: GROUND_BLOCK,
+  GROUND_EVENT: GROUND_EVENT,
+};
+
+/*
+  ---------------------------------
+		  Time Utilities
+  ---------------------------------
+  */
 
 export type DOY_STRING = string & { __brand: 'DOY_STRING' };
 export type HMS_STRING = string & { __brand: 'HMS_STRING' };
@@ -709,7 +1231,10 @@ function formatNumber(number: number, size: number): string {
 }
 
 // @ts-ignore : Used in generated code
-function A(...args: [TemplateStringsArray, ...string[]] | [Temporal.Instant] | [string]): typeof Commands {
+function A(
+  ...args: [TemplateStringsArray, ...string[]] | [Temporal.Instant] | [string]
+): // @ts-ignore : Commands Used in generated code
+typeof Commands & typeof STEPS {
   let time: Temporal.Instant;
   if (Array.isArray(args[0])) {
     time = doyToInstant(String.raw(...(args as [TemplateStringsArray, ...string[]])) as DOY_STRING);
@@ -723,7 +1248,10 @@ function A(...args: [TemplateStringsArray, ...string[]] | [Temporal.Instant] | [
 }
 
 // @ts-ignore : Used in generated code
-function R(...args: [TemplateStringsArray, ...string[]] | [Temporal.Duration] | [string]): typeof Commands {
+function R(
+  ...args: [TemplateStringsArray, ...string[]] | [Temporal.Duration] | [string]
+): // @ts-ignore : Commands Used in generated code
+typeof Commands & typeof STEPS {
   let duration: Temporal.Duration;
   if (Array.isArray(args[0])) {
     duration = hmsToDuration(String.raw(...(args as [TemplateStringsArray, ...string[]])) as HMS_STRING);
@@ -737,7 +1265,10 @@ function R(...args: [TemplateStringsArray, ...string[]] | [Temporal.Duration] | 
 }
 
 // @ts-ignore : Used in generated code
-function E(...args: [TemplateStringsArray, ...string[]] | [Temporal.Duration] | [string]): typeof Commands {
+function E(
+  ...args: [TemplateStringsArray, ...string[]] | [Temporal.Duration] | [string]
+): // @ts-ignore : Commands Used in generated code
+typeof Commands & typeof STEPS {
   let duration: Temporal.Duration;
   if (Array.isArray(args[0])) {
     duration = hmsToDuration(String.raw(...(args as [TemplateStringsArray, ...string[]])) as HMS_STRING);
@@ -752,39 +1283,68 @@ function E(...args: [TemplateStringsArray, ...string[]] | [Temporal.Duration] | 
 function commandsWithTimeValue<T extends TimingTypes>(
   timeValue: Temporal.Instant | Temporal.Duration,
   timeType: T,
-  // @ts-ignore : 'Commands' found in generated code
-): typeof Commands {
-  // @ts-ignore : 'Commands' found in generated code
-  return Object.keys(Commands).reduce((accum, key) => {
-    // @ts-ignore : 'Commands' found in generated code
-    const command = Commands[key as keyof Commands];
-    if (typeof command === 'function') {
-      if (timeType === TimingTypes.ABSOLUTE) {
+  // @ts-ignore : Commands Used in generated code
+): typeof Commands & typeof STEPS {
+  return {
+    // @ts-ignore : Commands Used in generated code
+    ...Object.keys(Commands).reduce((accum: { [key: string]: (...args: any[]) => any } = {}, key) => {
+      // @ts-ignore : Used in generated code
+      const command = Commands[key as keyof Commands];
+
+      if (typeof command === 'function') {
+        //if (timeType === TimingTypes.ABSOLUTE) {
         accum[key] = (...args: Parameters<typeof command>): typeof command => {
-          return command(...args).absoluteTiming(timeValue);
-        };
-      } else if (timeType === TimingTypes.COMMAND_RELATIVE) {
-        accum[key] = (...args: Parameters<typeof command>): typeof command => {
-          return command(...args).relativeTiming(timeValue);
+          switch (timeType) {
+            case TimingTypes.ABSOLUTE:
+              return command(...args).absoluteTiming(timeValue);
+            case TimingTypes.COMMAND_RELATIVE:
+              return command(...args).relativeTiming(timeValue);
+            case TimingTypes.EPOCH_RELATIVE:
+              return command(...args).epochTiming(timeValue);
+          }
         };
       } else {
-        accum[key] = (...args: Parameters<typeof command>): typeof command => {
-          return command(...args).epochTiming(timeValue);
-        };
+        switch (timeType) {
+          case TimingTypes.ABSOLUTE:
+            accum[key] = command.absoluteTiming(timeValue);
+            break;
+          case TimingTypes.COMMAND_RELATIVE:
+            accum[key] = command.relativeTiming(timeValue);
+            break;
+          case TimingTypes.EPOCH_RELATIVE:
+            accum[key] = command.epochTiming(timeValue);
+            break;
+        }
       }
-    } else {
-      if (timeType === TimingTypes.ABSOLUTE) {
-        accum[key] = command.absoluteTiming(timeValue);
-      } else if (timeType === TimingTypes.COMMAND_RELATIVE) {
-        accum[key] = command.relativeTiming(timeValue);
-      } else {
-        accum[key] = command.epochTiming(timeValue);
-      }
-    }
-    return accum;
-    // @ts-ignore : 'Commands' found in generated code
-  }, {} as typeof Commands);
+
+      return accum;
+      // @ts-ignore : Used in generated code
+    }, {} as typeof Commands),
+    ...Object.keys(STEPS).reduce((accum: { [key: string]: (...args: any[]) => any } = {}, key) => {
+      // @ts-ignore : Used in generated code
+      const step = STEPS[key as keyof STEPS];
+
+      accum[key] = (...args: Parameters<typeof step>): typeof step => {
+        switch (timeType) {
+          case TimingTypes.ABSOLUTE:
+            return step(...args).absoluteTiming(timeValue);
+          case TimingTypes.COMMAND_RELATIVE:
+            return step(...args).relativeTiming(timeValue);
+          case TimingTypes.EPOCH_RELATIVE:
+            return step(...args).epochTiming(timeValue);
+        }
+      };
+
+      return accum;
+    }, {} as typeof STEPS),
+  };
 }
+
+/*
+  ---------------------------------
+		  Utility Functions
+  ---------------------------------
+  */
 
 function indent(text: string, numTimes: number = 1, char: string = '  '): string {
   return text

--- a/sequencing-server/src/lib/codegen/CommandTypeCodegen.ts
+++ b/sequencing-server/src/lib/codegen/CommandTypeCodegen.ts
@@ -33,7 +33,7 @@ export const Commands = {${dictionary.fswCommands
     .map(fswCommand => `\t\t${fswCommand.stem}: ${fswCommand.stem},\n`)
     .join('')}};
 
-Object.assign(globalThis, { A:A, R:R, E:E, C:Commands, Sequence});
+Object.assign(globalThis, { A:A, R:R, E:E, C:Object.assign(Commands, STEPS), Sequence});
 `;
 
   return {

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -34,6 +34,30 @@ export type CommandOptions<A extends Args[] | { [argName: string]: any } = [] | 
   | {}
 );
 
+export type GroundOptions = {
+  name: string;
+  // @ts-ignore : 'Args' found in JSON Spec
+  args?: Args;
+  // @ts-ignore : 'Description' found in JSON Spec
+  description?: Description;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  metadata?: Metadata;
+  // @ts-ignore : 'Model' found in JSON Spec
+  models?: Model[];
+} & (
+  | {
+      absoluteTime: Temporal.Instant;
+    }
+  | {
+      epochTime: Temporal.Duration;
+    }
+  | {
+      relativeTime: Temporal.Duration;
+    }
+  // CommandComplete
+  | {}
+);
+
 export type Arrayable<T> = T | Arrayable<T>[];
 
 export interface SequenceOptions {
@@ -56,35 +80,6 @@ export interface SequenceOptions {
 }
 
 declare global {
-  // @ts-ignore : 'Args' found in JSON Spec
-  class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
-    // @ts-ignore : 'Args' found in JSON Spec
-    args: Args;
-    stem: string;
-    // @ts-ignore : 'TIME' found in JSON Spec
-    time: Time;
-    type: 'command';
-
-    public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): CommandStem<A>;
-
-    // @ts-ignore : 'Command' found in JSON Spec
-    public toSeqJson(): Command;
-
-    // @ts-ignore : 'Model' found in JSON Spec
-    public MODELS(models: Model[]): CommandStem<A>;
-    // @ts-ignore : 'Model' found in JSON Spec
-    public GET_MODELS(): Model[] | undefined;
-
-    // @ts-ignore : 'Metadata' found in JSON Spec
-    public METADATA(metadata: Metadata): CommandStem<A>;
-    // @ts-ignore : 'Metadata' found in JSON Spec
-    public GET_METADATA(): Metadata | undefined;
-
-    // @ts-ignore : 'Description' found in JSON Spec
-    public DESCRIPTION(description: Description): CommandStem<A>;
-    // @ts-ignore : 'Description' found in JSON Spec
-    public GET_DESCRIPTION(): Description | undefined;
-  }
   // @ts-ignore : 'SeqJson' found in JSON Spec
   class Sequence implements SeqJson {
     public readonly id: string;
@@ -132,6 +127,41 @@ declare global {
     public toSeqJson(): SeqJson;
   }
 
+  // @ts-ignore : 'Args' found in JSON Spec
+  class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
+    // @ts-ignore : 'Args' found in JSON Spec
+    args: Args;
+    stem: string;
+    // @ts-ignore : 'TIME' found in JSON Spec
+    time: Time;
+    type: 'command';
+
+    public static new<A extends any[] | { [argName: string]: any }>(opts: CommandOptions<A>): CommandStem<A>;
+
+    // @ts-ignore : 'Command' found in JSON Spec
+    public toSeqJson(): Command;
+
+    // @ts-ignore : 'Model' found in JSON Spec
+    public MODELS(models: Model[]): CommandStem<A>;
+    // @ts-ignore : 'Model' found in JSON Spec
+    public GET_MODELS(): Model[] | undefined;
+
+    // @ts-ignore : 'Metadata' found in JSON Spec
+    public METADATA(metadata: Metadata): CommandStem<A>;
+    // @ts-ignore : 'Metadata' found in JSON Spec
+    public GET_METADATA(): Metadata | undefined;
+
+    // @ts-ignore : 'Description' found in JSON Spec
+    public DESCRIPTION(description: Description): CommandStem<A>;
+    // @ts-ignore : 'Description' found in JSON Spec
+    public GET_DESCRIPTION(): Description | undefined;
+  }
+
+  const STEPS: {
+    GROUND_BLOCK: typeof GROUND_BLOCK;
+    GROUND_EVENT: typeof GROUND_EVENT;
+  };
+
   type Context = {};
   type ExpansionReturn = Arrayable<CommandStem>;
 
@@ -152,29 +182,147 @@ declare global {
   type F64 = F<64>;
 
   // @ts-ignore : 'Commands' found in generated code
-  function A(...args: [TemplateStringsArray, ...string[]]): typeof Commands;
+  function A(...args: [TemplateStringsArray, ...string[]]): typeof Commands & typeof STEPS;
   // @ts-ignore : 'Commands' found in generated code
-  function A(absoluteTime: Temporal.Instant): typeof Commands;
+  function A(absoluteTime: Temporal.Instant): typeof Commands & typeof STEPS;
   // @ts-ignore : 'Commands' found in generated code
   function A(timeDOYString: string): typeof Commands;
 
   // @ts-ignore : 'Commands' found in generated code
-  function R(...args: [TemplateStringsArray, ...string[]]): typeof Commands;
+  function R(...args: [TemplateStringsArray, ...string[]]): typeof Commands & typeof STEPS;
   // @ts-ignore : 'Commands' found in generated code
-  function R(duration: Temporal.Duration): typeof Commands;
+  function R(duration: Temporal.Duration): typeof Commands & typeof STEPS;
   // @ts-ignore : 'Commands' found in generated code
-  function R(timeHMSString: string): typeof Commands;
+  function R(timeHMSString: string): typeof Commands & typeof STEPS;
 
   // @ts-ignore : 'Commands' found in generated code
-  function E(...args: [TemplateStringsArray, ...string[]]): typeof Commands;
+  function E(...args: [TemplateStringsArray, ...string[]]): typeof Commands & typeof STEPS;
   // @ts-ignore : 'Commands' found in generated code
-  function E(duration: Temporal.Duration): typeof Commands;
+  function E(duration: Temporal.Duration): typeof Commands & typeof STEPS;
   // @ts-ignore : 'Commands' found in generated code
-  function E(timeHMSString: string): typeof Commands;
+  function E(timeHMSString: string): typeof Commands & typeof STEPS;
 
   // @ts-ignore : 'Commands' found in generated code
-  const C: typeof Commands;
+  const C: typeof Commands & typeof STEPS;
 }
+
+/*
+  ---------------------------------
+			  Sequence eDSL
+  ---------------------------------
+  */
+// @ts-ignore : 'SeqJson' found in JSON Spec
+export class Sequence implements SeqJson {
+  public readonly id: string;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public readonly metadata: Metadata;
+
+  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+  public readonly locals?: [VariableDeclaration, ...VariableDeclaration[]];
+  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+  public readonly parameters?: [VariableDeclaration, ...VariableDeclaration[]];
+  // @ts-ignore : 'Step' found in JSON Spec
+  public readonly steps?: Step[];
+  // @ts-ignore : 'Request' found in JSON Spec
+  public readonly requests?: Request[];
+  // @ts-ignore : 'ImmediateCommand' found in JSON Spec
+  public readonly immediate_commands?: ImmediateCommand[];
+  // @ts-ignore : 'HardwareCommand' found in JSON Spec
+  public readonly hardware_commands?: HardwareCommand[];
+  [k: string]: unknown;
+
+  // @ts-ignore : 'SeqJson' found in JSON Spec
+  private constructor(opts: SequenceOptions | SeqJson) {
+    if ('id' in opts) {
+      this.id = opts.id;
+    } else {
+      this.id = opts.seqId;
+    }
+    this.metadata = opts.metadata;
+
+    this.locals = opts.locals ?? undefined;
+    this.parameters = opts.parameters ?? undefined;
+    this.steps = opts.steps ?? undefined;
+    this.requests = opts.requests ?? undefined;
+    this.immediate_commands = opts.immediate_commands ?? undefined;
+    this.hardware_commands = opts.hardware_commands ?? undefined;
+  }
+  public static new(opts: SequenceOptions): Sequence {
+    return new Sequence(opts);
+  }
+
+  // @ts-ignore : 'SeqJson' found in JSON Spec
+  public toSeqJson(): SeqJson {
+    return {
+      id: this.id,
+      metadata: this.metadata,
+      ...(this.steps
+        ? {
+            steps: this.steps.map(step => {
+              if (step instanceof CommandStem || step instanceof Ground_Block || step instanceof Ground_Event)
+                return step.toSeqJson();
+              return step;
+            }),
+          }
+        : {}),
+    };
+  }
+
+  public toEDSLString(): string {
+    const commandsString =
+      this.steps && this.steps.length > 0
+        ? '\\n' +
+          indent(
+            this.steps
+              .map(step => {
+                if (step instanceof CommandStem || step instanceof Ground_Block) {
+                  return step.toEDSLString() + ',';
+                }
+                return step;
+              })
+              .join('\\n'),
+            1,
+          )
+        : '';
+    // prettier-ignore
+    return \`export default () =>
+\${indent(\`Sequence.new({\`, 1)}
+\${indent(\`seqId: '\${this.id}',\`, 2)}
+\${indent(\`metadata: \${JSON.stringify(this.metadata)},\`, 2)}\${commandsString.length > 0 ? \`\\n\${indent(\`steps: [\${commandsString}\`, 2)}\\n\${indent('],', 2)}\` : ''}
+\${indent(\`});\`, 1)}\`;
+  }
+
+  // @ts-ignore : 'Args' found in JSON Spec
+  public static fromSeqJson(json: SeqJson): Sequence {
+    return Sequence.new({
+      seqId: json.id,
+      metadata: json.metadata,
+      // @ts-ignore : 'Step' found in JSON Spec
+      ...(json.steps
+        ? {
+            // @ts-ignore : 'Step' found in JSON Spec
+            steps: json.steps.map((c: Step) => {
+              if (c.type === 'command') return CommandStem.fromSeqJson(c as CommandStem);
+              else if (c.type === 'ground_block') return Ground_Block.fromSeqJson(c as Ground_Block);
+              else if (c.type === 'ground_event') return Ground_Event.fromSeqJson(c as Ground_Event);
+              return c;
+            }),
+          }
+        : {}),
+      ...(json.locals ? { locals: json.locals } : {}),
+      ...(json.parameters ? { parameters: json.parameters } : {}),
+      ...(json.requests ? { requests: json.requests } : {}),
+      ...(json.immediate_commands ? { immediate_commands: json.immediate_commands } : {}),
+      ...(json.hardware_commands ? { hardware_commands: json.hardware_commands } : {}),
+    });
+  }
+}
+
+/*
+  ---------------------------------
+			  STEPS eDSL
+  ---------------------------------
+  */
 
 // @ts-ignore : 'Args' found in JSON Spec
 export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
@@ -473,6 +621,7 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
   // the function returns the result array of argument types -
   // StringArgument, NumberArgument, BooleanArgument, SymbolArgument, HexArgument, and RepeatArgument.
   // @ts-ignore : 'Args' found in JSON Spec
+  // @ts-ignore : 'Args' found in JSON Spec
   private static convertArgsToInterfaces(args: { [argName: string]: any }): Args {
     // @ts-ignore : 'Args' found in JSON Spec
     let result: Args = [];
@@ -525,103 +674,476 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
     return result;
   }
 }
+// @ts-ignore : 'GroundBlock' found in JSON Spec
+export class Ground_Block implements GroundBlock {
+  name: string;
+  // @ts-ignore : 'Time' found in JSON Spec
+  time!: Time;
+  type: 'ground_block' = 'ground_block';
 
-// @ts-ignore : 'SeqJson' found in JSON Spec
-export class Sequence implements SeqJson {
-  public readonly id: string;
+  private readonly _absoluteTime: Temporal.Instant | null = null;
+  private readonly _epochTime: Temporal.Duration | null = null;
+  private readonly _relativeTime: Temporal.Duration | null = null;
+
+  // @ts-ignore : 'Args' found in JSON Spec
+  private readonly _args: Args | undefined;
+  // @ts-ignore : 'Description' found in JSON Spec
+  private readonly _description: Description | undefined;
   // @ts-ignore : 'Metadata' found in JSON Spec
-  public readonly metadata: Metadata;
+  private readonly _metadata: Metadata | undefined;
+  // @ts-ignore : 'Model' found in JSON Spec
+  private readonly _models: Model[] | undefined;
 
-  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-  public readonly locals?: [VariableDeclaration, ...VariableDeclaration[]];
-  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-  public readonly parameters?: [VariableDeclaration, ...VariableDeclaration[]];
-  // @ts-ignore : 'Step' found in JSON Spec
-  public readonly steps?: Step[];
-  // @ts-ignore : 'Request' found in JSON Spec
-  public readonly requests?: Request[];
-  // @ts-ignore : 'ImmediateCommand' found in JSON Spec
-  public readonly immediate_commands?: ImmediateCommand[];
-  // @ts-ignore : 'HardwareCommand' found in JSON Spec
-  public readonly hardware_commands?: HardwareCommand[];
-  [k: string]: unknown;
+  constructor(opts: GroundOptions) {
+    this.name = opts.name;
 
-  // @ts-ignore : 'SeqJson' found in JSON Spec
-  private constructor(opts: SequenceOptions | SeqJson) {
-    if ('id' in opts) {
-      this.id = opts.id;
-    } else {
-      this.id = opts.seqId;
+    this._args = opts.args ?? undefined;
+    this._description = opts.description ?? undefined;
+    this._metadata = opts.metadata ?? undefined;
+    this._models = opts.models ?? undefined;
+
+    if ('absoluteTime' in opts) {
+      this._absoluteTime = opts.absoluteTime;
+    } else if ('epochTime' in opts) {
+      this._epochTime = opts.epochTime;
+    } else if ('relativeTime' in opts) {
+      this._relativeTime = opts.relativeTime;
     }
-    this.metadata = opts.metadata;
-
-    this.locals = opts.locals ?? undefined;
-    this.parameters = opts.parameters ?? undefined;
-    this.steps = opts.steps ?? undefined;
-    this.requests = opts.requests ?? undefined;
-    this.immediate_commands = opts.immediate_commands ?? undefined;
-    this.hardware_commands = opts.hardware_commands ?? undefined;
-  }
-  public static new(opts: SequenceOptions): Sequence {
-    return new Sequence(opts);
   }
 
-  // @ts-ignore : 'SeqJson' found in JSON Spec
-  public toSeqJson(): SeqJson {
+  public static new(opts: GroundOptions): Ground_Block {
+    return new Ground_Block(opts);
+  }
+
+  public absoluteTiming(absoluteTime: Temporal.Instant): Ground_Block {
+    return new Ground_Block({
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      name: this.name,
+      absoluteTime: absoluteTime,
+    });
+  }
+
+  public epochTiming(epochTime: Temporal.Duration): Ground_Block {
+    return new Ground_Block({
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      name: this.name,
+      epochTime: epochTime,
+    });
+  }
+
+  public relativeTiming(relativeTime: Temporal.Duration): Ground_Block {
+    return new Ground_Block({
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      name: this.name,
+      relativeTime: relativeTime,
+    });
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public MODELS(models: Model[]): Ground_Block {
+    return Ground_Block.new({
+      name: this.name,
+      models: models,
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public GET_MODELS(): Model[] | undefined {
+    return this._models;
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public METADATA(metadata: Metadata): Ground_Block {
+    return Ground_Block.new({
+      name: this.name,
+      ...(this._models && { models: this._models }),
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      metadata: metadata,
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public GET_METADATA(): Metadata | undefined {
+    return this._metadata;
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public DESCRIPTION(description: Description): Ground_Block {
+    return Ground_Block.new({
+      name: this.name,
+      ...(this._models && { models: this._models }),
+      ...(this._args && { args: this._args }),
+      description: description,
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+  // @ts-ignore : 'Description' found in JSON Spec
+  public GET_DESCRIPTION(): Description | undefined {
+    return this._description;
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public ARGUMENTS(args: Args): Ground_Block {
+    return Ground_Block.new({
+      name: this.name,
+      ...(this._models && { models: this._models }),
+      args: args,
+      ...(this._description && { description: this._description }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public GET_ARGUMENTS(): Args | undefined {
+    return this._args;
+  }
+
+  // @ts-ignore : 'GroundBlock' found in JSON Spec
+  public toSeqJson(): GroundBlock {
     return {
-      id: this.id,
-      metadata: this.metadata,
-      ...(this.steps
-        ? {
-            steps: this.steps.map(step => {
-              if (step instanceof CommandStem) return step.toSeqJson();
-              return step;
-            }),
-          }
-        : {}),
+      name: this.name,
+      time:
+        this._absoluteTime !== null
+          ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
+          : this._epochTime !== null
+          ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
+          : this._relativeTime !== null
+          ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
+          : { type: TimingTypes.COMMAND_COMPLETE },
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { models: this._models } : {}),
+      type: this.type,
     };
   }
 
-  public toEDSLString(): string {
-    const commandsString =
-      this.steps && this.steps.length > 0
-        ? '\\n' +
-          indent(
-            this.steps
-              .map(step => {
-                return (step as CommandStem).toEDSLString() + ',';
-              })
-              .join('\\n'),
-            1,
-          )
-        : '';
+  // @ts-ignore : 'GroundBlock' found in JSON Spec
+  public static fromSeqJson(json: GroundBlock): Ground_Block {
+    const timeValue =
+      json.time.type === TimingTypes.ABSOLUTE
+        ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
+        : json.time.type === TimingTypes.COMMAND_RELATIVE
+        ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
+        : json.time.type === TimingTypes.EPOCH_RELATIVE
+        ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+        : {};
 
-    return \`export default () =>
-  Sequence.new({
-	  seqId: '\${this.id}',
-	  metadata: \${JSON.stringify(this.metadata)},\${
-      commandsString.length > 0 ? \`\\n\${indent(\`steps: [\${commandsString}\`, 2)}\\n\${indent('],', 2)}\` : ''
-    }
-  });\`;
+    return Ground_Block.new({
+      name: json.name,
+      ...(json.args ? { args: json.args } : {}),
+      ...(json.description ? { description: json.description } : {}),
+      ...(json.metadata ? { metadata: json.metadata } : {}),
+      ...(json.models ? { models: json.models } : {}),
+      ...timeValue,
+    });
   }
 
-  // @ts-ignore : 'Args' found in JSON Spec
-  public static fromSeqJson(json: SeqJson): Sequence {
-    return Sequence.new({
-      seqId: json.id,
-      metadata: json.metadata,
-      // @ts-ignore : 'Step' found in JSON Spec
-      ...(json.steps ? { steps: json.steps.map((c: Step) => CommandStem.fromSeqJson(c as CommandStem)) } : {}),
-      ...(json.locals ? { locals: json.locals } : {}),
-      ...(json.parameters ? { parameters: json.parameters } : {}),
-      ...(json.requests ? { requests: json.requests } : {}),
-      ...(json.immediate_commands ? { immediate_commands: json.immediate_commands } : {}),
-      ...(json.hardware_commands ? { hardware_commands: json.hardware_commands } : {}),
-    });
+  public toEDSLString(): string {
+    const timeString = this._absoluteTime
+      ? \`A\\\`\${instantToDoy(this._absoluteTime)}\\\`\`
+      : this._epochTime
+      ? \`E\\\`\${durationToHms(this._epochTime)}\\\`\`
+      : this._relativeTime
+      ? \`R\\\`\${durationToHms(this._relativeTime)}\\\`\`
+      : 'C';
+
+    const args =
+      this._args && Object.keys(this._args).length !== 0
+        ? // @ts-ignore : 'A : Args' found in JSON Spec
+          \`\\n.ARGUMENTS([\\n\${this._args.map(a => indent(objectToString(a))).join(',\\n')}\\n])\`
+        : '';
+
+    const metadata =
+      this._metadata && Object.keys(this._metadata).length !== 0
+        ? \`\\n.METADATA(\${objectToString(this._metadata)})\`
+        : '';
+
+    const description =
+      this._description && this._description.length !== 0 ? \`\\n.DESCRIPTION('\${this._description}')\` : '';
+
+    const models =
+      this._models && Object.keys(this._models).length !== 0
+        ? \`\\n.MODELS([\\n\${this._models.map(m => indent(objectToString(m))).join(',\\n')}\\n])\`
+        : '';
+
+    return \`\${timeString}.GROUND_BLOCK('\${this.name}')\${args}\${description}\${metadata}\${models}\`;
   }
 }
 
-/** Time utilities */
+/**
+ * This is a Ground Block step
+ *
+ */
+function GROUND_BLOCK(name: string) {
+  return new Ground_Block({ name: name });
+}
+
+// @ts-ignore : 'GroundBlock' found in JSON Spec
+export class Ground_Event implements GroundEvent {
+  name: string;
+  // @ts-ignore : 'Time' found in JSON Spec
+  time!: Time;
+  type: 'ground_event' = 'ground_event';
+
+  private readonly _absoluteTime: Temporal.Instant | null = null;
+  private readonly _epochTime: Temporal.Duration | null = null;
+  private readonly _relativeTime: Temporal.Duration | null = null;
+
+  // @ts-ignore : 'Args' found in JSON Spec
+  private readonly _args: Args | undefined;
+  // @ts-ignore : 'Description' found in JSON Spec
+  private readonly _description: Description | undefined;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  private readonly _metadata: Metadata | undefined;
+  // @ts-ignore : 'Model' found in JSON Spec
+  private readonly _models: Model[] | undefined;
+
+  constructor(opts: GroundOptions) {
+    this.name = opts.name;
+
+    this._args = opts.args ?? undefined;
+    this._description = opts.description ?? undefined;
+    this._metadata = opts.metadata ?? undefined;
+    this._models = opts.models ?? undefined;
+
+    if ('absoluteTime' in opts) {
+      this._absoluteTime = opts.absoluteTime;
+    } else if ('epochTime' in opts) {
+      this._epochTime = opts.epochTime;
+    } else if ('relativeTime' in opts) {
+      this._relativeTime = opts.relativeTime;
+    }
+  }
+
+  public static new(opts: GroundOptions): Ground_Event {
+    return new Ground_Event(opts);
+  }
+
+  public absoluteTiming(absoluteTime: Temporal.Instant): Ground_Event {
+    return new Ground_Event({
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      name: this.name,
+      absoluteTime: absoluteTime,
+    });
+  }
+
+  public epochTiming(epochTime: Temporal.Duration): Ground_Event {
+    return new Ground_Event({
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      name: this.name,
+      epochTime: epochTime,
+    });
+  }
+
+  public relativeTiming(relativeTime: Temporal.Duration): Ground_Event {
+    return new Ground_Event({
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      name: this.name,
+      relativeTime: relativeTime,
+    });
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public MODELS(models: Model[]): Ground_Event {
+    return Ground_Event.new({
+      name: this.name,
+      models: models,
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public GET_MODELS(): Model[] | undefined {
+    return this._models;
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public METADATA(metadata: Metadata): Ground_Event {
+    return Ground_Event.new({
+      name: this.name,
+      ...(this._models && { models: this._models }),
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      metadata: metadata,
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public GET_METADATA(): Metadata | undefined {
+    return this._metadata;
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public DESCRIPTION(description: Description): Ground_Event {
+    return Ground_Event.new({
+      name: this.name,
+      ...(this._models && { models: this._models }),
+      ...(this._args && { args: this._args }),
+      description: description,
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+  // @ts-ignore : 'Description' found in JSON Spec
+  public GET_DESCRIPTION(): Description | undefined {
+    return this._description;
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public ARGUMENTS(args: Args): Ground_Event {
+    return Ground_Event.new({
+      name: this.name,
+      ...(this._models && { models: this._models }),
+      args: args,
+      ...(this._description && { description: this._description }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public GET_ARGUMENTS(): Args | undefined {
+    return this._args;
+  }
+
+  // @ts-ignore : 'Ground_Event' found in JSON Spec
+  public toSeqJson(): GroundEvent {
+    return {
+      name: this.name,
+      time:
+        this._absoluteTime !== null
+          ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
+          : this._epochTime !== null
+          ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
+          : this._relativeTime !== null
+          ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
+          : { type: TimingTypes.COMMAND_COMPLETE },
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { models: this._models } : {}),
+      type: this.type,
+    };
+  }
+
+  // @ts-ignore : 'GroundEvent' found in JSON Spec
+  public static fromSeqJson(json: GroundEvent): Ground_Event {
+    const timeValue =
+      json.time.type === TimingTypes.ABSOLUTE
+        ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
+        : json.time.type === TimingTypes.COMMAND_RELATIVE
+        ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
+        : json.time.type === TimingTypes.EPOCH_RELATIVE
+        ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+        : {};
+
+    return Ground_Event.new({
+      name: json.name,
+      ...(json.args ? { args: json.args } : {}),
+      ...(json.description ? { description: json.description } : {}),
+      ...(json.metadata ? { metadata: json.metadata } : {}),
+      ...(json.models ? { models: json.models } : {}),
+      ...timeValue,
+    });
+  }
+
+  public toEDSLString(): string {
+    const timeString = this._absoluteTime
+      ? \`A\\\`\${instantToDoy(this._absoluteTime)}\\\`\`
+      : this._epochTime
+      ? \`E\\\`\${durationToHms(this._epochTime)}\\\`\`
+      : this._relativeTime
+      ? \`R\\\`\${durationToHms(this._relativeTime)}\\\`\`
+      : 'C';
+
+    const args =
+      this._args && Object.keys(this._args).length !== 0
+        ? // @ts-ignore : 'A : Args' found in JSON Spec
+          \`\\n.ARGUMENTS([\\n\${this._args.map(a => indent(objectToString(a))).join(',\\n')}\\n])\`
+        : '';
+
+    const metadata =
+      this._metadata && Object.keys(this._metadata).length !== 0
+        ? \`\\n.METADATA(\${objectToString(this._metadata)})\`
+        : '';
+
+    const description =
+      this._description && this._description.length !== 0 ? \`\\n.DESCRIPTION('\${this._description}')\` : '';
+
+    const models =
+      this._models && Object.keys(this._models).length !== 0
+        ? \`\\n.MODELS([\\n\${this._models.map(m => indent(objectToString(m))).join(',\\n')}\\n])\`
+        : '';
+
+    return \`\${timeString}.GROUND_EVENT('\${this.name}')\${args}\${description}\${metadata}\${models}\`;
+  }
+}
+
+/**
+ * This is a Ground Event step
+ *
+ */
+function GROUND_EVENT(name: string) {
+  return new Ground_Event({ name: name });
+}
+
+export const STEPS = {
+  GROUND_BLOCK: GROUND_BLOCK,
+  GROUND_EVENT: GROUND_EVENT,
+};
+
+/*
+  ---------------------------------
+		  Time Utilities
+  ---------------------------------
+  */
 
 export type DOY_STRING = string & { __brand: 'DOY_STRING' };
 export type HMS_STRING = string & { __brand: 'HMS_STRING' };
@@ -712,7 +1234,10 @@ function formatNumber(number: number, size: number): string {
 }
 
 // @ts-ignore : Used in generated code
-function A(...args: [TemplateStringsArray, ...string[]] | [Temporal.Instant] | [string]): typeof Commands {
+function A(
+  ...args: [TemplateStringsArray, ...string[]] | [Temporal.Instant] | [string]
+): // @ts-ignore : Commands Used in generated code
+typeof Commands & typeof STEPS {
   let time: Temporal.Instant;
   if (Array.isArray(args[0])) {
     time = doyToInstant(String.raw(...(args as [TemplateStringsArray, ...string[]])) as DOY_STRING);
@@ -726,7 +1251,10 @@ function A(...args: [TemplateStringsArray, ...string[]] | [Temporal.Instant] | [
 }
 
 // @ts-ignore : Used in generated code
-function R(...args: [TemplateStringsArray, ...string[]] | [Temporal.Duration] | [string]): typeof Commands {
+function R(
+  ...args: [TemplateStringsArray, ...string[]] | [Temporal.Duration] | [string]
+): // @ts-ignore : Commands Used in generated code
+typeof Commands & typeof STEPS {
   let duration: Temporal.Duration;
   if (Array.isArray(args[0])) {
     duration = hmsToDuration(String.raw(...(args as [TemplateStringsArray, ...string[]])) as HMS_STRING);
@@ -740,7 +1268,10 @@ function R(...args: [TemplateStringsArray, ...string[]] | [Temporal.Duration] | 
 }
 
 // @ts-ignore : Used in generated code
-function E(...args: [TemplateStringsArray, ...string[]] | [Temporal.Duration] | [string]): typeof Commands {
+function E(
+  ...args: [TemplateStringsArray, ...string[]] | [Temporal.Duration] | [string]
+): // @ts-ignore : Commands Used in generated code
+typeof Commands & typeof STEPS {
   let duration: Temporal.Duration;
   if (Array.isArray(args[0])) {
     duration = hmsToDuration(String.raw(...(args as [TemplateStringsArray, ...string[]])) as HMS_STRING);
@@ -755,39 +1286,68 @@ function E(...args: [TemplateStringsArray, ...string[]] | [Temporal.Duration] | 
 function commandsWithTimeValue<T extends TimingTypes>(
   timeValue: Temporal.Instant | Temporal.Duration,
   timeType: T,
-  // @ts-ignore : 'Commands' found in generated code
-): typeof Commands {
-  // @ts-ignore : 'Commands' found in generated code
-  return Object.keys(Commands).reduce((accum, key) => {
-    // @ts-ignore : 'Commands' found in generated code
-    const command = Commands[key as keyof Commands];
-    if (typeof command === 'function') {
-      if (timeType === TimingTypes.ABSOLUTE) {
+  // @ts-ignore : Commands Used in generated code
+): typeof Commands & typeof STEPS {
+  return {
+    // @ts-ignore : Commands Used in generated code
+    ...Object.keys(Commands).reduce((accum: { [key: string]: (...args: any[]) => any } = {}, key) => {
+      // @ts-ignore : Used in generated code
+      const command = Commands[key as keyof Commands];
+
+      if (typeof command === 'function') {
+        //if (timeType === TimingTypes.ABSOLUTE) {
         accum[key] = (...args: Parameters<typeof command>): typeof command => {
-          return command(...args).absoluteTiming(timeValue);
-        };
-      } else if (timeType === TimingTypes.COMMAND_RELATIVE) {
-        accum[key] = (...args: Parameters<typeof command>): typeof command => {
-          return command(...args).relativeTiming(timeValue);
+          switch (timeType) {
+            case TimingTypes.ABSOLUTE:
+              return command(...args).absoluteTiming(timeValue);
+            case TimingTypes.COMMAND_RELATIVE:
+              return command(...args).relativeTiming(timeValue);
+            case TimingTypes.EPOCH_RELATIVE:
+              return command(...args).epochTiming(timeValue);
+          }
         };
       } else {
-        accum[key] = (...args: Parameters<typeof command>): typeof command => {
-          return command(...args).epochTiming(timeValue);
-        };
+        switch (timeType) {
+          case TimingTypes.ABSOLUTE:
+            accum[key] = command.absoluteTiming(timeValue);
+            break;
+          case TimingTypes.COMMAND_RELATIVE:
+            accum[key] = command.relativeTiming(timeValue);
+            break;
+          case TimingTypes.EPOCH_RELATIVE:
+            accum[key] = command.epochTiming(timeValue);
+            break;
+        }
       }
-    } else {
-      if (timeType === TimingTypes.ABSOLUTE) {
-        accum[key] = command.absoluteTiming(timeValue);
-      } else if (timeType === TimingTypes.COMMAND_RELATIVE) {
-        accum[key] = command.relativeTiming(timeValue);
-      } else {
-        accum[key] = command.epochTiming(timeValue);
-      }
-    }
-    return accum;
-    // @ts-ignore : 'Commands' found in generated code
-  }, {} as typeof Commands);
+
+      return accum;
+      // @ts-ignore : Used in generated code
+    }, {} as typeof Commands),
+    ...Object.keys(STEPS).reduce((accum: { [key: string]: (...args: any[]) => any } = {}, key) => {
+      // @ts-ignore : Used in generated code
+      const step = STEPS[key as keyof STEPS];
+
+      accum[key] = (...args: Parameters<typeof step>): typeof step => {
+        switch (timeType) {
+          case TimingTypes.ABSOLUTE:
+            return step(...args).absoluteTiming(timeValue);
+          case TimingTypes.COMMAND_RELATIVE:
+            return step(...args).relativeTiming(timeValue);
+          case TimingTypes.EPOCH_RELATIVE:
+            return step(...args).epochTiming(timeValue);
+        }
+      };
+
+      return accum;
+    }, {} as typeof STEPS),
+  };
 }
+
+/*
+  ---------------------------------
+		  Utility Functions
+  ---------------------------------
+  */
 
 function indent(text: string, numTimes: number = 1, char: string = '  '): string {
   return text
@@ -1462,6 +2022,6 @@ export const Commands = {		ECHO: ECHO,
 		EAT_BANANA: EAT_BANANA,
 };
 
-Object.assign(globalThis, { A:A, R:R, E:E, C:Commands, Sequence});
+Object.assign(globalThis, { A:A, R:R, E:E, C:Object.assign(Commands, STEPS), Sequence});
 "
 `;

--- a/sequencing-server/test/seqjson-to-edsl.spec.ts
+++ b/sequencing-server/test/seqjson-to-edsl.spec.ts
@@ -8,7 +8,6 @@ beforeEach(async () => {
 });
 
 describe('getEdslForSeqJson', () => {
-  /**
   it('should return the seqjson for a given sequence edsl', async () => {
     const res = await graphqlClient.request<{
       getEdslForSeqJson: string;
@@ -43,21 +42,18 @@ describe('getEdslForSeqJson', () => {
       },
     );
 
-    expect(res.getEdslForSeqJson).toEqual(
-      `export default () =>
+    expect(res.getEdslForSeqJson).toEqual(`export default () =>
   Sequence.new({
-\t  seqId: 'test_00001',
-\t  metadata: {},
+    seqId: 'test_00001',
+    metadata: {},
     steps: [
       C.BAKE_BREAD,
       A\`2020-060T03:45:19.000\`.PREHEAT_OVEN({
         temperature: 100,
       }),
     ],
-  });`,
-    );
+  });`);
   });
-    */
 
   it('should throw an error if the user uploads an invalid seqjson', async () => {
     try {
@@ -99,7 +95,6 @@ describe('getEdslForSeqJson', () => {
   });
 });
 
-/**
 describe('getEdslForSeqJsonBulk', () => {
   it('should return the seqjson for a given sequence edsl', async () => {
     const res = await graphqlClient.request<{
@@ -159,29 +154,8 @@ describe('getEdslForSeqJsonBulk', () => {
     );
 
     expect(res.getEdslForSeqJsonBulk).toEqual([
-      `export default () =>
-  Sequence.new({
-\t  seqId: 'test_00001',
-\t  metadata: {},
-    steps: [
-      C.BAKE_BREAD,
-      A\`2020-060T03:45:19.000\`.PREHEAT_OVEN({
-        temperature: 100,
-      }),
-    ],
-  });`,
-      `export default () =>
-  Sequence.new({
-\t  seqId: 'test_00002',
-\t  metadata: {},
-    steps: [
-      C.BAKE_BREAD,
-      A\`2020-060T03:45:19.000\`.PREHEAT_OVEN({
-        temperature: 100,
-      }),
-    ],
-  });`,
+      "export default () =>\n  Sequence.new({\n    seqId: 'test_00001',\n    metadata: {},\n    steps: [\n      C.BAKE_BREAD,\n      A`2020-060T03:45:19.000`.PREHEAT_OVEN({\n        temperature: 100,\n      }),\n    ],\n  });",
+      "export default () =>\n  Sequence.new({\n    seqId: 'test_00002',\n    metadata: {},\n    steps: [\n      C.BAKE_BREAD,\n      A`2020-060T03:45:19.000`.PREHEAT_OVEN({\n        temperature: 100,\n      }),\n    ],\n  });",
     ]);
   });
 });
-*/

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -2587,7 +2587,7 @@ describe('sequence generation', () => {
   }, 30000);
 });
 
-describe('expansion', () => {
+describe('expansion regressions', () => {
   test.only('should throw an error is an activity instance goes beyond the plan duration', async () => {
     /** Begin Setup*/
     const activityId = await insertActivityDirective(graphqlClient, planId, 'GrowBanana', '1 days');
@@ -2666,7 +2666,6 @@ describe('expansion', () => {
     }
     `,
     );
-
     const expansionSetId = await insertExpansionSet(graphqlClient, commandDictionaryId, missionModelId, [expansionId]);
     const expansionRunId = await expand(graphqlClient, expansionSetId, simulationArtifactPk.simulationDatasetId);
 
@@ -2924,6 +2923,25 @@ describe('user sequence to seqjson', () => {
                       }
                     ]
                 }),
+                R\`02:02:00.000\`.GROUND_BLOCK('GroundBlock2')
+                .ARGUMENTS([
+                  {
+                    name: 'intStartTime',
+                    type: 'number',
+                    value: 10,
+                  }
+                ])
+                .DESCRIPTION('Set the ground block time')
+                .METADATA({
+                  author: 'Ryan',
+                })
+                .MODELS([
+                  {
+                    offset: '00:10:00.001',
+                    value: true,
+                    variable: 'model_var_boolean',
+                  }
+                ])
               ],
             });
           `,
@@ -3024,6 +3042,31 @@ describe('user sequence to seqjson', () => {
             ],
           },
         ],
+      },
+      {
+        args: [
+          {
+            name: 'intStartTime',
+            type: 'number',
+            value: 10,
+          },
+        ],
+        description: 'Set the ground block time',
+        metadata: {
+          author: 'Ryan',
+        },
+        models: [
+          {
+            offset: '00:10:00.001',
+            value: true,
+            variable: 'model_var_boolean',
+          },
+        ],
+        time: {
+          tag: '02:02:00.000',
+          type: 'COMMAND_RELATIVE',
+        },
+        type: 'ground_block',
       },
     ]);
 


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Added `Ground_Block` and `Ground_Event` types to the `Sequence.step[]` object. You should be able to go back and forth between eDSL and SeqJSON also within the Sequence Editor.  

## Verification
 Ran the e2e test and manually tested 

## Documentation

```ts
C.GROUND_BLOCK("Block 1")
A`2050-45T00:12:00`.GROUND_BLOCK("Block 2")
E`10:00:00`.GROUND_BLOCK("Block 3")
R`04:39:23.000`.GROUND_BLOCK("Block 4")

C.GROUND_EVENT("EVENT 1")
A`2050-45T00:12:00`.GROUND_EVENT("EVENT 2")
E`10:00:00`.GROUND_EVENT("EVENT 3")
R`04:39:23.000`.GROUND_EVENT("EVENT 4")
```

You can also chain these objects' parameters

```ts
C.GROUND_BLOCK("").METADATA({}).ARGUMENTS([]).MODELS([]).DESCRIPTION("")
```

Here is an example of the SeqJSON generated

eDSL
```ts
R`02:02:00`
.GROUND_BLOCK('GroundBlock2')
.ARGUMENTS([{ name: 'intStartTime', type: 'number', value: 10 }])
.METADATA({ author: 'Ryan' })
.DESCRIPTION('Set the ground block time')
.MODELS([
	{
		offset: '00:10:00.001',
		value: true,
		variable: 'model_var_boolean',
	},
]);
```

```json
{
  "id": "test0000",
  "metadata": {
    "author": "XXXX",
    "name": "test sequence",
    "onboard_path": "/tmp/onboard/eis/"
  },
  "steps": [
    {
      "name": "GroundBlock2",
      "time": {
        "type": "COMMAND_RELATIVE",
        "tag": "02:02:00.000"
      },
      "args": [
        {
          "name": "intStartTime",
          "type": "number",
          "value": 10
        }
      ],
      "description": "Set the ground block time",
      "metadata": {
        "author": "Ryan"
      },
      "models": [
        {
          "offset": "00:10:00.001",
          "value": true,
          "variable": "model_var_boolean"
        }
      ],
      "type": "ground_block"
    }
  ]
}
```


## Future work
Add the last 2 step objects (Activate and Load)