### PR TITLE
Upload simulation results after scheduling

### DIFF
--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MerlinDatabaseTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MerlinDatabaseTests.java
@@ -136,26 +136,26 @@ class MerlinDatabaseTests {
   int getSimulationId(final int planId) throws SQLException {
     try (final var statement = connection.createStatement()) {
       final var res = statement.executeQuery(
-              """
+          """
                   SELECT id
                   FROM simulation
                   WHERE simulation.plan_id = '%s';
               """.formatted(planId)
-          );
+      );
       res.next();
       return res.getInt("id");
     }
   }
 
-   void addTemplateIdToSimulation(final int simulationTemplateId, final int simulationId) throws SQLException {
+  void addTemplateIdToSimulation(final int simulationTemplateId, final int simulationId) throws SQLException {
     try (final var statement = connection.createStatement()) {
       statement.executeUpdate(
           """
-              UPDATE simulation
-              SET simulation_template_id = '%s',
-                  arguments = '{}'
-              WHERE id = '%s';
-          """.formatted(simulationTemplateId, simulationId));
+                  UPDATE simulation
+                  SET simulation_template_id = '%s',
+                      arguments = '{}'
+                  WHERE id = '%s';
+              """.formatted(simulationTemplateId, simulationId));
     }
   }
 
@@ -544,13 +544,13 @@ class MerlinDatabaseTests {
     @Test
     void shouldCreateDefaultDatasetOnPlanDatasetInsertWithNullDatasetId() throws SQLException {
       final var res = connection.createStatement()
-          .executeQuery(
-              """
-                  INSERT INTO plan_dataset (plan_id, offset_from_plan_start)
-                  VALUES (%s, '0')
-                  RETURNING dataset_id;"""
-                  .formatted(planId)
-          );
+                                .executeQuery(
+                                    """
+                                        INSERT INTO plan_dataset (plan_id, offset_from_plan_start)
+                                        VALUES (%s, '0')
+                                        RETURNING dataset_id;"""
+                                        .formatted(planId)
+                                );
       res.next();
       final var newDatasetId = res.getInt("dataset_id");
       assertFalse(res.wasNull());
@@ -558,12 +558,12 @@ class MerlinDatabaseTests {
 
 
       final var datasetRes = connection.createStatement()
-          .executeQuery(
-              """
-                  SELECT * FROM dataset
-                  WHERE id = %s;"""
-                  .formatted(newDatasetId)
-          );
+                                       .executeQuery(
+                                           """
+                                               SELECT * FROM dataset
+                                               WHERE id = %s;"""
+                                               .formatted(newDatasetId)
+                                       );
 
       datasetRes.next();
       assertEquals(newDatasetId, datasetRes.getInt("id"));
@@ -575,23 +575,25 @@ class MerlinDatabaseTests {
     void shouldCalculatePlanDatasetOffsetOnPlanDatasetInsertWithNonNullDatasetId() throws SQLException {
 
       final var planRes = connection.createStatement()
-          .executeQuery(
-              """
-                  SELECT * from plan
-                  WHERE id = %s;"""
-                  .formatted(planDatasetRecord.plan_id())
-          );
+                                    .executeQuery(
+                                        """
+                                            SELECT * from plan
+                                            WHERE id = %s;"""
+                                            .formatted(planDatasetRecord.plan_id())
+                                    );
       planRes.next();
       final var planStartTime = planRes.getTimestamp("start_time");
       planRes.close();
 
       final var planDatasetSelectRes = connection.createStatement()
-          .executeQuery(
-              """
-                  SELECT * FROM plan_dataset
-                  WHERE plan_id = %s and dataset_id = %s;"""
-                  .formatted(planDatasetRecord.plan_id(), planDatasetRecord.dataset_id())
-          );
+                                                 .executeQuery(
+                                                     """
+                                                         SELECT * FROM plan_dataset
+                                                         WHERE plan_id = %s and dataset_id = %s;"""
+                                                         .formatted(
+                                                             planDatasetRecord.plan_id(),
+                                                             planDatasetRecord.dataset_id())
+                                                 );
       planDatasetSelectRes.next();
       final var offsetFromPlanStart = Duration.parse(planDatasetSelectRes.getString("offset_from_plan_start"));
       planDatasetSelectRes.close();
@@ -599,29 +601,30 @@ class MerlinDatabaseTests {
       final var newPlanId = insertPlan(missionModelId, "2020-1-1 01:00:00");
 
       final var newPlanRes = connection.createStatement()
-          .executeQuery(
-              """
-                  SELECT * from plan
-                  WHERE id = %s;"""
-                  .formatted(newPlanId)
-          );
+                                       .executeQuery(
+                                           """
+                                               SELECT * from plan
+                                               WHERE id = %s;"""
+                                               .formatted(newPlanId)
+                                       );
       newPlanRes.next();
       final var newPlanStartTime = newPlanRes.getTimestamp("start_time");
       newPlanRes.close();
 
       final var planDatasetInsertRes = connection.createStatement()
-          .executeQuery(
-              """
-                  INSERT INTO plan_dataset (plan_id, dataset_id)
-                  VALUES (%s, %s)
-                  RETURNING *;"""
-                  .formatted(newPlanId, planDatasetRecord.dataset_id())
-          );
+                                                 .executeQuery(
+                                                     """
+                                                         INSERT INTO plan_dataset (plan_id, dataset_id)
+                                                         VALUES (%s, %s)
+                                                         RETURNING *;"""
+                                                         .formatted(newPlanId, planDatasetRecord.dataset_id())
+                                                 );
       planDatasetInsertRes.next();
       final var newOffsetFromPlanStart = Duration.parse(planDatasetInsertRes.getString("offset_from_plan_start"));
       planDatasetInsertRes.close();
 
-      final var calculatedOffset = offsetFromPlanStart.minus(Duration.ofMillis(newPlanStartTime.getTime() - planStartTime.getTime()));
+      final var calculatedOffset = offsetFromPlanStart.minus(Duration.ofMillis(newPlanStartTime.getTime()
+                                                                               - planStartTime.getTime()));
 
       assertEquals(calculatedOffset, newOffsetFromPlanStart);
     }
@@ -670,7 +673,8 @@ class MerlinDatabaseTests {
                 FROM simulation_dataset
                 WHERE simulation_id = %s AND dataset_id = %s;"""
                 .formatted(simulationDatasetRecord.simulation_id(), simulationDatasetRecord.dataset_id())
-        )) {
+        )
+        ) {
           res.next();
           assertEquals(1, res.getInt("plan_revision"));
           assertEquals(0, res.getInt("model_revision"));
@@ -695,7 +699,8 @@ class MerlinDatabaseTests {
                 FROM dataset
                 WHERE id = %s;"""
                 .formatted(simulationDatasetRecord.dataset_id())
-        )) {
+        )
+        ) {
           res.next();
           assertEquals(0, res.getInt("count"));
         }
@@ -711,7 +716,8 @@ class MerlinDatabaseTests {
                 FROM simulation_dataset
                 WHERE simulation_id = %s;"""
                 .formatted(simulationDatasetRecord.simulation_id())
-        )) {
+        )
+        ) {
           res.next();
           assertFalse(res.getBoolean("canceled"));
         }
@@ -731,7 +737,8 @@ class MerlinDatabaseTests {
                 FROM simulation_dataset
                 WHERE simulation_id = %s;"""
                 .formatted(simulationDatasetRecord.simulation_id())
-        )) {
+        )
+        ) {
           res.next();
           assertTrue(res.getBoolean("canceled"));
         }
@@ -747,7 +754,8 @@ class MerlinDatabaseTests {
                 FROM simulation_dataset
                 WHERE simulation_id = %s;"""
                 .formatted(simulationDatasetRecord.simulation_id())
-        )) {
+        )
+        ) {
           res.next();
           assertFalse(res.getBoolean("canceled"));
         }
@@ -767,7 +775,8 @@ class MerlinDatabaseTests {
                 FROM simulation_dataset
                 WHERE simulation_id = %s;"""
                 .formatted(simulationDatasetRecord.simulation_id())
-        )) {
+        )
+        ) {
           res.next();
           assertTrue(res.getBoolean("canceled"));
         }
@@ -783,7 +792,8 @@ class MerlinDatabaseTests {
                 FROM simulation_dataset
                 WHERE simulation_id = %s;"""
                 .formatted(simulationDatasetRecord.simulation_id())
-        )) {
+        )
+        ) {
           res.next();
           assertFalse(res.getBoolean("canceled"));
         }
@@ -803,7 +813,8 @@ class MerlinDatabaseTests {
                 FROM simulation_dataset
                 WHERE simulation_id = %s;"""
                 .formatted(simulationDatasetRecord.simulation_id())
-        )) {
+        )
+        ) {
           res.next();
           assertTrue(res.getBoolean("canceled"));
         }
@@ -819,7 +830,8 @@ class MerlinDatabaseTests {
                 FROM simulation_dataset
                 WHERE simulation_id = %s;"""
                 .formatted(simulationDatasetRecord.simulation_id())
-        )) {
+        )
+        ) {
           res.next();
           assertFalse(res.getBoolean("canceled"));
         }
@@ -839,7 +851,8 @@ class MerlinDatabaseTests {
                 FROM simulation_dataset
                 WHERE simulation_id = %s;"""
                 .formatted(simulationDatasetRecord.simulation_id())
-        )) {
+        )
+        ) {
           res.next();
           assertTrue(res.getBoolean("canceled"));
         }
