### PR TITLE
Added time ordering with respect to commands in expanded sequences

### DIFF
--- a/sequencing-server/src/defaultSeqBuilder.ts
+++ b/sequencing-server/src/defaultSeqBuilder.ts
@@ -48,7 +48,7 @@ export const defaultSeqBuilder: SeqBuilder = (
 // Order commands by time in expanded sequences.
 function sortCommandsByTime(commands: CommandStem<{} | []>[]): CommandStem<{} | []>[] {
   const relativeTimeTracker: Record<string, Temporal.Instant> = {};
-  let previousAbsoluteTimestamp: Temporal.Instant;
+  let previousAbsoluteTimestamp: Temporal.Instant | undefined = undefined;
 
   for (const command of commands) {
     // If the command is epoch-relative, complete, or the first command and relative then short circuit and don't try and sort.
@@ -61,26 +61,25 @@ function sortCommandsByTime(commands: CommandStem<{} | []>[]): CommandStem<{} | 
     }
 
     // Keep track of the previously seen absolute time so we can convert the next relative timestamp we come across.
-    if (command.absoluteTime) {
-      previousAbsoluteTimestamp = command.absoluteTime!;
-    } else {
-      relativeTimeTracker[command.stem + command.relativeTime?.toString()] = previousAbsoluteTimestamp!.add(
-        command.relativeTime!,
+    if (command.absoluteTime !== null) {
+      previousAbsoluteTimestamp = command.absoluteTime;
+    } else if (command.relativeTime !== null && previousAbsoluteTimestamp !== undefined) {
+      relativeTimeTracker[command.stem + command.relativeTime?.toString()] = previousAbsoluteTimestamp.add(
+        command.relativeTime,
       );
     }
   }
 
   // The commands will either be absolute or relative at this point, so we just compare their times.
   commands.sort((a, b) => {
-    const firstCommandTime = a.absoluteTime
-      ? a.absoluteTime
-      : relativeTimeTracker[a.stem + a.relativeTime?.toString()]!;
+    const firstCommandTime = a.absoluteTime ?? relativeTimeTracker[a.stem + a.relativeTime?.toString()];
+    const secondCommandTime = b.absoluteTime ?? relativeTimeTracker[b.stem + b.relativeTime?.toString()];
 
-    const secondCommandTime = b.absoluteTime
-      ? b.absoluteTime
-      : relativeTimeTracker[b.stem + b.relativeTime?.toString()]!;
+    if (firstCommandTime !== undefined && secondCommandTime !== undefined) {
+      return Temporal.Instant.compare(firstCommandTime, secondCommandTime);
+    }
 
-    return Temporal.Instant.compare(firstCommandTime, secondCommandTime);
+    return 0;
   });
 
   return commands;

--- a/sequencing-server/src/defaultSeqBuilder.ts
+++ b/sequencing-server/src/defaultSeqBuilder.ts
@@ -48,14 +48,14 @@ export const defaultSeqBuilder: SeqBuilder = (
 // Order commands by time in expanded sequences.
 function sortCommandsByTime(commands: CommandStem<{} | []>[]): CommandStem<{} | []>[] {
   const relativeTimeTracker: Record<string, Temporal.Instant> = {};
-  let previousAbsoluteTimestamp: Temporal.Instant | undefined = undefined;
+  let previousAbsoluteTimestamp: Temporal.Instant | null = null;
 
   for (const command of commands) {
     // If the command is epoch-relative, complete, or the first command and relative then short circuit and don't try and sort.
     if (
-      command.epochTime ||
-      (!command.absoluteTime && !command.epochTime && !command.relativeTime) ||
-      (command.relativeTime && commands.indexOf(command) === 0)
+      command.epochTime !== null ||
+      (command.absoluteTime === null && command.epochTime === null && command.relativeTime === null) ||
+      (command.relativeTime !== null && commands.indexOf(command) === 0)
     ) {
       return commands;
     }
@@ -63,7 +63,7 @@ function sortCommandsByTime(commands: CommandStem<{} | []>[]): CommandStem<{} | 
     // Keep track of the previously seen absolute time so we can convert the next relative timestamp we come across.
     if (command.absoluteTime !== null) {
       previousAbsoluteTimestamp = command.absoluteTime;
-    } else if (command.relativeTime !== null && previousAbsoluteTimestamp !== undefined) {
+    } else if (command.relativeTime !== null && previousAbsoluteTimestamp !== null) {
       relativeTimeTracker[command.stem + command.relativeTime?.toString()] = previousAbsoluteTimestamp.add(
         command.relativeTime,
       );

--- a/sequencing-server/src/lib/codegen/CommandTypeCodegen.ts
+++ b/sequencing-server/src/lib/codegen/CommandTypeCodegen.ts
@@ -1,7 +1,7 @@
 // Language: TypeScript
 // Path: src/libs/CommandTypeCodegen.ts
 
-import * as ampcs from '@nasa-jpl/aerie-ampcs';
+import type * as ampcs from '@nasa-jpl/aerie-ampcs';
 import fs from 'fs';
 import reservedWords from 'reserved-words';
 import { getEnv } from '../../env.js';

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -2631,6 +2631,338 @@ describe('sequence generation', () => {
     await removeExpansionSet(graphqlClient, expansionSetId);
     /** End Cleanup */
   }, 30000);
+
+  describe('step sorting', () => {
+    it('should sort expansions correctly with relative and absolute times', async () => {
+      const expansionId = await insertExpansion(
+        graphqlClient,
+        'GrowBanana',
+        `
+    export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
+      return [
+        A\`2023-091T08:19:00.000\`.ADD_WATER,
+        R\`04:00:00.000\`.PICK_BANANA,
+        A\`2023-091T04:20:00.000\`.GROW_BANANA({ quantity: 10, durationSecs: 7200 })
+      ];
+    }
+    `,
+      );
+      /** Begin Setup */
+      // Create Expansion Set
+      const expansionSetId = await insertExpansionSet(graphqlClient, commandDictionaryId, missionModelId, [
+        expansionId,
+      ]);
+
+      // Create Activity Directives
+      const [activityId1, activityId2, activityId3] = await Promise.all([
+        insertActivityDirective(graphqlClient, planId, 'GrowBanana'),
+        insertActivityDirective(graphqlClient, planId, 'PeelBanana', '30 minutes'),
+        insertActivityDirective(graphqlClient, planId, 'ThrowBanana', '60 minutes'),
+      ]);
+
+      // Simulate Plan
+      const simulationArtifactPk = await executeSimulation(graphqlClient, planId);
+      // Expand Plan to Sequence Fragments
+      const expansionRunPk = await expand(graphqlClient, expansionSetId, simulationArtifactPk.simulationDatasetId);
+      // Create Sequence
+      const sequencePk = await insertSequence(graphqlClient, {
+        seqId: 'test00000',
+        simulationDatasetId: simulationArtifactPk.simulationDatasetId,
+      });
+      // Link Activity Instances to Sequence
+      await Promise.all([
+        linkActivityInstance(graphqlClient, sequencePk, activityId1),
+        linkActivityInstance(graphqlClient, sequencePk, activityId2),
+        linkActivityInstance(graphqlClient, sequencePk, activityId3),
+      ]);
+
+      // Get the simulated activity ids
+      const [simulatedActivityId1] = await Promise.all([
+        convertActivityDirectiveIdToSimulatedActivityId(
+          graphqlClient,
+          simulationArtifactPk.simulationDatasetId,
+          activityId1,
+        ),
+      ]);
+      /** End Setup */
+
+      // Retrieve seqJson
+      const getSequenceSeqJsonResponse = await getSequenceSeqJson(
+        graphqlClient,
+        'test00000',
+        simulationArtifactPk.simulationDatasetId,
+      );
+
+      if (getSequenceSeqJsonResponse.status !== FallibleStatus.SUCCESS) {
+        throw getSequenceSeqJsonResponse.errors;
+      }
+
+      expect(getSequenceSeqJsonResponse.seqJson.id).toBe('test00000');
+      expect(getSequenceSeqJsonResponse.seqJson.metadata).toEqual({
+        planId: planId,
+        simulationDatasetId: simulationArtifactPk.simulationDatasetId,
+      });
+
+      expect(getSequenceSeqJsonResponse.seqJson.steps).toEqual([
+        {
+          type: 'command',
+          stem: 'GROW_BANANA',
+          time: { tag: '2023-091T04:20:00.000', type: TimingTypes.ABSOLUTE },
+          args: [
+            { value: 10, name: 'quantity', type: 'number' },
+            { value: 7200, name: 'durationSecs', type: 'number' },
+          ],
+          metadata: { simulatedActivityId: simulatedActivityId1 },
+        },
+        {
+          type: 'command',
+          stem: 'ADD_WATER',
+          time: { tag: '2023-091T08:19:00.000', type: TimingTypes.ABSOLUTE },
+          args: [],
+          metadata: { simulatedActivityId: simulatedActivityId1 },
+        },
+        {
+          type: 'command',
+          stem: 'PICK_BANANA',
+          time: { tag: '04:00:00.000', type: TimingTypes.COMMAND_RELATIVE },
+          args: [],
+          metadata: { simulatedActivityId: simulatedActivityId1 },
+        },
+      ]);
+
+      /** Begin Cleanup */
+      await removeSequence(graphqlClient, sequencePk);
+      await removeExpansionRun(graphqlClient, expansionRunPk);
+      await removeSimulationArtifacts(graphqlClient, simulationArtifactPk);
+      await Promise.all([
+        removeActivityDirective(graphqlClient, activityId1, planId),
+        removeActivityDirective(graphqlClient, activityId2, planId),
+        removeActivityDirective(graphqlClient, activityId3, planId),
+      ]);
+      await removeExpansionSet(graphqlClient, expansionSetId);
+      /** End Cleanup */
+    }, 30000);
+
+    it('should not sort if the expansion contains complete commands', async () => {
+      const expansionId = await insertExpansion(
+        graphqlClient,
+        'GrowBanana',
+        `
+    export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
+      return [
+        A\`2023-091T08:19:00.000\`.ADD_WATER,
+        C.PICK_BANANA,
+        A\`2023-091T04:20:00.000\`.GROW_BANANA({ quantity: 10, durationSecs: 7200 })
+      ];
+    }
+    `,
+      );
+      /** Begin Setup */
+      // Create Expansion Set
+      const expansionSetId = await insertExpansionSet(graphqlClient, commandDictionaryId, missionModelId, [
+        expansionId,
+      ]);
+
+      // Create Activity Directives
+      const [activityId1, activityId2, activityId3] = await Promise.all([
+        insertActivityDirective(graphqlClient, planId, 'GrowBanana'),
+        insertActivityDirective(graphqlClient, planId, 'PeelBanana', '30 minutes'),
+        insertActivityDirective(graphqlClient, planId, 'ThrowBanana', '60 minutes'),
+      ]);
+
+      // Simulate Plan
+      const simulationArtifactPk = await executeSimulation(graphqlClient, planId);
+      // Expand Plan to Sequence Fragments
+      const expansionRunPk = await expand(graphqlClient, expansionSetId, simulationArtifactPk.simulationDatasetId);
+      // Create Sequence
+      const sequencePk = await insertSequence(graphqlClient, {
+        seqId: 'test00000',
+        simulationDatasetId: simulationArtifactPk.simulationDatasetId,
+      });
+      // Link Activity Instances to Sequence
+      await Promise.all([
+        linkActivityInstance(graphqlClient, sequencePk, activityId1),
+        linkActivityInstance(graphqlClient, sequencePk, activityId2),
+        linkActivityInstance(graphqlClient, sequencePk, activityId3),
+      ]);
+
+      // Get the simulated activity ids
+      const [simulatedActivityId1] = await Promise.all([
+        convertActivityDirectiveIdToSimulatedActivityId(
+          graphqlClient,
+          simulationArtifactPk.simulationDatasetId,
+          activityId1,
+        ),
+      ]);
+      /** End Setup */
+
+      // Retrieve seqJson
+      const getSequenceSeqJsonResponse = await getSequenceSeqJson(
+        graphqlClient,
+        'test00000',
+        simulationArtifactPk.simulationDatasetId,
+      );
+
+      if (getSequenceSeqJsonResponse.status !== FallibleStatus.SUCCESS) {
+        throw getSequenceSeqJsonResponse.errors;
+      }
+
+      expect(getSequenceSeqJsonResponse.seqJson.id).toBe('test00000');
+      expect(getSequenceSeqJsonResponse.seqJson.metadata).toEqual({
+        planId: planId,
+        simulationDatasetId: simulationArtifactPk.simulationDatasetId,
+      });
+
+      expect(getSequenceSeqJsonResponse.seqJson.steps).toEqual([
+        {
+          type: 'command',
+          stem: 'ADD_WATER',
+          time: { tag: '2023-091T08:19:00.000', type: TimingTypes.ABSOLUTE },
+          args: [],
+          metadata: { simulatedActivityId: simulatedActivityId1 },
+        },
+        {
+          type: 'command',
+          stem: 'PICK_BANANA',
+          time: { type: TimingTypes.COMMAND_COMPLETE },
+          args: [],
+          metadata: { simulatedActivityId: simulatedActivityId1 },
+        },
+        {
+          type: 'command',
+          stem: 'GROW_BANANA',
+          time: { tag: '2023-091T04:20:00.000', type: TimingTypes.ABSOLUTE },
+          args: [
+            { value: 10, name: 'quantity', type: 'number' },
+            { value: 7200, name: 'durationSecs', type: 'number' },
+          ],
+          metadata: { simulatedActivityId: simulatedActivityId1 },
+        },
+      ]);
+
+      /** Begin Cleanup */
+      await removeSequence(graphqlClient, sequencePk);
+      await removeExpansionRun(graphqlClient, expansionRunPk);
+      await removeSimulationArtifacts(graphqlClient, simulationArtifactPk);
+      await Promise.all([
+        removeActivityDirective(graphqlClient, activityId1, planId),
+        removeActivityDirective(graphqlClient, activityId2, planId),
+        removeActivityDirective(graphqlClient, activityId3, planId),
+      ]);
+      await removeExpansionSet(graphqlClient, expansionSetId);
+      /** End Cleanup */
+    }, 30000);
+
+    it('should not sort if the expansion contains epoch relative commands', async () => {
+      const expansionId = await insertExpansion(
+        graphqlClient,
+        'GrowBanana',
+        `
+    export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
+      return [
+        A\`2023-091T08:19:00.000\`.ADD_WATER,
+        E\`04:00:00.000\`.PICK_BANANA,
+        A\`2023-091T04:20:00.000\`.GROW_BANANA({ quantity: 10, durationSecs: 7200 })
+      ];
+    }
+    `,
+      );
+      /** Begin Setup */
+      // Create Expansion Set
+      const expansionSetId = await insertExpansionSet(graphqlClient, commandDictionaryId, missionModelId, [
+        expansionId,
+      ]);
+
+      // Create Activity Directives
+      const [activityId1, activityId2, activityId3] = await Promise.all([
+        insertActivityDirective(graphqlClient, planId, 'GrowBanana'),
+        insertActivityDirective(graphqlClient, planId, 'PeelBanana', '30 minutes'),
+        insertActivityDirective(graphqlClient, planId, 'ThrowBanana', '60 minutes'),
+      ]);
+
+      // Simulate Plan
+      const simulationArtifactPk = await executeSimulation(graphqlClient, planId);
+      // Expand Plan to Sequence Fragments
+      const expansionRunPk = await expand(graphqlClient, expansionSetId, simulationArtifactPk.simulationDatasetId);
+      // Create Sequence
+      const sequencePk = await insertSequence(graphqlClient, {
+        seqId: 'test00000',
+        simulationDatasetId: simulationArtifactPk.simulationDatasetId,
+      });
+      // Link Activity Instances to Sequence
+      await Promise.all([
+        linkActivityInstance(graphqlClient, sequencePk, activityId1),
+        linkActivityInstance(graphqlClient, sequencePk, activityId2),
+        linkActivityInstance(graphqlClient, sequencePk, activityId3),
+      ]);
+
+      // Get the simulated activity ids
+      const [simulatedActivityId1] = await Promise.all([
+        convertActivityDirectiveIdToSimulatedActivityId(
+          graphqlClient,
+          simulationArtifactPk.simulationDatasetId,
+          activityId1,
+        ),
+      ]);
+      /** End Setup */
+
+      // Retrieve seqJson
+      const getSequenceSeqJsonResponse = await getSequenceSeqJson(
+        graphqlClient,
+        'test00000',
+        simulationArtifactPk.simulationDatasetId,
+      );
+
+      if (getSequenceSeqJsonResponse.status !== FallibleStatus.SUCCESS) {
+        throw getSequenceSeqJsonResponse.errors;
+      }
+
+      expect(getSequenceSeqJsonResponse.seqJson.id).toBe('test00000');
+      expect(getSequenceSeqJsonResponse.seqJson.metadata).toEqual({
+        planId: planId,
+        simulationDatasetId: simulationArtifactPk.simulationDatasetId,
+      });
+
+      expect(getSequenceSeqJsonResponse.seqJson.steps).toEqual([
+        {
+          type: 'command',
+          stem: 'ADD_WATER',
+          time: { tag: '2023-091T08:19:00.000', type: TimingTypes.ABSOLUTE },
+          args: [],
+          metadata: { simulatedActivityId: simulatedActivityId1 },
+        },
+        {
+          type: 'command',
+          stem: 'PICK_BANANA',
+          time: { tag: '04:00:00.000', type: TimingTypes.EPOCH_RELATIVE },
+          args: [],
+          metadata: { simulatedActivityId: simulatedActivityId1 },
+        },
+        {
+          type: 'command',
+          stem: 'GROW_BANANA',
+          time: { tag: '2023-091T04:20:00.000', type: TimingTypes.ABSOLUTE },
+          args: [
+            { value: 10, name: 'quantity', type: 'number' },
+            { value: 7200, name: 'durationSecs', type: 'number' },
+          ],
+          metadata: { simulatedActivityId: simulatedActivityId1 },
+        },
+      ]);
+
+      /** Begin Cleanup */
+      await removeSequence(graphqlClient, sequencePk);
+      await removeExpansionRun(graphqlClient, expansionRunPk);
+      await removeSimulationArtifacts(graphqlClient, simulationArtifactPk);
+      await Promise.all([
+        removeActivityDirective(graphqlClient, activityId1, planId),
+        removeActivityDirective(graphqlClient, activityId2, planId),
+        removeActivityDirective(graphqlClient, activityId3, planId),
+      ]);
+      await removeExpansionSet(graphqlClient, expansionSetId);
+      /** End Cleanup */
+    }, 30000);
+  });
 });
 
 it('should provide start, end, and computed attributes on activities', async () => {


### PR DESCRIPTION
* **Tickets addressed:** Closes #828 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Consulted with @camargo on how the times work which I previously didn't fully understand and read the ticket.

## Verification
Added some unit tests to check sorting and non-sorting cases.

## Documentation
NA

## Future work
Depends on how we want to support this for other missions, for now all the code just lives in the `defaultSeqBuilder`.
