### PR TITLE
Add activity presets to scheduling edsl

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/MissionModelService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/MissionModelService.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchMissionModelException;
 import gov.nasa.jpl.aerie.scheduler.server.models.MissionModelId;
@@ -26,7 +27,7 @@ public interface MissionModelService {
     }
   }
 
-  record ActivityType(String name, Map<String, ValueSchema> parameters) {}
+  record ActivityType(String name, Map<String, ValueSchema> parameters, Map<String, Map<String, SerializedValue>> presets) {}
 
   record ResourceType(String name, ValueSchema schema) {}
 

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
@@ -68,6 +68,17 @@ const ActivityTemplateConstructors = {
     return { activityType: ActivityType.SampleActivityEmpty, args: {} };
   },
 };
+const ActivityPresetMap = {
+  SampleActivity1: {
+  },
+  SampleActivity2: {
+    "my preset": {
+      quantity: 5,
+    },
+  },
+  SampleActivityEmpty: {
+  },
+};
 export enum Resource {
   "/sample/resource/1" = "/sample/resource/1",
   "/sample/resource/3" = "/sample/resource/3",
@@ -75,11 +86,13 @@ export enum Resource {
 };
 declare global {
   var ActivityTemplates: typeof ActivityTemplateConstructors;
+  var ActivityPresets: typeof ActivityPresetMap;
   var Resources: typeof Resource;
 }
 // Make ActivityTemplates and ActivityTypes available on the global object
 Object.assign(globalThis, {
   ActivityTemplates: ActivityTemplateConstructors,
+  ActivityPresets: ActivityPresetMap,
   ActivityTypes: ActivityType,
   Resources: Resource,
 });

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
@@ -68,17 +68,21 @@ const ActivityTemplateConstructors = {
     return { activityType: ActivityType.SampleActivityEmpty, args: {} };
   },
 };
