### PR TITLE
Update @nasa-jpl/aerie-ampcs to 1.0.1

### DIFF
--- a/sequencing-server/package-lock.json
+++ b/sequencing-server/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@js-temporal/polyfill": "~0.4.3",
-        "@nasa-jpl/aerie-ampcs": "~1.0.0",
+        "@nasa-jpl/aerie-ampcs": "~1.0.1",
         "@nasa-jpl/aerie-ts-user-code-runner": "~0.5.0",
         "@nasa-jpl/seq-json-schema": "1.0.17",
         "body-parser": "~1.20.1",
@@ -1101,9 +1101,9 @@
       "dev": true
     },
     "node_modules/@nasa-jpl/aerie-ampcs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-ampcs/-/aerie-ampcs-1.0.0.tgz",
-      "integrity": "sha512-WkNWIFWpTi7UbFFsiOppQVSFuH1rZVhnAO4tc4V8pb5MP29/sRvVY0D/vHQZYjOph/OJUsNFegjQDN5ntQxlgA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-ampcs/-/aerie-ampcs-1.0.1.tgz",
+      "integrity": "sha512-BNkyv2PEbdBmC+F9z39+G3mst4eOa1Un+um9Y+CbNnODCgB5/GowYsBJOm0EOHSou3RxxD0PAzGg4tN5bvJC1g==",
       "dependencies": {
         "xml-js": "^1.6.11"
       }
@@ -6477,9 +6477,9 @@
       "dev": true
     },
     "@nasa-jpl/aerie-ampcs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-ampcs/-/aerie-ampcs-1.0.0.tgz",
-      "integrity": "sha512-WkNWIFWpTi7UbFFsiOppQVSFuH1rZVhnAO4tc4V8pb5MP29/sRvVY0D/vHQZYjOph/OJUsNFegjQDN5ntQxlgA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-ampcs/-/aerie-ampcs-1.0.1.tgz",
+      "integrity": "sha512-BNkyv2PEbdBmC+F9z39+G3mst4eOa1Un+um9Y+CbNnODCgB5/GowYsBJOm0EOHSou3RxxD0PAzGg4tN5bvJC1g==",
       "requires": {
         "xml-js": "^1.6.11"
       }

--- a/sequencing-server/package.json
+++ b/sequencing-server/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@js-temporal/polyfill": "~0.4.3",
-    "@nasa-jpl/aerie-ampcs": "~1.0.0",
+    "@nasa-jpl/aerie-ampcs": "~1.0.1",
     "@nasa-jpl/aerie-ts-user-code-runner": "~0.5.0",
     "@nasa-jpl/seq-json-schema": "1.0.17",
     "body-parser": "~1.20.1",

--- a/sequencing-server/src/app.ts
+++ b/sequencing-server/src/app.ts
@@ -111,7 +111,8 @@ app.post('/put-dictionary', async (req, res, next) => {
   const dictionary = req.body.input.dictionary as string;
   logger.info(`Dictionary received`);
 
-  const parsedDictionary = ampcs.parse(dictionary);
+  // Note we ignore comments when parsing dictionary because the parser breaks otherwise.
+  const parsedDictionary = ampcs.parse(dictionary, null, { ignoreComment: true });
   logger.info(
     `Dictionary parsed - version: ${parsedDictionary.header.version}, mission: ${parsedDictionary.header.mission_name}`,
   );


### PR DESCRIPTION
## Description

* Part of https://github.com/NASA-AMMOS/aerie-ampcs/pull/1
* Exclude parsing comments from dictionary XML since parser cannot handle them

## Verification

Unit tested in the `@nasa-jpl/aerie-ampcs` lib.