@@ -874,7 +887,9 @@ class MerlinDatabaseTests {
           );
       fail();
     } catch (SQLException e) {
-      if (!e.getMessage().contains("foreign key violation: there is no topic with topic_index 1234 in dataset %d".formatted(datasetId))) {
+      if (!e
+          .getMessage()
+          .contains("foreign key violation: there is no topic with topic_index 1234 in dataset %d".formatted(datasetId))) {
         throw e;
       }
     }
@@ -898,7 +913,9 @@ class MerlinDatabaseTests {
           );
       fail();
     } catch (SQLException e) {
-      if (!e.getMessage().contains("foreign key violation: there is no profile with id %d in dataset %d".formatted(profileId + 1, datasetId))) {
+      if (!e.getMessage().contains("foreign key violation: there is no profile with id %d in dataset %d".formatted(
+          profileId + 1,
+          datasetId))) {
         throw e;
       }
     }
@@ -915,15 +932,20 @@ class MerlinDatabaseTests {
 
     try (final var statement = connection.createStatement()) {
       statement.executeUpdate(
-              """
+          """
               UPDATE event
               set topic_index=%d
               where dataset_id=%d and topic_index=%d;
               """.formatted(topicIndex + 1, datasetId, topicIndex)
-          );
+      );
       fail();
     } catch (SQLException e) {
-      if (!e.getMessage().contains("foreign key violation: there is no topic with topic_index %d in dataset %d".formatted(topicIndex + 1, datasetId))) {
+      if (!e
+          .getMessage()
+          .contains("foreign key violation: there is no topic with topic_index %d in dataset %d".formatted(
+              topicIndex
+              + 1,
+              datasetId))) {
         throw e;
       }
     }
@@ -939,9 +961,9 @@ class MerlinDatabaseTests {
       statement
           .executeUpdate(
               """
-              DELETE FROM profile
-              WHERE dataset_id=%d and id=%d
-              """.formatted(datasetId, profileId)
+                  DELETE FROM profile
+                  WHERE dataset_id=%d and id=%d
+                  """.formatted(datasetId, profileId)
           );
     }
 
@@ -960,16 +982,17 @@ class MerlinDatabaseTests {
       statement
           .executeUpdate(
               """
-              DELETE FROM topic
-              WHERE dataset_id=%d and topic_index=%d
-              """.formatted(datasetId, topicIndex)
+                  DELETE FROM topic
+                  WHERE dataset_id=%d and topic_index=%d
+                  """.formatted(datasetId, topicIndex)
           );
 
       try (final var res = statement.executeQuery(
           """
-          SELECT count(1) FROM event WHERE dataset_id=%d and topic_index=%d
-          """.formatted(datasetId, topicIndex)
-      )) {
+              SELECT count(1) FROM event WHERE dataset_id=%d and topic_index=%d
+              """.formatted(datasetId, topicIndex)
+      )
+      ) {
         res.next();
         assertEquals(0, res.getInt("count"));
       }
@@ -985,17 +1008,17 @@ class MerlinDatabaseTests {
     final int newProfileId;
     try (final var statement = connection.createStatement();
          final var res = statement.executeQuery(
-              """
-              UPDATE profile
-              SET id=default
-              WHERE dataset_id=%d and id=%d
-              RETURNING id;
-              """.formatted(datasetId, profileId)
-          )
-      ) {
-        res.next();
-        newProfileId = res.getInt("id");
-      }
+             """
+                 UPDATE profile
+                 SET id=default
+                 WHERE dataset_id=%d and id=%d
+                 RETURNING id;
+                 """.formatted(datasetId, profileId)
+         )
+    ) {
+      res.next();
+      newProfileId = res.getInt("id");
+    }
 
     assertNotEquals(profileId, newProfileId);
     assertEquals(1, getProfileSegmentCount(datasetId, newProfileId));
@@ -1013,17 +1036,18 @@ class MerlinDatabaseTests {
       statement
           .executeUpdate(
               """
-              UPDATE topic
-              SET topic_index=%d
-              WHERE dataset_id=%d and topic_index=%d
-              """.formatted(topicIndex + 1, datasetId, topicIndex)
+                  UPDATE topic
+                  SET topic_index=%d
+                  WHERE dataset_id=%d and topic_index=%d
+                  """.formatted(topicIndex + 1, datasetId, topicIndex)
           );
 
       try (final var res = statement.executeQuery(
           """
-          SELECT count(1) FROM event WHERE dataset_id=%d and topic_index=%d
-          """.formatted(datasetId, topicIndex + 1)
-      )) {
+              SELECT count(1) FROM event WHERE dataset_id=%d and topic_index=%d
+              """.formatted(datasetId, topicIndex + 1)
+      )
+      ) {
         res.next();
         assertEquals(1, res.getInt("count"));
       }
@@ -1041,7 +1065,7 @@ class MerlinDatabaseTests {
     final var winnerType = "{\"type\": \"discrete\", \"schema\": {\"type\": \"string\"}}";
 
     final var contestantCountId = insertProfile(datasetId, contestantName, contestantType, "12 hours");
-    final var winnerId = insertProfile(datasetId, winnerName, winnerType,  "12 hours");
+    final var winnerId = insertProfile(datasetId, winnerName, winnerType, "12 hours");
 
     // Contestant Count Segments:
     insertProfileSegment(datasetId, contestantCountId, "0 seconds", "20", false);
@@ -1060,17 +1084,52 @@ class MerlinDatabaseTests {
     assertEquals(2, segmentsAtOneHour.size());
     assertEquals(2, segmentsAtTwelveHours.size());
 
-    final var atStartSegment0 = new ProfileSegmentAtATimeRecord(datasetId, contestantCountId, contestantName, contestantType, "PT0S", "20", false);
+    final var atStartSegment0 = new ProfileSegmentAtATimeRecord(
+        datasetId,
+        contestantCountId,
+        contestantName,
+        contestantType,
+        "PT0S",
+        "20",
+        false);
     assertEquals(atStartSegment0, segmentsAtStart.get(0));
 
-    final var atOneSegment0 = new ProfileSegmentAtATimeRecord(datasetId, contestantCountId, contestantName, contestantType, "PT2H", "12", false);
-    final var atOneSegment1 = new ProfileSegmentAtATimeRecord(datasetId, winnerId, winnerName, winnerType, "PT6H", "\"Bob or Alice\"", false);
+    final var atOneSegment0 = new ProfileSegmentAtATimeRecord(
+        datasetId,
+        contestantCountId,
+        contestantName,
+        contestantType,
+        "PT2H",
+        "12",
+        false);
+    final var atOneSegment1 = new ProfileSegmentAtATimeRecord(
+        datasetId,
+        winnerId,
+        winnerName,
+        winnerType,
+        "PT6H",
+        "\"Bob or Alice\"",
+        false);
 
     assertEquals(atOneSegment0, segmentsAtOneHour.get(0));
     assertEquals(atOneSegment1, segmentsAtOneHour.get(1));
 
-    final var atTwelveSegment0 = new ProfileSegmentAtATimeRecord(datasetId, contestantCountId, contestantName, contestantType, "PT12H", "1", false);
-    final var atTwelveSegment1 = new ProfileSegmentAtATimeRecord(datasetId, winnerId, winnerName, winnerType, "PT10H", "\"Alice\"", false);
+    final var atTwelveSegment0 = new ProfileSegmentAtATimeRecord(
+        datasetId,
+        contestantCountId,
+        contestantName,
+        contestantType,
+        "PT12H",
+        "1",
+        false);
+    final var atTwelveSegment1 = new ProfileSegmentAtATimeRecord(
+        datasetId,
+        winnerId,
+        winnerName,
+        winnerType,
+        "PT10H",
+        "\"Alice\"",
+        false);
 
     assertEquals(atTwelveSegment0, segmentsAtTwelveHours.get(0));
     assertEquals(atTwelveSegment1, segmentsAtTwelveHours.get(1));
@@ -1080,16 +1139,18 @@ class MerlinDatabaseTests {
     return insertProfile(datasetId, "fred", "{}", "0 seconds");
   }
 
-  private int insertProfile(final int datasetId, final String name, final String type, final String duration) throws SQLException {
-    try(final var statement = connection.createStatement()) {
+  private int insertProfile(final int datasetId, final String name, final String type, final String duration)
+  throws SQLException
+  {
+    try (final var statement = connection.createStatement()) {
       final var results = statement.executeQuery(
-        """
-        INSERT INTO profile(dataset_id, name, type, duration)
-        VALUES (%d, '%s', '%s', '%s')
-        RETURNING id;
-        """.formatted(datasetId, name, type, duration));
-        assertTrue(results.first());
-        return results.getInt("id");
+          """
+              INSERT INTO profile(dataset_id, name, type, duration)
+              VALUES (%d, '%s', '%s', '%s')
+              RETURNING id;
+              """.formatted(datasetId, name, type, duration));
+      assertTrue(results.first());
+      return results.getInt("id");
     }
   }
 
@@ -1097,13 +1158,19 @@ class MerlinDatabaseTests {
     insertProfileSegment(datasetId, profileId, "0 seconds", "{}", false);
   }
 
-  private void insertProfileSegment(final int datasetId, final int profileId, final String startOffset, final String dynamics, final boolean isGap) throws SQLException {
-    try(final var statement = connection.createStatement()) {
+  private void insertProfileSegment(
+      final int datasetId,
+      final int profileId,
+      final String startOffset,
+      final String dynamics,
+      final boolean isGap) throws SQLException
+  {
+    try (final var statement = connection.createStatement()) {
       statement.execute(
-        """
-        INSERT INTO profile_segment(dataset_id, profile_id, start_offset, dynamics, is_gap)
-        VALUES (%d, %d, '%s'::interval, '%s'::jsonb, %b);
-        """.formatted(datasetId, profileId, startOffset, dynamics, isGap));
+          """
+              INSERT INTO profile_segment(dataset_id, profile_id, start_offset, dynamics, is_gap)
+              VALUES (%d, %d, '%s'::interval, '%s'::jsonb, %b);
+              """.formatted(datasetId, profileId, startOffset, dynamics, isGap));
     }
   }
 
@@ -1141,14 +1208,17 @@ class MerlinDatabaseTests {
     }
   }
 
-  private ArrayList<ProfileSegmentAtATimeRecord> getResourcesAtStartOffset(final int datasetId, final String startOffset) throws SQLException {
-    try(final var statement = connection.createStatement()) {
+  private ArrayList<ProfileSegmentAtATimeRecord> getResourcesAtStartOffset(
+      final int datasetId,
+      final String startOffset) throws SQLException
+  {
+    try (final var statement = connection.createStatement()) {
       final var res = statement.executeQuery("""
-        select * from hasura_functions.get_resources_at_start_offset(%d, '%s');
-        """.formatted(datasetId, startOffset));
+                                                 select * from hasura_functions.get_resources_at_start_offset(%d, '%s');
+                                                 """.formatted(datasetId, startOffset));
 
       final var segments = new ArrayList<ProfileSegmentAtATimeRecord>();
-      while (res.next()){
+      while (res.next()) {
         segments.add(new ProfileSegmentAtATimeRecord(
             res.getInt("dataset_id"),
             res.getInt("id"),
@@ -1172,17 +1242,10 @@ class MerlinDatabaseTests {
             DEFAULT VALUES
             RETURNING id;
             """)) {
-        res.next();
-        datasetId = res.getInt("id");
-      }
-
-      statement
-        .executeUpdate(
-            """
-            SELECT FROM allocate_dataset_partitions(%d)
-            """.formatted(datasetId)
-        );
-      return datasetId;
+      res.next();
+      datasetId = res.getInt("id");
     }
+    return datasetId;
   }
+}
 }

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -248,6 +248,7 @@ type SchedulingResponse {
   status: SchedulingStatus!
   reason: SchedulingFailureReason
   analysisId: Int!
+  datasetId: Int
 }
 
 type DslTypescriptResponse {

--- a/deployment/hasura/migrations/AerieMerlin/10_add_create_partition_trigger/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/10_add_create_partition_trigger/down.sql
@@ -1,0 +1,3 @@
+drop trigger create_partition_on_simulation on dataset;
+drop function call_create_partition();
+call migrations.mark_migration_rolled_back('10');

--- a/deployment/hasura/migrations/AerieMerlin/10_add_create_partition_trigger/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/10_add_create_partition_trigger/up.sql
@@ -1,0 +1,14 @@
+create function call_create_partition()
+  returns trigger
+  security invoker
+  language plpgsql as $$ begin
+    perform allocate_dataset_partitions(new.id);
+return new;
+end $$;
+
+create trigger create_partition_on_simulation
+  after insert on dataset
+  for each row
+  execute function call_create_partition();
+
+call migrations.mark_migration_applied('10')

--- a/deployment/hasura/migrations/AerieScheduler/3_reference_dataset_id_from_scheduling_request/down.sql
+++ b/deployment/hasura/migrations/AerieScheduler/3_reference_dataset_id_from_scheduling_request/down.sql
@@ -1,0 +1,4 @@
+alter table scheduling_request
+  drop column dataset_id;
+
+call migrations.mark_migration_rolled_back('3');

--- a/deployment/hasura/migrations/AerieScheduler/3_reference_dataset_id_from_scheduling_request/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/3_reference_dataset_id_from_scheduling_request/up.sql
@@ -1,0 +1,4 @@
+alter table scheduling_request
+  add column dataset_id integer default null;
+
+call migrations.mark_migration_applied('3');

--- a/e2e-tests/src/tests/scheduler.test.ts
+++ b/e2e-tests/src/tests/scheduler.test.ts
@@ -2,6 +2,11 @@ import { expect, test } from '@playwright/test';
 import req from '../utilities/requests.js';
 import time from '../utilities/time.js';
 
+const eqSet = (xs, ys) =>
+    xs.size === ys.size &&
+    [...xs].every((x) => ys.has(x));
+
+
 test.describe('Scheduling', () => {
   const rd = Math.random() * 100;
   const plan_start_timestamp = "2021-001T00:00:00.000";
@@ -13,6 +18,7 @@ test.describe('Scheduling', () => {
   let second_goal_id: number;
   let plan_revision: number;
   let specification_id: number;
+  let dataset_id:number;
 
   test('Upload jar and create mission model', async ({ request }) => {
     //upload bananation jar
@@ -184,11 +190,12 @@ test.describe('Scheduling', () => {
     let it = 0;
     let reason_local: string;
     while (it++ < max_it && (status == 'pending' || status == 'incomplete')) {
-      const { reason, status, analysisId } = await req.schedule(request, specification_id);
+      const { reason, status, analysisId, datasetId } = await req.schedule(request, specification_id);
       status_local = status;
       reason_local = reason;
       expect(status).not.toBeNull();
       expect(status).toBeDefined();
+      dataset_id = datasetId
       await delay(1000);
     }
     if (status_local == "failed") {
@@ -196,6 +203,87 @@ test.describe('Scheduling', () => {
     }
     expect(status_local).toEqual("complete")
     expect(analysisId_local).toEqual(analysisId)
+    expect(dataset_id).not.toBeNull();
+  });
+
+  test('Verify posting of simulation results', async ({ request }) => {
+    let plan = await req.getPlan(request, plan_id)
+    let directiveIds = new Set<number>()
+    let startOffsetsActivityDirectives = new Set<string>()
+    for(const activity of plan.activity_directives){
+      directiveIds.add(activity['id'])
+    }
+    const activities = await req.getSimulationDatasetByDatasetId(request,dataset_id)
+    expect(activities.simulated_activities.length).toEqual(plan.activity_directives.length)
+    let refDirectiveIds = new Set<number>()
+    for(let simulated_activity of activities.simulated_activities){
+      refDirectiveIds.add(simulated_activity.activity_directive.id)
+      startOffsetsActivityDirectives.add(simulated_activity.start_offset)
+    }
+    //all directive have their simulated activity
+    expect(eqSet(refDirectiveIds,directiveIds))
+    const dataset = await req.getProfiles(request, dataset_id)
+    //expect one profile per resource in the banananation model
+    expect(dataset.length).toEqual(7)
+    for(let resource of dataset){
+      if(resource.name =="/fruit" || resource.name == "/peel"){
+        let startOffsetOfResource = new Set<string>()
+        for(let segment of resource.profile_segments){
+          startOffsetOfResource.add(segment.start_offset)
+        }
+        //these two resources are affected by the peel, grow and bite banana
+        expect(eqSet(startOffsetOfResource, startOffsetsActivityDirectives)).toEqual(true)
+      }
+    }
+    let topics = await req.getTopicsEvents(request, dataset_id)
+    let prefixInput = "ActivityType.Input."
+    let prefixOutput = "ActivityType.Output."
+    let peelInputIsThere = false
+    let biteInputIsThere = false
+    let growInputIsThere = false
+    let peelOutputIsThere = false
+    let biteOutputIsThere = false
+    let growOutputIsThere = false
+    //topic added in the mission model
+    let producerIsThere = false
+    for(let topic of topics){
+      switch (topic.name){
+        case prefixInput+"BiteBanana":
+          biteInputIsThere = true
+          expect(topic.events.length).toEqual(1)
+          break
+        case prefixOutput+"BiteBanana":
+          biteOutputIsThere = true
+          expect(topic.events.length).toEqual(1)
+          break
+        case prefixInput+"GrowBanana":
+          growInputIsThere = true
+          expect(topic.events.length).toEqual(1)
+          break
+        case prefixOutput+"GrowBanana":
+          growOutputIsThere = true
+          expect(topic.events.length).toEqual(1)
+          break
+        case prefixInput+"PeelBanana":
+          peelInputIsThere = true
+          expect(topic.events.length).toEqual(12)
+          break
+        case prefixOutput+"PeelBanana":
+          peelOutputIsThere = true
+          expect(topic.events.length).toEqual(12)
+          break
+        case "/producer":
+          producerIsThere = true
+          expect(topic.events.length).toEqual(0)
+      }
+    }
+    expect(peelInputIsThere)
+    expect(growInputIsThere)
+    expect(biteInputIsThere)
+    expect(peelOutputIsThere)
+    expect(growOutputIsThere)
+    expect(biteOutputIsThere)
+    expect(producerIsThere)
   });
 
   test('Get Plan', async ({ request }) => {

--- a/e2e-tests/src/types/scheduling-goal.d.ts
+++ b/e2e-tests/src/types/scheduling-goal.d.ts
@@ -40,6 +40,7 @@ type SchedulingResponse = {
   reason: any;
   status: SchedulingResponseStatus;
   analysisId: number;
+  datasetId: number | null;
 };
 
 type SchedulingSpec = {

--- a/e2e-tests/src/utilities/gql.ts
+++ b/e2e-tests/src/utilities/gql.ts
@@ -18,12 +18,43 @@ const gql = {
     }
   `,
 
+
+  GET_TOPIC_EVENTS:`#graphql
+  query GetTopicsEvents($datasetId: Int!) {
+    topic(where: {dataset_id: {_eq: $datasetId}}) {
+      name
+      value_schema
+      events {
+        causal_time
+        real_time
+        topic_index
+        transaction_index
+        value
+      }
+    }
+  }
+  `,
+
+  GET_PROFILES:`#graphql
+    query GetProfiles($datasetId: Int!){
+      profile(where: {dataset_id: {_eq: $datasetId}}) {
+        name
+        profile_segments {
+          dynamics
+          is_gap
+          start_offset
+        }
+    }
+  }
+  `,
+
   SCHEDULE: `#graphql
     query Schedule($specificationId: Int!) {
       schedule(specificationId: $specificationId){
         reason
         status
         analysisId
+        datasetId
       }
     }
   `,
@@ -87,8 +118,24 @@ const gql = {
   `,
 
   GET_SIMULATION_DATASET: `#graphql
+  query GetSimulationDataset($id: Int!) {
+    simulationDataset: simulation_dataset_by_pk(id: $id) {
+      canceled
+      simulation_start_time
+      simulation_end_time
+      simulated_activities {
+        activity_directive { id }
+        duration
+        start_time
+        start_offset
+      }
+    }
+  }
+  `,
+
+  GET_SIMULATION_DATASET_BY_DATASET_ID: `#graphql
     query GetSimulationDataset($id: Int!) {
-      simulationDataset: simulation_dataset_by_pk(id: $id) {
+      simulation_dataset(where: {dataset_id: {_eq: $id}}) {
         canceled
         simulation_start_time
         simulation_end_time

--- a/e2e-tests/src/utilities/requests.ts
+++ b/e2e-tests/src/utilities/requests.ts
@@ -140,6 +140,12 @@ const req = {
     return simulationDataset as SimulationDataset;
   },
 
+  async getSimulationDatasetByDatasetId(request: APIRequestContext, simulationDatasetId: number) {
+    const data = await req.hasura(request, gql.GET_SIMULATION_DATASET_BY_DATASET_ID, {id: simulationDatasetId});
+    const {simulation_dataset} = data;
+    return simulation_dataset[0] as SimulationDataset;
+  },
+
   async insertAndAssociateSimulationTemplate(request: APIRequestContext, template: InsertSimulationTemplateInput,simulationId: number){
     const data = await req.hasura(request, gql.INSERT_SIMULATION_TEMPLATE, {simulationTemplateInsertInput: template} );
     const {insert_simulation_template_one} = data;
@@ -266,6 +272,18 @@ const req = {
     const { delete_plan_dataset_by_pk } = data;
     const { dataset_id } = delete_plan_dataset_by_pk;
     return dataset_id;
+  },
+
+  async getProfiles(request: APIRequestContext, datasetId:number){
+    const data = await req.hasura(request, gql.GET_PROFILES, {datasetId:datasetId});
+    const { profile } = data;
+    return profile
+  },
+
+  async getTopicsEvents(request: APIRequestContext, datasetId:number){
+    const data = await req.hasura(request, gql.GET_TOPIC_EVENTS, {datasetId:datasetId});
+    const { topic } = data;
+    return topic
   }
 };
 /**

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -12,3 +12,4 @@ call migrations.mark_migration_applied('6');
 call migrations.mark_migration_applied('7');
 call migrations.mark_migration_applied('8');
 call migrations.mark_migration_applied('9');
+call migrations.mark_migration_applied('10');

--- a/merlin-server/sql/merlin/tables/dataset.sql
+++ b/merlin-server/sql/merlin/tables/dataset.sql
@@ -93,4 +93,17 @@ begin
 end$$;
 
 comment on function allocate_dataset_partitions is e''
-  'Creates partition tables for the components of a dataset and attaches them to their partitioned tables.'
+  'Creates partition tables for the components of a dataset and attaches them to their partitioned tables.';
+
+create function call_create_partition()
+  returns trigger
+  security invoker
+  language plpgsql as $$ begin
+    perform allocate_dataset_partitions(new.id);
+return new;
+end $$;
+
+create trigger create_partition_on_simulation
+  after insert on dataset
+  for each row
+  execute function call_create_partition();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -356,10 +356,8 @@ public final class PostgresPlanRepository implements PlanRepository {
       final Timestamp planStart,
       final Timestamp datasetStart
   ) throws SQLException {
-    try (final var createPlanDatasetAction = new CreatePlanDatasetAction(connection);
-         final var createDatasetPartitionsAction = new CreateDatasetPartitionsAction(connection)) {
+    try (final var createPlanDatasetAction = new CreatePlanDatasetAction(connection)) {
       final var pdr = createPlanDatasetAction.apply(planId.id(), planStart, datasetStart);
-      createDatasetPartitionsAction.apply(pdr.datasetId());
       return pdr;
     }
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -214,9 +214,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
         claimSimulationAction.apply(datasetId);
     }
 
-    try (final var transactionContext = new TransactionContext(connection);
-         final var createDatasetPartitionsAction = new CreateDatasetPartitionsAction(connection)) {
-      createDatasetPartitionsAction.apply(datasetId);
+    try (final var transactionContext = new TransactionContext(connection)) {
       transactionContext.commit();
     } catch (final SQLException ex) {
       throw new DatabaseException(String.format("Failed to create partitions for simulation dataset id %s", datasetId), ex);

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -21,6 +21,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
 
@@ -51,6 +52,10 @@ public class SimulationFacade implements AutoCloseable{
     return lastSimConstraintResults;
   }
 
+  public SimulationResults getLatestDriverSimulationResults(){
+    return lastSimDriverResults;
+  }
+
   public SimulationFacade(final PlanningHorizon planningHorizon, final MissionModel<?> missionModel) {
     this.missionModel = missionModel;
     this.planningHorizon = planningHorizon;
@@ -68,6 +73,10 @@ public class SimulationFacade implements AutoCloseable{
   public void setActivityTypes(final Collection<ActivityType> activityTypes){
     this.activityTypes = new HashMap<>();
     activityTypes.forEach(at -> this.activityTypes.put(at.getName(), at));
+  }
+
+  public Map<SchedulingActivityDirectiveId, ActivityDirectiveId> getActivityIdCorrespondence(){
+    return planActDirectiveIdToSimulationActivityDirectiveId;
   }
 
   /**

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -5,3 +5,4 @@ This file denotes which migrations occur "before" this version of the schema.
 call migrations.mark_migration_applied('0');
 call migrations.mark_migration_applied('1');
 call migrations.mark_migration_applied('2');
+call migrations.mark_migration_applied('3');

--- a/scheduler-server/sql/scheduler/tables/scheduling_request.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_request.sql
@@ -7,6 +7,7 @@ create table scheduling_request (
   status status_t not null default 'pending',
   reason jsonb null,
   canceled boolean not null default false,
+  dataset_id integer default null,
 
   specification_revision integer not null,
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/ResultsProtocol.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/ResultsProtocol.java
@@ -1,6 +1,8 @@
 package gov.nasa.jpl.aerie.scheduler.server;
 
+import java.util.Optional;
 import java.util.function.Consumer;
+import gov.nasa.jpl.aerie.scheduler.server.models.DatasetId;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleFailure;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleResults;
 
@@ -38,7 +40,7 @@ public final class ResultsProtocol {
      *
      * @param results the results of the scheduling run
      */
-    record Success(ScheduleResults results, long analysisId) implements State {}
+    record Success(ScheduleResults results, long analysisId, Optional<Long> datasetId) implements State {}
 
     /**
      * scheduling failed; likely need to change inputs before re-running
@@ -91,7 +93,7 @@ public final class ResultsProtocol {
      *
      * @param results the summary results of the scheduling run, including satisfaction metrics etc
      */
-    void succeedWith(ScheduleResults results);
+    void succeedWith(ScheduleResults results, Optional<DatasetId> datasetId);
 
     /**
      * mark the scheduling run as having failed with the given reason

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/EventGraphFlattener.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/EventGraphFlattener.java
@@ -1,0 +1,138 @@
+package gov.nasa.jpl.aerie.scheduler.server.http;
+
+import gov.nasa.jpl.aerie.merlin.driver.timeline.EventGraph;
+import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public final class EventGraphFlattener {
+  private EventGraphFlattener() {}
+
+  public static <T> List<Pair<String, T>> flatten(final EventGraph<T> graph) {
+    final var accumulator = new ArrayList<Pair<String, T>>();
+
+    graph.evaluate(new TagLogger.Trait<>(), TagLogger.Atom::new)
+         .accept(Tag.origin(), (tag, event) -> accumulator.add(Pair.of(tag.serialize(), event)));
+
+    return accumulator;
+  }
+
+  private enum BranchType {
+    Sequentially,
+    Concurrently;
+
+    private BranchType opposite() {
+      return switch (this) {
+        case Sequentially -> Concurrently;
+        case Concurrently -> Sequentially;
+      };
+    }
+  }
+
+  private record Tag(Optional<Tag> prefix, BranchType branchType, int index) {
+    public static Tag origin() {
+      return new Tag(Optional.empty(), BranchType.Sequentially, 1);
+    }
+
+    public Tag bump() {
+      return new Tag(this.prefix, this.branchType, this.index + 1);
+    }
+
+    public Tag descend() {
+      return new Tag(Optional.of(this), this.branchType.opposite(), 1);
+    }
+
+    public String serialize() {
+      final var builder = new StringBuilder();
+      this.serialize(builder);
+      return builder.toString();
+    }
+
+    public void serialize(final StringBuilder builder) {
+      this.prefix.ifPresent($ -> $.serialize(builder));
+      builder.append('.');
+      builder.append(this.index);
+    }
+  }
+
+  private interface Log<T> {
+    void put(Tag tag, T event);
+  }
+
+  private sealed interface TagLogger<T> {
+    Tag accept(Tag tag, Log<T> log);
+
+    record Atom<T>(T event) implements TagLogger<T> {
+      @Override
+      public Tag accept(final Tag tag, final Log<T> log) {
+        log.put(tag, this.event);
+        return tag.bump();
+      }
+    }
+
+    record Empty<T>() implements TagLogger<T> {
+      @Override
+      public Tag accept(final Tag tag, final Log<T> log) {
+        return tag;
+      }
+    }
+
+    record Sequentially<T>(TagLogger<T> prefix, TagLogger<T> suffix) implements TagLogger<T> {
+      @Override
+      public Tag accept(final Tag tag, final Log<T> log) {
+        return switch (tag.branchType()) {
+          case Sequentially -> {
+            yield this.suffix.accept(this.prefix.accept(tag, log), log);
+          }
+
+          case Concurrently -> {
+            this.suffix.accept(this.prefix.accept(tag.descend(), log), log);
+            yield tag.bump();
+          }
+        };
+      }
+    }
+
+    record Concurrently<T>(TagLogger<T> left, TagLogger<T> right) implements TagLogger<T> {
+      @Override
+      public Tag accept(final Tag tag, final Log<T> log) {
+        return switch (tag.branchType()) {
+          case Sequentially -> {
+            this.right.accept(this.left.accept(tag.descend(), log), log);
+            yield tag.bump();
+          }
+
+          case Concurrently -> {
+            yield this.right.accept(this.left.accept(tag, log), log);
+          }
+        };
+      }
+    }
+
+    record Trait<T>() implements EffectTrait<TagLogger<T>> {
+      @Override
+      public TagLogger<T> empty() {
+        return new Empty<>();
+      }
+
+      @Override
+      public TagLogger<T> sequentially(final TagLogger<T> prefix, final TagLogger<T> suffix) {
+        if (prefix instanceof Empty<T>) return suffix;
+        if (suffix instanceof Empty<T>) return prefix;
+
+        return new Sequentially<>(prefix, suffix);
+      }
+
+      @Override
+      public TagLogger<T> concurrently(final TagLogger<T> left, final TagLogger<T> right) {
+        if (left instanceof Empty<T>) return right;
+        if (right instanceof Empty<T>) return left;
+
+        return new Concurrently<>(left, right);
+      }
+    }
+  }
+}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/ResponseSerializers.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/ResponseSerializers.java
@@ -66,12 +66,15 @@ public class ResponseSerializers {
           .add("analysisId", r.analysisId())
           .build();
     } else if (response instanceof ScheduleAction.Response.Complete r) {
-      return Json
+      final var responseJson = Json
           .createObjectBuilder()
           .add("status", "complete")
           .add("results", serializeScheduleResults(r.results()))
-          .add("analysisId", r.analysisId())
-          .build();
+          .add("analysisId", r.analysisId());
+      if(r.datasetId().isPresent()){
+        responseJson.add("datasetId", r.datasetId().get());
+      }
+      return responseJson.build();
     } else {
       throw new UnexpectedSubtypeError(ScheduleAction.Response.class, response);
     }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/ActivityAttributesRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/ActivityAttributesRecord.java
@@ -1,0 +1,12 @@
+package gov.nasa.jpl.aerie.scheduler.server.models;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+
+import java.util.Map;
+import java.util.Optional;
+
+public record ActivityAttributesRecord(
+    Optional<Long> directiveId,
+    Map<String, SerializedValue> arguments,
+    Optional<SerializedValue> computedAttributes
+) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/DatasetId.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/DatasetId.java
@@ -1,0 +1,3 @@
+package gov.nasa.jpl.aerie.scheduler.server.models;
+
+public record DatasetId(long id) { }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/ProfileSet.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/ProfileSet.java
@@ -1,0 +1,75 @@
+package gov.nasa.jpl.aerie.scheduler.server.models;
+
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
+import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
+
+public record ProfileSet(
+    Map<String, Pair<ValueSchema, List<ProfileSegment<Optional<RealDynamics>>>>> realProfiles,
+    Map<String, Pair<ValueSchema, List<ProfileSegment<Optional<SerializedValue>>>>> discreteProfiles
+) {
+  public static ProfileSet ofNullable(
+      final Map<String, Pair<ValueSchema, List<ProfileSegment<Optional<RealDynamics>>>>> realProfiles,
+      final Map<String, Pair<ValueSchema, List<ProfileSegment<Optional<SerializedValue>>>>> discreteProfiles
+  ) {
+    return new ProfileSet(
+        realProfiles,
+        discreteProfiles
+    );
+  }
+  public static ProfileSet of(
+      final Map<String, Pair<ValueSchema, List<ProfileSegment<RealDynamics>>>> realProfiles,
+      final Map<String, Pair<ValueSchema, List<ProfileSegment<SerializedValue>>>> discreteProfiles
+  ) {
+    return new ProfileSet(
+        wrapInOptional(realProfiles),
+        wrapInOptional(discreteProfiles)
+    );
+  }
+
+  public static <T> Map<String, Pair<ValueSchema, List<ProfileSegment<Optional<T>>>>> wrapInOptional(
+      final Map<String, Pair<ValueSchema, List<ProfileSegment<T>>>> profileMap
+  ) {
+    return profileMap
+      .entrySet().stream()
+      .map($ -> Pair.of(
+          $.getKey(),
+          Pair.of(
+              $.getValue().getLeft(),
+              $.getValue().getRight()
+               .stream()
+               .map(untuple(segment -> new ProfileSegment<>(segment.extent(), Optional.of(segment.dynamics()))))
+               .toList()
+          )
+      ))
+      .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+  }
+
+  public static <T> Map<String, Pair<ValueSchema, List<ProfileSegment<T>>>> unwrapOptional(
+      final Map<String, Pair<ValueSchema, List<ProfileSegment<Optional<T>>>>> profileMap
+  ) throws NoSuchElementException {
+    return profileMap
+        .entrySet().stream()
+        .map($ -> Pair.of(
+            $.getKey(),
+            Pair.of(
+                $.getValue().getLeft(),
+                $.getValue().getRight()
+                 .stream()
+                 .map(segment -> new ProfileSegment<>(segment.extent(), segment.dynamics().get()))
+                 .toList()
+            )
+        ))
+        .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+  }
+}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/CreateRequestAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/CreateRequestAction.java
@@ -8,6 +8,8 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Optional;
 
+import static gov.nasa.jpl.aerie.scheduler.server.remotes.postgres.PreparedStatements.getDatasetId;
+
 /*package-local*/ final class CreateRequestAction implements AutoCloseable {
   private final @Language("SQL") String sql = """
       insert into scheduling_request (specification_id, specification_revision)
@@ -16,7 +18,8 @@ import java.util.Optional;
         analysis_id,
         status,
         reason,
-        canceled
+        canceled,
+        dataset_id
     """;
 
   private final PreparedStatement statement;
@@ -42,6 +45,7 @@ import java.util.Optional;
     final var analysis_id = result.getLong("analysis_id");
     final var failureReason$ = PreparedStatements.getFailureReason(result, "reason");
     final var canceled = result.getBoolean("canceled");
+    final var datasetId = getDatasetId(result, "dataset_id");
 
     return new RequestRecord(
         specification.id(),
@@ -49,7 +53,8 @@ import java.util.Optional;
         specification.revision(),
         status,
         failureReason$,
-        canceled
+        canceled,
+        datasetId
     );
   }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetRequestAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/GetRequestAction.java
@@ -18,7 +18,8 @@ import java.util.Optional;
       r.analysis_id,
       r.status,
       r.reason,
-      r.canceled
+      r.canceled,
+      r.dataset_id
     from scheduling_request as r
     where
       r.specification_id = ? and
@@ -56,14 +57,15 @@ import java.util.Optional;
     final var analysisId = resultSet.getLong("analysis_id");
     final var failureReason$ = PreparedStatements.getFailureReason(resultSet, "reason");
     final var canceled = resultSet.getBoolean("canceled");
-
+    final var datasetId = PreparedStatements.getDatasetId(resultSet, "dataset_id");
     return Optional.of(new RequestRecord(
         specificationId,
         analysisId,
         specificationRevision,
         status,
         failureReason$,
-        canceled));
+        canceled,
+        datasetId));
   }
 
   @Override

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PreparedStatements.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PreparedStatements.java
@@ -36,4 +36,13 @@ public final class PreparedStatements {
       return SchedulerParsers.scheduleFailureP.parse(reader.readValue()).getSuccessOrThrow();
     }
   }
+
+  public static Optional<Long> getDatasetId(final ResultSet results, final String columnLabel)
+  throws SQLException
+  {
+    final var datasetId = results.getObject(columnLabel);
+    return datasetId == null ?
+        Optional.empty() :
+        Optional.of(results.getLong(columnLabel));
+  }
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/RequestRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/RequestRecord.java
@@ -9,7 +9,8 @@ public record RequestRecord(
     long specificationRevision,
     Status status,
     Optional<ScheduleFailure> reason,
-    boolean canceled
+    boolean canceled,
+    Optional<Long> datasetId
 ) {
   public enum Status {
     PENDING("pending"),

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -1,28 +1,46 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
+import com.impossibl.postgres.api.data.Interval;
 import gov.nasa.jpl.aerie.json.BasicParsers;
+import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityDirective;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityDirectiveId;
+import gov.nasa.jpl.aerie.merlin.driver.SimulatedActivity;
+import gov.nasa.jpl.aerie.merlin.driver.SimulatedActivityId;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
+import gov.nasa.jpl.aerie.merlin.driver.UnfinishedActivity;
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
+import gov.nasa.jpl.aerie.merlin.driver.timeline.EventGraph;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
+import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
-import gov.nasa.jpl.aerie.scheduler.model.*;
+import gov.nasa.jpl.aerie.scheduler.model.Plan;
+import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
+import gov.nasa.jpl.aerie.scheduler.model.Problem;
 import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
+import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirectiveId;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchMissionModelException;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.scheduler.server.http.EventGraphFlattener;
 import gov.nasa.jpl.aerie.scheduler.server.http.InvalidEntityException;
 import gov.nasa.jpl.aerie.scheduler.server.http.InvalidJsonException;
+import gov.nasa.jpl.aerie.scheduler.server.models.ActivityAttributesRecord;
+import gov.nasa.jpl.aerie.scheduler.server.models.DatasetId;
 import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
 import gov.nasa.jpl.aerie.scheduler.server.models.MerlinPlan;
 import gov.nasa.jpl.aerie.scheduler.server.models.MissionModelId;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanMetadata;
+import gov.nasa.jpl.aerie.scheduler.server.models.ProfileSet;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 
 import javax.json.Json;
 import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
 import javax.json.JsonException;
 import javax.json.JsonObject;
 import javax.json.JsonValue;
@@ -42,11 +60,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static gov.nasa.jpl.aerie.merlin.driver.json.SerializedValueJsonParser.serializedValueP;
 import static gov.nasa.jpl.aerie.merlin.driver.json.ValueSchemaJsonParser.valueSchemaP;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECOND;
+import static gov.nasa.jpl.aerie.scheduler.server.graphql.GraphQLParsers.activityAttributesP;
+import static gov.nasa.jpl.aerie.scheduler.server.graphql.GraphQLParsers.discreteProfileTypeP;
 import static gov.nasa.jpl.aerie.scheduler.server.graphql.GraphQLParsers.parseGraphQLInterval;
 import static gov.nasa.jpl.aerie.scheduler.server.graphql.GraphQLParsers.parseGraphQLTimestamp;
+import static gov.nasa.jpl.aerie.scheduler.server.graphql.GraphQLParsers.realDynamicsP;
+import static gov.nasa.jpl.aerie.scheduler.server.graphql.GraphQLParsers.realProfileTypeP;
+import static gov.nasa.jpl.aerie.scheduler.server.graphql.GraphQLParsers.simulationArgumentsP;
 
 /**
  * {@inheritDoc}
@@ -658,6 +683,542 @@ public record GraphQLMerlinService(URI merlinGraphqlURI) implements PlanService.
     }
 
     return resourceTypes;
+  }
+
+
+public SimulationId getSimulationId(PlanId planId) throws PlanServiceException, IOException {
+    final var request = """
+        query {
+          simulation(where: {plan_id: {_eq: %d}}) {
+            id
+          }
+        }
+        """.formatted(planId.id());
+  final JsonObject response;
+  response = postRequest(request).get();
+  final var data = response.getJsonObject("data");
+  final var simulationId = data.getJsonArray("simulation").get(0).asJsonObject().getInt("id");
+  return new SimulationId(simulationId);
+}
+
+  private record SimulationId(long id){}
+
+  private record ProfileRecord(
+      long id,
+      long datasetId,
+      String name,
+      Pair<String, ValueSchema> type,
+      Duration duration
+  ) {}
+
+  private record SpanRecord(
+      String type,
+      Instant start,
+      Optional<Duration> duration,
+      Optional<Long> parentId,
+      List<Long> childIds,
+      ActivityAttributesRecord attributes
+  ) {}
+
+  public DatasetId storeSimulationResults(final PlanMetadata planMetadata,
+                                          final SimulationResults results,
+                                          final Map<ActivityDirectiveId, ActivityDirectiveId> simulationActivityDirectiveIdToMerlinActivityDirectiveId) throws PlanServiceException, IOException
+  {
+    final var simulationId = getSimulationId(planMetadata.planId());
+    final var datasetIds = createSimulationDataset(simulationId, planMetadata);
+    final var profileSet = ProfileSet.of(results.realProfiles, results.discreteProfiles);
+    final var profileRecords = postResourceProfiles(
+        datasetIds.datasetId(),
+        profileSet.realProfiles(),
+        profileSet.discreteProfiles());
+    postProfileSegments(datasetIds.datasetId(), profileRecords, profileSet);
+    postActivities(datasetIds.datasetId(), results.simulatedActivities, results.unfinishedActivities, results.startTime, simulationActivityDirectiveIdToMerlinActivityDirectiveId);
+    insertSimulationTopics(datasetIds.datasetId(), results.topics);
+    insertSimulationEvents(datasetIds.datasetId(), results.events);
+    setSimulationDatasetStatus(datasetIds.simulationDatasetId(), SimulationStateRecord.success());
+    return datasetIds.datasetId();
+  }
+
+  private SimulationId createSimulation(final PlanId planId, final Map<String, SerializedValue> arguments)
+  throws PlanServiceException, IOException
+  {
+    final var request = """
+        mutation {
+          insert_simulation_one(object: {plan_id: %d, arguments: %s}) {
+            id
+            revision
+          }
+        }""".formatted(
+            planId.id(),
+            simulationArgumentsP.unparse(arguments)
+    );
+    final JsonObject response;
+    response = postRequest(request).get();
+    final var data = response.getJsonObject("data");
+    final var simulationId = data.getJsonObject("insert_simulation_one").getInt("id");
+    return new SimulationId(simulationId);
+  }
+
+
+  private void setSimulationDatasetStatus(SimulationDatasetId id, SimulationStateRecord state)
+  throws PlanServiceException, IOException
+  {
+    final var request = """
+        mutation {
+          update_simulation_dataset(where: {id: {_eq: %d}}, _set: {status: %s}) {
+            affected_rows
+          }
+        }
+        """.formatted(
+        id.id(),
+        state.status().label
+    );
+    final JsonObject response;
+    response = postRequest(request).get();
+    final var data = response.getJsonObject("data");
+    final var affected = data.getJsonObject("update_simulation_dataset").getInt("affected_rows");
+    if(affected != 1){
+      throw new PlanServiceException("Unable to modify the status of simulation dataset with id %d".formatted(id.id()));
+    }
+  }
+
+  public record SimulationDatasetId(int id){}
+
+  public record DatasetIds(DatasetId datasetId, SimulationDatasetId simulationDatasetId){}
+
+  private DatasetIds createSimulationDataset(SimulationId simulationId, PlanMetadata planMetadata)
+  throws PlanServiceException, IOException
+  {
+    final var request = """
+        mutation {
+          insert_simulation_dataset_one(object: {simulation_id: %d, simulation_start_time:"%s", simulation_end_time:"%s", arguments:{}, status: %s}) {
+            id
+            dataset_id
+          }
+        }
+        """.formatted(
+            simulationId.id(),
+            planMetadata.horizon().getStartInstant(),
+            planMetadata.horizon().getEndInstant(),
+            SimulationStateRecord.Status.INCOMPLETE.label
+    );
+    final JsonObject response;
+    response = postRequest(request).get();
+    final var data = response.getJsonObject("data");
+    final var datasetId = data.getJsonObject("insert_simulation_dataset_one").getInt("dataset_id");
+    final var simulationDatasetId = data.getJsonObject("insert_simulation_dataset_one").getInt("id");
+    return new DatasetIds(new DatasetId(datasetId), new SimulationDatasetId(simulationDatasetId));
+  }
+
+  private static <T> Duration sumDurations(final List<ProfileSegment<Optional<T>>> segments) {
+    return segments.stream().reduce(
+        Duration.ZERO,
+        (acc, pair) -> acc.plus(pair.extent()),
+        Duration::plus
+    );
+  }
+  private HashMap<String, ProfileRecord> postResourceProfiles(DatasetId datasetId,
+                                                              final Map<String, Pair<ValueSchema, List<ProfileSegment<Optional<RealDynamics>>>>> realProfiles,
+                                                              final Map<String, Pair<ValueSchema, List<ProfileSegment<Optional<SerializedValue>>>>> discreteProfiles)
+  throws PlanServiceException, IOException
+  {
+    final var req = """
+        mutation($profiles: [profile_insert_input!]!) {
+          insert_profile(objects: $profiles){
+            returning {
+              id
+              name
+            }
+          }
+        }""";
+    final var allProfiles = Json.createArrayBuilder();
+    final var resourceNames = new ArrayList<String>();
+    final var resourceTypes = new ArrayList<Pair<String, ValueSchema>>();
+    final var durations = new ArrayList<Duration>();
+    for (final var entry : realProfiles.entrySet()) {
+      final var resource = entry.getKey();
+      final var schema = entry.getValue().getLeft();
+      final var realResourceType = Pair.of("real", schema);
+      final var segments = entry.getValue().getRight();
+      final var duration = sumDurations(segments);
+      resourceNames.add(resource);
+      resourceTypes.add(realResourceType);
+      durations.add(duration);
+      allProfiles.add(Json.createObjectBuilder()
+          .add("dataset_id", datasetId.id())
+          .add("duration", graphQLIntervalFromDuration(duration).toString())
+          .add("name", resource)
+          .add("type",realProfileTypeP.unparse(realResourceType))
+          .build()
+      );
+    }
+    for (final var entry : discreteProfiles.entrySet()) {
+      final var resource = entry.getKey();
+      final var schema = entry.getValue().getLeft();
+      final var resourceType = Pair.of("discrete", schema);
+      final var segments = entry.getValue().getRight();
+      final var duration = sumDurations(segments);
+      resourceNames.add(resource);
+      resourceTypes.add(resourceType);
+      durations.add(duration);
+      allProfiles.add(Json.createObjectBuilder()
+                      .add("dataset_id", datasetId.id())
+                      .add("duration", graphQLIntervalFromDuration(duration).toString())
+                      .add("name", resource)
+                      .add("type",discreteProfileTypeP.unparse(resourceType))
+                      .build()
+      );
+    }
+    final var arguments = Json.createObjectBuilder()
+                              .add("profiles", allProfiles.build())
+                              .build();
+    final JsonObject response;
+    response = postRequest(req, arguments).get();
+    final var data = response.getJsonObject("data").getJsonObject("insert_profile").getJsonArray("returning");
+    final var profileRecords = new HashMap<String, ProfileRecord>(resourceNames.size());
+    for (int i = 0; i < resourceNames.size(); i++) {
+      final var dataReturned = data.get(i);
+      final var resource = resourceNames.get(i);
+      final var type = resourceTypes.get(i);
+      final var duration = durations.get(i);
+      final var id = dataReturned.asJsonObject().getInt("id");
+      final var nameResourceReturned = dataReturned.asJsonObject().getString("name");
+      if(!nameResourceReturned.equals(resource)){
+        throw new PlanServiceException("Resource do not match");
+      }
+      profileRecords.put(resource, new ProfileRecord(
+          id,
+          datasetId.id(),
+          resource,
+          type,
+          duration
+      ));
+    }
+    return profileRecords;
+  }
+
+  public com.impossibl.postgres.api.data.Interval graphQLIntervalFromDuration(Duration duration){
+    return Interval.of(java.time.Duration.ofNanos(duration.in(MICROSECOND)*1000));
+  }
+
+  public com.impossibl.postgres.api.data.Interval graphQLIntervalFromDuration(Instant instant1, Instant instant2){
+    return Interval.of(java.time.Duration.between(instant1, instant2));
+  }
+
+  private void postProfileSegments(
+      final DatasetId datasetId,
+      final Map<String, ProfileRecord> records,
+      final ProfileSet profileSet
+  ) throws PlanServiceException, IOException
+  {
+    final var realProfiles = profileSet.realProfiles();
+    final var discreteProfiles = profileSet.discreteProfiles();
+    for (final var entry : records.entrySet()) {
+      final ProfileRecord record =  entry.getValue();
+      final var resource =  entry.getKey();
+      switch (record.type().getLeft()) {
+        case "real" -> postRealProfileSegments(
+            datasetId,
+            record,
+            realProfiles.get(resource).getRight());
+        case "discrete" -> postDiscreteProfileSegments(
+            datasetId,
+            record,
+            discreteProfiles.get(resource).getRight());
+        default -> throw new Error("Unrecognized profile type " + record.type().getLeft());
+      }
+    }
+  }
+
+  private <Dynamics> void postProfileSegment(
+      final DatasetId datasetId,
+      final ProfileRecord profileRecord,
+      final List<ProfileSegment<Optional<Dynamics>>> segments,
+      final JsonParser<Dynamics> dynamicsP
+  ) throws PlanServiceException, IOException
+  {
+    final var req = """
+        mutation($profileSegments:[profile_segment_insert_input!]!) {
+          insert_profile_segment(objects: $profileSegments) {
+            affected_rows
+          }
+        }
+        """;
+    final var profiles = Json.createArrayBuilder();
+    var accumulatedOffset = Duration.ZERO;
+    for (final var pair : segments) {
+      final var duration = pair.extent();
+      final var dynamics = pair.dynamics();
+
+      final String stringDynamics;
+      final boolean stringIsGap;
+      if(dynamics.isPresent()){
+        stringDynamics = serializeDynamics(dynamics.get(), dynamicsP);
+        stringIsGap = false;
+      } else{
+        stringDynamics = null;
+        stringIsGap = true;
+      }
+      profiles.add(Json.createObjectBuilder()
+          .add("dataset_id", datasetId.id())
+          .add("profile_id", profileRecord.id())
+          .add("start_offset", graphQLIntervalFromDuration(accumulatedOffset).toString())
+          .add("is_gap", stringIsGap)
+          .add("dynamics", stringDynamics)
+          .build());
+      accumulatedOffset = Duration.add(accumulatedOffset, duration);
+    }
+
+    final var arguments = Json.createObjectBuilder()
+                              .add("profileSegments", profiles)
+                              .build();
+
+    final JsonObject response;
+    try {
+      response = postRequest(req, arguments).get();
+    } catch (PlanServiceException e) {
+      throw new PlanServiceException(e.toString());
+    }
+    final var affected_rows = response.getJsonObject("data").getJsonObject("insert_profile_segment").getInt("affected_rows");
+    if(affected_rows!=segments.size()) {
+      throw new PlanServiceException("not the same size");
+    }
+}
+  private <Dynamics> String serializeDynamics(final Dynamics dynamics, final JsonParser<Dynamics> dynamicsP) {
+    return dynamicsP.unparse(dynamics).toString();
+  }
+  private void postRealProfileSegments(final DatasetId datasetId,
+                                              final ProfileRecord profileRecord,
+                                              final List<ProfileSegment<Optional<RealDynamics>>> segments)
+  throws PlanServiceException, IOException
+  {
+    postProfileSegment(datasetId, profileRecord, segments, realDynamicsP);
+  }
+
+  private void postDiscreteProfileSegments(final DatasetId datasetId,
+                                                  final ProfileRecord profileRecord,
+                                                  final List<ProfileSegment<Optional<SerializedValue>>> segments)
+  throws PlanServiceException, IOException
+  {
+    postProfileSegment(datasetId, profileRecord, segments, serializedValueP);
+  }
+
+  private void insertSimulationTopics(
+      DatasetId datasetId,
+      final List<Triple<Integer, String, ValueSchema>> topics) throws PlanServiceException, IOException
+  {
+    final var req = """
+        mutation($topics:[topic_insert_input!]!) {
+          insert_topic(objects: $topics){
+            affected_rows
+          }
+        }
+        """;
+    final var jsonTopics = Json.createArrayBuilder();
+    for (final var topic : topics) {
+      jsonTopics.add(
+          Json.createObjectBuilder()
+              .add("dataset_id", datasetId.id())
+              .add("topic_index", topic.getLeft())
+              .add("name", topic.getMiddle())
+              .add("value_schema", valueSchemaP.unparse(topic.getRight()))
+              .build()
+      );
+    }
+    final var arguments = Json.createObjectBuilder()
+                              .add("topics", jsonTopics.build())
+                              .build();
+    postRequest(req, arguments);
+  }
+
+  private void insertSimulationEvents(
+      DatasetId datasetId,
+      Map<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>> eventPoints) throws PlanServiceException, IOException
+  {
+    final var req = """
+            mutation($events:[event_insert_input!]!){
+                  insert_event(objects: $events) {
+                    affected_rows
+                  }
+            }
+        """;
+    final var events = Json.createArrayBuilder();
+    for (final var eventPoint : eventPoints.entrySet()) {
+      final var time = eventPoint.getKey();
+      final var transactions = eventPoint.getValue();
+      for (int transactionIndex = 0; transactionIndex < transactions.size(); transactionIndex++) {
+        final var eventGraph = transactions.get(transactionIndex);
+        final var flattenedEventGraph = EventGraphFlattener.flatten(eventGraph);
+        events.addAll(batchInsertEventGraph(datasetId.id(), time, transactionIndex, flattenedEventGraph));
+      }
+    }
+    final var arguments = Json.createObjectBuilder()
+                              .add("events", events)
+                              .build();
+    postRequest(req, arguments);
+  }
+
+  private JsonArrayBuilder batchInsertEventGraph(
+      final long datasetId,
+      final Duration duration,
+      final int transactionIndex,
+      final List<Pair<String, Pair<Integer, SerializedValue>>> flattenedEventGraph
+  ) {
+    final var events = Json.createArrayBuilder();
+    for (final Pair<String, Pair<Integer, SerializedValue>> entry : flattenedEventGraph) {
+      final var causalTime = entry.getLeft();
+      final Pair<Integer, SerializedValue> event = entry.getRight();
+      events.add(
+          Json.createObjectBuilder()
+              .add("dataset_id",datasetId)
+              .add("real_time", graphQLIntervalFromDuration(duration).toString())
+              .add("transaction_index", transactionIndex)
+              .add("causal_time", causalTime)
+              .add("topic_index", event.getLeft())
+              .add("value", serializedValueP.unparse(event.getRight()))
+              .build()
+      );
+    }
+    return events;
+  }
+
+  private void postActivities(
+      final DatasetId datasetId,
+      final Map<SimulatedActivityId, SimulatedActivity> simulatedActivities,
+      final Map<SimulatedActivityId, UnfinishedActivity> unfinishedActivities,
+      final Instant simulationStart,
+      final Map<ActivityDirectiveId, ActivityDirectiveId> simulationActivityDirectiveIdToMerlinActivityDirectiveId
+  ) throws PlanServiceException, IOException
+  {
+      final var simulatedActivityRecords = simulatedActivities.entrySet().stream()
+                                                              .collect(Collectors.toMap(
+                                                                  e -> simulationActivityDirectiveIdToMerlinActivityDirectiveId.get(e.getValue().directiveId().get()).id(),
+                                                                  e -> simulatedActivityToRecord(e.getValue(), simulationActivityDirectiveIdToMerlinActivityDirectiveId)));
+      final var allActivityRecords = unfinishedActivities.entrySet().stream()
+                                                         .collect(Collectors.toMap(
+                                                             e -> simulationActivityDirectiveIdToMerlinActivityDirectiveId.get(e.getValue().directiveId().get()).id(),
+                                                             e -> unfinishedActivityToRecord(e.getValue(), simulationActivityDirectiveIdToMerlinActivityDirectiveId)));
+      allActivityRecords.putAll(simulatedActivityRecords);
+      final var simIdToPgId = postSpans(
+          datasetId,
+          allActivityRecords,
+          simulationStart);
+      updateSimulatedActivityParentsAction(
+          datasetId,
+          simulatedActivityRecords,
+          simIdToPgId);
+  }
+
+  public void updateSimulatedActivityParentsAction(
+    final DatasetId datasetId,
+    final Map<Long, SpanRecord> simulatedActivities,
+    final Map<Long, Long> simIdToPgId
+) throws PlanServiceException, IOException
+  {
+  final var req = """
+      mutation($updates:[span_updates!]!) {
+        update_span_many(updates: $updates) {
+          affected_rows
+        }
+      }
+      """;
+  final var updates = Json.createArrayBuilder();
+  int updateCounter = 0;
+  for (final var entry : simulatedActivities.entrySet()) {
+    final var activity =  entry.getValue();
+    final var id =  entry.getKey();
+    if (activity.parentId().isEmpty()) continue;
+    updates.add(Json.createObjectBuilder()
+                   .add("where", Json.createObjectBuilder()
+                                     .add("dataset_id",Json.createObjectBuilder().add("_eq", datasetId.id()).build())
+                                     .add("id", Json.createObjectBuilder().add("_eq", simIdToPgId.get(id)).build()))
+                   .add("_set", Json.createObjectBuilder().add("parent_id", simIdToPgId.get(activity.parentId().get())))
+                   .build());
+    updateCounter++;
+  }
+  final var arguments = Json.createObjectBuilder()
+                            .add("updates", updates.build())
+                            .build();
+
+  final JsonObject response;
+  response = postRequest(req, arguments).get();
+  final var affected_rows = response.getJsonObject("data").getJsonObject("update_span_many").getInt("affected_rows");
+  if(affected_rows != updateCounter) {
+    throw new PlanServiceException("not the same size");
+  }
+}
+
+  private static SpanRecord simulatedActivityToRecord(final SimulatedActivity activity,
+                                                      final Map<ActivityDirectiveId, ActivityDirectiveId> simulationActivityDirectiveIdToMerlinActivityDirectiveId) {
+    return new SpanRecord(
+        activity.type(),
+        activity.start(),
+        Optional.of(activity.duration()),
+        Optional.ofNullable(activity.parentId()).map(SimulatedActivityId::id),
+        activity.childIds().stream().map(SimulatedActivityId::id).collect(Collectors.toList()),
+        new ActivityAttributesRecord(
+            activity.directiveId().map(id -> simulationActivityDirectiveIdToMerlinActivityDirectiveId.get(id).id()),
+            activity.arguments(),
+            Optional.of(activity.computedAttributes())));
+  }
+
+  private static SpanRecord unfinishedActivityToRecord(final UnfinishedActivity activity,
+                                                       final Map<ActivityDirectiveId, ActivityDirectiveId> simulationActivityDirectiveIdToMerlinActivityDirectiveId) {
+    return new SpanRecord(
+        activity.type(),
+        activity.start(),
+        Optional.empty(),
+        Optional.ofNullable(activity.parentId()).map(SimulatedActivityId::id),
+        activity.childIds().stream().map(SimulatedActivityId::id).collect(Collectors.toList()),
+        new ActivityAttributesRecord(
+            activity.directiveId().map(id -> simulationActivityDirectiveIdToMerlinActivityDirectiveId.get(id).id()),
+            activity.arguments(),
+            Optional.empty()));
+  }
+
+  public HashMap<Long, Long> postSpans(final DatasetId datasetId,
+                                       final Map<Long, SpanRecord> spans,
+                                       final Instant simulationStart
+  ) throws PlanServiceException, IOException
+  {
+    final var req = """
+                        mutation($spans:[span_insert_input!]!) {
+                        insert_span(objects: $spans) {
+                          returning {
+                            id
+                          }
+                         }
+                        }
+                        """;
+    final var spansJson = Json.createArrayBuilder();
+    final var ids = spans.keySet().stream().toList();
+    for (final var id : ids) {
+      final var act = spans.get(id);
+      final var startTime = graphQLIntervalFromDuration(simulationStart, act.start);
+      spansJson.add(Json.createObjectBuilder()
+                        .add("dataset_id", datasetId.id())
+                        .add("start_offset", startTime.toString())
+                        .add("duration", act.duration.isPresent() ? graphQLIntervalFromDuration(act.duration().get()).toString() : "null")
+                        .add("type", act.type())
+                        .add("attributes", buildAttributes(act.attributes().directiveId(), act.attributes().arguments(), act.attributes().computedAttributes()))
+                        .build());
+    }
+    final var arguments = Json.createObjectBuilder()
+                              .add("spans", spansJson)
+                              .build();
+    final JsonObject response;
+    response = postRequest(req, arguments).get();
+    final var returnedIds = response.getJsonObject("data").getJsonObject("insert_span").getJsonArray("returning");
+    final var simIdToPostgresId = new HashMap<Long, Long>(ids.size());
+    int i = 0;
+    for (final var id : ids) {
+      simIdToPostgresId.put(id, (long) returnedIds.get(i).asJsonObject().getInt("id"));
+    }
+    return simIdToPostgresId;
+  }
+
+  private JsonValue buildAttributes(final Optional<Long> directiveId, final Map<String, SerializedValue> arguments, final Optional<SerializedValue> returnValue) {
+    return activityAttributesP.unparse(new ActivityAttributesRecord(directiveId, arguments, returnValue));
   }
 
   /**

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/PlanService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/PlanService.java
@@ -1,15 +1,17 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityDirectiveId;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
-import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
 import gov.nasa.jpl.aerie.scheduler.model.Plan;
 import gov.nasa.jpl.aerie.scheduler.model.Problem;
+import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
 import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirectiveId;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchActivityInstanceException;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.scheduler.server.http.InvalidJsonException;
+import gov.nasa.jpl.aerie.scheduler.server.models.DatasetId;
 import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
 import gov.nasa.jpl.aerie.scheduler.server.models.MerlinPlan;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
@@ -145,6 +147,20 @@ public interface PlanService {
         final Map<SchedulingActivityDirective, GoalId> activityToGoalId
     )
     throws IOException, NoSuchPlanException, PlanServiceException;
+
+    /**
+     * Stores the simulation results produced during scheduling
+     *
+     * @param planMetadata the plan metadata
+     * @param results the simulation results
+     * @param simulationActivityDirectiveIdToMerlinActivityDirectiveId the translation between activity ids in the
+     *     local simulation and the merlin activity ids
+     * @return
+     * @throws PlanServiceException
+     * @throws IOException
+     */
+   DatasetId storeSimulationResults(final PlanMetadata planMetadata, final SimulationResults results,
+                                    final Map<ActivityDirectiveId, ActivityDirectiveId> simulationActivityDirectiveIdToMerlinActivityDirectiveId) throws PlanServiceException, IOException;
   }
 
   interface OwnerRole extends ReaderRole, WriterRole {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleAction.java
@@ -1,6 +1,8 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
 import java.io.IOException;
+import java.util.Optional;
+
 import gov.nasa.jpl.aerie.scheduler.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchSpecificationException;
 import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
@@ -39,7 +41,7 @@ public record ScheduleAction(SpecificationService specificationService, Schedule
     /**
      * scheduler completed successfully; contains the requested results
      */
-    record Complete(ScheduleResults results, long analysisId) implements Response {}
+    record Complete(ScheduleResults results, long analysisId, Optional<Long> datasetId) implements Response {}
   }
 
   /**
@@ -79,7 +81,7 @@ public record ScheduleAction(SpecificationService specificationService, Schedule
     } else if (response instanceof ResultsProtocol.State.Success r) {
       final var results = r.results();
       //NB: could elaborate with more response content here, like merlin...SimResults adds in violation analytics
-      return new Response.Complete(results, r.analysisId());
+      return new Response.Complete(results, r.analysisId(), r.datasetId());
     } else {
       throw new UnexpectedSubtypeError(ResultsProtocol.State.class, response);
     }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SimulationStateRecord.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SimulationStateRecord.java
@@ -1,0 +1,54 @@
+package gov.nasa.jpl.aerie.scheduler.server.services;
+
+import gov.nasa.jpl.aerie.merlin.driver.SimulationFailure;
+
+import java.util.Optional;
+
+public record SimulationStateRecord(Status status, Optional<SimulationFailure> reason) {
+  public static SimulationStateRecord pending() {
+    return new SimulationStateRecord(Status.PENDING, Optional.empty());
+  }
+
+  public static SimulationStateRecord incomplete() {
+    return new SimulationStateRecord(Status.INCOMPLETE, Optional.empty());
+  }
+
+  public static SimulationStateRecord failed(final SimulationFailure reason) {
+    return new SimulationStateRecord(Status.FAILED, Optional.of(reason));
+  }
+
+  public static SimulationStateRecord success() {
+    return new SimulationStateRecord(Status.SUCCESS, Optional.empty());
+  }
+
+  public enum Status {
+    PENDING("pending"),
+    INCOMPLETE("incomplete"),
+    FAILED("failed"),
+    SUCCESS("success");
+
+    public final String label;
+    Status(final String label) {
+      this.label = label;
+    }
+
+    public static Status fromString(final String label) throws InvalidSimulationStatusException {
+      return switch(label) {
+        case "pending" -> PENDING;
+        case "incomplete" -> INCOMPLETE;
+        case "failed" -> FAILED;
+        case "success" -> SUCCESS;
+        default -> throw new InvalidSimulationStatusException(label);
+      };
+    }
+
+    public static final class InvalidSimulationStatusException extends Exception {
+      public final String invalidStatus;
+
+      public InvalidSimulationStatusException(final String invalidStatus) {
+        super(String.format("Invalid Simulation Status: %s", invalidStatus));
+        this.invalidStatus = invalidStatus;
+      }
+    }
+  }
+}

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/MockMerlinService.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/MockMerlinService.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.scheduler.worker.services;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -10,19 +11,23 @@ import java.util.Optional;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityDirective;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityDirectiveId;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.scheduler.TimeUtility;
 import gov.nasa.jpl.aerie.scheduler.model.*;
 import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
+import gov.nasa.jpl.aerie.scheduler.server.models.DatasetId;
 import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
 import gov.nasa.jpl.aerie.scheduler.server.models.MerlinPlan;
 import gov.nasa.jpl.aerie.scheduler.server.models.MissionModelId;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanMetadata;
+import gov.nasa.jpl.aerie.scheduler.server.services.GraphQLMerlinService;
 import gov.nasa.jpl.aerie.scheduler.server.services.MissionModelService;
 import gov.nasa.jpl.aerie.scheduler.server.services.PlanService;
+import gov.nasa.jpl.aerie.scheduler.server.services.PlanServiceException;
 import org.apache.commons.lang3.tuple.Pair;
 
 class MockMerlinService implements MissionModelService, PlanService.OwnerRole {
@@ -141,6 +146,15 @@ class MockMerlinService implements MissionModelService, PlanService.OwnerRole {
   )
   {
     return null;
+  }
+
+  @Override
+  public DatasetId storeSimulationResults(
+          final PlanMetadata planMetadata,
+          final SimulationResults results,
+          final Map<ActivityDirectiveId, ActivityDirectiveId> activityIdCorrespondance)
+  {
+    return new DatasetId(0);
   }
 
   @Override

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/MockResultsProtocolWriter.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/MockResultsProtocolWriter.java
@@ -1,7 +1,10 @@
 package gov.nasa.jpl.aerie.scheduler.worker.services;
 
 import java.util.ArrayList;
+import java.util.Optional;
+
 import gov.nasa.jpl.aerie.scheduler.server.ResultsProtocol;
+import gov.nasa.jpl.aerie.scheduler.server.models.DatasetId;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleFailure;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleResults;
 
@@ -13,7 +16,7 @@ class MockResultsProtocolWriter implements ResultsProtocol.WriterRole {
   }
 
   sealed interface Result {
-    record Success(ScheduleResults results) implements Result {}
+    record Success(ScheduleResults results, Optional<DatasetId> datasetId) implements Result {}
 
     record Failure(ScheduleFailure reason) implements Result {}
   }
@@ -24,8 +27,8 @@ class MockResultsProtocolWriter implements ResultsProtocol.WriterRole {
   }
 
   @Override
-  public void succeedWith(final ScheduleResults results) {
-    this.results.add(new Result.Success(results));
+  public void succeedWith(final ScheduleResults results, final Optional<DatasetId> datasetId) {
+    this.results.add(new Result.Success(results, datasetId));
   }
 
   @Override


### PR DESCRIPTION
* **Tickets addressed:** resolves #676 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
After scheduling, the simulation results are posted to the merlin db via graphql. The id of the created dataset is returned as part of the schedule action and it is saved in the `request` table of the scheduler database. 

Also, the creation of partitions has been replaced with a trigger after insert on `dataset`, thank you @Mythicaeda. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Verified through local tests.
Right now, the user has to refresh the UI to see the new dataset after scheduling.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None. 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Make the UI update the dataset id shown based of the id returned by the `schedule` call.