### PR TITLE
Add hardware commands to Command eDSL

### DIFF
--- a/sequencing-server/cdict/command_banananation.xml
+++ b/sequencing-server/cdict/command_banananation.xml
@@ -249,5 +249,11 @@
                 <prime_string_restriction prime_string_only="No" />
             </restricted_modes>
         </fsw_command>
+        <hw_command opcode="0x0000" stem="HDW_BLENDER_DUMP">
+          <categories>
+            <ops_category>UPL</ops_category>
+          </categories>
+          <description>Dump the blender configuration file.</description>
+        </hw_command>
     </command_definitions>
 </command_dictionary>

--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
@@ -1,5 +1,6 @@
 import {
   CommandStem,
+  HardwareStem,
   doyToInstant,
   DOY_STRING,
   hmsToDuration,
@@ -268,6 +269,31 @@ describe('Sequence', () => {
       }),
     ],
   });`);
+    });
+
+    it('should convert with Hardware,', () => {
+      const sequence = Sequence.new({
+        seqId: 'HW',
+        metadata: {},
+        hardware_commands: [
+          HardwareStem.new({ stem: 'HW_PYRO_DUMP' }).DESCRIPTION('Fire the pyros').METADATA({ author: 'Emery' }),
+        ],
+      });
+
+      expect(sequence.toEDSLString()).toEqual(
+        'export default () =>\n' +
+          '  Sequence.new({\n' +
+          "    seqId: 'HW',\n" +
+          '    metadata: {},\n' +
+          '    hardware_commands: [\n' +
+          '      HW_PYRO_DUMP\n' +
+          "      .DESCRIPTION('Fire the pyros')\n" +
+          '      .METADATA({\n' +
+          "        author: 'Emery',\n" +
+          '      })\n' +
+          '    ],\n' +
+          '  });',
+      );
     });
   });
 });

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -34,6 +34,14 @@ export type CommandOptions<A extends Args[] | { [argName: string]: any } = [] | 
   | {}
 );
 
+export type HardwareOptions = {
+  stem: string;
+  // @ts-ignore : 'Description' found in JSON Spec
+  description?: Description;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  metadata?: Metadata;
+};
+
 export type GroundOptions = {
   name: string;
   // @ts-ignore : 'Args' found in JSON Spec
@@ -153,6 +161,26 @@ declare global {
 
     // @ts-ignore : 'Description' found in JSON Spec
     public DESCRIPTION(description: Description): CommandStem<A>;
+    // @ts-ignore : 'Description' found in JSON Spec
+    public GET_DESCRIPTION(): Description | undefined;
+  }
+
+  // @ts-ignore : 'HardwareCommand' found in JSON Spec
+  class HardwareStem implements HardwareCommand {
+    stem: string;
+
+    public static new(opts: HardwareOptions): HardwareStem;
+
+    // @ts-ignore : 'Command' found in JSON Spec
+    public toSeqJson(): HardwareCommand;
+
+    // @ts-ignore : 'Metadata' found in JSON Spec
+    public METADATA(metadata: Metadata): HardwareStem;
+    // @ts-ignore : 'Metadata' found in JSON Spec
+    public GET_METADATA(): Metadata | undefined;
+
+    // @ts-ignore : 'Description' found in JSON Spec
+    public DESCRIPTION(description: Description): HardwareStem;
     // @ts-ignore : 'Description' found in JSON Spec
     public GET_DESCRIPTION(): Description | undefined;
   }
@@ -295,7 +323,13 @@ export class Sequence implements SeqJson {
           }
         : {}),
       ...(this.immediate_commands ? { immediate_commands: this.immediate_commands } : {}),
-      ...(this.hardware_commands ? { hardware_commands: this.hardware_commands } : {}),
+      ...(this.hardware_commands
+        ? {
+            hardware_commands: this.hardware_commands.map(h => {
+              return h instanceof HardwareStem ? h.toSeqJson() : h;
+            }),
+          }
+        : {}),
     };
   }
 
@@ -340,7 +374,7 @@ export class Sequence implements SeqJson {
     // ]\`;
 
     const hardwareString = this.hardware_commands
-      ? \`[\\n\${indent(this.hardware_commands.map(h => objectToString(h)).join(',\\n'), 1)}\\n]\`
+      ? \`[\\n\${indent(this.hardware_commands.map(h => (h as HardwareStem).toEDSLString()).join(',\\n'), 1)}\\n]\`
       : '';
     //ex.
     // hardware_commands: [
@@ -495,7 +529,10 @@ export class Sequence implements SeqJson {
           }
         : {}),
       ...(json.immediate_commands ? { immediate_commands: json.immediate_commands } : {}),
-      ...(json.hardware_commands ? { hardware_commands: json.hardware_commands } : {}),
+      ...(json.hardware_commands
+        ? // @ts-ignore : 'HardwareCommand' found in JSON Spec
+          { hardware_commands: json.hardware_commands.map((h: HardwareCommand) => HardwareStem.fromSeqJson(h)) }
+        : {}),
     });
   }
 }
@@ -1348,6 +1385,84 @@ export const STEPS = {
   GROUND_EVENT: GROUND_EVENT,
 };
 
+/*-----------------------------------
+	  HW Commands
+	------------------------------------- */
+// @ts-ignore : 'HardwareCommand' found in JSON Spec
+export class HardwareStem implements HardwareCommand {
+  public readonly stem: string;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  private readonly _metadata?: Metadata | undefined;
+  // @ts-ignore : 'Description' found in JSON Spec
+  private readonly _description?: Description | undefined;
+
+  private constructor(opts: HardwareOptions) {
+    this.stem = opts.stem;
+    this._metadata = opts.metadata;
+    this._description = opts.description;
+  }
+
+  public static new(opts: HardwareOptions): HardwareStem {
+    return new HardwareStem(opts);
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public METADATA(metadata: Metadata): HardwareStem {
+    return HardwareStem.new({
+      stem: this.stem,
+      metadata: metadata,
+      description: this._description,
+    });
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public GET_METADATA(): Metadata | undefined {
+    return this._metadata;
+  }
+
+  // @ts-ignore : 'Description' found in JSON Spec
+  public DESCRIPTION(description: Description): HardwareStem {
+    return HardwareStem.new({
+      stem: this.stem,
+      metadata: this._metadata,
+      description: description,
+    });
+  }
+  // @ts-ignore : 'Description' found in JSON Spec
+  public GET_DESCRIPTION(): Description | undefined {
+    return this._description;
+  }
+
+  // @ts-ignore : 'Command' found in JSON Spec
+  public toSeqJson(): HardwareCommand {
+    return {
+      stem: this.stem,
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._description ? { description: this._description } : {}),
+    };
+  }
+
+  // @ts-ignore : 'Command' found in JSON Spec
+  public static fromSeqJson(json: HardwareCommand): HardwareStem {
+    return HardwareStem.new({
+      stem: json.stem,
+      metadata: json.metadata,
+      description: json.description,
+    });
+  }
+
+  public toEDSLString(): string {
+    const metadata =
+      this._metadata && Object.keys(this._metadata).length !== 0
+        ? \`\\n.METADATA(\${objectToString(this._metadata)})\`
+        : '';
+    const description =
+      this._description && this._description.length !== 0 ? \`\\n.DESCRIPTION('\${this._description}')\` : '';
+
+    return \`\${this.stem}\${description}\${metadata}\`;
+  }
+}
+
 /*
 	---------------------------------
 			Time Utilities
@@ -2062,6 +2177,13 @@ declare global {
 */
 	interface EAT_BANANA extends CommandStem<[]> {}
 
+/**
+* Dump the blender configuration file.
+*
+*/
+interface HDW_BLENDER_DUMP extends HardwareStem {}
+const HDW_BLENDER_DUMP: HDW_BLENDER_DUMP
+
 	const Commands: {
 		ECHO: typeof ECHO,
 		PREHEAT_OVEN: typeof PREHEAT_OVEN,
@@ -2076,6 +2198,9 @@ declare global {
 		PICK_BANANA: typeof PICK_BANANA,
 		EAT_BANANA: typeof EAT_BANANA,
 	};
+
+	const Hardwares : {
+		HDW_BLENDER_DUMP: typeof HDW_BLENDER_DUMP 	};
 }
 
 
@@ -2217,6 +2342,15 @@ const EAT_BANANA: EAT_BANANA = CommandStem.new({
 	stem: 'EAT_BANANA',
 	arguments: [],
 })
+
+/**
+* Dump the blender configuration file.
+*
+*/
+const HDW_BLENDER_DUMP: HDW_BLENDER_DUMP = HardwareStem.new({
+	stem: 'HDW_BLENDER_DUMP'
+})
+
 export const Commands = {		ECHO: ECHO,
 		PREHEAT_OVEN: PREHEAT_OVEN,
 		THROW_BANANA: THROW_BANANA,
@@ -2231,6 +2365,9 @@ export const Commands = {		ECHO: ECHO,
 		EAT_BANANA: EAT_BANANA,
 };
 
-Object.assign(globalThis, { A:A, R:R, E:E, C:Object.assign(Commands, STEPS), Sequence});
+export const Hardwares = {		HDW_BLENDER_DUMP: HDW_BLENDER_DUMP,
+};
+
+Object.assign(globalThis, { A:A, R:R, E:E, C:Object.assign(Commands, STEPS), Sequence}, Hardwares);
 "
 `;

