### PR TITLE
Add View to track Approximate Absolute Start Time

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_extended.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_extended.yaml
@@ -1,0 +1,22 @@
+table:
+  name: activity_directive_extended
+  schema: public
+object_relationships:
+- name: anchoring_activity
+  using:
+    manual_configuration:
+      remote_table:
+        name: activity_directive_extended
+        schema: public
+      column_mapping:
+        id: anchor_id
+- name: activity_directive
+  using:
+    manual_configuration:
+      remote_table:
+        schema: public
+        name: activity_directive
+      insertion_order: null
+      column_mapping:
+        id: id
+        plan_id: plan_id

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
@@ -20,6 +20,7 @@
 - "!include public_event.yaml"
 - "!include public_simulated_activity_view.yaml"
 - "!include public_resource_profile_view.yaml"
+- "!include public_activity_directive_extended.yaml"
 - "!include hasura_functions_duplicate_plan_return_value.yaml"
 - "!include hasura_functions_get_plan_history_return_value.yaml"
 - "!include public_merge_request.yaml"

--- a/deployment/hasura/migrations/AerieMerlin/8_add_approx_start_offset/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/8_add_approx_start_offset/down.sql
@@ -1,0 +1,3 @@
+drop view activity_directive_extended;
+drop function get_approximate_start_time(_activity_id int, _plan_id int);
+call migrations.mark_migration_rolled_back('8');

--- a/deployment/hasura/migrations/AerieMerlin/8_add_approx_start_offset/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/8_add_approx_start_offset/up.sql
@@ -1,0 +1,74 @@
+create function get_approximate_start_time(_activity_id int, _plan_id int)
+  returns timestamptz
+  security definer
+  language plpgsql as $$
+  declare
+    _plan_duration interval;
+    _plan_start_time timestamptz;
+    _net_offset interval;
+    _root_activity_id int;
+    _root_anchored_to_start boolean;
+begin
+    -- Sum up all the activities from here until the plan
+    with recursive get_net_offset(activity_id, plan_id, anchor_id, net_offset) as (
+      select id, plan_id, anchor_id, start_offset
+      from activity_directive ad
+      where (ad.id, ad.plan_id) = (_activity_id, _plan_id)
+      union
+      select ad.id, ad.plan_id, ad.anchor_id, ad.start_offset+gno.net_offset
+      from activity_directive ad, get_net_offset gno
+      where (ad.id, ad.plan_id) = (gno.anchor_id, gno.plan_id)
+    )
+    select gno.net_offset, activity_id from get_net_offset gno
+    where gno.anchor_id is null
+    into _net_offset, _root_activity_id;
+
+  -- Get the plan start time and duration
+  select start_time, duration
+  from plan
+  where id = _plan_id
+  into _plan_start_time, _plan_duration;
+
+  select anchored_to_start
+  from activity_directive
+  where (id, plan_id) = (_root_activity_id, _plan_id)
+  into _root_anchored_to_start;
+
+  -- If the root activity is anchored to the end of the plan, add the net to duration
+  if not _root_anchored_to_start then
+    _net_offset = _plan_duration + _net_offset;
+  end if;
+
+  return _plan_start_time+_net_offset;
+end
+$$;
+
+create view activity_directive_extended as
+(
+  select
+    -- Activity Directive Properties
+    ad.id as id,
+    ad.plan_id as plan_id,
+    -- Additional Properties
+    ad.name as name,
+    ad.tags as tags,
+    ad.source_scheduling_goal_id as source_scheduling_goal_id,
+    ad.created_at as created_at,
+    ad.last_modified_at as last_modified_at,
+    ad.start_offset as start_offset,
+    ad.type as type,
+    ad.arguments as arguments,
+    ad.last_modified_arguments_at as last_modified_arguments_at,
+    ad.metadata as metadata,
+    ad.anchor_id as anchor_id,
+    ad.anchored_to_start as anchored_to_start,
+    -- Derived Properties
+    get_approximate_start_time(ad.id, ad.plan_id) as approximate_start_time,
+    ptd.preset_id as preset_id,
+    ap.arguments as preset_arguments
+   from activity_directive ad
+   left join preset_to_directive ptd on ad.id = ptd.activity_id and ad.plan_id = ptd.plan_id
+   left join activity_presets ap on ptd.preset_id = ap.id
+);
+
+call migrations.mark_migration_applied('8');

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -7,7 +7,7 @@ call migrations.mark_migration_applied('1');
 call migrations.mark_migration_applied('2');
 call migrations.mark_migration_applied('3');
 call migrations.mark_migration_applied('4');
