### PR TITLE
Constrain scheduling goals and specifications

### DIFF
--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
@@ -41,13 +41,13 @@ class SchedulerDatabaseTests {
     helper = null;
   }
 
-  int insertSpecification() throws SQLException {
+  int insertSpecification(final long planId) throws SQLException {
     try (final var statement = connection.createStatement()) {
       final var res = statement.executeQuery("""
         insert into scheduling_specification(
           revision, plan_id, plan_revision, horizon_start, horizon_end, simulation_arguments, analysis_only
-        ) values (0, 0, 0, now(), now(), '{}', false) returning id;
-      """);
+        ) values (0, %d, 0, now(), now(), '{}', false) returning id;
+      """.formatted(planId));
       res.next();
       return res.getInt("id");
     }
@@ -86,7 +86,7 @@ class SchedulerDatabaseTests {
     @BeforeEach
     void beforeEach() throws SQLException {
       specAndTemplateIds = new HashMap<>();
-      specAndTemplateIds.put("specification", new int[]{insertSpecification(), insertSpecification()});
+      specAndTemplateIds.put("specification", new int[]{insertSpecification(0), insertSpecification(1)});
       specAndTemplateIds.put("template", new int[]{insertTemplate(), insertTemplate()});
       goalIds = new int[]{insertGoal(), insertGoal(), insertGoal()};
     }

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/SchedulerDatabaseTests.java
@@ -88,7 +88,7 @@ class SchedulerDatabaseTests {
       specAndTemplateIds = new HashMap<>();
       specAndTemplateIds.put("specification", new int[]{insertSpecification(0), insertSpecification(1)});
       specAndTemplateIds.put("template", new int[]{insertTemplate(), insertTemplate()});
-      goalIds = new int[]{insertGoal(), insertGoal(), insertGoal()};
+      goalIds = new int[]{insertGoal(), insertGoal(), insertGoal(), insertGoal(), insertGoal(), insertGoal()};
     }
 
     @AfterEach
@@ -100,7 +100,7 @@ class SchedulerDatabaseTests {
       helper.clearTable("scheduling_template_goals");
     }
 
-    void insertGoalPriorities(String tableStem, int specOrTemplateIndex, int[] priorities) throws SQLException {
+    void insertGoalPriorities(String tableStem, int specOrTemplateIndex, final int[] goalIndices, int[] priorities) throws SQLException {
       for (int i = 0; i < priorities.length; i++) {
         connection.createStatement().executeUpdate("""
           insert into scheduling_%s_goals(%s_id, goal_id, priority)
@@ -108,7 +108,7 @@ class SchedulerDatabaseTests {
         """.formatted(
             tableStem, tableStem,
             specAndTemplateIds.get(tableStem)[specOrTemplateIndex],
-            goalIds[i],
+            goalIds[goalIndices[i]],
             priorities[i]
         ));
       }
@@ -136,20 +136,20 @@ class SchedulerDatabaseTests {
     @ValueSource(strings = {"specification", "template"})
     void shouldIncrementPrioritiesOnCollision(String tableStem) throws SQLException {
       // untouched values in table, should be unchanged
-      insertGoalPriorities(tableStem, 1, new int[]{0, 1, 2});
-
-      // should cause increments
-      insertGoalPriorities(tableStem, 0, new int[]{0, 0, 0});
-
-      checkPriorities(
-          tableStem, 0,
-          new int[]{0, 1},
-          new int[]{2, 1}
-      );
+      insertGoalPriorities(tableStem, 1, new int[] {0, 1, 2}, new int[]{0, 1, 2});
       checkPriorities(
           tableStem, 1,
           new int[]{0, 1, 2},
           new int[]{0, 1, 2}
+      );
+
+      helper.clearTable("scheduling_%s_goals".formatted(tableStem));
+      // should cause increments
+      insertGoalPriorities(tableStem, 0, new int[] {0, 1, 2}, new int[]{0, 0, 0});
+      checkPriorities(
+          tableStem, 0,
+          new int[]{0, 1, 2},
+          new int[]{2, 1, 0}
       );
     }
 
@@ -157,24 +157,24 @@ class SchedulerDatabaseTests {
     @ValueSource(strings = {"specification", "template"})
     void shouldErrorWhenInsertingNegativePriority(String tableStem) {
       assertThrows(SQLException.class, () -> insertGoalPriorities(
-          tableStem, 0, new int[]{-1}
+          tableStem, 0, new int[] {0, 1, 2}, new int[]{-1}
       ));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"specification", "template"})
     void shouldErrorWhenInsertingNonConsecutivePriority(String tableStem) throws SQLException {
-      insertGoalPriorities(tableStem, 1, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 1, new int[] {0, 1, 2}, new int[]{0, 1, 2});
       assertThrows(SQLException.class, () -> insertGoalPriorities(
-          tableStem, 0, new int[]{1}
+          tableStem, 0, new int[] {0, 1, 2}, new int[]{1}
       ));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"specification", "template"})
     void shouldReorderPrioritiesOnUpdate(String tableStem) throws SQLException {
-      insertGoalPriorities(tableStem, 0, new int[]{0, 1, 2});
-      insertGoalPriorities(tableStem, 1, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 0, new int[] {0, 1, 2}, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 1, new int[] {3, 4, 5}, new int[]{0, 1, 2});
 
       // First test lowering a priority
       connection.createStatement().executeUpdate("""
@@ -188,7 +188,7 @@ class SchedulerDatabaseTests {
       );
       checkPriorities(
           tableStem, 1,
-          new int[]{0, 1, 2},
+          new int[]{3, 4, 5},
           new int[]{0, 1, 2}
       );
 
@@ -197,20 +197,23 @@ class SchedulerDatabaseTests {
         update scheduling_%s_goals
         set priority = 2 where %s_id = %d and goal_id = %d;
       """.formatted(tableStem, tableStem, specAndTemplateIds.get(tableStem)[0], goalIds[2]));
-      for (int i : new int[]{0, 1}) {
-        checkPriorities(
-            tableStem, i,
-            new int[]{0, 1, 2},
-            new int[]{0, 1, 2}
-        );
-      }
+      checkPriorities(
+          tableStem, 0,
+          new int[] {0, 1, 2},
+          new int[] {0, 1, 2}
+      );
+      checkPriorities(
+          tableStem, 1,
+          new int[] {3, 4, 5},
+          new int[] {0, 1, 2}
+      );
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"specification", "template"})
     void shouldDecrementPrioritiesOnDelete(String tableStem) throws SQLException {
-      insertGoalPriorities(tableStem, 0, new int[]{0, 1, 2});
-      insertGoalPriorities(tableStem, 1, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 0, new int[] {0, 1, 2}, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 1, new int[] {3, 4, 5}, new int[]{0, 1, 2});
 
       connection.createStatement().executeUpdate("""
         delete from scheduling_%s_goals
@@ -223,7 +226,7 @@ class SchedulerDatabaseTests {
       );
       checkPriorities(
           tableStem, 1,
-          new int[]{0, 1, 2},
+          new int[]{3, 4, 5},
           new int[]{0, 1, 2}
       );
     }
@@ -231,26 +234,33 @@ class SchedulerDatabaseTests {
     @ParameterizedTest
     @ValueSource(strings = {"specification", "template"})
     void shouldTriggerMultipleReorders(String tableStem) throws SQLException {
-      insertGoalPriorities(tableStem, 0, new int[]{0, 1, 2});
-      insertGoalPriorities(tableStem, 1, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 0, new int[] {0, 1, 2}, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 1, new int[] {3, 4, 5}, new int[]{0, 1, 2});
 
       connection.createStatement().executeUpdate("""
         delete from scheduling_%s_goals
         where goal_id = %d;
       """.formatted(tableStem, goalIds[1]));
-      for (int i : new int[]{0, 1}) {
-        checkPriorities(
-            tableStem, i,
-            new int[]{0, 2},
-            new int[]{0, 1}
-        );
-      }
+      connection.createStatement().executeUpdate("""
+        delete from scheduling_%s_goals
+        where goal_id = %d;
+      """.formatted(tableStem, goalIds[4]));
+      checkPriorities(
+          tableStem, 0,
+          new int[] {0, 2},
+          new int[] {0, 1}
+      );
+      checkPriorities(
+          tableStem, 1,
+          new int[] {3, 5},
+          new int[] {0, 1}
+      );
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"specification", "template"})
     void shouldNotTriggerWhenPriorityIsUnchanged(String tableStem) throws SQLException {
-      insertGoalPriorities(tableStem, 1, new int[]{0, 1, 2});
+      insertGoalPriorities(tableStem, 1, new int[] {0, 1, 2}, new int[]{0, 1, 2});
       connection.createStatement().executeUpdate("""
         update scheduling_%s_goals
         set %s_id = %d

--- a/deployment/hasura/migrations/AerieScheduler/2_constrain_goals_and_specs/down.sql
+++ b/deployment/hasura/migrations/AerieScheduler/2_constrain_goals_and_specs/down.sql
@@ -1,0 +1,4 @@
+alter table scheduling_specification_goals drop constraint scheduling_specification_unique_goal_id;
+alter table scheduling_specification drop constraint scheduling_specification_unique_plan_id;
+
+call migrations.mark_migration_rolled_back('2');

--- a/deployment/hasura/migrations/AerieScheduler/2_constrain_goals_and_specs/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/2_constrain_goals_and_specs/up.sql
@@ -1,0 +1,4 @@
+alter table scheduling_specification_goals add constraint scheduling_specification_unique_goal_id unique (goal_id);
+alter table scheduling_specification add constraint scheduling_specification_unique_plan_id unique (plan_id);
+
+call migrations.mark_migration_applied('2');

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -4,3 +4,4 @@ This file denotes which migrations occur "before" this version of the schema.
 
 call migrations.mark_migration_applied('0');
 call migrations.mark_migration_applied('1');
+call migrations.mark_migration_applied('2');

--- a/scheduler-server/sql/scheduler/tables/scheduling_specification.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_specification.sql
@@ -9,7 +9,9 @@ create table scheduling_specification (
   simulation_arguments jsonb not null,
   analysis_only boolean not null,
   constraint scheduling_specification_synthetic_key
-    primary key(id)
+    primary key(id),
+  constraint scheduling_specification_unique_plan_id
+    unique (plan_id)
 );
 
 comment on table scheduling_specification is e''

--- a/scheduler-server/sql/scheduler/tables/scheduling_specification_goals.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_specification_goals.sql
@@ -23,7 +23,9 @@ create table scheduling_specification_goals (
     foreign key (goal_id)
       references scheduling_goal
       on update cascade
-      on delete cascade
+      on delete cascade,
+  constraint scheduling_specification_unique_goal_id
+    unique (goal_id)
 );
 
 comment on table scheduling_specification_goals is e''


### PR DESCRIPTION
* **Tickets addressed:** Closes #471 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

This PR constrains scheduling goals to at most one scheduling specification, and constrains scheduling specifications to at most one plan.

This will need to be rebased onto #708 (or vice versa), to keep our migrations in linear order. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Using the API, I checked that it was no longer possible to associate a goal with multiple specifications. I created Goal 1 with the UI, and it was automatically associated with Specification 1. Here, I attempted to associate it with Specification 2:
```graphql
mutation AssociateSchedulingGoalWithNewSpec{
  insert_scheduling_specification_goals_one(object:{
    goal_id: 1,
    specification_id: 2
  }) {
    enabled
  }
}
```

Error message:
```json
{
  "errors": [
    {
      "extensions": {
        "code": "constraint-violation",
        "path": "$.selectionSet.insert_scheduling_specification_goals_one.args.object"
      },
      "message": "Uniqueness violation. duplicate key value violates unique constraint \"scheduling_specification_unique_goal_id\""
    }
  ]
}
```

Similarly, I tried to add a new specification for plan 1:

```graphql
mutation CreateSchedulingSpecification{
  insert_scheduling_specification_one(object:{
    plan_id:1,
    plan_revision: 1,
    horizon_start: "2023-03-03T00:00:00+00:00",
    horizon_end: "2023-03-17T00:00:00+00:00",
    simulation_arguments: {},
    analysis_only: false
  }) {
    id
  }
}
```

```json
{
  "errors": [
    {
      "extensions": {
        "code": "constraint-violation",
        "path": "$.selectionSet.insert_scheduling_specification_one.args.object"
      },
      "message": "Uniqueness violation. duplicate key value violates unique constraint \"scheduling_specification_unique_plan_id\""
    }
  ]
}
```

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
https://github.com/NASA-AMMOS/aerie-docs/pull/18

## Future work
<!-- What next steps can we anticipate from here, if any? -->
If it turns out that this is a limitation we want to keep for the long term, we can consider normalizing our schema
