### PR TITLE
Add missing mark_migration_rolled_back

### DIFF
--- a/deployment/hasura/migrations/AerieMerlin/7_store_sim_args_in_dataset/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/7_store_sim_args_in_dataset/down.sql
@@ -51,3 +51,5 @@ alter table simulation_dataset
 drop column arguments,
 drop column simulation_start_time,
 drop column simulation_end_time;
+
+call migrations.mark_migration_rolled_back('7');


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This down migration was missing a call to  `migrations.mark_migration_rolled_back('7');`. This PR adds it.