### PR TITLE
Add Bulk Anchor Delete Functions

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/functions/functions.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/functions/functions.yaml
@@ -89,6 +89,24 @@
     custom_root_fields:
       function: delete_activity_by_pk_delete_subtree
 - function:
+    name: delete_activity_by_pk_reanchor_plan_start_bulk
+    schema: hasura_functions
+  configuration:
+    custom_root_fields:
+      function: delete_activity_by_pk_reanchor_plan_start_bulk
+- function:
+    name: delete_activity_by_pk_reanchor_to_anchor_bulk
+    schema: hasura_functions
+  configuration:
+    custom_root_fields:
+      function: delete_activity_by_pk_reanchor_to_anchor_bulk
+- function:
+    name: delete_activity_by_pk_delete_subtree_bulk
+    schema: hasura_functions
+  configuration:
+    custom_root_fields:
+      function: delete_activity_by_pk_delete_subtree_bulk
+- function:
     name: apply_preset_to_activity
     schema: hasura_functions
   configuration:

--- a/deployment/hasura/migrations/AerieMerlin/4_bulk_anchor_deletion/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/4_bulk_anchor_deletion/down.sql
@@ -1,0 +1,6 @@
+-- Bulk versions of Anchor Deletion
+drop function hasura_functions.delete_activity_by_pk_reanchor_plan_start_bulk(_activity_ids int[], _plan_id int);
+drop function hasura_functions.delete_activity_by_pk_reanchor_to_anchor_bulk(_activity_ids int[], _plan_id int);
+drop function hasura_functions.delete_activity_by_pk_delete_subtree_bulk(_activity_ids int[], _plan_id int);
+call migrations.mark_migration_rolled_back('4');
+

--- a/deployment/hasura/migrations/AerieMerlin/4_bulk_anchor_deletion/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/4_bulk_anchor_deletion/up.sql
@@ -1,0 +1,55 @@
+-- Bulk versions of Anchor Deletion
+create function hasura_functions.delete_activity_by_pk_reanchor_plan_start_bulk(_activity_ids int[], _plan_id int)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+language plpgsql as $$
+  declare activity_id int;
+  begin
+    set constraints public.validate_anchors_update_trigger immediate;
+    foreach activity_id in array _activity_ids loop
+      -- An activity ID might've been deleted in a prior step, so validate that it exists first
+      if exists(select id from public.activity_directive where (id, plan_id) = (activity_id, _plan_id)) then
+        return query
+          select * from hasura_functions.delete_activity_by_pk_reanchor_plan_start(activity_id, _plan_id);
+      end if;
+    end loop;
+    set constraints public.validate_anchors_update_trigger deferred;
+  end
+$$;
+
+create function hasura_functions.delete_activity_by_pk_reanchor_to_anchor_bulk(_activity_ids int[], _plan_id int)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+language plpgsql as $$
+  declare activity_id int;
+  begin
+    set constraints public.validate_anchors_update_trigger immediate;
+    foreach activity_id in array _activity_ids loop
+      -- An activity ID might've been deleted in a prior step, so validate that it exists first
+      if exists(select id from public.activity_directive where (id, plan_id) = (activity_id, _plan_id)) then
+        return query
+          select * from hasura_functions.delete_activity_by_pk_reanchor_to_anchor(activity_id, _plan_id);
+      end if;
+    end loop;
+    set constraints public.validate_anchors_update_trigger deferred;
+  end
+$$;
+
+create function hasura_functions.delete_activity_by_pk_delete_subtree_bulk(_activity_ids int[], _plan_id int)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+language plpgsql as $$
+  declare activity_id int;
+  begin
+    set constraints public.validate_anchors_update_trigger immediate;
+    foreach activity_id in array _activity_ids loop
+      if exists(select id from public.activity_directive where (id, plan_id) = (activity_id, _plan_id)) then
+        return query
+          select * from hasura_functions.delete_activity_by_pk_delete_subtree(activity_id, _plan_id);
+      end if;
+    end loop;
+    set constraints public.validate_anchors_update_trigger deferred;
+  end
+$$;
+
+call migrations.mark_migration_applied('4');

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -6,3 +6,4 @@ call migrations.mark_migration_applied('0');
 call migrations.mark_migration_applied('1');
 call migrations.mark_migration_applied('2');
 call migrations.mark_migration_applied('3');
