### PR TITLE
Support Full export and import of SeqJson

### DIFF
--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -204,10 +204,10 @@ declare global {
 }
 
 /*
-  ---------------------------------
-			  Sequence eDSL
-  ---------------------------------
-  */
+	---------------------------------
+				Sequence eDSL
+	---------------------------------
+	*/
 // @ts-ignore : 'SeqJson' found in JSON Spec
 export class Sequence implements SeqJson {
   public readonly id: string;
@@ -262,31 +262,181 @@ export class Sequence implements SeqJson {
             }),
           }
         : {}),
+      ...(this.locals ? { locals: this.locals } : {}),
+      ...(this.parameters ? { parameters: this.parameters } : {}),
+      ...(this.requests
+        ? {
+            requests: this.requests.map(request => {
+              return {
+                name: request.name,
+                steps: [
+                  request.steps[0] instanceof CommandStem ||
+                  request.steps[0] instanceof Ground_Block ||
+                  request.steps[0] instanceof Ground_Event
+                    ? request.steps[0].toSeqJson()
+                    : request.steps[0],
+                  // @ts-ignore : 'step' found in JSON Spec
+                  ...request.steps.slice(1).map(step => {
+                    if (step instanceof CommandStem || step instanceof Ground_Block || step instanceof Ground_Event)
+                      return step.toSeqJson();
+                    return step;
+                  }),
+                ],
+                type: request.type,
+                ...(request.description ? { description: request.description } : {}),
+                ...(request.ground_epoch ? { ground_epoch: request.ground_epoch } : {}),
+                ...(request.time ? { time: request.time } : {}),
+                ...(request.metadata ? { metadata: request.metadata } : {}),
+              };
+            }),
+          }
+        : {}),
+      ...(this.immediate_commands ? { immediate_commands: this.immediate_commands } : {}),
+      ...(this.hardware_commands ? { hardware_commands: this.hardware_commands } : {}),
     };
   }
 
   public toEDSLString(): string {
     const commandsString =
       this.steps && this.steps.length > 0
-        ? '\n' +
+        ? '[\n' +
           indent(
             this.steps
               .map(step => {
-                if (step instanceof CommandStem || step instanceof Ground_Block) {
+                if (step instanceof CommandStem || step instanceof Ground_Block || step instanceof Ground_Event) {
                   return step.toEDSLString() + ',';
                 }
-                return step;
+                return step + ',';
               })
               .join('\n'),
             1,
-          )
+          ) +
+          '\n]'
         : '';
-    // prettier-ignore
-    return `export default () =>
-${indent(`Sequence.new({`, 1)}
-${indent(`seqId: '${this.id}',`, 2)}
-${indent(`metadata: ${JSON.stringify(this.metadata)},`, 2)}${commandsString.length > 0 ? `\n${indent(`steps: [${commandsString}`, 2)}\n${indent('],', 2)}` : ''}
-${indent(`});`, 1)}`;
+    //ex.
+    // [C.ADD_WATER]
+    const metadataString = Object.keys(this.metadata).length == 0 ? `{}` : `${objectToString(this.metadata)}`;
+
+    const localsString = this.locals ? `[\n${indent(this.locals.map(l => objectToString(l)).join(',\n'), 1)}\n]` : '';
+
+    const parameterString = this.parameters
+      ? `[\n${indent(this.parameters.map(l => objectToString(l)).join(',\n'), 1)}\n]`
+      : '';
+    //ex.
+    // `parameters: [
+    //   {
+    //     allowable_ranges: [
+    //       {
+    //         max: 3600,
+    //         min: 1,
+    //       },
+    //     ],
+    //     name: 'duration',
+    //     type: 'UINT',
+    //   }
+    // ]`;
+
+    const hardwareString = this.hardware_commands
+      ? `[\n${indent(this.hardware_commands.map(h => objectToString(h)).join(',\n'), 1)}\n]`
+      : '';
+    //ex.
+    // hardware_commands: [
+    //   {
+    //     description: 'FIRE THE PYROS',
+    //     metadata:{
+    //       author: 'rrgoetz',
+    //     },
+    //     stem: 'HDW_PYRO_ENGINE',
+    //   }
+    // ],
+
+    const immediateString = this.immediate_commands
+      ? `[\n${indent(this.immediate_commands.map(i => objectToString(i)).join(',\n'), 1)}\n]`
+      : '';
+    //ex.
+    // immediate_commands: [
+    //   {
+    //     args: [
+    //       {
+    //         name: 'direction',
+    //         type: 'string',
+    //         value: 'FromStem',
+    //       },
+    //     ],
+    //     stem: 'PEEL_BANANA',
+    //   }
+    // ]
+
+    const requestString = this.requests
+      ? `[\n${indent(
+          this.requests
+            .map(r => {
+              return (
+                `{\n` +
+                indent(
+                  `name: '${r.name}',\n` +
+                    `steps: [\n${indent(
+                      r.steps
+                        // @ts-ignore : 's: Step' found in JSON Spec
+                        .map(s => {
+                          if (s instanceof CommandStem || s instanceof Ground_Block || s instanceof Ground_Event) {
+                            return s.toEDSLString() + ',';
+                          }
+                          return s + ',';
+                        })
+                        .join('\n'),
+                      1,
+                    )}\n],` +
+                    `\ntype: '${r.type}',` +
+                    `${r.description ? `\ndescription: '${r.description}',` : ''}` +
+                    `${r.ground_epoch ? `\nground_epoch: ${objectToString(r.ground_epoch)},` : ''}` +
+                    `${r.time ? `\ntime: ${objectToString(r.time)},` : ''}` +
+                    `${r.metadata ? `\nmetadata: ${objectToString(r.metadata)},` : ''}`,
+                  1,
+                ) +
+                `\n}`
+              );
+            })
+            .join(',\n'),
+          1,
+        )}\n]`
+      : '';
+    //ex.
+    /*requests: [
+        {
+          name: 'power',
+          steps: [
+            R`04:39:22.000`.PREHEAT_OVEN({
+              temperature: 360,
+            }),
+            C.ADD_WATER,
+          ],
+          type: 'request',
+          description: ' Activate the oven',
+          ground_epoch: {
+            delta: 'now',
+            name: 'activate',
+          },
+          metadata: {
+            author: 'rrgoet',
+          },
+        }
+      ]
+    }*/
+
+    return (
+      `export default () =>\n` +
+      `${indent(`Sequence.new({`, 1)}\n` +
+      `${indent(`seqId: '${this.id}'`, 2)},\n` +
+      `${indent(`metadata: ${metadataString}`, 2)},\n` +
+      `${localsString.length !== 0 ? `${indent(`locals: ${localsString}`, 2)},\n` : ''}` +
+      `${parameterString.length !== 0 ? `${indent(`parameters: ${parameterString}`, 2)},\n` : ''}` +
+      `${commandsString.length !== 0 ? `${indent(`steps: ${commandsString}`, 2)},\n` : ''}` +
+      `${hardwareString.length !== 0 ? `${indent(`hardware_commands: ${hardwareString}`, 2)},\n` : ''}` +
+      `${immediateString.length !== 0 ? `${indent(`immediate_commands: ${immediateString}`, 2)},\n` : ''}` +
+      `${requestString.length !== 0 ? `${indent(`requests: ${requestString}`, 2)},\n` : ''}` +
+      `${indent(`});`, 1)}`
+    );
   }
 
   // @ts-ignore : 'Args' found in JSON Spec