-
 call migrations.mark_migration_applied('5');
 call migrations.mark_migration_applied('6');
 call migrations.mark_migration_applied('7');
+call migrations.mark_migration_applied('8');

--- a/merlin-server/sql/merlin/init.sql
+++ b/merlin-server/sql/merlin/init.sql
@@ -42,10 +42,6 @@ begin;
   \ir tables/simulation_dataset.sql
   \ir tables/plan_dataset.sql
 
-  -- Views
-  \ir views/simulated_activity.sql
-  \ir views/resource_profile.sql
-
   -- Plan Collaboration
   \ir plan_collaboration.sql
   \ir merge_request.sql
@@ -55,4 +51,9 @@ begin;
 
   -- Presets
   \ir tables/activity_presets.sql
+
+  -- Views
+  \ir views/simulated_activity.sql
+  \ir views/resource_profile.sql
+  \ir views/activity_directive_extended.sql
 end;

--- a/merlin-server/sql/merlin/views/activity_directive_extended.sql
+++ b/merlin-server/sql/merlin/views/activity_directive_extended.sql
@@ -1,0 +1,72 @@
+create function get_approximate_start_time(_activity_id int, _plan_id int)
+  returns timestamptz
+  security definer
+  language plpgsql as $$
+  declare
+    _plan_duration interval;
+    _plan_start_time timestamptz;
+    _net_offset interval;
+    _root_activity_id int;
+    _root_anchored_to_start boolean;
+begin
+    -- Sum up all the activities from here until the plan
+    with recursive get_net_offset(activity_id, plan_id, anchor_id, net_offset) as (
+      select id, plan_id, anchor_id, start_offset
+      from activity_directive ad
+      where (ad.id, ad.plan_id) = (_activity_id, _plan_id)
+      union
+      select ad.id, ad.plan_id, ad.anchor_id, ad.start_offset+gno.net_offset
+      from activity_directive ad, get_net_offset gno
+      where (ad.id, ad.plan_id) = (gno.anchor_id, gno.plan_id)
+    )
+    select gno.net_offset, activity_id from get_net_offset gno
+    where gno.anchor_id is null
+    into _net_offset, _root_activity_id;
+
+  -- Get the plan start time and duration
+  select start_time, duration
+  from plan
+  where id = _plan_id
+  into _plan_start_time, _plan_duration;
+
+  select anchored_to_start
+  from activity_directive
+  where (id, plan_id) = (_root_activity_id, _plan_id)
+  into _root_anchored_to_start;
+
+  -- If the root activity is anchored to the end of the plan, add the net to duration
+  if not _root_anchored_to_start then
+    _net_offset = _plan_duration + _net_offset;
+  end if;
+
+  return _plan_start_time+_net_offset;
+end
+$$;
+
+create view activity_directive_extended as
+(
+  select
+    -- Activity Directive Properties
+    ad.id as id,
+    ad.plan_id as plan_id,
+    -- Additional Properties
+    ad.name as name,
+    ad.tags as tags,
+    ad.source_scheduling_goal_id as source_scheduling_goal_id,
+    ad.created_at as created_at,
+    ad.last_modified_at as last_modified_at,
+    ad.start_offset as start_offset,
+    ad.type as type,
+    ad.arguments as arguments,
+    ad.last_modified_arguments_at as last_modified_arguments_at,
+    ad.metadata as metadata,
+    ad.anchor_id as anchor_id,
+    ad.anchored_to_start as anchored_to_start,
+    -- Derived Properties
+    get_approximate_start_time(ad.id, ad.plan_id) as approximate_start_time,
+    ptd.preset_id as preset_id,
+    ap.arguments as preset_arguments
+   from activity_directive ad
+   left join preset_to_directive ptd on ad.id = ptd.activity_id and ad.plan_id = ptd.plan_id
+   left join activity_presets ap on ptd.preset_id = ap.id
+);


### PR DESCRIPTION
* **Tickets addressed:** Closes #722
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Adds the view `activity_directive_plus_plus`, which contains all the content of an activity directive plus:
- Its approximate start time
- Its preset id
- The arguments of its assigned preset

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
AnchorTests now use this view to fetch Activity Directives.

The `createAnchor` anchor test now checks that the offset is set and updated correctly as the anchor changes. 
