### PR TITLE
Remove Simulation Bounds from Simulation Templates

### DIFF
--- a/deployment/hasura/migrations/AerieMerlin/11_remove_sim_bounds_presets/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/11_remove_sim_bounds_presets/down.sql
@@ -1,0 +1,20 @@
+alter table public.simulation_template
+  add column simulation_start_time timestamptz default null,
+  add column simulation_end_time timestamptz default null;
+
+alter table public.simulation
+  alter column simulation_start_time drop not null,
+  alter column simulation_end_time drop not null,
+  drop constraint simulation_end_after_simulation_start;
+
+create or replace function create_simulation_row_for_new_plan()
+returns trigger
+security definer
+language plpgsql as $$begin
+  insert into simulation (revision, simulation_template_id, plan_id, arguments)
+  values (0, null, new.id, '{}');
+  return new;
+end
+$$;
+
+call migrations.mark_migration_rolled_back('11');

--- a/deployment/hasura/migrations/AerieMerlin/11_remove_sim_bounds_presets/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/11_remove_sim_bounds_presets/up.sql
@@ -1,0 +1,34 @@
+create or replace function create_simulation_row_for_new_plan()
+returns trigger
+security definer
+language plpgsql as $$begin
+  insert into simulation (revision, simulation_template_id, plan_id, arguments, simulation_start_time, simulation_end_time)
+  values (0, null, new.id, '{}', new.start_time, new.start_time+new.duration);
+  return new;
+end
+$$;
+
+alter table public.simulation_template
+  drop column simulation_start_time,
+  drop column simulation_end_time;
+
+update simulation s
+set simulation_start_time = p.start_time
+from plan p
+where s.plan_id = p.id
+  and s.simulation_start_time is null;
+
+update simulation s
+set simulation_end_time = p.start_time+p.duration
+from plan p
+where s.plan_id = p.id
+  and s.simulation_end_time is null;
+
+-- Add not null constraints
+alter table public.simulation
+  alter column simulation_start_time set not null,
+  alter column simulation_end_time set not null,
+  add constraint simulation_end_after_simulation_start
+    check (simulation_start_time <= simulation_end_time);
+
+call migrations.mark_migration_applied('11');