@@ -308,7 +458,39 @@ ${indent(`});`, 1)}`;
         : {}),
       ...(json.locals ? { locals: json.locals } : {}),
       ...(json.parameters ? { parameters: json.parameters } : {}),
-      ...(json.requests ? { requests: json.requests } : {}),
+      ...(json.requests
+        ? {
+            // @ts-ignore : 'r: Request' found in JSON Spec
+            requests: json.requests.map(r => {
+              return {
+                name: r.name,
+                type: r.type,
+                ...(r.description ? { description: r.description } : {}),
+                ...(r.ground_epoch ? { ground_epoch: r.ground_epoch } : {}),
+                ...(r.time ? { time: r.time } : {}),
+                ...(r.metadata ? { metadata: r.metadata } : {}),
+                steps: [
+                  r.steps[0].type === 'command'
+                    ? CommandStem.fromSeqJson(r.steps[0] as CommandStem)
+                    : r.steps[0].type === 'ground_block'
+                    ? // @ts-ignore : 'GroundBlock' found in JSON Spec
+                      Ground_Block.fromSeqJson(r.steps[0] as GroundBlock)
+                    : r.steps[0].type === 'ground_event'
+                    ? // @ts-ignore : 'GroundEvent' found in JSON Spec
+                      Ground_Event.fromSeqJson(r.steps[0] as GroundEvent)
+                    : r.steps[0],
+                  // @ts-ignore : 'step : Step' found in JSON Spec
+                  ...r.steps.slice(1).map(step => {
+                    if (step.type === 'command') return CommandStem.fromSeqJson(step as CommandStem);
+                    else if (step.type === 'ground_block') return Ground_Block.fromSeqJson(step as Ground_Block);
+                    else if (step.type === 'ground_event') return Ground_Event.fromSeqJson(step as Ground_Event);
+                    return step;
+                  }),
+                ],
+              };
+            }),
+          }
+        : {}),
       ...(json.immediate_commands ? { immediate_commands: json.immediate_commands } : {}),
       ...(json.hardware_commands ? { hardware_commands: json.hardware_commands } : {}),
     });
@@ -316,10 +498,10 @@ ${indent(`});`, 1)}`;
 }
 
 /*
-  ---------------------------------
-			  STEPS eDSL
-  ---------------------------------
-  */
+	---------------------------------
+				STEPS eDSL
+	---------------------------------
+	*/
 
 // @ts-ignore : 'Args' found in JSON Spec
 export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
