### PR TITLE
Typecheck Immediate and Hardware Commands

### DIFF
--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -177,6 +177,7 @@ declare global {
     // @ts-ignore : 'Args' found in JSON Spec
     args: Args;
     stem: string;
+    type: 'immediate';
 
     public static new<A extends any[] | { [argName: string]: any }>(opts: ImmediateOptions<A>): ImmediateStem<A>;
 
@@ -197,6 +198,7 @@ declare global {
   // @ts-ignore : 'HardwareCommand' found in JSON Spec
   class HardwareStem implements HardwareCommand {
     stem: string;
+    type: 'hardware';
 
     public static new(opts: HardwareOptions): HardwareStem;
 
@@ -355,17 +357,6 @@ export class Sequence implements SeqJson {
         ? {
             immediate_commands: this.immediate_commands.map(command => {
               if (command instanceof ImmediateStem) return command.toSeqJson();
-              if (command instanceof CommandStem)
-                return {
-                  args: [
-                    {
-                      name: 'message',
-                      type: 'string',
-                      value: `ERROR: ${command.toEDSLString()}, is not an immediate command.`,
-                    },
-                  ],
-                  stem: '$$ERROR$$',
-                };
               else return command;
             }),
           }
@@ -821,6 +812,7 @@ export class ImmediateStem<A extends Args[] | { [argName: string]: any } = [] | 
   private readonly _metadata?: Metadata | undefined;
   // @ts-ignore : 'Description' found in JSON Spec
   private readonly _description?: Description | undefined;
+  public readonly type: 'immediate' = 'immediate';
 
   private constructor(opts: ImmediateOptions<A>) {
     this.stem = opts.stem;
@@ -867,6 +859,7 @@ export class ImmediateStem<A extends Args[] | { [argName: string]: any } = [] | 
     return {
       args: convertArgsToInterfaces(this.arguments),
       stem: this.stem,
+      type: this.type,
       ...(this._metadata ? { metadata: this._metadata } : {}),
       ...(this._description ? { description: this._description } : {}),
     };
@@ -1405,6 +1398,7 @@ export class HardwareStem implements HardwareCommand {
   private readonly _metadata?: Metadata | undefined;
   // @ts-ignore : 'Description' found in JSON Spec
   private readonly _description?: Description | undefined;
+  public readonly type: 'hardware' = 'hardware';
 
   private constructor(opts: HardwareOptions) {
     this.stem = opts.stem;
@@ -1447,6 +1441,7 @@ export class HardwareStem implements HardwareCommand {
   public toSeqJson(): HardwareCommand {
     return {
       stem: this.stem,
+      type: this.type,
       ...(this._metadata ? { metadata: this._metadata } : {}),
       ...(this._description ? { description: this._description } : {}),
     };


### PR DESCRIPTION
* **Tickets addressed:** AERIE-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
We are currently in discussions with the SeqJSON Spec team to add a `type: immediate` for the `ImmediateCommand` type and `type:hardware` for the `hardwareCommands`. Within the `immediate_command[]` array, the editor is not flagging `C.<Command>`. Within the `hardwareCommands[]` array the editor is not flagging `C.<Command>, <Command>`. In TypeScript, an object literal can be used as a value of an interface if the object has all the same properties, and optionally some more, with compatible types as specified in the interface. However, adding `type: immediate` and  `type: hardware` will resolve this issue. 

Trying to fix this:
<img width="762" alt="Screenshot 2023-03-31 at 9 22 26 AM" src="https://user-images.githubusercontent.com/70245883/229210807-3c1cfd9f-59ab-49e0-a9e9-6307ce34c690.png">




- [x] Update Preface
- [ ] Update seq-json-schema 

## Verification
ran the e2e test and manually checked the Sequence Editro

