### PR TITLE
Use correct join type when querying scheduling conditions

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetSpecificationConditionsAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetSpecificationConditionsAction.java
@@ -17,7 +17,7 @@ import java.util.List;
       c.definition,
       c.revision
     from scheduling_specification_conditions as s
-      left join scheduling_condition as c
+      join scheduling_condition as c
       on s.specification_id = ?
       and s.condition_id = c.id
     """;


### PR DESCRIPTION
* **Tickets addressed:** Fixes #679 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

`GetSpecificationConditionsAction` needs to get all of the conditions associated with a particular specification. It did this via a left join, which would return a `null` value for each scheduling condition in the database that isn't in the plan of interest. The intention of this query is to get the scheduling conditions for the given specification - other specifications are irrelevant - so an inner join is the appropriate choice here.

This PR replaces that left join with an inner join.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

To reproduce the issue, I brought up aerie with two plans, and added a global scheduling condition to each one.

I then added a scheduling goal to one of the plans, and attempted to run scheduling on that plan. This triggered the null pointer exception.

After making the fix, I rebuilt one of the scheduler workers, and left the other using the old code. By bringing down one of those workers at a time, I demonstrated that the old code exhibited this issue, while the new code ran with no errors.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

No documentation updates, given that this is an unexpected bug.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
No future work - but mental note to choose my joins carefully