### PR TITLE
Allow for separation of activity matching from activity creation in scheduling eDSL

### DIFF
--- a/merlin-server/constraints-dsl-compiler/src/libs/mission-model-generated-code.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/mission-model-generated-code.ts
@@ -32,3 +32,11 @@ export type ParameterTypeactivity = {
 export type ActivityTypeParameterMap = {
   [ActivityType.activity]: ParameterTypeactivity
 };
+
+//same as above but parameters can be undefined
+export type ParameterTypeWithUndefinedactivity = {
+  parameter: string | undefined
+}
+export type ActivityTypeParameterMapWithUndefined = {
+  [ActivityType.activity]: ParameterTypeWithUndefinedactivity
+};

--- a/merlin-server/constraints-dsl-compiler/src/main.ts
+++ b/merlin-server/constraints-dsl-compiler/src/main.ts
@@ -39,6 +39,19 @@ interface AstNode {
   __astNode: object
 }
 
+function toJson(unwrappedErr: any){
+  var completeStackValue = "";
+  if ('error' in unwrappedErr && 'stack' in unwrappedErr.error){
+    completeStackValue = JSON.stringify(unwrappedErr.error.stack)
+  }
+  return {
+    message: unwrappedErr.message,
+    stack: unwrappedErr.stack,
+    location: unwrappedErr.location,
+    completeStack:  completeStackValue,
+  }
+}
+
 async function handleRequest(data: Buffer) {
   try {
     // Test the health of the service by responding to "ping" with "pong".
@@ -73,8 +86,9 @@ async function handleRequest(data: Buffer) {
     );
 
     if (result.isErr()) {
+      const secondLine = JSON.stringify(result.unwrapErr().map(err => toJson(err))) + '\n';
       process.stdout.write('error\n')
-      process.stdout.write(JSON.stringify(result.unwrapErr().map(err => err.toJSON())) + '\n');
+      process.stdout.write(secondLine);
       lineReader.once('line', handleRequest);
       return;
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ConstraintsCompilationError.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ConstraintsCompilationError.java
@@ -22,13 +22,14 @@ public class ConstraintsCompilationError {
           .field("message", stringP)
           .field("stack", stringP)
           .field("location", codeLocationP)
+          .field("completeStack", stringP)
           .map(
               untuple(UserCodeError::new),
-              $ -> tuple($.message, $.stack, $.location));
+              $ -> tuple($.message, $.stack, $.location, $.completeStack));
 
   public static final JsonParser<List<UserCodeError>> constraintsErrorJsonP = listP(userCodeErrorP);
 
   public record CodeLocation(Integer line, Integer column) {}
 
-  public record UserCodeError(String message, String stack, CodeLocation location) {}
+  public record UserCodeError(String message, String stack, CodeLocation location, String completeStack) {}
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
@@ -15,7 +15,7 @@ class TypescriptCodeGenerationServiceTest {
   @Test
   void testCodeGen() throws MissionModelService.NoSuchMissionModelException, NoSuchPlanException {
     final var codeGenService = new TypescriptCodeGenerationServiceAdapter(new StubMissionModelService(), new StubPlanService());
-
+    final var expected = codeGenService.generateTypescriptTypes("abc", Optional.of(new PlanId(1L)));
     assertEquals(
         """
             /** Start Codegen */
@@ -71,6 +71,18 @@ class TypescriptCodeGenerationServiceTest {
               [ActivityType.activity2]:ParameterTypeactivity2,
               [ActivityType.activity]:ParameterTypeactivity,
             };
+            export type ParameterTypeWithUndefinedactivity2 = {
+              Param?: (( | "hello" | "there") | Discrete<( | "hello" | "there")> | undefined),
+            }
+            export type ParameterTypeWithUndefinedactivity = {
+              Param?: (string | Discrete<string> | undefined),
+              AnotherParam?: (number | Real | undefined),
+              Duration?: (Temporal.Duration | Discrete<Temporal.Duration> | undefined),
+            }
+            export type ActivityTypeParameterMapWithUndefined = {
+              [ActivityType.activity2]:ParameterTypeWithUndefinedactivity2,
+              [ActivityType.activity]:ParameterTypeWithUndefinedactivity,
+            };
             declare global {
               enum ActivityType {
                 activity2 = "activity2",
@@ -81,7 +93,7 @@ class TypescriptCodeGenerationServiceTest {
               ActivityType
             });
             /** End Codegen */""",
-        codeGenService.generateTypescriptTypes("abc", Optional.of(new PlanId(1L)))
+        expected
     );
   }
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/TypescriptCodeGenerationServiceTest.java
@@ -16,7 +16,7 @@ class TypescriptCodeGenerationServiceTest {
   void testCodeGen() throws MissionModelService.NoSuchMissionModelException, NoSuchPlanException {
     final var codeGenService = new TypescriptCodeGenerationServiceAdapter(new StubMissionModelService(), new StubPlanService());
     final var expected = codeGenService.generateTypescriptTypes("abc", Optional.of(new PlanId(1L)));
-    assertEquals(
+    assertEquals(expected,
         """
             /** Start Codegen */
             import * as AST from './constraints-ast.js';
@@ -92,8 +92,7 @@ class TypescriptCodeGenerationServiceTest {
             Object.assign(globalThis, {
               ActivityType
             });
-            /** End Codegen */""",
-        expected
+            /** End Codegen */"""
     );
   }
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/ActivityTemplateGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/ActivityTemplateGoal.java
@@ -1,13 +1,13 @@
 package gov.nasa.jpl.aerie.scheduler.goals;
 
 import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
-import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.constraints.tree.Expression;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate;
-import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
+import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
 import gov.nasa.jpl.aerie.scheduler.model.Plan;
 import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
+import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
 import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
 
 import java.util.Optional;
@@ -36,7 +36,13 @@ public class ActivityTemplateGoal extends ActivityExistentialGoal {
       return getThis();
     }
 
+    public T match(ActivityExpression expression){
+      matchingActTemplate = expression;
+      return getThis();
+    }
+
     protected ActivityCreationTemplate thereExists;
+    protected ActivityExpression matchingActTemplate;
 
     /**
      * {@inheritDoc}
@@ -63,6 +69,12 @@ public class ActivityTemplateGoal extends ActivityExistentialGoal {
             "activity template goal requires non-null thereExists activity creation template");
       }
       goal.desiredActTemplate = thereExists;
+
+      if(matchingActTemplate == null){
+        goal.matchActTemplate = thereExists;
+      } else {
+        goal.matchActTemplate = matchingActTemplate;
+      }
 
       goal.initiallyEvaluatedTemporalContext = null;
 
@@ -112,10 +124,15 @@ public class ActivityTemplateGoal extends ActivityExistentialGoal {
   protected ActivityTemplateGoal() { }
 
   /**
-   * the pattern used to match with satisfying activity instances, or to
-   * create new instances if none already exist
+   * the pattern used to create new instances if none already exist
    */
   protected ActivityCreationTemplate desiredActTemplate;
+
+  /**
+   * the pattern used to match with satisfying activity instances
+   */
+  protected ActivityExpression matchActTemplate;
+
 
   /**
    * checked by getConflicts every time it is invoked to see if the Window(s)

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CardinalityGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CardinalityGoal.java
@@ -139,7 +139,7 @@ public class CardinalityGoal extends ActivityTemplateGoal {
     for(Interval subInterval : windows.iterateEqualTo(true)) {
       final var subIntervalWindows = new Windows(false).set(subInterval, true);
       final var actTB =
-          new ActivityExpression.Builder().basedOn(this.desiredActTemplate).startsOrEndsIn(subIntervalWindows).build();
+          new ActivityExpression.Builder().basedOn(this.matchActTemplate).startsOrEndsIn(subIntervalWindows).build();
 
       final var acts = new LinkedList<>(plan.find(actTB, simulationResults, new EvaluationEnvironment()));
       acts.sort(Comparator.comparing(SchedulingActivityDirective::startOffset));

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CoexistenceGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CoexistenceGoal.java
@@ -12,13 +12,11 @@ import gov.nasa.jpl.aerie.scheduler.conflicts.MissingAssociationConflict;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplateDisjunction;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
-import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
-import gov.nasa.jpl.aerie.scheduler.conflicts.Conflict;
 import gov.nasa.jpl.aerie.scheduler.constraints.durationexpressions.DurationExpression;
 import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.TimeAnchor;
 import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.TimeExpression;
-import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
 import gov.nasa.jpl.aerie.scheduler.model.Plan;
+import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -212,39 +210,39 @@ public class CoexistenceGoal extends ActivityTemplateGoal {
     final var conflicts = new java.util.LinkedList<Conflict>();
     for (var window : anchors) {
       boolean disj = false;
-      ActivityExpression.AbstractBuilder actTB = null;
+      ActivityExpression.AbstractBuilder activityFinder = null;
+      ActivityExpression.AbstractBuilder activityCreationTemplate = null;
       if (this.desiredActTemplate instanceof ActivityCreationTemplateDisjunction) {
         disj = true;
-        actTB = new ActivityCreationTemplateDisjunction.OrBuilder();
+        activityFinder = new ActivityCreationTemplateDisjunction.OrBuilder();
+        activityCreationTemplate = new ActivityCreationTemplateDisjunction.OrBuilder();
       } else if (this.desiredActTemplate != null) {
-        actTB = new ActivityCreationTemplate.Builder();
+        activityFinder = new ActivityExpression.Builder();
+        activityCreationTemplate = new ActivityCreationTemplate.Builder();
       }
-      assert actTB != null;
-      actTB.basedOn(this.desiredActTemplate);
-
+      assert activityFinder != null;
+      activityFinder.basedOn(this.matchActTemplate);
+      activityCreationTemplate.basedOn(this.desiredActTemplate);
       if(this.startExpr != null) {
         Interval startTimeRange = null;
         startTimeRange = this.startExpr.computeTime(simulationResults, plan, window.interval());
-        actTB.startsIn(startTimeRange);
+        activityFinder.startsIn(startTimeRange);
+        activityCreationTemplate.startsIn(startTimeRange);
       }
       if(this.endExpr != null) {
         Interval endTimeRange = null;
         endTimeRange = this.endExpr.computeTime(simulationResults, plan, window.interval());
-        actTB.endsIn(endTimeRange);
+        activityFinder.endsIn(endTimeRange);
+        activityCreationTemplate.endsIn(endTimeRange);
       }
       /* this will override whatever might be already present in the template */
       if(durExpr!=null){
         var durRange = this.durExpr.compute(window.interval(), simulationResults);
-        actTB.durationIn(durRange);
+        activityFinder.durationIn(durRange);
+        activityCreationTemplate.durationIn(durRange);
       }
 
-      ActivityCreationTemplate temp;
-      if (disj) {
-        temp = (ActivityCreationTemplateDisjunction) actTB.build();
-      } else {
-        temp = (ActivityCreationTemplate) actTB.build();
-      }
-      final var existingActs = plan.find(temp, simulationResults, createEvaluationEnvironmentFromAnchor(window));
+      final var existingActs = plan.find(activityFinder.build(), simulationResults, createEvaluationEnvironmentFromAnchor(window));
 
       var missingActAssociations = new ArrayList<SchedulingActivityDirective>();
       var planEvaluation = plan.getEvaluation();
@@ -265,6 +263,12 @@ public class CoexistenceGoal extends ActivityTemplateGoal {
         }
       }
 
+      ActivityCreationTemplate temp;
+      if (disj) {
+        temp = (ActivityCreationTemplateDisjunction) activityCreationTemplate.build();
+      } else {
+        temp = (ActivityCreationTemplate) activityCreationTemplate.build();
+      }
       if (!alreadyOneActivityAssociated) {
         //create conflict if no matching target activity found
         if (existingActs.isEmpty()) {

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/RecurrenceGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/RecurrenceGoal.java
@@ -121,7 +121,7 @@ public class RecurrenceGoal extends ActivityTemplateGoal {
       //collect all matching target acts ordered by start time
       //REVIEW: could collapse with prior template start time query too?
       final var satisfyingActSearch = new ActivityExpression.Builder()
-          .basedOn(desiredActTemplate)
+          .basedOn(matchActTemplate)
           .startsIn(subInterval)
           .build();
       final var acts = new java.util.LinkedList<>(plan.find(satisfyingActSearch, simulationResults, new EvaluationEnvironment()));

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SerializedValueSubsetTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SerializedValueSubsetTest.java
@@ -1,0 +1,102 @@
+package gov.nasa.jpl.aerie.scheduler;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression.subsetOrEqual;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SerializedValueSubsetTest {
+
+  @Test
+  public void testSubsetEqualityMap(){
+    final var reference = SerializedValue.of(
+        Map.of("A", SerializedValue.of(8.0),
+               "B", SerializedValue.of(
+                Map.of("C", SerializedValue.of(14), "D", SerializedValue.of(15))
+            )));
+
+    final var subsetMap = SerializedValue.of(
+        Map.of(
+            "B", SerializedValue.of(
+                Map.of("D", SerializedValue.of(15))
+            )));
+    final var subsetMapWithSerializedNull = SerializedValue.of(
+        Map.of(
+            "B", SerializedValue.of(
+                Map.of("D", SerializedValue.NULL)
+            )));
+    final var notSubsetMap = SerializedValue.of(
+        Map.of(
+            "B", SerializedValue.of(
+                Map.of("D", SerializedValue.of(7))
+            )));
+
+    assertTrue(subsetOrEqual(reference, subsetMap));
+    assertFalse(subsetOrEqual(reference, notSubsetMap));
+    assertTrue(subsetOrEqual(reference, subsetMapWithSerializedNull));
+
+  }
+
+  @Test
+  public void testSubsetEqualityList(){
+    final var reference = SerializedValue.of(List.of(SerializedValue.of(8.0), SerializedValue.of(6.0), SerializedValue.of(9.0)));
+    final var subsetList = SerializedValue.of(List.of(SerializedValue.of(8.0),SerializedValue.of(6.0)));
+    final var nullList = SerializedValue.of(List.of(SerializedValue.NULL));
+    final var notSubsetList = SerializedValue.of(List.of(SerializedValue.of(8.0),SerializedValue.of(7.0)));
+    final var wrongOrderList = SerializedValue.of(List.of(SerializedValue.of(9.0), SerializedValue.of(6.0), SerializedValue.of(8.0)));
+    assertTrue(subsetOrEqual(reference, subsetList));
+    assertTrue(subsetOrEqual(reference, nullList));
+    assertFalse(subsetOrEqual(reference, notSubsetList));
+    assertFalse(subsetOrEqual(reference, wrongOrderList));
+  }
+  @Test
+  public void testSubsetEqualityValuesInteger(){
+    final var reference = SerializedValue.of(1111);
+    final var sameValue = SerializedValue.of(1111);
+    final var differentValue = SerializedValue.of(1112);
+    assertTrue(subsetOrEqual(reference, sameValue));
+    assertFalse(subsetOrEqual(reference, differentValue));
+  }
+
+  @Test
+  public void testSubsetEqualityValuesBoolean(){
+    final var reference = SerializedValue.of(true);
+    final var sameValue = SerializedValue.of(true);
+    final var differentValue = SerializedValue.of(false);
+    final var differentType = SerializedValue.of(11);
+    assertTrue(subsetOrEqual(reference, sameValue));
+    assertFalse(subsetOrEqual(reference, differentValue));
+    assertFalse(subsetOrEqual(reference, differentType));
+  }
+
+  @Test
+  public void testSubsetEqualityValuesDecimal(){
+    final var reference = SerializedValue.of(BigDecimal.valueOf(122.56));
+    final var sameValue = SerializedValue.of(BigDecimal.valueOf(122.56));
+    final var differentValue = SerializedValue.of(BigDecimal.valueOf(122.57));
+    final var differentType = SerializedValue.of(11);
+    assertTrue(subsetOrEqual(reference, sameValue));
+    assertFalse(subsetOrEqual(reference, differentValue));
+    assertFalse(subsetOrEqual(reference, differentType));
+  }
+
+  @Test
+  public void testSubsetEqualityValuesString(){
+    final var reference = SerializedValue.of("AbCd");
+    final var sameValue = SerializedValue.of("AbCd");
+    final var differentValue = SerializedValue.of("bCd");
+    final var differentType = SerializedValue.of(11);
+    final var differentCase = SerializedValue.of("abcd");
+    assertTrue(subsetOrEqual(reference, sameValue));
+    assertFalse(subsetOrEqual(reference, differentValue));
+    assertFalse(subsetOrEqual(reference, differentCase));
+    assertFalse(subsetOrEqual(reference, differentType));
+  }
+}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/SchedulingCompilationError.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/SchedulingCompilationError.java
@@ -25,13 +25,14 @@ public class SchedulingCompilationError {
           .field("message", stringP)
           .field("stack", stringP)
           .field("location", codeLocationP)
+          .field("completeStack", stringP)
           .map(
               untuple(UserCodeError::new),
-              $ -> tuple($.message, $.stack, $.location));
+              $ -> tuple($.message, $.stack, $.location, $.completeStack));
 
   public static final JsonParser<List<UserCodeError>> schedulingErrorJsonP = listP(userCodeErrorP);
 
   public record CodeLocation(Integer line, Integer column) {}
 
-  public record UserCodeError(String message, String stack, CodeLocation location) {}
+  public record UserCodeError(String message, String stack, CodeLocation location, String completeStack) {}
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
@@ -62,7 +62,10 @@ public final class TypescriptCodeGenerationService {
   private static String getCastingMethod(){
     return """
 export function makeAllDiscreteProfile (argument: any) : any{
- if ((argument instanceof Discrete) || (argument instanceof Real)) {
+  if (argument === undefined){
+    return undefined
+  }
+  else if ((argument instanceof Discrete) || (argument instanceof Real)) {
    return argument.__astNode
  } else if ((argument instanceof Temporal.Duration) || (argument.kind === 'IntervalDuration')) {
    return argument;
@@ -91,7 +94,7 @@ export function makeAllDiscreteProfile (argument: any) : any{
  }
 }
 
-export function makeAll<T>(args : T):T{
+export function makeArgumentsDiscreteProfiles<T>(args : T):T{
 // @ts-ignore
 return (<T>makeAllDiscreteProfile(args))
 }
@@ -113,7 +116,7 @@ return (<T>makeAllDiscreteProfile(args))
         result.add(indent("%s: function %sConstructor(args:  ConstraintEDSL.Gen.ActivityTypeParameterMap[ActivityType.%s]".formatted(activityTypeCode.activityTypeName,activityTypeCode.activityTypeName,activityTypeCode.activityTypeName)));
         result.add(indent("): %s {".formatted(activityTypeCode.activityTypeName())));
         result.add(indent("// @ts-ignore"));
-        result.add(indent(indent("return { activityType: ActivityType.%s, args: makeAll(args) };".formatted(activityTypeCode.activityTypeName()))));
+        result.add(indent(indent("return { activityType: ActivityType.%s, args: makeArgumentsDiscreteProfiles(args) };".formatted(activityTypeCode.activityTypeName()))));
         result.add(indent("},"));
       }
     }

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
@@ -9,6 +9,7 @@ public final class TypescriptCodeGenerationServiceTest {
 
   @Test
   void testCodeGen() {
+    final var expected = TypescriptCodeGenerationService.generateTypescriptTypesFromMissionModel(MISSION_MODEL_TYPES);
     assertEquals(
         """
 /** Start Codegen */
@@ -19,7 +20,10 @@ interface SampleActivity1 extends ActivityTemplate<ActivityType.SampleActivity1>
 interface SampleActivity2 extends ActivityTemplate<ActivityType.SampleActivity2> {}
 interface SampleActivityEmpty extends ActivityTemplate<ActivityType.SampleActivityEmpty> {}
 export function makeAllDiscreteProfile (argument: any) : any{
- if ((argument instanceof Discrete) || (argument instanceof Real)) {
+  if (argument === undefined){
+    return undefined
+  }
+  else if ((argument instanceof Discrete) || (argument instanceof Real)) {
    return argument.__astNode
  } else if ((argument instanceof Temporal.Duration) || (argument.kind === 'IntervalDuration')) {
    return argument;
@@ -48,7 +52,7 @@ export function makeAllDiscreteProfile (argument: any) : any{
  }
 }
 
-export function makeAll<T>(args : T):T{
+export function makeArgumentsDiscreteProfiles<T>(args : T):T{
 // @ts-ignore
 return (<T>makeAllDiscreteProfile(args))
 }
@@ -57,12 +61,12 @@ const ActivityTemplateConstructors = {
   SampleActivity1: function SampleActivity1Constructor(args:  ConstraintEDSL.Gen.ActivityTypeParameterMap[ActivityType.SampleActivity1]
   ): SampleActivity1 {
   // @ts-ignore
-    return { activityType: ActivityType.SampleActivity1, args: makeAll(args) };
+    return { activityType: ActivityType.SampleActivity1, args: makeArgumentsDiscreteProfiles(args) };
   },
   SampleActivity2: function SampleActivity2Constructor(args:  ConstraintEDSL.Gen.ActivityTypeParameterMap[ActivityType.SampleActivity2]
   ): SampleActivity2 {
   // @ts-ignore
-    return { activityType: ActivityType.SampleActivity2, args: makeAll(args) };
+    return { activityType: ActivityType.SampleActivity2, args: makeArgumentsDiscreteProfiles(args) };
   },
   SampleActivityEmpty: function SampleActivityEmptyConstructor(): SampleActivityEmpty {
     return { activityType: ActivityType.SampleActivityEmpty, args: {} };
@@ -101,6 +105,6 @@ Object.assign(globalThis, {
   Resources: Resource,
 });
 /** End Codegen */""",
-        TypescriptCodeGenerationService.generateTypescriptTypesFromMissionModel(MISSION_MODEL_TYPES));
+        expected);
   }
 }

--- a/scheduler-worker/scheduling-dsl-compiler/src/libs/scheduler-ast.ts
+++ b/scheduler-worker/scheduling-dsl-compiler/src/libs/scheduler-ast.ts
@@ -57,6 +57,7 @@ export type Goal =
 export interface ActivityRecurrenceGoal {
   kind: NodeKind.ActivityRecurrenceGoal,
   activityTemplate: ActivityTemplate<any>,
+  activityFinder: ActivityExpression<any> | undefined,
   interval: Temporal.Duration,
   shouldRollbackIfUnsatisfied: boolean
 }
@@ -64,6 +65,7 @@ export interface ActivityRecurrenceGoal {
 export interface ActivityCardinalityGoal {
   kind: NodeKind.ActivityCardinalityGoal,
   activityTemplate: ActivityTemplate<any>,
+  activityFinder: ActivityExpression<any> | undefined,
   specification: CardinalityGoalArguments,
   shouldRollbackIfUnsatisfied: boolean
 }
@@ -71,16 +73,18 @@ export interface ActivityCardinalityGoal {
 export interface ActivityCoexistenceGoal {
   kind: NodeKind.ActivityCoexistenceGoal,
   activityTemplate: ActivityTemplate<any>,
+  activityFinder: ActivityExpression<any> | undefined,
   alias: string,
-  forEach: WindowsExpressions.WindowsExpression | ActivityExpression,
+  forEach: WindowsExpressions.WindowsExpression | ActivityExpression<any>,
   startConstraint: ActivityTimingConstraintSingleton | ActivityTimingConstraintRange | undefined,
   endConstraint: ActivityTimingConstraintSingleton | ActivityTimingConstraintRange | undefined,
   shouldRollbackIfUnsatisfied: boolean
 }
 
-export interface ActivityExpression {
-  kind: NodeKind.ActivityExpression
-  type: string
+export interface ActivityExpression<A extends ConstraintEDSL.Gen.ActivityType> {
+  kind: NodeKind.ActivityExpression,
+  type: string,
+  matchingArguments: ConstraintEDSL.Gen.ActivityTypeParameterMapWithUndefined[A] | undefined
 }
 
 export type TimeExpression =

--- a/scheduler-worker/scheduling-dsl-compiler/src/libs/scheduler-mission-model-generated-code.ts
+++ b/scheduler-worker/scheduling-dsl-compiler/src/libs/scheduler-mission-model-generated-code.ts
@@ -10,3 +10,8 @@ export enum ActivityType {
   _ = '_',
 }
 
+
+export function makeArgumentsDiscreteProfiles<T>(args : T):T{
+  //placeholder function
+  return args
+}

--- a/scheduler-worker/scheduling-dsl-compiler/src/main.ts
+++ b/scheduler-worker/scheduling-dsl-compiler/src/main.ts
@@ -47,6 +47,19 @@ interface AstNode {
   __astNode: object
 }
 
+function toJson(unwrappedErr: any){
+  var completeStackValue = "";
+  if ('error' in unwrappedErr && 'stack' in unwrappedErr.error){
+    completeStackValue = JSON.stringify(unwrappedErr.error.stack)
+  }
+    return {
+        message: unwrappedErr.message,
+        stack: unwrappedErr.stack,
+        location: unwrappedErr.location,
+        completeStack:  completeStackValue,
+  }
+}
+
 async function handleRequest(data: Buffer) {
   try {
     // Test the health of the service by responding to "ping" with "pong".
@@ -85,8 +98,9 @@ async function handleRequest(data: Buffer) {
     );
 
     if (result.isErr()) {
+      const errorCause = JSON.stringify(result.unwrapErr().map(err => toJson(err))) + '\n';
       process.stdout.write('error\n');
-      process.stdout.write(JSON.stringify(result.unwrapErr().map(err => err.toJSON())) + '\n');
+      process.stdout.write(errorCause);
       lineReader.once('line', handleRequest);
       return;
     }


### PR DESCRIPTION
Resolves #751 
Resolves #782 

* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
In this PR, we provide an optional `activityFinder` for each eDSL goal. If passed, it is used for activity matching, replacing the activity template.

This `activityFinder` is an `ActivityExpression` that can match on activity type and also parameters. Users may only define a subset of the parameters they are looking for and the expression will match all activities that have a superset of these defined parameters. 

Let's say the parameters of an activity X looks like that: 
```
A : "1"
B : { C: "2" D: "3}
E : "4"
```
Then if the user specifies the following parameters in the activity finder :
`{ A:"1"}` will match X
`{A : "1", B : { C: "2"}}` will also match X 
`{A : "1", B : { C: "4"}}` will not match X

Edit:
The first commit also returns the full stacktrace to our backend if a compilation error happens when running user code in the ts-code-runner, in both constraints and scheduling edsl compilers.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
New tests 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
- [x] I have to update the scheduling eDSL doc 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
More operators on `ActivityExpression` other than parameter equality