--- a/e2e-tests/src/tests/scheduler.test.ts
+++ b/e2e-tests/src/tests/scheduler.test.ts
@@ -226,7 +226,7 @@ test.describe('Scheduling', () => {
     //expect one profile per resource in the banananation model
     expect(dataset.length).toEqual(7)
     for(let resource of dataset){
-      if(resource.name =="/fruit" || resource.name == "/peel"){
+      if(resource.name == "/fruit" || resource.name == "/peel"){
         let startOffsetOfResource = new Set<string>()
         for(let segment of resource.profile_segments){
           startOffsetOfResource.add(segment.start_offset)
@@ -244,8 +244,6 @@ test.describe('Scheduling', () => {
     let peelOutputIsThere = false
     let biteOutputIsThere = false
     let growOutputIsThere = false
-    //topic added in the mission model
-    let producerIsThere = false
     for(let topic of topics){
       switch (topic.name){
         case prefixInput+"BiteBanana":
@@ -272,9 +270,9 @@ test.describe('Scheduling', () => {
           peelOutputIsThere = true
           expect(topic.events.length).toEqual(12)
           break
-        case "/producer":
-          producerIsThere = true
-          expect(topic.events.length).toEqual(0)
+        default:
+          test.fail(topic.events.length !== 0, "Unexpected topic with events: "+topic.name)
+          break
       }
     }
     expect(peelInputIsThere)
@@ -283,7 +281,6 @@ test.describe('Scheduling', () => {
     expect(peelOutputIsThere)
     expect(growOutputIsThere)
     expect(biteOutputIsThere)
-    expect(producerIsThere)
   });
 
   test('Get Plan', async ({ request }) => {

--- a/e2e-tests/src/tests/temporal-subset-simulation.test.ts
+++ b/e2e-tests/src/tests/temporal-subset-simulation.test.ts
@@ -2,209 +2,7 @@ import { expect, test } from '@playwright/test';
 import req from '../utilities/requests.js';
 import time from "../utilities/time.js";
 
-
-/*
-  Tests various simulation and simulation template start and end time configurations.
-  On all tests, unless otherwise specified, these are the following values:
-  - Simulation's simulation_start_time: Plan Start (January 1, 2023, at 00:00:00 Z)
-  - Simulation's simulation_end_time: Halfway through plan (January 1, 2023, at 12:00:00 Z)
-  - Simulation Template's simulation_start_time: Halfway through plan (January 1, 2023, at 12:00:00 Z)
-  - Simulation Template's simulation_end_time: Plan End (January 2, 2023, at 00:00:00 Z)
-*/
-
-test.describe('Temporal Subset Simulation Config and Template Inputs: Exception Cases', () => {
-  const plan_start_timestamp = "2023-01-01T00:00:00+00:00";
-  const midway_plan_timestamp = "2023-01-01T12:00:00+00:00";
-  const plan_end_timestamp = "2023-01-02T00:00:00+00:00";
-
-  let mission_model_id: number;
-  let plan_id: number;
-  let simulation_id: number;
-  let simulation_template_id: number;
-
-  test.beforeEach(async ({ request }) => {
-    let rd = Math.random()*100000;
-    let jar_id = await req.uploadJarFile(request);
-    const model: MissionModelInsertInput = {
-      jar_id,
-      mission: 'aerie_e2e_tests',
-      name: 'Banananation (e2e tests)',
-      version: rd + "",
-    };
-    mission_model_id = await req.createMissionModel(request, model);
-    const plan_input : CreatePlanInput = {
-      model_id : mission_model_id,
-      name : 'test_plan' + rd,
-      start_time : plan_start_timestamp,
-      duration : time.getIntervalFromDoyRange(plan_start_timestamp, plan_end_timestamp)
-    };
-    plan_id = await req.createPlan(request, plan_input);
-    simulation_id = await req.getSimulationId(request, plan_id);
-    const simulation_template : InsertSimulationTemplateInput = {
-      model_id: mission_model_id,
-      arguments: {},
-      description: 'Template for Plan ' +plan_id
-    };
-    simulation_template_id = await req.insertAndAssociateSimulationTemplate(request, simulation_template, simulation_id );
-    const firstHalfActivity : ActivityInsertInput =
-        {
-          arguments : {
-            "duration": 3600000000 //1hr
-          },
-          plan_id: plan_id,
-          type : "ControllableDurationActivity",
-          start_offset : "1h"
-        };
-    const midpointActivity : ActivityInsertInput =
-        {
-          arguments : {
-            "duration": 7200000000 //2hrs
-          },
-          plan_id: plan_id,
-          type : "ControllableDurationActivity",
-          start_offset : "12h"
-        };
-    const secondHalfActivity : ActivityInsertInput =
-        {
-          arguments : {
-            "duration": 10800000000 //3hrs
-          },
-          plan_id: plan_id,
-          type : "ControllableDurationActivity",
-          start_offset : "14h"
-        };
-    await req.insertActivity(request, firstHalfActivity);
-    await req.insertActivity(request, midpointActivity);
-    await req.insertActivity(request, secondHalfActivity);
-  });
-  test.afterEach(async ({ request }) => {
-    // Delete Plan and Model cascades the rest of the cleanup
-    await req.deleteMissionModel(request, mission_model_id);
-    await req.deletePlan(request, plan_id);
-  });
-
-  // ~~~~~~~~ Exception Cases ~~~~~~~~ //
-  test('Simulation start time, end time are null; Template start time, end time are null', async ({ request }) => {
-    // Expect a 500 error bc of a RuntimeException
-    try{
-      await req.simulate(request, plan_id);
-      test.fail();
-    } catch(error) {
-      const err = error as Error;
-      expect(err.message).toEqual("internal error");
-    }
-  });
-  test('Simulation start time is defined, end time is null; Template start time, end time are null', async({request}) => {
-    // Expect a 500 error bc of a RuntimeException
-    const simulationBounds : UpdateSimulationBoundsInput = {
-      plan_id : plan_id,
-      simulation_start_time: plan_start_timestamp,
-      simulation_end_time: null
-    };
-    await req.updateSimulationBounds(request, simulationBounds);
-    try{
-      await req.simulate(request, plan_id);
-      test.fail();
-    } catch(error) {
-      const err = error as Error;
-      expect(err.message).toEqual("internal error");
-    }
-  });
-  test('Simulation start time is null, end time is defined; Template start time, end time are null', async({request}) => {
-    // Expect a 500 error bc of a RuntimeException
-    const simulationBounds : UpdateSimulationBoundsInput = {
-      plan_id : plan_id,
-      simulation_start_time: null,
-      simulation_end_time: midway_plan_timestamp
-    };
-    await req.updateSimulationBounds(request, simulationBounds);
-    try{
-      await req.simulate(request, plan_id);
-      test.fail();
-    } catch(error) {
-      const err = error as Error;
-      expect(err.message).toEqual("internal error");
-    }
-  });
-  test('Simulation start time, end time is null; Template start time is defined, end time is null', async({request}) => {
-    // Expect a 500 error bc of a RuntimeException
-    const templateBounds : UpdateSimulationTemplateBoundsInput = {
-      simulation_template_id : simulation_template_id,
-      simulation_start_time: plan_start_timestamp,
-      simulation_end_time: null
-    };
-    await req.updateSimulationTemplateBounds(request, templateBounds);
-    try{
-      await req.simulate(request, plan_id);
-      test.fail();
-    } catch(error) {
-      const err = error as Error;
-      expect(err.message).toEqual("internal error");
-    }
-  });
-  test('Simulation start time, end time is null; Template start time is null, end time is defined', async({request}) => {
-    // Expect a 500 error bc of a RuntimeException
-    const templateBounds : UpdateSimulationTemplateBoundsInput = {
-      simulation_template_id : simulation_template_id,
-      simulation_start_time: null,
-      simulation_end_time: plan_end_timestamp
-    };
-    await req.updateSimulationTemplateBounds(request, templateBounds);
-    try{
-      await req.simulate(request, plan_id);
-      test.fail();
-    } catch(error) {
-      const err = error as Error;
-      expect(err.message).toEqual("internal error");
-    }
-  });
-  test('Simulation start time is defined, end time is null; Template start time is defined, end time is null', async({request}) => {
-    // Expect a 500 error bc of a RuntimeException
-    const simulationBounds : UpdateSimulationBoundsInput = {
-      plan_id : plan_id,
-      simulation_start_time: plan_start_timestamp,
-      simulation_end_time: null
-    };
-    const templateBounds : UpdateSimulationTemplateBoundsInput = {
-      simulation_template_id : simulation_template_id,
-      simulation_start_time: midway_plan_timestamp,
-      simulation_end_time: null
-    };
-    await req.updateSimulationBounds(request, simulationBounds);
-    await req.updateSimulationTemplateBounds(request, templateBounds);
-    try{
-      await req.simulate(request, plan_id);
-      test.fail();
-    } catch(error) {
-      const err = error as Error;
-      expect(err.message).toEqual("internal error");
-    }
-  });
-  test('Simulation start time is null, end time is defined; Template start time is null, end time is defined', async({request}) => {
-    // Expect a 500 error bc of a RuntimeException
-    const simulationBounds : UpdateSimulationBoundsInput = {
-      plan_id : plan_id,
-      simulation_start_time: null,
-      simulation_end_time: midway_plan_timestamp
-    };
-    const templateBounds : UpdateSimulationTemplateBoundsInput = {
-      simulation_template_id : simulation_template_id,
-      simulation_start_time: null,
-      simulation_end_time: plan_end_timestamp
-    };
-    await req.updateSimulationBounds(request, simulationBounds);
-    await req.updateSimulationTemplateBounds(request, templateBounds);
-    try{
-      await req.simulate(request, plan_id);
-      test.fail();
-    } catch(error) {
-      const err = error as Error;
-      expect(err.message).toEqual("internal error");
-    }
-  });
-});
-
-test.describe('Temporal Subset Simulation Config and Template Inputs: Valid Cases', () => {
+test.describe('Temporal Subset Simulation', () => {
   const plan_start_timestamp = "2023-01-01T00:00:00+00:00";
   const midway_plan_timestamp = "2023-01-01T12:00:00+00:00";
   const plan_end_timestamp = "2023-01-02T00:00:00+00:00";
@@ -278,7 +76,7 @@ test.describe('Temporal Subset Simulation Config and Template Inputs: Valid Case
     await req.deletePlan(request, plan_id);
   });
 
-  test('Simulation start time, end time are defined; Template start time, end time are null', async ({ request }) => {
+  test('Simulate first half of plan', async ({ request }) => {
     // Expect the first half of the plan to be simulated
     const simulationBounds : UpdateSimulationBoundsInput = {
       plan_id : plan_id,
@@ -309,14 +107,14 @@ test.describe('Temporal Subset Simulation Config and Template Inputs: Valid Case
     expect(firstActivity.start_offset).toEqual("01:00:00");
     expect(firstActivity.start_time).toEqual("2023-01-01T01:00:00+00:00");
   });
-  test('Simulation start time, end time are null; Template start time, end time are defined', async ({ request }) => {
-    // Expect the second half of the plan to be simulated
-    const templateSimulationBounds : UpdateSimulationTemplateBoundsInput = {
-      simulation_template_id : simulation_template_id,
+  test('Simulate second half of plan', async ({ request }) => {
+    // Expect the first half of the plan to be simulated
+    const simulationBounds : UpdateSimulationBoundsInput = {
+      plan_id : plan_id,
       simulation_start_time: midway_plan_timestamp,
       simulation_end_time: plan_end_timestamp
     };
-    await req.updateSimulationTemplateBounds(request, templateSimulationBounds);
+    await req.updateSimulationBounds(request, simulationBounds);
 
     let simulationDatasetId = await awaitSimulation(request, plan_id);
 
@@ -340,20 +138,43 @@ test.describe('Temporal Subset Simulation Config and Template Inputs: Valid Case
     expect(firstActivity.start_offset).toEqual("00:00:00");
     expect(firstActivity.start_time).toEqual(midway_plan_timestamp);
   });
-  test('Simulation start time is defined, end time is null; Template start time is null, end time are defined', async ({ request }) => {
-    // Expect the entire plan to be simulated
+  test('Simulate middle section of plan', async({request}) => {
+    /*
+      In this test:
+        - Simulation's simulation_start_time: (January 1, 2023, at 02:00:00 Z)
+        - Simulation's simulation_end_time: (January 1, 2023, at 13:00:00 Z)
+    */
+    // Expect the simulation to be 11 Hours long (02:00:00 Z to 13:00:00 Z)
+    const simulationBounds : UpdateSimulationBoundsInput = {
+      plan_id : plan_id,
+      simulation_start_time: "2023-01-01T02:00:00+00:00",
+      simulation_end_time: "2023-01-01T13:00:00+00:00"
+    };
+
+    await req.updateSimulationBounds(request, simulationBounds);
+
+    let simulationDatasetId = await awaitSimulation(request, plan_id);
+
+    let {canceled, simulation_start_time, simulation_end_time, simulated_activities} = await req.getSimulationDataset(request, simulationDatasetId);
+    expect(canceled).toEqual(false);
+    expect(simulation_start_time).toEqual(simulationBounds.simulation_start_time);
+    expect(simulation_end_time).toEqual(simulationBounds.simulation_end_time);
+    expect(simulated_activities.length).toEqual(1);
+
+    let unfinishedActivity = simulated_activities.pop();
+    expect(unfinishedActivity.activity_directive.id).toEqual(midpoint_activity_id);
+    expect(unfinishedActivity.duration).toEqual(null);
+    expect(unfinishedActivity.start_offset).toEqual("10:00:00");
+    expect(unfinishedActivity.start_time).toEqual(midway_plan_timestamp);
+  });
+  test('Simulate complete plan', async ({ request }) => {
+    // Expect the first half of the plan to be simulated
     const simulationBounds : UpdateSimulationBoundsInput = {
       plan_id : plan_id,
       simulation_start_time: plan_start_timestamp,
-      simulation_end_time: null
-    };
-    const templateSimulationBounds : UpdateSimulationTemplateBoundsInput = {
-      simulation_template_id : simulation_template_id,
-      simulation_start_time: null,
       simulation_end_time: plan_end_timestamp
     };
     await req.updateSimulationBounds(request, simulationBounds);
-    await req.updateSimulationTemplateBounds(request, templateSimulationBounds);
 
     let simulationDatasetId = await awaitSimulation(request, plan_id);
 
@@ -376,179 +197,6 @@ test.describe('Temporal Subset Simulation Config and Template Inputs: Valid Case
     expect(secondActivity.duration).toEqual("02:00:00");
     expect(secondActivity.start_offset).toEqual("12:00:00");
     expect(secondActivity.start_time).toEqual(midway_plan_timestamp);
-
-    let firstActivity = simulated_activities.pop();
-    expect(firstActivity.activity_directive.id).toEqual(first_half_activity_id);
-    expect(firstActivity.duration).toEqual("01:00:00");
-    expect(firstActivity.start_offset).toEqual("01:00:00");
-    expect(firstActivity.start_time).toEqual("2023-01-01T01:00:00+00:00");
-  });
-  test('Simulation start time is null, end time is defined; Template start time is defined, end time is null', async({request}) => {
-    // Expect the simulation to have no duration
-    const simulationBounds : UpdateSimulationBoundsInput = {
-      plan_id : plan_id,
-      simulation_start_time: null,
-      simulation_end_time: midway_plan_timestamp
-    };
-    const templateSimulationBounds : UpdateSimulationTemplateBoundsInput = {
-      simulation_template_id : simulation_template_id,
-      simulation_start_time: midway_plan_timestamp,
-      simulation_end_time: null
-    };
-    await req.updateSimulationBounds(request, simulationBounds);
-    await req.updateSimulationTemplateBounds(request, templateSimulationBounds);
-
-    let simulationDatasetId = await awaitSimulation(request, plan_id);
-
-    let {canceled, simulation_start_time, simulation_end_time, simulated_activities} = await req.getSimulationDataset(request, simulationDatasetId);
-    expect(canceled).toEqual(false);
-    expect(simulation_start_time).toEqual(midway_plan_timestamp);
-    expect(simulation_end_time).toEqual(midway_plan_timestamp);
-    expect(simulated_activities.length).toEqual(1);
-
-    let unfinishedActivity = simulated_activities.pop();
-    expect(unfinishedActivity.activity_directive.id).toEqual(midpoint_activity_id);
-    expect(unfinishedActivity.duration).toEqual(null);
-    expect(unfinishedActivity.start_offset).toEqual("00:00:00");
-    expect(unfinishedActivity.start_time).toEqual(midway_plan_timestamp);
-  });
-  test('Simulation start time, end time is defined; Template start time, end time is defined', async({request}) => {
-    /*
-      In this test:
-        - Simulation's simulation_start_time: (January 1, 2023, at 02:00:00 Z)
-        - Simulation's simulation_end_time: (January 1, 2023, at 13:00:00 Z)
-    */
-    // Expect the simulation to be 11 Hours long (02:00:00 Z to 13:00:00 Z)
-    const simulationBounds : UpdateSimulationBoundsInput = {
-      plan_id : plan_id,
-      simulation_start_time: "2023-01-01T02:00:00+00:00",
-      simulation_end_time: "2023-01-01T13:00:00+00:00"
-    };
-    const templateSimulationBounds : UpdateSimulationTemplateBoundsInput = {
-      simulation_template_id : simulation_template_id,
-      simulation_start_time: midway_plan_timestamp,
-      simulation_end_time: plan_end_timestamp
-    };
-
-    await req.updateSimulationBounds(request, simulationBounds);
-    await req.updateSimulationTemplateBounds(request, templateSimulationBounds);
-
-    let simulationDatasetId = await awaitSimulation(request, plan_id);
-
-    let {canceled, simulation_start_time, simulation_end_time, simulated_activities} = await req.getSimulationDataset(request, simulationDatasetId);
-    expect(canceled).toEqual(false);
-    expect(simulation_start_time).toEqual(simulationBounds.simulation_start_time);
-    expect(simulation_end_time).toEqual(simulationBounds.simulation_end_time);
-    expect(simulated_activities.length).toEqual(1);
-
-    let unfinishedActivity = simulated_activities.pop();
-    expect(unfinishedActivity.activity_directive.id).toEqual(midpoint_activity_id);
-    expect(unfinishedActivity.duration).toEqual(null);
-    expect(unfinishedActivity.start_offset).toEqual("10:00:00");
-    expect(unfinishedActivity.start_time).toEqual(midway_plan_timestamp);
-  });
-});
-
-test.describe('Temporal Subset Simulation Config: No Template', () => {
-  const plan_start_timestamp = "2023-01-01T00:00:00+00:00";
-  const midway_plan_timestamp = "2023-01-01T12:00:00+00:00";
-  const plan_end_timestamp = "2023-01-02T00:00:00+00:00";
-
-  let mission_model_id: number;
-  let plan_id: number;
-  let simulation_id: number;
-  let first_half_activity_id: number;
-  let midpoint_activity_id: number;
-
-  test.beforeEach(async ({ request }) => {
-    let rd = Math.random()*100000;
-    let jar_id = await req.uploadJarFile(request);
-    const model: MissionModelInsertInput = {
-      jar_id,
-      mission: 'aerie_e2e_tests',
-      name: 'Banananation (e2e tests)',
-      version: rd + "",
-    };
-    mission_model_id = await req.createMissionModel(request, model);
-    const plan_input : CreatePlanInput = {
-      model_id : mission_model_id,
-      name : 'test_plan' + rd,
-      start_time : plan_start_timestamp,
-      duration : time.getIntervalFromDoyRange(plan_start_timestamp, plan_end_timestamp)
-    };
-    plan_id = await req.createPlan(request, plan_input);
-    simulation_id = await req.getSimulationId(request, plan_id);
-
-    const firstHalfActivity : ActivityInsertInput =
-        {
-          arguments : {
-            "duration": 3600000000 //1hr
-          },
-          plan_id: plan_id,
-          type : "ControllableDurationActivity",
-          start_offset : "1h"
-        };
-    const midpointActivity : ActivityInsertInput =
-        {
-          arguments : {
-            "duration": 7200000000 //2hrs
-          },
-          plan_id: plan_id,
-          type : "ControllableDurationActivity",
-          start_offset : "12h"
-        };
-    const secondHalfActivity : ActivityInsertInput =
-        {
-          arguments : {
-            "duration": 10800000000 //3hrs
-          },
-          plan_id: plan_id,
-          type : "ControllableDurationActivity",
-          start_offset : "14h"
-        };
-    first_half_activity_id = await req.insertActivity(request, firstHalfActivity);
-    midpoint_activity_id = await req.insertActivity(request, midpointActivity);
-    await req.insertActivity(request, secondHalfActivity);
-  });
-  test.afterEach(async ({ request }) => {
-    // Delete Plan and Model cascades the rest of the cleanup
-    await req.deleteMissionModel(request, mission_model_id);
-    await req.deletePlan(request, plan_id);
-  });
-  test('Simulation start time, end time are null', async ({ request }) => {
-    // Expect a 500 error bc of a RuntimeException
-    try{
-      await req.simulate(request, plan_id);
-      test.fail();
-    } catch(error) {
-      const err = error as Error;
-      expect(err.message).toEqual("internal error");
-    }
-  });
-  test('Simulation start time, end time are defined', async ({ request }) => {
-    // Expect the first half of the plan to be simulated
-    const simulationBounds : UpdateSimulationBoundsInput = {
-      plan_id : plan_id,
-      simulation_start_time: plan_start_timestamp,
-      simulation_end_time: midway_plan_timestamp
-    };
-    await req.updateSimulationBounds(request, simulationBounds);
-
-    let simulationDatasetId = await awaitSimulation(request, plan_id);
-
-    let {canceled, simulation_start_time, simulation_end_time, simulated_activities} = await req.getSimulationDataset(request, simulationDatasetId);
-    expect(canceled).toEqual(false);
-    expect(simulation_start_time).toEqual(plan_start_timestamp);
-    expect(simulation_end_time).toEqual(midway_plan_timestamp);
-    expect(simulated_activities.length).toEqual(2);
-
-    simulated_activities.sort((firstElement, secondElement) => {return firstElement.activity_directive.id-secondElement.activity_directive.id});
-
-    let unfinishedActivity = simulated_activities.pop();
-    expect(unfinishedActivity.activity_directive.id).toEqual(midpoint_activity_id);
-    expect(unfinishedActivity.duration).toEqual(null);
-    expect(unfinishedActivity.start_offset).toEqual("12:00:00");
-    expect(unfinishedActivity.start_time).toEqual(midway_plan_timestamp);
 
     let firstActivity = simulated_activities.pop();
     expect(firstActivity.activity_directive.id).toEqual(first_half_activity_id);

--- a/e2e-tests/src/types/simulation.d.ts
+++ b/e2e-tests/src/types/simulation.d.ts
@@ -6,11 +6,6 @@ type Simulation = {
   simulation_end_time: string | null;
 };
 
-type SimulationCreation = {
-  arguments: ArgumentsMap;
-  plan_id: number;
-};
-
 type UpdateSimulationBoundsInput = {
   plan_id: number,
   simulation_start_time: string,
@@ -21,20 +16,12 @@ type SimulationTemplate = {
   arguments: ArgumentsMap;
   description: string;
   id: number;
-  simulation_start_time: string | null;
-  simulation_end_time: string | null;
 };
 
 type InsertSimulationTemplateInput = {
   arguments: ArgumentsMap;
   description: string;
   model_id: number;
-}
-
-type UpdateSimulationTemplateBoundsInput = {
-  simulation_template_id: number,
-  simulation_start_time: string,
-  simulation_end_time: string
 }
 
 type Resource = {

--- a/e2e-tests/src/utilities/gql.ts
+++ b/e2e-tests/src/utilities/gql.ts
@@ -243,8 +243,6 @@ const gql = {
             arguments
             description
             id
-            simulation_start_time
-            simulation_end_time
           }
         }
         startTime: start_time
@@ -265,17 +263,6 @@ const gql = {
       update_simulation_by_pk(pk_columns: {id: $simulation_id}, _set: {simulation_template_id: $simulation_template_id}) {
         simulation_template_id
       }
-    }
-  `,
-
-  UPDATE_SIMULATION_TEMPLATE_BOUNDS: `#graphql
-    mutation updateSimulationTemplateBounds($simulation_template_id: Int!, $simulation_start_time: timestamptz!, $simulation_end_time: timestamptz!) {
-      update_simulation_template_by_pk(pk_columns: {id: $simulation_template_id},
-      _set: {
-        simulation_start_time: $simulation_start_time,
-        simulation_end_time: $simulation_end_time}) {
-        id
-       }
     }
   `,
 

--- a/e2e-tests/src/utilities/requests.ts
+++ b/e2e-tests/src/utilities/requests.ts
@@ -146,7 +146,7 @@ const req = {
     return simulation_dataset[0] as SimulationDataset;
   },
 
-  async insertAndAssociateSimulationTemplate(request: APIRequestContext, template: InsertSimulationTemplateInput,simulationId: number){
+  async insertAndAssociateSimulationTemplate(request: APIRequestContext, template: InsertSimulationTemplateInput, simulationId: number){
     const data = await req.hasura(request, gql.INSERT_SIMULATION_TEMPLATE, {simulationTemplateInsertInput: template} );
     const {insert_simulation_template_one} = data;
     const {id: template_id} = insert_simulation_template_one;
@@ -159,13 +159,6 @@ const req = {
     const data = await req.hasura(request, gql.UPDATE_SIMULATION_BOUNDS, {plan_id: plan_id, simulation_start_time: simulation_start_time, simulation_end_time: simulation_end_time});
     const {update_simulation} = data;
     const {id} = update_simulation
-    return id;
-  },
-
-  async updateSimulationTemplateBounds(request: APIRequestContext, templateBounds: UpdateSimulationTemplateBoundsInput) {
-    const {simulation_template_id, simulation_start_time, simulation_end_time} = templateBounds;
-    const data = await req.hasura(request, gql.UPDATE_SIMULATION_TEMPLATE_BOUNDS, {simulation_template_id: simulation_template_id, simulation_start_time: simulation_start_time, simulation_end_time: simulation_end_time});
-    const {id} = data;
     return id;
   },
 

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -13,3 +13,4 @@ call migrations.mark_migration_applied('7');
 call migrations.mark_migration_applied('8');
 call migrations.mark_migration_applied('9');
 call migrations.mark_migration_applied('10');
+call migrations.mark_migration_applied('11');

--- a/merlin-server/sql/merlin/tables/plan.sql
+++ b/merlin-server/sql/merlin/tables/plan.sql
@@ -114,8 +114,8 @@ create function create_simulation_row_for_new_plan()
 returns trigger
 security definer
 language plpgsql as $$begin
-  insert into simulation (revision, simulation_template_id, plan_id, arguments)
-  values (0, null, new.id, '{}');
+  insert into simulation (revision, simulation_template_id, plan_id, arguments, simulation_start_time, simulation_end_time)
+  values (0, null, new.id, '{}', new.start_time, new.start_time+new.duration);
   return new;
 end
 $$;

--- a/merlin-server/sql/merlin/tables/simulation.sql
+++ b/merlin-server/sql/merlin/tables/simulation.sql
@@ -6,8 +6,8 @@ create table simulation (
   plan_id integer not null,
   arguments merlin_argument_set not null,
 
-  simulation_start_time timestamptz default null,
-  simulation_end_time timestamptz default null,
+  simulation_start_time timestamptz not null,
+  simulation_end_time timestamptz not null,
 
   constraint simulation_synthetic_key
     primary key (id),
@@ -22,7 +22,9 @@ create table simulation (
     on update cascade
     on delete cascade,
   constraint one_simulation_per_plan
-    unique(plan_id)
+    unique(plan_id),
+  constraint simulation_end_after_simulation_start
+    check (simulation_start_time <= simulation_end_time)
 );
 
 

--- a/merlin-server/sql/merlin/tables/simulation_template.sql
+++ b/merlin-server/sql/merlin/tables/simulation_template.sql
@@ -6,9 +6,6 @@ create table simulation_template (
   description text not null,
   arguments merlin_argument_set not null,
 
-  simulation_start_time timestamptz default null,
-  simulation_end_time timestamptz default null,
-
   constraint simulation_template_synthetic_key
     primary key (id),
   constraint simulation_template_owned_by_model

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationAction.java
@@ -49,10 +49,8 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
           .getSuccessOrThrow(
               failureReason -> new Error("Corrupt simulation arguments cannot be parsed: " + failureReason.reason())
           );
-      final String simStartString = results.getString("simulation_start_time");
-      final String simEndString = results.getString("simulation_end_time");
-      final var simulationStartTime = simStartString == null ? null : Timestamp.fromString(simStartString);
-      final var simulationEndTime = simEndString == null ? null : Timestamp.fromString(simEndString);
+      final var simulationStartTime = Timestamp.fromString(results.getString("simulation_start_time"));
+      final var simulationEndTime = Timestamp.fromString(results.getString("simulation_end_time"));
       return new SimulationRecord(id, revision, planId, templateId$, arguments, simulationStartTime, simulationEndTime);
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationTemplateAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationTemplateAction.java
@@ -1,6 +1,5 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
-import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
@@ -18,9 +17,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
           t.model_id,
           t.revision,
           t.description,
-          t.arguments,
-          to_char(t.simulation_start_time, 'YYYY-DDD"T"HH24:MI:SS.FF6') as simulation_start_time,
-          to_char(t.simulation_end_time, 'YYYY-DDD"T"HH24:MI:SS.FF6') as simulation_end_time
+          t.arguments
       from simulation_template as t
       where t.id = ?
     """;
@@ -46,11 +43,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
               failureReason -> new Error("Corrupt simulation template arguments cannot be parsed: "
                                          + failureReason.reason())
           );
-      final String simStartString = results.getString("simulation_start_time");
-      final String simEndString = results.getString("simulation_end_time");
-      final var simStartTime = simStartString == null ? null : Timestamp.fromString(simStartString);
-      final var simEndTime = simEndString == null ? null : Timestamp.fromString(simEndString);
-      return Optional.of(new SimulationTemplateRecord(simulationTemplateId, revision, modelId, description, arguments, simStartTime, simEndTime));
+      return Optional.of(new SimulationTemplateRecord(simulationTemplateId, revision, modelId, description, arguments));
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -82,8 +82,8 @@ public final class PostgresPlanRepository implements PlanRepository {
 
       final var activities = getPlanActivities(connection, planId);
       final var arguments = getSimulationArguments(simulationRecord, templateRecord);
-      final var simStartTime = getSimStartTime(simulationRecord, templateRecord);
-      final var simEndTime = getSimEndTime(simulationRecord, templateRecord);
+      final var simStartTime = simulationRecord.simulationStartTime();
+      final var simEndTime = simulationRecord.simulationEndTime();
 
       return new Plan(
           planRecord.name(),
@@ -153,30 +153,6 @@ public final class PostgresPlanRepository implements PlanRepository {
 
     arguments.putAll(simulationRecord.arguments());
     return arguments;
-  }
-
-    private Timestamp getSimStartTime(SimulationRecord simulationRecord, Optional<SimulationTemplateRecord> templateRecord) {
-    final var templateId = simulationRecord.simulationTemplateId();
-    if(simulationRecord.simulationStartTime() != null) return simulationRecord.simulationStartTime();
-
-    if(templateId.isPresent()){
-      if(templateRecord.isEmpty()) throw new RuntimeException("TemplateRecord should not be empty");
-      if(templateRecord.get().simulationStartTime() != null) return templateRecord.get().simulationStartTime();
-      throw new RuntimeException("Either \"simulationRecord\" or \"templateRecord\" must define \"simulationStartTime\".");
-    }
-    throw new RuntimeException("\"simulationRecord\" must either define \"simulationStartTime\" or have a \"simulationTemplateId\".");
-  }
-
-  private Timestamp getSimEndTime(SimulationRecord simulationRecord, Optional<SimulationTemplateRecord> templateRecord) {
-    final var templateId = simulationRecord.simulationTemplateId();
-    if(simulationRecord.simulationEndTime() != null) return simulationRecord.simulationEndTime();
-
-    if(templateId.isPresent()){
-      if(templateRecord.isEmpty()) throw new RuntimeException("TemplateRecord should not be empty");
-      if(templateRecord.get().simulationEndTime() != null) return templateRecord.get().simulationEndTime();
-      throw new RuntimeException("Either \"simulationRecord\" or \"templateRecord\" must define \"simulationEndTime\".");
-    }
-    throw new RuntimeException("\"simulationRecord\" must either define \"simulationEndTime\" or have a \"simulationTemplateId\".");
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -47,19 +47,17 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
     try (final var connection = this.dataSource.getConnection()) {
       final SimulationRecord simulation = getSimulation(connection, planId);
       final SimulationTemplateRecord template;
-      Timestamp startTime = simulation.simulationStartTime();
-      Timestamp endTime = simulation.simulationEndTime();
+      final Timestamp startTime = simulation.simulationStartTime();
+      final Timestamp endTime = simulation.simulationEndTime();
       final var arguments = new HashMap<String, SerializedValue>();
 
-      if ((startTime == null || endTime == null) && simulation.simulationTemplateId().isPresent()) {
+      if (simulation.simulationTemplateId().isPresent()) {
           try (final var getSimulationTemplate = new GetSimulationTemplateAction(connection)) {
             final var templateOptional = getSimulationTemplate.get(simulation.simulationTemplateId().get());
             if (templateOptional.isEmpty()) {
               throw new RuntimeException("TemplateRecord should not be empty");
             }
             template = templateOptional.get();
-            startTime = (startTime == null ? template.simulationStartTime() : startTime);
-            endTime = (endTime == null ? template.simulationEndTime() : endTime);
             arguments.putAll(template.arguments());
           }
       }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulationTemplateRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/SimulationTemplateRecord.java
@@ -1,7 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
-import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 
 import java.util.Map;
 
@@ -10,8 +9,6 @@ public record SimulationTemplateRecord(
     long revision,
     long modelId,
     String description,
-    Map<String, SerializedValue> arguments,
-    Timestamp simulationStartTime,
-    Timestamp simulationEndTime
+    Map<String, SerializedValue> arguments
     ) {}
 


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
- Removes the ability for a simulation template to specify the simulation bounds.
- Forces the sim bounds in the sim config to be non null. 
- Initializes the sim bounds to the plan bounds on creation of a simulation row
- Enforces the sim end bound to be >= sim start bound. The "or equal to" was added so that plans with duration zero can be created, although I'm not sure what their use case would be.
- Removed Optional wrapper around return of `GetSimulationTemplateAction.get()`

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
- Updated Temporal Subset Simulation e2eTests and removed those that no longer apply (ie those that tested whether bounds specified in the sim config or sim config template took precedence)
- Updated "Verify posting of simulation results" test in scheduler

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
- [ ] Docs issue [here](https://github.com/NASA-AMMOS/aerie-docs/issues/32).

## Future work
<!-- What next steps can we anticipate from here, if any? -->
