### PR TITLE
Make simulation optional for scheduling goals

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Spans.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Spans.java
@@ -174,7 +174,7 @@ public class Spans implements IntervalContainer<Spans>, Iterable<Segment<Optiona
 
   public Spans intersectWith(final Windows windows){
     final var ret = new Spans();
-    this.intervals.forEach(x -> windows.iterator().forEachRemaining(y -> ret.add(Interval.intersect(y.interval(), x.interval()), x.value())));
+    this.intervals.forEach(x -> windows.iterateEqualTo(true).iterator().forEachRemaining(y -> ret.add(Interval.intersect(x.interval(), y), x.value())));
     return ret;
   }
 

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/time/SpansTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/time/SpansTest.java
@@ -193,4 +193,15 @@ public class SpansTest {
 
     assertIterableEquals(expected, acc);
   }
+
+  @Test
+  public void testIntersectWindows() {
+    final var intersection = new Spans(interval(0, 2, SECONDS)).intersectWith(
+        new Windows(false).set(interval(1, 10, SECONDS), true)
+    );
+
+    final var expected = new Spans(interval(1,2, SECONDS));
+
+    assertIterableEquals(expected, intersection);
+  }
 }

--- a/deployment/hasura/migrations/AerieScheduler/1_optional_sim_per_goal/down.sql
+++ b/deployment/hasura/migrations/AerieScheduler/1_optional_sim_per_goal/down.sql
@@ -1,0 +1,4 @@
+comment on column scheduling_specification_goals.simulate_after is null;
+alter table scheduling_specification_goals drop column simulate_after;
+
+call migrations.mark_migration_rolled_back('1');

