### PR TITLE
Get Resources at a Time

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/functions/functions.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/functions/functions.yaml
@@ -112,3 +112,8 @@
   configuration:
     custom_root_fields:
       function: apply_preset_to_activity
+- function:
+    name: get_resources_at_start_offset
+    schema: hasura_functions
+  configuration:
+    custom_name: getResourcesAtStartOffset

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
@@ -59,3 +59,6 @@
 - table:
     name: delete_anchor_return_value
     schema: hasura_functions
+- table:
+    name: resource_at_start_offset_return_value
+    schema: hasura_functions

--- a/deployment/hasura/migrations/AerieMerlin/9_get_resources_at_offset/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/9_get_resources_at_offset/down.sql
@@ -1,0 +1,3 @@
+drop function hasura_functions.get_resources_at_start_offset(_dataset_id int, _start_offset interval);
+drop table hasura_functions.resource_at_start_offset_return_value;
+call migrations.mark_migration_rolled_back('9');

--- a/deployment/hasura/migrations/AerieMerlin/9_get_resources_at_offset/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/9_get_resources_at_offset/up.sql
@@ -1,0 +1,30 @@
+create table hasura_functions.resource_at_start_offset_return_value(
+  dataset_id integer not null,
+  id integer not null,
+  name text not null,
+  type jsonb,
+  start_offset interval not null,
+  dynamics jsonb,
+  is_gap bool not null
+);
+
+create function hasura_functions.get_resources_at_start_offset(_dataset_id int, _start_offset interval)
+returns setof hasura_functions.resource_at_start_offset_return_value
+strict
+immutable
+security invoker
+language plpgsql as $$
+begin
+  return query
+    select distinct on (p.name)
+      p.dataset_id, p.id, p.name, p.type, ps.start_offset, ps.dynamics, ps.is_gap
+    from profile p, profile_segment ps
+	  where ps.profile_id = p.id
+	    and p.dataset_id = _dataset_id
+	    and ps.dataset_id = _dataset_id
+	    and ps.start_offset <= _start_offset
+	  order by p.name, ps.start_offset desc;
+end
+$$;
+
+call migrations.mark_migration_applied('9');

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -11,3 +11,4 @@ call migrations.mark_migration_applied('5');
 call migrations.mark_migration_applied('6');
 call migrations.mark_migration_applied('7');
 call migrations.mark_migration_applied('8');
+call migrations.mark_migration_applied('9');

--- a/merlin-server/sql/merlin/hasura_functions.sql
+++ b/merlin-server/sql/merlin/hasura_functions.sql
@@ -414,3 +414,33 @@ begin
     return returning_directive;
 end
 $$;
+
+-- Simulation Resources
+create table hasura_functions.resource_at_start_offset_return_value(
+  dataset_id integer not null,
+  id integer not null,
+  name text not null,
+  type jsonb,
+  start_offset interval not null,
+  dynamics jsonb,
+  is_gap bool not null
+);
+
+create function hasura_functions.get_resources_at_start_offset(_dataset_id int, _start_offset interval)
+returns setof hasura_functions.resource_at_start_offset_return_value
+strict
+immutable
+security invoker
+language plpgsql as $$
+begin
+  return query
+    select distinct on (p.name)
+      p.dataset_id, p.id, p.name, p.type, ps.start_offset, ps.dynamics, ps.is_gap
+    from profile p, profile_segment ps
+	  where ps.profile_id = p.id
+	    and p.dataset_id = _dataset_id
+	    and ps.dataset_id = _dataset_id
+	    and ps.start_offset <= _start_offset
+	  order by p.name, ps.start_offset desc;
+end
+$$;


### PR DESCRIPTION
* **Tickets addressed:** Closes #741.
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Added Hasura Function: `get_resources_at_start_offset`, which can be called as a query in GraphQL like:
```graphql
query GetResources {
  getResourcesAtStartOffset(args: {_dataset_id: 1, _start_offset: "24:00:00"}) {
    id
    dataset_id
    dynamics
    is_gap
    name
    start_offset
    type
  }
}
```

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
The test `getResourcesAtTimeFetchesLatestData` was added to MerlinDBTests. 

Additionally, the dataset/profile/event/topic tests were lightly refactored by moving the commonly repeated `INSERT INTO X` SQL calls into `insertX` methods. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

https://github.com/NASA-AMMOS/aerie-docs/issues/21 has been updated to include adding this query to its tasks.