--- a/sequencing-server/test/seqjson-to-edsl.spec.ts
+++ b/sequencing-server/test/seqjson-to-edsl.spec.ts
@@ -250,13 +250,11 @@ describe('getEdslForSeqJson', () => {
       }
     ],
     hardware_commands: [
-      {
-        description: 'FIRE THE PYROS',
-        metadata:{
-          author: 'rrgoetz',
-        },
-        stem: 'HDW_PYRO_ENGINE',
-      }
+      HDW_PYRO_ENGINE
+      .DESCRIPTION('FIRE THE PYROS')
+      .METADATA({
+        author: 'rrgoetz',
+      })
     ],
     immediate_commands: [
       {

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -2913,13 +2913,9 @@ describe('user sequence to seqjson', () => {
                 }
               ],
               hardware_commands: [
-                {
-                  description: 'FIRE THE PYROS',
-                  metadata:{
-                    author: 'rrgoetz',
-                  },
-                  stem: 'HDW_PYRO_ENGINE',
-                }
+                HDW_BLENDER_DUMP
+                .DESCRIPTION("FIRE THE PYROS")
+                .METADATA({author: 'rrgoetz'})
               ],
               immediate_commands: [
                 {
@@ -3168,7 +3164,7 @@ describe('user sequence to seqjson', () => {
         metadata: {
           author: 'rrgoetz',
         },
-        stem: 'HDW_PYRO_ENGINE',
+        stem: 'HDW_BLENDER_DUMP',
       },
     ]);
     expect(results[1]!.immediate_commands).toEqual([


### PR DESCRIPTION
* **Tickets addressed:** closes https://github.com/NASA-AMMOS/aerie/issues/744
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Added hardware command generation and support to the eDSL from the command dictionary.

ex.
```ts
export default () =>
  Sequence.new({
    seqId: 'test000.0001',
    metadata: {},
    hardware_commands: [
      HDW_BLENDER_DUMP
      .DESCRIPTION('dump blender')
      .METADATA({
        author: 'rrgoetz',
      })
    ],
  });
```

## Verification
Tested generation with a clipper command dictionary and updated the e2e test.

## Documentation
none

## Future work
Immediate commands