--- a/deployment/hasura/migrations/AerieScheduler/1_optional_sim_per_goal/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/1_optional_sim_per_goal/up.sql
@@ -1,0 +1,6 @@
+alter table scheduling_specification_goals add column simulate_after boolean not null default true;
+
+comment on column scheduling_specification_goals.simulate_after is e''
+  'Whether to re-simulate after evaluating this goal and before the next goal.';
+
+call migrations.mark_migration_applied('1');

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Goal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Goal.java
@@ -32,12 +32,16 @@ public class Goal {
    * state constraints applying to the goal
    */
   protected Expression<Windows> resourceConstraints;
-  
+
   /**
-   * Whether to resimulate after this goal or use stale results
+   * Whether to resimulate after this goal or make the next goal use stale results.
+   *
+   * True is the default behavior. If False, the durations of the activities inserted by
+   * *this* goal will not be simulated and checked, and the *next* goal will not have up-to-date
+   * sim results if this goal placed any activities.
    */
   public boolean simulateAfter;
-  
+
   /** Set to true if partial satisfaction is ok, the scheduler will try to do its best */
   private boolean shouldRollbackIfUnsatisfied = false;
 

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Goal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Goal.java
@@ -32,6 +32,12 @@ public class Goal {
    * state constraints applying to the goal
    */
   protected Expression<Windows> resourceConstraints;
+  
+  /**
+   * Whether to resimulate after this goal or use stale results
+   */
+  public boolean simulateAfter;
+  
   /** Set to true if partial satisfaction is ok, the scheduler will try to do its best */
   private boolean shouldRollbackIfUnsatisfied = false;
 
@@ -148,6 +154,13 @@ public class Goal {
 
     boolean shouldRollbackIfUnsatisfied;
 
+    public T simulateAfter(boolean simAfter) {
+      this.simulateAfter = simAfter;
+      return getThis();
+    }
+
+    boolean simulateAfter = true;
+
     /**
      * uses all pending specifications to construct a matching new goal object
      *
@@ -205,6 +218,8 @@ public class Goal {
         final var windows = new Windows(false).set(Interval.between(starting, ending), true);
         goal.temporalContext = new WindowsWrapperExpression(windows);
       }
+
+      goal.simulateAfter = this.simulateAfter;
 
       return goal;
     }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -150,7 +150,7 @@ public class PrioritySolver implements Solver {
     for(var act: acts){
       //if some parameters are left uninstantiated, this is the last moment to do it
       var duration = act.duration();
-      if(duration != null && duration.longerThan(this.problem.getPlanningHorizon().getEndAerie())){
+      if(duration != null && act.startOffset().plus(duration).longerThan(this.problem.getPlanningHorizon().getEndAerie())) {
         logger.warn("Activity " + act
                            + " is planned to finish after the end of the planning horizon, not simulating. Extend the planning horizon.");
         allGood = false;

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -45,6 +45,7 @@ public class PrioritySolver implements Solver {
   private static final Logger logger = LoggerFactory.getLogger(PrioritySolver.class);
 
   boolean checkSimBeforeInsertingActivities;
+  boolean checkSimBeforeEvaluatingGoal;
 
   /**
    * boolean stating whether only conflict analysis should be performed or not
@@ -88,6 +89,7 @@ public class PrioritySolver implements Solver {
   public PrioritySolver(final Problem problem, final boolean analysisOnly) {
     checkNotNull(problem, "creating solver with null input problem descriptor");
     this.checkSimBeforeInsertingActivities = true;
+    this.checkSimBeforeEvaluatingGoal = true;
     this.problem = problem;
     this.simulationFacade = problem.getSimulationFacade();
     this.analysisOnly = analysisOnly;
@@ -95,11 +97,6 @@ public class PrioritySolver implements Solver {
 
   public PrioritySolver(final Problem problem) {
     this(problem, false);
-  }
-
-  //TODO: should probably be part of sched configuration; maybe even per rule
-  public void doNotcheckSimBeforeInsertingActInPlan(){
-    this.checkSimBeforeInsertingActivities = false;
   }
 
   /**
@@ -165,7 +162,7 @@ public class PrioritySolver implements Solver {
           break;
         }
         var simDur = simulationFacade.getActivityDuration(act);
-        if (!simDur.isPresent()) {
+        if (simDur.isEmpty()) {
           logger.error("Activity " + act + " could not be simulated");
           allGood = false;
           break;
@@ -352,6 +349,8 @@ public class PrioritySolver implements Solver {
   }
 
   private void satisfyGoal(Goal goal) {
+    final boolean checkSimConfig = this.checkSimBeforeInsertingActivities;
+    this.checkSimBeforeInsertingActivities = goal.simulateAfter;
     if (goal instanceof CompositeAndGoal) {
       satisfyCompositeGoal((CompositeAndGoal) goal);
     } else if (goal instanceof OptionGoal) {
@@ -359,6 +358,8 @@ public class PrioritySolver implements Solver {
     } else {
       satisfyGoalGeneral(goal);
     }
+    this.checkSimBeforeEvaluatingGoal = goal.simulateAfter;
+    this.checkSimBeforeInsertingActivities = checkSimConfig;
   }
 
 
@@ -505,6 +506,8 @@ public class PrioritySolver implements Solver {
     evaluation.forGoal(goal).setNbConflictsDetected(missingConflicts.size());
     assert missingConflicts != null;
     boolean madeProgress = true;
+
+
     while (!missingConflicts.isEmpty() && madeProgress) {
       madeProgress = false;
 
@@ -576,8 +579,12 @@ public class PrioritySolver implements Solver {
     assert goal != null;
     assert plan != null;
     //REVIEW: maybe should have way to request only certain kinds of conflicts
-    this.simulationFacade.computeSimulationResultsUntil(this.problem.getPlanningHorizon().getEndAerie());
-    final var rawConflicts = goal.getConflicts(plan, this.simulationFacade.getLatestConstraintSimulationResults());
+    var lastSimResults = this.simulationFacade.getLatestConstraintSimulationResults();
+    if (lastSimResults == null || this.checkSimBeforeEvaluatingGoal) {
+      this.simulationFacade.computeSimulationResultsUntil(this.problem.getPlanningHorizon().getEndAerie());
+      lastSimResults = this.simulationFacade.getLatestConstraintSimulationResults();
+    }
+    final var rawConflicts = goal.getConflicts(plan, lastSimResults);
     assert rawConflicts != null;
     return rawConflicts;
   }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
@@ -861,7 +861,7 @@ public class TestApplyWhen {
     partialPlan.add(SchedulingActivityDirective.of(actTypeA, planningHorizon.getStartAerie().plus(Duration.of(7, Duration.SECONDS)), Duration.of(4, Duration.SECONDS), null, true)); //create an activity that's 5 seconds long, 11s after start
     partialPlan.add(SchedulingActivityDirective.of(actTypeA, planningHorizon.getStartAerie().plus(Duration.of(14, Duration.SECONDS)), Duration.of(4, Duration.SECONDS), null, true)); //create an activity that's 5 seconds long, 16s after start
     partialPlan.add(SchedulingActivityDirective.of(actTypeA, planningHorizon.getStartAerie().plus(Duration.of(19, Duration.SECONDS)), Duration.of(4, Duration.SECONDS), null, true)); //create an activity that's 5 seconds long, 16s after start
-    partialPlan.add(SchedulingActivityDirective.of(actTypeA, planningHorizon.getStartAerie().plus(Duration.of(25, Duration.SECONDS)), Duration.of(4, Duration.SECONDS), null, true)); //create an activity that's 5 seconds long, 16s after start
+    partialPlan.add(SchedulingActivityDirective.of(actTypeA, planningHorizon.getStartAerie().plus(Duration.of(25, Duration.SECONDS)), Duration.of(2, Duration.SECONDS), null, true)); //create an activity that's 5 seconds long, 16s after start
 
 
     //  pass this plan as initialPlan to Problem object
@@ -933,7 +933,7 @@ public class TestApplyWhen {
     PlanInMemory partialPlan = new PlanInMemory();
     final var actTypeA = problem.getActivityType("ControllableDurationActivity");
     partialPlan.add(SchedulingActivityDirective.of(actTypeA, planningHorizon.getStartAerie(), Duration.of(4, Duration.SECONDS), null, true)); //create an activity that's 5 seconds long, start at start
-    partialPlan.add(SchedulingActivityDirective.of(actTypeA, planningHorizon.getStartAerie().plus(Duration.of(8, Duration.SECONDS)), Duration.of(5, Duration.SECONDS), null, true)); //create an activity that's 5 seconds long, 11s after start
+    partialPlan.add(SchedulingActivityDirective.of(actTypeA, planningHorizon.getStartAerie().plus(Duration.of(8, Duration.SECONDS)), Duration.of(3, Duration.SECONDS), null, true)); //create an activity that's 5 seconds long, 11s after start
 
     //  pass this plan as initialPlan to Problem object
     problem.setInitialPlan(partialPlan);

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
@@ -861,7 +861,7 @@ public class TestApplyWhen {
     partialPlan.add(SchedulingActivityDirective.of(actTypeA, planningHorizon.getStartAerie().plus(Duration.of(7, Duration.SECONDS)), Duration.of(4, Duration.SECONDS), null, true)); //create an activity that's 5 seconds long, 11s after start
     partialPlan.add(SchedulingActivityDirective.of(actTypeA, planningHorizon.getStartAerie().plus(Duration.of(14, Duration.SECONDS)), Duration.of(4, Duration.SECONDS), null, true)); //create an activity that's 5 seconds long, 16s after start
     partialPlan.add(SchedulingActivityDirective.of(actTypeA, planningHorizon.getStartAerie().plus(Duration.of(19, Duration.SECONDS)), Duration.of(4, Duration.SECONDS), null, true)); //create an activity that's 5 seconds long, 16s after start
-    partialPlan.add(SchedulingActivityDirective.of(actTypeA, planningHorizon.getStartAerie().plus(Duration.of(25, Duration.SECONDS)), Duration.of(2, Duration.SECONDS), null, true)); //create an activity that's 5 seconds long, 16s after start
+    partialPlan.add(SchedulingActivityDirective.of(actTypeA, planningHorizon.getStartAerie().plus(Duration.of(25, Duration.SECONDS)), Duration.of(2, Duration.SECONDS), null, true)); //create an activity that's 2 seconds long, 25s after start
 
 
     //  pass this plan as initialPlan to Problem object

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -3,3 +3,4 @@ This file denotes which migrations occur "before" this version of the schema.
 */
 
 call migrations.mark_migration_applied('0');
+call migrations.mark_migration_applied('1');

--- a/scheduler-server/sql/scheduler/tables/scheduling_specification_goals.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_specification_goals.sql
@@ -8,6 +8,8 @@ create table scheduling_specification_goals (
     constraint non_negative_specification_goal_priority check (priority >= 0),
   enabled boolean default true,
 
+  simulate_after boolean not null default true,
+
   constraint scheduling_specification_goals_primary_key
     primary key (specification_id, goal_id),
   constraint scheduling_specification_goals_unique_priorities
@@ -33,6 +35,8 @@ comment on column scheduling_specification_goals.goal_id is e''
 comment on column scheduling_specification_goals.priority is e''
   'The relative priority of a scheduling goal in relation to other '
   'scheduling goals within the same specification.';
+comment on column scheduling_specification_goals.simulate_after is e''
+  'Whether to re-simulate after evaluating this goal and before the next goal.';
 
 create or replace function insert_scheduling_specification_goal_func()
   returns trigger as $$begin

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GoalRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/GoalRecord.java
@@ -1,3 +1,3 @@
 package gov.nasa.jpl.aerie.scheduler.server.models;
 
-public record GoalRecord(GoalId id, GoalSource definition, boolean enabled) {}
+public record GoalRecord(GoalId id, GoalSource definition, boolean enabled, boolean simulateAfter) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetSpecificationGoalsAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetSpecificationGoalsAction.java
@@ -10,28 +10,16 @@ import java.util.List;
 
 /*package-local*/ final class GetSpecificationGoalsAction implements AutoCloseable {
   private final @Language("SQL") String sql = """
-    with
-      goals as
-        ( select
-            s.specification_id,
+    select
             s.goal_id,
-            s.priority,
-            s.enabled,
             g.name,
             g.definition,
-            g.revision
-          from scheduling_specification_goals as s
-            left join scheduling_goal as g
-            on s.goal_id = g.id )
-    select
-      g.goal_id,
-      g.name,
-      g.definition,
       g.revision,
-      g.enabled
-    from goals as g
-      where g.specification_id = ?
-      order by g.priority asc
+      s.enabled,
+          from scheduling_specification_goals as s
+    left join scheduling_goal as g on s.goal_id = g.id
+    where s.specification_id = ?
+    order by s.priority;
     """;
 
   private final PreparedStatement statement;

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetSpecificationGoalsAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetSpecificationGoalsAction.java
@@ -11,12 +11,13 @@ import java.util.List;
 /*package-local*/ final class GetSpecificationGoalsAction implements AutoCloseable {
   private final @Language("SQL") String sql = """
     select
-            s.goal_id,
-            g.name,
-            g.definition,
+      s.goal_id,
+      g.name,
+      g.definition,
       g.revision,
       s.enabled,
-          from scheduling_specification_goals as s
+      s.simulate_after
+    from scheduling_specification_goals as s
     left join scheduling_goal as g on s.goal_id = g.id
     where s.specification_id = ?
     order by s.priority;
@@ -39,7 +40,8 @@ import java.util.List;
       final var name = resultSet.getString("name");
       final var definition = resultSet.getString("definition");
       final var enabled = resultSet.getBoolean("enabled");
-      goals.add(new PostgresGoalRecord(id, revision, name, definition, enabled));
+      final var simulateAfter = resultSet.getBoolean("simulate_after");
+      goals.add(new PostgresGoalRecord(id, revision, name, definition, enabled, simulateAfter));
     }
 
     return goals;

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresGoalRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresGoalRecord.java
@@ -5,5 +5,6 @@ public record PostgresGoalRecord(
     long revision,
     String name,
     String definition,
-    boolean enabled
+    boolean enabled,
+    boolean simulateAfter
 ) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresSpecificationRepository.java
@@ -51,7 +51,8 @@ public final class PostgresSpecificationRepository implements SpecificationRepos
         .map((PostgresGoalRecord pgGoal) -> new GoalRecord(
                 new GoalId(pgGoal.id()),
                 new GoalSource(pgGoal.definition()),
-                pgGoal.enabled()
+                pgGoal.enabled(),
+                pgGoal.simulateAfter()
             ))
         .toList();
 


### PR DESCRIPTION
* **Tickets addressed:** closes #674 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

This makes re-simulation between goals optional. Each goal has two opportunities to simulate:
- before it evaluates, to make sure it has up-to-date results
- after it evaluates, to make sure the durations of the inserted activities are as expected

When there are multiple goals, some of the simulation is already avoided:
- Sim before goal 1
- Eval goal 1
- Sim after goal 1
- Sim before goal 2 (*no-op*, results are up-to-date)
- Eval goal 2
- Sim after goal 2

However, if "Sim after goal 1" is turned off, at "Sim before goal 2" it will recognize that results are out of date and resimulate, doing the same amount of work as before. This means that both "Sim after goal 1" and "Sim before goal 2" have to be turned off.

We already have a flag for turning off sim after a goal: `checkSimBeforeInsertingActivities`. I've added a second flag, `checkSimBeforeEvaluatingGoal` which does what it says it does. If goal 1 is set to not re-simulate after, then `checkSimBeforeInsertingActivites` will be `false` during goal 1, and `checkSimBeforeEvaluatingGoal` will be `false` during goal 2.

This PR also adds a column to the scheduling spec goals table, with a migration, and fixes a couple bugs I found on the way.

## Verification
I've added an integration test, which also doubles as a demonstration of how this feature turns off the correctness guarantee.

## Documentation
- [ ] This one's definitely worthy of an update to the docs.

## Future work
UI