@@ -1164,10 +1346,10 @@ export const STEPS = {
 };
 
 /*
-  ---------------------------------
-		  Time Utilities
-  ---------------------------------
-  */
+	---------------------------------
+			Time Utilities
+	---------------------------------
+	*/
 
 export type DOY_STRING = string & { __brand: 'DOY_STRING' };
 export type HMS_STRING = string & { __brand: 'HMS_STRING' };
@@ -1368,10 +1550,10 @@ function commandsWithTimeValue<T extends TimingTypes>(
 }
 
 /*
-  ---------------------------------
-		  Utility Functions
-  ---------------------------------
-  */
+	---------------------------------
+			Utility Functions
+	---------------------------------
+	*/
 
 function indent(text: string, numTimes: number = 1, char: string = '  '): string {
   return text

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -207,10 +207,10 @@ declare global {
 }
 
 /*
-  ---------------------------------
-			  Sequence eDSL
-  ---------------------------------
-  */
+	---------------------------------
+				Sequence eDSL
+	---------------------------------
+	*/
 // @ts-ignore : 'SeqJson' found in JSON Spec
 export class Sequence implements SeqJson {
   public readonly id: string;
@@ -265,31 +265,181 @@ export class Sequence implements SeqJson {
             }),
           }
         : {}),
