### PR TITLE
Report the time at which an exception occurs during simulation

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationException.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationException.java
@@ -1,0 +1,71 @@
+package gov.nasa.jpl.aerie.merlin.driver;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.HOUR;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECOND;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MINUTE;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECOND;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.negate;
+
+public class SimulationException extends RuntimeException {
+  // This builder must be used to get optional subsecond values
+  // See: https://stackoverflow.com/questions/30090710/java-8-datetimeformatter-parsing-for-optional-fractional-seconds-of-varying-sign
+  public static final DateTimeFormatter format =
+      new DateTimeFormatterBuilder()
+          .appendPattern("uuuu-DDD'T'HH:mm:ss")
+          .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+          .toFormatter();
+
+  public final Duration elapsedTime;
+  public final Instant instant;
+  public final Throwable cause;
+
+  public SimulationException(final Duration elapsedTime, final Instant startTime, final Throwable cause) {
+    super("Exception occurred " + formatDuration(elapsedTime) + " into the simulation at " + formatInstant(addDurationToInstant(startTime, elapsedTime)), cause);
+    this.elapsedTime = elapsedTime;
+    this.instant = addDurationToInstant(startTime, elapsedTime);
+    this.cause = cause;
+  }
+
+  public static String formatDuration(final Duration duration) {
+    final var sign = (duration.isNegative()) ? "-" : "";
+    var rest = duration;
+    final long hours;
+    if (duration.isNegative()) {
+      hours = -rest.dividedBy(HOUR);
+      rest = negate(rest.remainderOf(HOUR));
+    } else {
+      hours = rest.dividedBy(HOUR);
+      rest = rest.remainderOf(HOUR);
+    }
+
+    final var minutes = rest.dividedBy(MINUTE);
+    rest = rest.remainderOf(MINUTE);
+
+    final var seconds = rest.dividedBy(SECOND);
+    rest = rest.remainderOf(SECOND);
+
+    final var microseconds = rest.dividedBy(MICROSECOND);
+
+    return String.format("%s%02d:%02d:%02d.%06d", sign, hours, minutes, seconds, microseconds);
+  }
+
+  public static String formatInstant(final Instant instant) {
+    return format.format(instant.atZone(ZoneOffset.UTC));
+  }
+
+  private static Instant addDurationToInstant(final Instant instant, final Duration duration) {
+    return instant
+        .plusSeconds(duration.in(Duration.SECONDS))
+        .plusNanos(duration
+                       .remainderOf(Duration.SECONDS)
+                       .in(Duration.MICROSECONDS) * 1000);
+  }
+}


### PR DESCRIPTION
* **Tickets addressed:** Related to #659 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Users have reported that it's difficult to debug an exception that occurs during simulation because they don't know where in the plan the exception occurred.

There are two aspects to this: reporting simulation time, and reporting a specific directive and/or child activity in which the exception occurred. The simulation time aspect of this is very straightforward, and I believe will deliver a lot of value even without the specifics of which activity caused the exception.

The approach taken is to introduce a SimulationException that holds on to the time at which the exception was thrown. The simulation loop in the driver is wrapped in a try/catch, which will rethrow any exception, but wrap it in a SimulationException. The simulation agent reports the wrapped exception as a new SIMULATION_EXCEPTION failure type, and attaches two fields to that - "elapsedTime", and "utcTimeDoy".

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I modified BiteBanana to throw an exception, and tested via the UI - note the JSON object above the trace.

<img width="1125" alt="Screenshot 2023-03-10 at 6 40 11 AM" src="https://user-images.githubusercontent.com/1189602/224344373-4c390fb2-5bed-4d42-a2a1-ef8320f4a2c5.png">

This required a slight change in the UI - since it currently assumes that either there is a stack trace, or there is json data - this is a case where we want both.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No documentation was updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Look into how we could report the specific directive id, and think about implications for daemon tasks or child activities.