+call migrations.mark_migration_applied('4');

--- a/merlin-server/sql/merlin/hasura_functions.sql
+++ b/merlin-server/sql/merlin/hasura_functions.sql
@@ -320,6 +320,61 @@ begin
 end
 $$;
 
+-- Bulk versions of Anchor Deletion
+create function hasura_functions.delete_activity_by_pk_reanchor_plan_start_bulk(_activity_ids int[], _plan_id int)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+language plpgsql as $$
+  declare activity_id int;
+  begin
+    set constraints public.validate_anchors_update_trigger immediate;
+    foreach activity_id in array _activity_ids loop
+      -- An activity ID might've been deleted in a prior step, so validate that it exists first
+      if exists(select id from public.activity_directive where (id, plan_id) = (activity_id, _plan_id)) then
+        return query
+          select * from hasura_functions.delete_activity_by_pk_reanchor_plan_start(activity_id, _plan_id);
+      end if;
+    end loop;
+    set constraints public.validate_anchors_update_trigger deferred;
+  end
+$$;
+
+create function hasura_functions.delete_activity_by_pk_reanchor_to_anchor_bulk(_activity_ids int[], _plan_id int)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+language plpgsql as $$
+  declare activity_id int;
+  begin
+    set constraints public.validate_anchors_update_trigger immediate;
+    foreach activity_id in array _activity_ids loop
+      -- An activity ID might've been deleted in a prior step, so validate that it exists first
+      if exists(select id from public.activity_directive where (id, plan_id) = (activity_id, _plan_id)) then
+        return query
+          select * from hasura_functions.delete_activity_by_pk_reanchor_to_anchor(activity_id, _plan_id);
+      end if;
+    end loop;
+    set constraints public.validate_anchors_update_trigger deferred;
+  end
+$$;
+
+create function hasura_functions.delete_activity_by_pk_delete_subtree_bulk(_activity_ids int[], _plan_id int)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+language plpgsql as $$
+  declare activity_id int;
+  begin
+    set constraints public.validate_anchors_update_trigger immediate;
+    foreach activity_id in array _activity_ids loop
+      if exists(select id from public.activity_directive where (id, plan_id) = (activity_id, _plan_id)) then
+        return query
+          select * from hasura_functions.delete_activity_by_pk_delete_subtree(activity_id, _plan_id);
+      end if;
+    end loop;
+    set constraints public.validate_anchors_update_trigger deferred;
+  end
+$$;
+
+-- Activity Presets
 create function hasura_functions.apply_preset_to_activity(_preset_id int, _activity_id int, _plan_id int)
 returns activity_directive
 strict


### PR DESCRIPTION
* **Tickets addressed:** Closes #697
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Added Hasura functions that accept an array of activity_ids and a plan_id and deletes all of the activities one at a time while handling their anchors with the specified resolution. Created so that the UI only needs to send a maximum of 4 requests when a user bulk deletes activity directives: one for each anchor resolution type and the default delete.

Having the `validate_anchors_update_trigger` run `immediately` during the function has it run per-statement instead of per-transaction, which avoids a foreign key violation that occurs if an activity is both updated and deleted during a function (ie, the input is `{anchor, activity}` to `delete_activity_by_pk_reanchor_plan_start_bulk`. `activity` will be updated when `anchor` is processed and then deleted when it is processed.)

Note regarding what these functions return: If an activity is both updated and deleted, or updated multiple times, there will be a row returned for each change.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Manually tested the functions and had no issues with running them or with the Hasura metadata.