+      ...(this.locals ? { locals: this.locals } : {}),
+      ...(this.parameters ? { parameters: this.parameters } : {}),
+      ...(this.requests
+        ? {
+            requests: this.requests.map(request => {
+              return {
+                name: request.name,
+                steps: [
+                  request.steps[0] instanceof CommandStem ||
+                  request.steps[0] instanceof Ground_Block ||
+                  request.steps[0] instanceof Ground_Event
+                    ? request.steps[0].toSeqJson()
+                    : request.steps[0],
+                  // @ts-ignore : 'step' found in JSON Spec
+                  ...request.steps.slice(1).map(step => {
+                    if (step instanceof CommandStem || step instanceof Ground_Block || step instanceof Ground_Event)
+                      return step.toSeqJson();
+                    return step;
+                  }),
+                ],
+                type: request.type,
+                ...(request.description ? { description: request.description } : {}),
+                ...(request.ground_epoch ? { ground_epoch: request.ground_epoch } : {}),
+                ...(request.time ? { time: request.time } : {}),
+                ...(request.metadata ? { metadata: request.metadata } : {}),
+              };
+            }),
+          }
+        : {}),
+      ...(this.immediate_commands ? { immediate_commands: this.immediate_commands } : {}),
+      ...(this.hardware_commands ? { hardware_commands: this.hardware_commands } : {}),
     };
   }
 
   public toEDSLString(): string {
     const commandsString =
       this.steps && this.steps.length > 0
-        ? '\\n' +
+        ? '[\\n' +
           indent(
             this.steps
               .map(step => {
-                if (step instanceof CommandStem || step instanceof Ground_Block) {
+                if (step instanceof CommandStem || step instanceof Ground_Block || step instanceof Ground_Event) {
                   return step.toEDSLString() + ',';
                 }
-                return step;
+                return step + ',';
               })
               .join('\\n'),
             1,
-          )
+          ) +
+          '\\n]'
         : '';
-    // prettier-ignore
-    return \`export default () =>
-\${indent(\`Sequence.new({\`, 1)}
-\${indent(\`seqId: '\${this.id}',\`, 2)}
-\${indent(\`metadata: \${JSON.stringify(this.metadata)},\`, 2)}\${commandsString.length > 0 ? \`\\n\${indent(\`steps: [\${commandsString}\`, 2)}\\n\${indent('],', 2)}\` : ''}
-\${indent(\`});\`, 1)}\`;
+    //ex.
+    // [C.ADD_WATER]
+    const metadataString = Object.keys(this.metadata).length == 0 ? \`{}\` : \`\${objectToString(this.metadata)}\`;
+
+    const localsString = this.locals ? \`[\\n\${indent(this.locals.map(l => objectToString(l)).join(',\\n'), 1)}\\n]\` : '';
+
+    const parameterString = this.parameters
+      ? \`[\\n\${indent(this.parameters.map(l => objectToString(l)).join(',\\n'), 1)}\\n]\`
+      : '';
+    //ex.
+    // \`parameters: [
+    //   {
+    //     allowable_ranges: [
+    //       {
+    //         max: 3600,
+    //         min: 1,
+    //       },
+    //     ],
+    //     name: 'duration',
+    //     type: 'UINT',
+    //   }
+    // ]\`;
+
+    const hardwareString = this.hardware_commands
+      ? \`[\\n\${indent(this.hardware_commands.map(h => objectToString(h)).join(',\\n'), 1)}\\n]\`
+      : '';
+    //ex.
+    // hardware_commands: [
+    //   {
+    //     description: 'FIRE THE PYROS',
+    //     metadata:{
+    //       author: 'rrgoetz',
+    //     },
+    //     stem: 'HDW_PYRO_ENGINE',
+    //   }
+    // ],
+
+    const immediateString = this.immediate_commands
+      ? \`[\\n\${indent(this.immediate_commands.map(i => objectToString(i)).join(',\\n'), 1)}\\n]\`
+      : '';
+    //ex.
+    // immediate_commands: [
+    //   {
+    //     args: [
+    //       {
+    //         name: 'direction',
+    //         type: 'string',
+    //         value: 'FromStem',
+    //       },
+    //     ],
+    //     stem: 'PEEL_BANANA',
+    //   }
+    // ]
+
+    const requestString = this.requests
+      ? \`[\\n\${indent(
+          this.requests
+            .map(r => {
+              return (
+                \`{\\n\` +
+                indent(
+                  \`name: '\${r.name}',\\n\` +
+                    \`steps: [\\n\${indent(
+                      r.steps
+                        // @ts-ignore : 's: Step' found in JSON Spec
+                        .map(s => {
+                          if (s instanceof CommandStem || s instanceof Ground_Block || s instanceof Ground_Event) {
+                            return s.toEDSLString() + ',';
+                          }
+                          return s + ',';
+                        })
+                        .join('\\n'),
+                      1,
+                    )}\\n],\` +
+                    \`\\ntype: '\${r.type}',\` +
+                    \`\${r.description ? \`\\ndescription: '\${r.description}',\` : ''}\` +
+                    \`\${r.ground_epoch ? \`\\nground_epoch: \${objectToString(r.ground_epoch)},\` : ''}\` +
+                    \`\${r.time ? \`\\ntime: \${objectToString(r.time)},\` : ''}\` +
+                    \`\${r.metadata ? \`\\nmetadata: \${objectToString(r.metadata)},\` : ''}\`,
+                  1,
+                ) +
+                \`\\n}\`
+              );
+            })
+            .join(',\\n'),
+          1,
+        )}\\n]\`
+      : '';
+    //ex.
+    /*requests: [
+        {
+          name: 'power',
+          steps: [
+            R\`04:39:22.000\`.PREHEAT_OVEN({
+              temperature: 360,
+            }),
+            C.ADD_WATER,
+          ],
+          type: 'request',
+          description: ' Activate the oven',
+          ground_epoch: {
+            delta: 'now',
+            name: 'activate',
+          },
+          metadata: {
+            author: 'rrgoet',
+          },
+        }
+      ]
+    }*/
+
+    return (
+      \`export default () =>\\n\` +
+      \`\${indent(\`Sequence.new({\`, 1)}\\n\` +
+      \`\${indent(\`seqId: '\${this.id}'\`, 2)},\\n\` +
+      \`\${indent(\`metadata: \${metadataString}\`, 2)},\\n\` +
+      \`\${localsString.length !== 0 ? \`\${indent(\`locals: \${localsString}\`, 2)},\\n\` : ''}\` +
+      \`\${parameterString.length !== 0 ? \`\${indent(\`parameters: \${parameterString}\`, 2)},\\n\` : ''}\` +
+      \`\${commandsString.length !== 0 ? \`\${indent(\`steps: \${commandsString}\`, 2)},\\n\` : ''}\` +
+      \`\${hardwareString.length !== 0 ? \`\${indent(\`hardware_commands: \${hardwareString}\`, 2)},\\n\` : ''}\` +
+      \`\${immediateString.length !== 0 ? \`\${indent(\`immediate_commands: \${immediateString}\`, 2)},\\n\` : ''}\` +
+      \`\${requestString.length !== 0 ? \`\${indent(\`requests: \${requestString}\`, 2)},\\n\` : ''}\` +
+      \`\${indent(\`});\`, 1)}\`
+    );
   }
 
   // @ts-ignore : 'Args' found in JSON Spec
@@ -311,7 +461,39 @@ export class Sequence implements SeqJson {
         : {}),
       ...(json.locals ? { locals: json.locals } : {}),
       ...(json.parameters ? { parameters: json.parameters } : {}),
-      ...(json.requests ? { requests: json.requests } : {}),
+      ...(json.requests
+        ? {
+            // @ts-ignore : 'r: Request' found in JSON Spec
+            requests: json.requests.map(r => {
+              return {
+                name: r.name,
+                type: r.type,
+                ...(r.description ? { description: r.description } : {}),
+                ...(r.ground_epoch ? { ground_epoch: r.ground_epoch } : {}),
+                ...(r.time ? { time: r.time } : {}),
+                ...(r.metadata ? { metadata: r.metadata } : {}),
+                steps: [
+                  r.steps[0].type === 'command'
+                    ? CommandStem.fromSeqJson(r.steps[0] as CommandStem)
+                    : r.steps[0].type === 'ground_block'
+                    ? // @ts-ignore : 'GroundBlock' found in JSON Spec
+                      Ground_Block.fromSeqJson(r.steps[0] as GroundBlock)
+                    : r.steps[0].type === 'ground_event'
+                    ? // @ts-ignore : 'GroundEvent' found in JSON Spec
+                      Ground_Event.fromSeqJson(r.steps[0] as GroundEvent)
+                    : r.steps[0],
+                  // @ts-ignore : 'step : Step' found in JSON Spec
+                  ...r.steps.slice(1).map(step => {
+                    if (step.type === 'command') return CommandStem.fromSeqJson(step as CommandStem);
+                    else if (step.type === 'ground_block') return Ground_Block.fromSeqJson(step as Ground_Block);
+                    else if (step.type === 'ground_event') return Ground_Event.fromSeqJson(step as Ground_Event);
+                    return step;
+                  }),
+                ],
+              };
+            }),
+          }
+        : {}),
       ...(json.immediate_commands ? { immediate_commands: json.immediate_commands } : {}),
       ...(json.hardware_commands ? { hardware_commands: json.hardware_commands } : {}),
     });
@@ -319,10 +501,10 @@ export class Sequence implements SeqJson {
 }
 
 /*
-  ---------------------------------
-			  STEPS eDSL
-  ---------------------------------
-  */
+	---------------------------------
+				STEPS eDSL
+	---------------------------------
+	*/
 
 // @ts-ignore : 'Args' found in JSON Spec
 export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
@@ -1167,10 +1349,10 @@ export const STEPS = {
 };
 
 /*
-  ---------------------------------
-		  Time Utilities
-  ---------------------------------
-  */
+	---------------------------------
+			Time Utilities
+	---------------------------------
+	*/
 
 export type DOY_STRING = string & { __brand: 'DOY_STRING' };
 export type HMS_STRING = string & { __brand: 'HMS_STRING' };
@@ -1371,10 +1553,10 @@ function commandsWithTimeValue<T extends TimingTypes>(
 }
 
 /*
-  ---------------------------------
-		  Utility Functions
-  ---------------------------------
-  */
+	---------------------------------
+			Utility Functions
+	---------------------------------
+	*/
 
 function indent(text: string, numTimes: number = 1, char: string = '  '): string {
   return text

--- a/sequencing-server/test/seqjson-to-edsl.spec.ts
+++ b/sequencing-server/test/seqjson-to-edsl.spec.ts
@@ -93,6 +93,220 @@ describe('getEdslForSeqJson', () => {
       ).toThrow();
     } catch (e) {}
   });
+
+  it('should return the full edsl', async () => {
+    const res = await graphqlClient.request<{
+      getEdslForSeqJson: string;
+    }>(
+      gql`
+        query GetEdslForSeqJson($seqJson: SequenceSeqJson!) {
+          getEdslForSeqJson(seqJson: $seqJson)
+        }
+      `,
+      {
+        seqJson: {
+          hardware_commands: [
+            {
+              description: 'FIRE THE PYROS',
+              metadata: {
+                author: 'rrgoetz',
+              },
+              stem: 'HDW_PYRO_ENGINE',
+            },
+          ],
+          id: 'banana1001.0000a',
+          immediate_commands: [
+            {
+              args: [
+                {
+                  name: 'direction',
+                  type: 'string',
+                  value: 'FromStem',
+                },
+              ],
+              stem: 'PEEL_BANANA',
+            },
+          ],
+          locals: [
+            {
+              allowable_ranges: [
+                {
+                  max: 3600,
+                  min: 1,
+                },
+              ],
+              name: 'duration',
+              type: 'UINT',
+            },
+          ],
+          metadata: {
+            author: 'rrgoetz',
+          },
+          parameters: [
+            {
+              allowable_ranges: [
+                {
+                  max: 3600,
+                  min: 1,
+                },
+              ],
+              name: 'duration',
+              type: 'UINT',
+            },
+          ],
+          requests: [
+            {
+              description: ' Activate the oven',
+              ground_epoch: {
+                delta: 'now',
+                name: 'activate',
+              },
+              metadata: {
+                author: 'rrgoetz',
+              },
+              name: 'power',
+              steps: [
+                {
+                  args: [
+                    {
+                      name: 'temperature',
+                      type: 'number',
+                      value: 360,
+                    },
+                  ],
+                  stem: 'PREHEAT_OVEN',
+                  time: {
+                    tag: '04:39:22.000',
+                    type: 'COMMAND_RELATIVE',
+                  },
+                  type: 'command',
+                },
+                {
+                  args: [],
+                  stem: 'ADD_WATER',
+                  time: {
+                    type: 'COMMAND_COMPLETE',
+                  },
+                  type: 'command',
+                },
+              ],
+              type: 'request',
+            },
+            {
+              description: ' Activate the water',
+              ground_epoch: {
+                delta: 'now',
+                name: 'activate',
+              },
+              metadata: {
+                author: 'rrgoetz',
+              },
+              name: 'water',
+              steps: [
+                {
+                  args: [],
+                  stem: 'ADD_WATER',
+                  time: {
+                    type: 'COMMAND_COMPLETE',
+                  },
+                  type: 'command',
+                },
+              ],
+              type: 'request',
+            },
+          ],
+        },
+      },
+    );
+
+    expect(res.getEdslForSeqJson).toEqual(`export default () =>
+  Sequence.new({
+    seqId: 'banana1001.0000a',
+    metadata: {
+      author: 'rrgoetz',
+    },
+    locals: [
+      {
+        allowable_ranges: [
+          {
+            max: 3600,
+            min: 1,
+          },
+        ],
+        name: 'duration',
+        type: 'UINT',
+      }
+    ],
+    parameters: [
+      {
+        allowable_ranges: [
+          {
+            max: 3600,
+            min: 1,
+          },
+        ],
+        name: 'duration',
+        type: 'UINT',
+      }
+    ],
+    hardware_commands: [
+      {
+        description: 'FIRE THE PYROS',
+        metadata:{
+          author: 'rrgoetz',
+        },
+        stem: 'HDW_PYRO_ENGINE',
+      }
+    ],
+    immediate_commands: [
+      {
+        args: [
+          {
+            name: 'direction',
+            type: 'string',
+            value: 'FromStem',
+          },
+        ],
+        stem: 'PEEL_BANANA',
+      }
+    ],
+    requests: [
+      {
+        name: 'power',
+        steps: [
+          R\`04:39:22.000\`.PREHEAT_OVEN({
+            temperature: 360,
+          }),
+          C.ADD_WATER,
+        ],
+        type: 'request',
+        description: ' Activate the oven',
+        ground_epoch: {
+          delta: 'now',
+          name: 'activate',
+        },
+        metadata: {
+          author: 'rrgoetz',
+        },
+      },
+      {
+        name: 'water',
+        steps: [
+          C.ADD_WATER,
+        ],
+        type: 'request',
+        description: ' Activate the water',
+        ground_epoch: {
+          delta: 'now',
+          name: 'activate',
+        },
+        metadata: {
+          author: 'rrgoetz',
+        },
+      }
+    ],
+  });`);
+  });
 });
 
 describe('getEdslForSeqJsonBulk', () => {

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -2887,6 +2887,86 @@ describe('user sequence to seqjson', () => {
                     variable: 'model_var_boolean',
                   }]),
               ],
+              locals: [
+                {
+                  allowable_ranges: [
+                    {
+                      max: 3600,
+                      min: 1,
+                    },
+                  ],
+                  name: 'duration',
+                  type: 'UINT',
+                }
+              ],
+              parameters: [
+                {
+                  allowable_ranges: [
+                    {
+                      max: 3600,
+                      min: 1,
+                    },
+                  ],
+                  name: 'duration',
+                  type: 'UINT',
+                }
+              ],
+              hardware_commands: [
+                {
+                  description: 'FIRE THE PYROS',
+                  metadata:{
+                    author: 'rrgoetz',
+                  },
+                  stem: 'HDW_PYRO_ENGINE',
+                }
+              ],
+              immediate_commands: [
+                {
+                  args: [
+                    {
+                      name: 'direction',
+                      type: 'string',
+                      value: 'FromStem',
+                    },
+                  ],
+                  stem: 'PEEL_BANANA',
+                }
+              ],
+              requests: [
+                {
+                  name: 'power',
+                  steps: [
+                    R\`04:39:22.000\`.PREHEAT_OVEN({
+                      temperature: 360,
+                    }),
+                    C.ADD_WATER,
+                  ],
+                  type: 'request',
+                  description: ' Activate the oven',
+                  ground_epoch: {
+                    delta: 'now',
+                    name: 'activate',
+                  },
+                  metadata: {
+                    author: 'rrgoet',
+                  },
+                },
+                {
+                  name: 'power2',
+                  steps: [
+                    C.ADD_WATER,
+                  ],
+                  type: 'request',
+                  description: ' Activate the oven',
+                  ground_epoch: {
+                    delta: 'now',
+                    name: 'activate',
+                  },
+                  metadata: {
+                    author: 'rrgoet',
+                  },
+                }
+              ],
             });
           `,
       },
@@ -3055,6 +3135,110 @@ describe('user sequence to seqjson', () => {
             variable: 'model_var_boolean',
           },
         ],
+      },
+    ]);
+    expect(results[1]!.locals).toEqual([
+      {
+        allowable_ranges: [
+          {
+            max: 3600,
+            min: 1,
+          },
+        ],
+        name: 'duration',
+        type: 'UINT',
+      },
+    ]);
+    expect(results[1]!.parameters).toEqual([
+      {
+        allowable_ranges: [
+          {
+            max: 3600,
+            min: 1,
+          },
+        ],
+        name: 'duration',
+        type: 'UINT',
+      },
+    ]);
+    expect(results[1]!.hardware_commands).toEqual([
+      {
+        description: 'FIRE THE PYROS',
+        metadata: {
+          author: 'rrgoetz',
+        },
+        stem: 'HDW_PYRO_ENGINE',
+      },
+    ]);
+    expect(results[1]!.immediate_commands).toEqual([
+      {
+        args: [
+          {
+            name: 'direction',
+            type: 'string',
+            value: 'FromStem',
+          },
+        ],
+        stem: 'PEEL_BANANA',
+      },
+    ]);
+    expect(results[1]!.requests).toEqual([
+      {
+        description: ' Activate the oven',
+        ground_epoch: {
+          delta: 'now',
+          name: 'activate',
+        },
+        metadata: {
+          author: 'rrgoet',
+        },
+        name: 'power',
+        steps: [
+          {
+            args: [
+              {
+                name: 'temperature',
+                type: 'number',
+                value: 360,
+              },
+            ],
+            stem: 'PREHEAT_OVEN',
+            time: {
+              tag: '04:39:22.000',
+              type: 'COMMAND_RELATIVE',
+            },
+            type: 'command',
+          },
+          {
+            args: [],
+            stem: 'ADD_WATER',
+            time: {
+              type: 'COMMAND_COMPLETE',
+            },
+            type: 'command',
+          },
+        ],
+        type: 'request',
+      },
+      {
+        description: ' Activate the oven',
+        ground_epoch: {
+          delta: 'now',
+          name: 'activate',
+        },
+        metadata: {
+          author: 'rrgoet',
+        },
+        name: 'power2',
+        steps: [
+          {
+            args: [],
+            stem: 'ADD_WATER',
+            time: { type: 'COMMAND_COMPLETE' },
+            type: 'command',
+          },
+        ],
+        type: 'request',
       },
     ]);
   }, 30000);


### PR DESCRIPTION
* **Tickets addressed:** Closes https://github.com/NASA-AMMOS/aerie/issues/736
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Now that we have linked the eDSL with the Json Spec, exporting the full spec from the Sequence eDSL should be possible. I have updated the Sequence export to include the remaining SeqJson spec values such as local, parameters, hardware_commands, immediate_commands, and activate. With this update, you should now be able to export and import the complete SeqJson spec from within the Sequence editor.

However, please note that there are some limitations to the Spec due to embedded logic that is not captured by the TS conversion process. Some known limitations at this time include the fact that for Local and Parameter, the enum_name is only valid if it is of type ENUM. Additionally, for Activate, you can only have ground_epoch or time attributes, but not both simultaneously.

## Verification
Updated the e2e test

## Documentation
Note the limitation below:

For Local and Parameter fields, the enum_name is only valid if it is of type ENUM. Additionally, for Activate, you can only have ground_epoch or time attributes, but not both simultaneously.

## Future work
A more complex test could involve an exhaustive end-to-end test using a large eDSL that is converted to SeqJson and back again.
