### PR TITLE
Close SimulationEngine when Scheduling Finishes

### DIFF
--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public class ResumableSimulationDriver<Model> {
+public class ResumableSimulationDriver<Model> implements AutoCloseable {
 
   private Duration curTime = Duration.ZERO;
   private SimulationEngine engine = new SimulationEngine();
@@ -90,6 +90,11 @@ public class ResumableSimulationDriver<Model> {
       final var commit = engine.performJobs(batch.jobs(), cells, curTime, Duration.MAX_VALUE);
       timeline.add(commit);
     }
+  }
+
+  @Override
+  public void close() {
+    this.engine.close();
   }
 
   private void simulateUntil(Duration endTime){

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -27,7 +27,7 @@ import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
 /**
  * A facade for simulating plans and processing simulation results.
  */
-public class SimulationFacade {
+public class SimulationFacade implements AutoCloseable{
 
   private static final Logger logger = LoggerFactory.getLogger(SimulationFacade.class);
 
@@ -58,6 +58,11 @@ public class SimulationFacade {
     this.itSimActivityId = 0;
     this.insertedActivities = new HashMap<>();
     this.activityTypes = new HashMap<>();
+  }
+
+  @Override
+  public void close(){
+    driver.close();
   }
 
   public void setActivityTypes(final Collection<ActivityType> activityTypes){
@@ -129,7 +134,7 @@ public class SimulationFacade {
       final var oldInsertedActivities = new HashMap<>(insertedActivities);
       insertedActivities.clear();
       planActDirectiveIdToSimulationActivityDirectiveId.clear();
-      driver = new ResumableSimulationDriver<>(missionModel, planningHorizon.getAerieHorizonDuration());
+      driver.initSimulation();
       simulateActivities(oldInsertedActivities.keySet());
     }
   }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -134,7 +134,8 @@ public class SimulationFacade implements AutoCloseable{
       final var oldInsertedActivities = new HashMap<>(insertedActivities);
       insertedActivities.clear();
       planActDirectiveIdToSimulationActivityDirectiveId.clear();
-      driver.initSimulation();
+      if (driver != null) driver.close();
+      driver = new ResumableSimulationDriver<>(missionModel, planningHorizon.getAerieHorizonDuration());
       simulateActivities(oldInsertedActivities.keySet());
     }
   }


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
While we closed the SimulationEngine when we restarted simulation while solving a Scheduling problem, we weren't closing the Engine when we were done with the Driver. This PR adds a `close` method to ResumableSimulationDriver and SimulationFacade and changes the SynchronousSchedulerAgent to create the SimulationFacade in a try-with-resources block so that the Engine is properly disposed of post-scheduling.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