-const ActivityPresetMap = {
-  SampleActivity1: {
-  },
-  SampleActivity2: {
-    "my preset": {
-      quantity: 5,
+const ActivityPresetMap = Object.freeze({
+  SampleActivity1: Object.freeze({
+  }),
+  SampleActivity2: Object.freeze({
+    get "my preset"(): {
+      "quantity": number,
+    } {
+      return {
+        "quantity": 5,
+      };
     },
-  },
-  SampleActivityEmpty: {
-  },
-};
+  }),
+  SampleActivityEmpty: Object.freeze({
+  }),
+});
 export enum Resource {
   "/sample/resource/1" = "/sample/resource/1",
   "/sample/resource/3" = "/sample/resource/3",

--- a/scheduler-server/src/testFixtures/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTestFixtures.java
+++ b/scheduler-server/src/testFixtures/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTestFixtures.java
@@ -2,56 +2,75 @@ package gov.nasa.jpl.aerie.scheduler.server.services;
 
 import java.util.List;
 import java.util.Map;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
 public final class TypescriptCodeGenerationServiceTestFixtures {
 
   public static final MissionModelService.MissionModelTypes MISSION_MODEL_TYPES =
       new MissionModelService.MissionModelTypes(
-          List.of(new MissionModelService.ActivityType(
-              "SampleActivity1",
-              Map.of(
-                  "variant",
-                  ValueSchema.ofVariant(List.of(
-                      new ValueSchema.Variant(
-                          "option1", "option1"
-                      ),
-                      new ValueSchema.Variant(
-                          "option2",
-                          "option2"))),
-                  "duration",
-                  ValueSchema.DURATION,
-                  "fancy",
-                  ValueSchema.ofStruct(Map.of(
-                      "subfield1",
-                      ValueSchema.STRING,
-                      "subfield2",
-                      ValueSchema.ofSeries(ValueSchema.ofStruct(Map.of("subsubfield1", ValueSchema.REAL)))
-                  )))),
-                  new MissionModelService.ActivityType(
-                      "SampleActivity2",
-                      Map.of(
-                          "quantity",
-                          ValueSchema.REAL
-                      )
+          List.of(
+              new MissionModelService.ActivityType(
+                  "SampleActivity1",
+                  Map.of(
+                      "variant",
+                      ValueSchema.ofVariant(List.of(
+                          new ValueSchema.Variant(
+                              "option1", "option1"
+                          ),
+                          new ValueSchema.Variant(
+                              "option2",
+                              "option2")
+                      )),
+                      "duration",
+                      ValueSchema.DURATION,
+                      "fancy",
+                      ValueSchema.ofStruct(Map.of(
+                          "subfield1",
+                          ValueSchema.STRING,
+                          "subfield2",
+                          ValueSchema.ofSeries(ValueSchema.ofStruct(Map.of("subsubfield1", ValueSchema.REAL)))
+                      ))
                   ),
-                  new MissionModelService.ActivityType(
-                      "SampleActivityEmpty",
-                      Map.of()
+                  Map.of()
+              ),
+              new MissionModelService.ActivityType(
+                  "SampleActivity2",
+                  Map.of(
+                      "quantity",
+                      ValueSchema.REAL
+                  ),
+                  Map.of(
+                      "my preset",
+                      Map.of("quantity", SerializedValue.of(5))
                   )
+              ),
+              new MissionModelService.ActivityType(
+                  "SampleActivityEmpty",
+                  Map.of(),
+                  Map.of()
+              )
           ),
-          List.of(new MissionModelService.ResourceType("/sample/resource/1", ValueSchema.REAL),
-                  new MissionModelService.ResourceType("/sample/resource/3", ValueSchema.ofVariant(List.of(
-                      new ValueSchema.Variant(
-                          "option1", "option1"
-                      ),
-                      new ValueSchema.Variant(
-                          "option2",
-                          "option2")))),
-                  new MissionModelService.ResourceType("/sample/resource/2", ValueSchema.ofStruct(
-                      Map.of("field1", ValueSchema.BOOLEAN,
-                             "field2", ValueSchema.ofVariant(List.of(
-                                 new ValueSchema.Variant("ABC", "ABC"),
-                                 new ValueSchema.Variant("DEF", "DEF")))))))
+          List.of(
+              new MissionModelService.ResourceType("/sample/resource/1", ValueSchema.REAL),
+              new MissionModelService.ResourceType("/sample/resource/3", ValueSchema.ofVariant(List.of(
+                  new ValueSchema.Variant(
+                      "option1", "option1"
+                  ),
+                  new ValueSchema.Variant(
+                      "option2", "option2"
+                  )
+              ))),
+              new MissionModelService.ResourceType("/sample/resource/2", ValueSchema.ofStruct(
+                  Map.of(
+                      "field1", ValueSchema.BOOLEAN,
+                      "field2", ValueSchema.ofVariant(List.of(
+                          new ValueSchema.Variant("ABC", "ABC"),
+                          new ValueSchema.Variant("DEF", "DEF")
+                      ))
+                  )
+              ))
+          )
       );
 }

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingDSLCompilationServiceTests.java
@@ -149,6 +149,12 @@ class SchedulingDSLCompilationServiceTests {
     ));
   }
 
+  private static StructExpressionAt getSampleActivity2PresetParameters() {
+    return new StructExpressionAt(Map.of(
+        "quantity", new ProfileExpression<>(new DiscreteValue(SerializedValue.of(5)))
+    ));
+  }
+
   @Test
   void  testSchedulingDSL_basic()
   {
@@ -818,6 +824,32 @@ class SchedulingDSLCompilationServiceTests {
           r.value()
       );
     } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error r) {
+      fail(r.toString());
+    }
+  }
+
+  @Test
+  void  testActivityPreset() {
+    final var result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+        missionModelService,
+        PLAN_ID, """
+                export default (): Goal => {
+                  return Goal.ActivityRecurrenceGoal({
+                    activityTemplate: ActivityTemplates.SampleActivity2(ActivityPresets.SampleActivity2["my preset"]),
+                    interval: Temporal.Duration.from({ hours: 1 })
+                  })
+                }
+            """);
+    final var expectedGoalDefinition = new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
+        new SchedulingDSL.ActivityTemplate(
+            "SampleActivity2",
+            getSampleActivity2PresetParameters()
+        ),
+        HOUR,
+        false);
+    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success<SchedulingDSL.GoalSpecifier> r) {
+      assertEquals(expectedGoalDefinition, r.value());
+    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
       fail(r.toString());
     }
   }

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
@@ -1248,7 +1248,9 @@ public class SchedulingIntegrationTests {
               .getInputType()
               .getParameters()
               .stream()
-              .collect(Collectors.toMap(Parameter::name, Parameter::schema))));
+              .collect(Collectors.toMap(Parameter::name, Parameter::schema)),
+          Map.of()
+      ));
     }
 
     final var resourceTypes = new ArrayList<MissionModelService.ResourceType>();


### PR DESCRIPTION
* **Tickets addressed:** closes #678 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

This serializes all presets for a mission model into a `ActivityPresets` object in the scheduling edsl, so goal authors can use then to construct activity templates. For example if they have a BiteBanana preset called "large bite", they can use it like:

```ts
export default (): Goal => {
  return Goal.CoexistenceGoal({
    forEach: ...,
    activityTemplate: ActivityTemplates.BiteBanana(ActivityPresets.BiteBanana["large bite"]),
    startsAt: ...
  });
}
```

`ActivityPresets.BiteBanana["large bite"]` is a concrete object containing the actual values of the preset, not an expression. This means it is easy for the author to override specific values such as:

```ts
let biteArgs = ActivityPresets.BiteBanana["large bite"];
biteArgs.biteSize += 10; // even bigger

// use AcitivityTemplates.BiteBanana(biteArgs)
```

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Added a compilation service test

## Documentation
- [x] documentation written
- [ ] documentation merged

## Future work
<!-- What next steps can we anticipate from here, if any? -->
