### PR TITLE
Use simulated id rather than directive id as key for simulatedActivityRecords

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -1166,10 +1166,18 @@ public SimulationId getSimulationId(PlanId planId) throws PlanServiceException, 
 
   final JsonObject response;
   response = postRequest(req, arguments).get();
-  final var affected_rows = response.getJsonObject("data").getJsonObject("update_span_many").getInt("affected_rows");
-  if(affected_rows != updateCounter) {
-    throw new PlanServiceException("not the same size");
-  }
+    final var jsonValue = response.getJsonObject("data").get("update_span_many");
+    var affected_rows = 0;
+    if (jsonValue.getValueType() == JsonValue.ValueType.ARRAY) {
+      for (final var jsonObject : response.getJsonObject("data").getJsonArray("update_span_many").getValuesAs(JsonObject.class)) {
+        affected_rows += jsonObject.getInt("affected_rows");
+      }
+    } else {
+      affected_rows = response.getJsonObject("data").getJsonObject("update_span_many").getInt("affected_rows");
+    }
+    if(affected_rows != updateCounter) {
+      throw new PlanServiceException("not the same size");
+    }
 }
 
   private static SpanRecord simulatedActivityToRecord(final SimulatedActivity activity,

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -1116,11 +1116,11 @@ public SimulationId getSimulationId(PlanId planId) throws PlanServiceException, 
   {
       final var simulatedActivityRecords = simulatedActivities.entrySet().stream()
                                                               .collect(Collectors.toMap(
-                                                                  e -> simulationActivityDirectiveIdToMerlinActivityDirectiveId.get(e.getValue().directiveId().get()).id(),
+                                                                  e -> e.getKey().id(),
                                                                   e -> simulatedActivityToRecord(e.getValue(), simulationActivityDirectiveIdToMerlinActivityDirectiveId)));
       final var allActivityRecords = unfinishedActivities.entrySet().stream()
                                                          .collect(Collectors.toMap(
-                                                             e -> simulationActivityDirectiveIdToMerlinActivityDirectiveId.get(e.getValue().directiveId().get()).id(),
+                                                             e -> e.getKey().id(),
                                                              e -> unfinishedActivityToRecord(e.getValue(), simulationActivityDirectiveIdToMerlinActivityDirectiveId)));
       allActivityRecords.putAll(simulatedActivityRecords);
       final var simIdToPgId = postSpans(


### PR DESCRIPTION
* **Tickets addressed:** Fixes #834 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

The logic of `postActivities` expects a map from long to SpanRecord - the value of the long is immaterial, and used only to be able to correlate newly generated database ids with the records, so that they can be updated to point at the correct parent spans.

Since not every record has a directive id - we can use the simulated activity id as the key for this purpose.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Manual testing in progress - will report back momentarily
- [x] Manual testing

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None, this is a bugfix on a brand new feature.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None, hopefully.
