### PR TITLE
Added Locals and Parameters to the eDSL

### DIFF
--- a/sequencing-server/src/lib/codegen/CommandTypeCodegen.ts
+++ b/sequencing-server/src/lib/codegen/CommandTypeCodegen.ts
@@ -57,7 +57,7 @@ export const Hardwares = {\n${dictionary.hwCommands
     .map(hwCommands => `\t\t${hwCommands.stem}: ${hwCommands.stem},\n`)
     .join('')}};
 
-Object.assign(globalThis, { A:A, R:R, E:E, C:Object.assign(Commands, STEPS), Sequence}, Hardwares, Immediates);
+Object.assign(globalThis, { A:A, R:R, E:E, C:Object.assign(Commands, STEPS), Sequence, VARIABLE, BUILD_LOCALS, BUILD_PARAMETERS, MAP_VARIABLES}, Hardwares, Immediates);
 `;
 
   return {
@@ -139,7 +139,9 @@ function ${fswCommandName}(...args: [{ ${argsWithType.map(arg => arg.name + ': '
     arguments: args
   }) as ${fswCommandName}_IMMEDIATE;
 }
-function ${fswCommandName}_STEP(...args: [{ ${argsWithType.map(arg => arg.name + ': ' + arg.type).join(',')} }]) {
+function ${fswCommandName}_STEP(...args: [{ ${argsWithType
+    .map(arg => arg.name + ': ' + arg.type + '| VariableDeclaration')
+    .join(',')} }]) {
   return CommandStem.new({
     stem: '${fswCommandName}',
     arguments: sortCommandArguments(args, argumentOrders['${fswCommandName}'])
@@ -151,7 +153,7 @@ function ${fswCommandName}_STEP(...args: [{ ${argsWithType.map(arg => arg.name +
     .map(arg => arg.name + ': ' + arg.type)
     .join(',')} }] ]> {}
 \tinterface ${fswCommandName}_STEP extends CommandStem<[ [{ ${argsWithType
-    .map(arg => arg.name + ': ' + arg.type)
+    .map(arg => arg.name + ': ' + arg.type + '| VariableDeclaration')
     .join(',')} }] ]> {}
 \tfunction ${fswCommandName}(...args: [{ ${argsWithType
     .map(arg => arg.name + ': ' + arg.type)

--- a/sequencing-server/src/routes/seqjson.ts
+++ b/sequencing-server/src/routes/seqjson.ts
@@ -199,7 +199,7 @@ seqjsonRouter.post('/get-seqjson-for-seqid-and-simulation-dataset', async (req, 
     return next();
   }
 
-  const sortedActivityInstances = (simulatedActivities as Exclude<(typeof simulatedActivities)[number], Error>[]).sort(
+  const sortedActivityInstances = (simulatedActivities as Exclude<typeof simulatedActivities[number], Error>[]).sort(
     (a, b) => Temporal.Duration.compare(a.startOffset, b.startOffset),
   );
 
@@ -215,7 +215,7 @@ seqjsonRouter.post('/get-seqjson-for-seqid-and-simulation-dataset', async (req, 
     }
     return {
       ...ai,
-      commands: row.commands?.map(CommandStem.fromSeqJson) ?? null,
+      commands: row.commands?.map(c => CommandStem.fromSeqJson(c)) ?? null,
       errors: row.errors,
     };
   });
@@ -359,7 +359,7 @@ seqjsonRouter.post('/bulk-get-seqjson-for-seqid-and-simulation-dataset', async (
       }
 
       const sortedActivityInstances = (
-        simulatedActivitiesForSeqId as Exclude<(typeof simulatedActivitiesLoadErrors)[number], Error>[]
+        simulatedActivitiesForSeqId as Exclude<typeof simulatedActivitiesLoadErrors[number], Error>[]
       ).sort((a, b) => Temporal.Instant.compare(a.startTime, b.startTime));
 
       const sortedSimulatedActivitiesWithCommands = sortedActivityInstances.map(ai => {
@@ -374,7 +374,7 @@ seqjsonRouter.post('/bulk-get-seqjson-for-seqid-and-simulation-dataset', async (
         }
         return {
           ...ai,
-          commands: row.commands?.map(CommandStem.fromSeqJson) ?? null,
+          commands: row.commands?.map(c => CommandStem.fromSeqJson(c)) ?? null,
           errors: row.errors,
         };
       });

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -10,6 +10,17 @@ export enum TimingTypes {
   COMMAND_COMPLETE = 'COMMAND_COMPLETE',
 }
 
+const VariableType = ['FLOAT', 'INT', 'STRING', 'UINT', 'ENUM'] as const;
+
+export type VariableOptions = {
+  name: string;
+  type: typeof VariableType[number];
+  enum_name?: string | undefined;
+  allowable_values?: unknown[] | undefined;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  allowable_ranges?: VariableRange[] | undefined;
+};
+
 // @ts-ignore : 'Args' found in JSON Spec
 export type CommandOptions<A extends Args[] | { [argName: string]: any } = [] | {}> = {
   stem: string;
@@ -241,6 +252,36 @@ declare global {
   type F32 = F<32>;
   type F64 = F<64>;
 
+  function VARIABLE(name: string, type: typeof VariableType[number]): Variable;
+
+  /**
+   * Construct an object of locals that can be used as arguments for commands
+   *
+   * @param locals: Variable[]
+   */
+  function BUILD_LOCALS(...locals: (Variable | VariableOptions)[]): {
+    [key: string]: Variable;
+  };
+
+  /**
+   * Construct an object of parameters that can be used as arguments for commands
+   *
+   * @param locals: Variable[]
+   *
+   */
+  function BUILD_PARAMETERS(...parameters: (Variable | VariableOptions)[]): {
+    [key: string]: Variable;
+  };
+
+  /**
+   * Map the locals or parameters from the eDSL BUILD_LOCALS or BUILD_PARAMETERS
+   * to a SeqJSON local or parameter
+   *
+   * @param opt: Record<string, Variable>
+   */
+  // @ts-ignore : 'VariableDeclaration' found in generated code
+  function MAP_VARIABLES(opt: Record<string, Variable>): [VariableDeclaration, ...VariableDeclaration[]];
+
   // @ts-ignore : 'Commands' found in generated code
   function A(...args: [TemplateStringsArray, ...string[]]): typeof Commands & typeof STEPS;
   // @ts-ignore : 'Commands' found in generated code
@@ -266,11 +307,11 @@ declare global {
   const C: typeof Commands & typeof STEPS;
 }
 
-/*
-		  ---------------------------------
-					  Sequence eDSL
-		  ---------------------------------
-		  */
+/**
+ *  ---------------------------------
+ * 			 Sequence eDSL
+ * ---------------------------------
+ */
 // @ts-ignore : 'SeqJson' found in JSON Spec
 export class Sequence implements SeqJson {
   public readonly id: string;
@@ -325,8 +366,28 @@ export class Sequence implements SeqJson {
             }),
           }
         : {}),
-      ...(this.locals ? { locals: this.locals } : {}),
-      ...(this.parameters ? { parameters: this.parameters } : {}),
+      ...(this.locals
+        ? {
+            locals: [
+              this.locals[0] instanceof Variable ? this.locals[0].toSeqJson() : this.locals[0],
+              ...this.locals.slice(1).map(local => {
+                if (local instanceof Variable) return local.toSeqJson();
+                return local;
+              }),
+            ],
+          }
+        : {}),
+      ...(this.parameters
+        ? {
+            parameters: [
+              this.parameters[0] instanceof Variable ? this.parameters[0].toSeqJson() : this.parameters[0],
+              ...this.parameters.slice(1).map(parameter => {
+                if (parameter instanceof Variable) return parameter.toSeqJson();
+                return parameter;
+              }),
+            ],
+          }
+        : {}),
       ...(this.requests
         ? {
             requests: this.requests.map(request => {
@@ -384,6 +445,49 @@ export class Sequence implements SeqJson {
   }
 
   public toEDSLString(): string {
+    const localBuilderString =
+      this.locals && this.locals.length > 0
+        ? 'const LOCALS = BUILD_LOCALS(\\n' +
+          indent(
+            this.locals
+              .map(l => {
+                if (l instanceof Variable) return l.toEDSLString();
+                return objectToString(l);
+              })
+              .join(',\\n'),
+            1,
+          ) +
+          '\\n)'
+        : '';
+    //ex.
+    // const LOCALS = BUILD_LOCALS([
+    //   Variable({
+    //     name: 'duration',
+    //     type: 'UINT',
+    //   }),
+    //	])
+
+    const parameterBuilderString =
+      this.parameters && this.parameters.length > 0
+        ? 'const PARAMETERS = BUILD_PARAMETERS(\\n' +
+          indent(
+            this.parameters
+              .map(p => {
+                if (p instanceof Variable) return p.toEDSLString();
+                return objectToString(p);
+              })
+              .join(',\\n'),
+            1,
+          ) +
+          '\\n)'
+        : '';
+    //ex.
+    // const PARAMETERS = BUILD_PARAMETERS([
+    //   Variable({
+    //     name: 'duration',
+    //     type: 'UINT',
+    //   }
+
     const commandsString =
       this.steps && this.steps.length > 0
         ? '[\\n' +
@@ -404,37 +508,20 @@ export class Sequence implements SeqJson {
     // [C.ADD_WATER]
     const metadataString = Object.keys(this.metadata).length == 0 ? \`{}\` : \`\${objectToString(this.metadata)}\`;
 
-    const localsString = this.locals ? \`[\\n\${indent(this.locals.map(l => objectToString(l)).join(',\\n'), 1)}\\n]\` : '';
-
-    const parameterString = this.parameters
-      ? \`[\\n\${indent(this.parameters.map(l => objectToString(l)).join(',\\n'), 1)}\\n]\`
-      : '';
+    const localsString = this.locals ? \`MAP_VARIABLES(LOCALS)\` : '';
     //ex.
-    // \`parameters: [
-    //   {
-    //     allowable_ranges: [
-    //       {
-    //         max: 3600,
-    //         min: 1,
-    //       },
-    //     ],
-    //     name: 'duration',
-    //     type: 'UINT',
-    //   }
-    // ]\`;
+    // \`locals: MAP_VARIABLES(LOCALS)\`;
+
+    const parameterString = this.parameters ? \`MAP_VARIABLES(PARAMETERS)\` : '';
+    //ex.
+    // \`locals: MAP_VARIABLES(PARAMETERS)\`;;
 
     const hardwareString = this.hardware_commands
       ? \`[\\n\${indent(this.hardware_commands.map(h => (h as HardwareStem).toEDSLString()).join(',\\n'), 1)}\\n]\`
       : '';
     //ex.
     // hardware_commands: [
-    //   {
-    //     description: 'FIRE THE PYROS',
-    //     metadata:{
-    //       author: 'rrgoetz',
-    //     },
-    //     stem: 'HDW_PYRO_ENGINE',
-    //   }
+    //   HWD_PYRO_BURN,
     // ],
 
     const immediateString =
@@ -454,18 +541,7 @@ export class Sequence implements SeqJson {
           '\\n]'
         : '';
     //ex.
-    // immediate_commands: [
-    //   {
-    //     args: [
-    //       {
-    //         name: 'direction',
-    //         type: 'string',
-    //         value: 'FromStem',
-    //       },
-    //     ],
-    //     stem: 'PEEL_BANANA',
-    //   }
-    // ]
+    // immediate_commands: [ADD_WATER]
 
     const requestString = this.requests
       ? \`[\\n\${indent(
@@ -506,25 +582,25 @@ export class Sequence implements SeqJson {
     {
       name: 'power',
       steps: [
-      R\`04:39:22.000\`.PREHEAT_OVEN({
-      temperature: 360,
-      }),
-      C.ADD_WATER,
-      ],
+        R\`04:39:22.000\`.PREHEAT_OVEN({
+        temperature: 360,
+        }),
+        C.ADD_WATER,
+        ],
       type: 'request',
       description: ' Activate the oven',
       ground_epoch: {
-      delta: 'now',
-      name: 'activate',
+        delta: 'now',
+        name: 'activate',
       },
       metadata: {
-      author: 'rrgoet',
-      },
-    }
-    ]
-    }*/
+        author: 'rrgoetz',
+        },
+    }]*/
 
     return (
+      \`\${localBuilderString.length !== 0 ? \`\${localBuilderString}\\n\\n\` : ''}\` +
+      \`\${parameterBuilderString.length !== 0 ? \`\${parameterBuilderString}\\n\\n\` : ''}\` +
       \`export default () =>\\n\` +
       \`\${indent(\`Sequence.new({\`, 1)}\\n\` +
       \`\${indent(\`seqId: '\${this.id}'\`, 2)},\\n\` +
@@ -541,6 +617,26 @@ export class Sequence implements SeqJson {
 
   // @ts-ignore : 'Args' found in JSON Spec
   public static fromSeqJson(json: SeqJson): Sequence {
+    const localNames = json.locals
+      ? [
+          json.locals[0].name,
+          // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+          ...json.locals.slice(1).map((l: VariableDeclaration) => {
+            return l.name;
+          }),
+        ]
+      : [];
+
+    const parameterNames = json.parameters
+      ? [
+          json.parameters[0].name,
+          // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+          ...json.parameters.slice(1).map((p: VariableDeclaration) => {
+            return p.name;
+          }),
+        ]
+      : [];
+
     return Sequence.new({
       seqId: json.id,
       metadata: json.metadata,
@@ -549,15 +645,35 @@ export class Sequence implements SeqJson {
         ? {
             // @ts-ignore : 'Step' found in JSON Spec
             steps: json.steps.map((c: Step) => {
-              if (c.type === 'command') return CommandStem.fromSeqJson(c as CommandStem);
+              if (c.type === 'command') return CommandStem.fromSeqJson(c as CommandStem, localNames, parameterNames);
               else if (c.type === 'ground_block') return Ground_Block.fromSeqJson(c as Ground_Block);
               else if (c.type === 'ground_event') return Ground_Event.fromSeqJson(c as Ground_Event);
               return c;
             }),
           }
         : {}),
-      ...(json.locals ? { locals: json.locals } : {}),
-      ...(json.parameters ? { parameters: json.parameters } : {}),
+      ...(json.locals
+        ? {
+            locals: [
+              Variable.fromSeqJson(json.locals[0]),
+              // @ts-ignore : 'l: Request' found in JSON Spec
+              ...json.locals.slice(1).map(l => {
+                return Variable.fromSeqJson(l as Variable);
+              }),
+            ],
+          }
+        : {}),
+      ...(json.parameters
+        ? {
+            parameters: [
+              Variable.fromSeqJson(json.parameters[0]),
+              // @ts-ignore : 'l: Request' found in JSON Spec
+              ...json.parameters.slice(1).map(p => {
+                return Variable.fromSeqJson(p as Variable);
+              }),
+            ],
+          }
+        : {}),
       ...(json.requests
         ? {
             // @ts-ignore : 'r: Request' found in JSON Spec
@@ -571,7 +687,7 @@ export class Sequence implements SeqJson {
                 ...(r.metadata ? { metadata: r.metadata } : {}),
                 steps: [
                   r.steps[0].type === 'command'
-                    ? CommandStem.fromSeqJson(r.steps[0] as CommandStem)
+                    ? CommandStem.fromSeqJson(r.steps[0] as CommandStem, localNames, parameterNames)
                     : r.steps[0].type === 'ground_block'
                     ? // @ts-ignore : 'GroundBlock' found in JSON Spec
                       Ground_Block.fromSeqJson(r.steps[0] as GroundBlock)
@@ -581,7 +697,8 @@ export class Sequence implements SeqJson {
                     : r.steps[0],
                   // @ts-ignore : 'step : Step' found in JSON Spec
                   ...r.steps.slice(1).map(step => {
-                    if (step.type === 'command') return CommandStem.fromSeqJson(step as CommandStem);
+                    if (step.type === 'command')
+                      return CommandStem.fromSeqJson(step as CommandStem, localNames, parameterNames);
                     else if (step.type === 'ground_block') return Ground_Block.fromSeqJson(step as Ground_Block);
                     else if (step.type === 'ground_event') return Ground_Event.fromSeqJson(step as Ground_Event);
                     return step;
@@ -594,7 +711,9 @@ export class Sequence implements SeqJson {
       ...(json.immediate_commands
         ? {
             // @ts-ignore : 'Step' found in JSON Spec
-            immediate_commands: json.immediate_commands.map((c: ImmediateCommand) => ImmediateStem.fromSeqJson(c)),
+            immediate_commands: json.immediate_commands.map((c: ImmediateCommand) =>
+              ImmediateStem.fromSeqJson(c, localNames, parameterNames),
+            ),
           }
         : {}),
       ...(json.hardware_commands
@@ -605,11 +724,214 @@ export class Sequence implements SeqJson {
   }
 }
 
-/*
-	  ---------------------------------
-				  STEPS eDSL
-	  ---------------------------------
-	  */
+/**
+ * ----------------------------------------
+ * 			Local, and Parmaeters
+ * ----------------------------------------
+ */
+
+// @ts-ignore : 'VariableDeclaration: Request' found in JSON Spec
+class Variable implements VariableDeclaration {
+  name: string;
+  type: typeof VariableType[number];
+  [x: string]: unknown;
+
+  private kind: 'LOCALS' | 'PARAMETERS' | 'UNKNOWN' = 'LOCALS';
+  private readonly _enum_name?: string | undefined;
+  // @ts-ignore : 'VariableRange: Request' found in JSON Spec
+  private readonly _allowable_ranges?: VariableRange[] | undefined;
+  private readonly _allowable_values?: unknown[] | undefined;
+
+  constructor(opts: VariableOptions) {
+    this.name = opts.name;
+    this.type = opts.type;
+
+    this._enum_name = opts.enum_name ?? undefined;
+    this._allowable_ranges = opts.allowable_ranges ?? undefined;
+    this._allowable_values = opts.allowable_values ?? undefined;
+  }
+
+  public static new(opts: VariableOptions): Variable {
+    return new Variable(opts);
+  }
+
+  public ENUM_NAME(enum_name: string): Variable {
+    return Variable.new({
+      name: this.name,
+      type: this.type,
+      enum_name: enum_name,
+      ...(this._allowable_ranges && { allowable_ranges: this._allowable_ranges }),
+      ...(this._allowable_values && { allowable_values: this._allowable_values }),
+    });
+  }
+
+  public GET_ENUM_NAME(): string | undefined {
+    return this._enum_name;
+  }
+
+  // @ts-ignore : 'VariableRange: Request' found in JSON Spec
+  public ALLOWABLE_RANGES(Variable_range: VariableRange[]): Variable {
+    return Variable.new({
+      name: this.name,
+      type: this.type,
+      ...(this._enum_name && { enum_name: this._enum_name }),
+      allowable_ranges: Variable_range,
+      ...(this._allowable_values && { allowable_values: this._allowable_values }),
+    });
+  }
+
+  // @ts-ignore : 'VariableRange: Request' found in JSON Spec
+  public GET_ALLOWABLE_RANGES(): VariableRange[] | undefined {
+    return this._allowable_ranges;
+  }
+
+  public ALLOWABLE_VALUES(allowable_values: unknown[]): Variable {
+    return Variable.new({
+      name: this.name,
+      type: this.type,
+      ...(this._enum_name && { enum_name: this._enum_name }),
+      ...(this._allowable_ranges && { allowable_ranges: this._allowable_ranges }),
+      allowable_values: allowable_values,
+    });
+  }
+
+  public setKind(kind: 'LOCALS' | 'PARAMETERS' | 'UNKNOWN') {
+    this.kind = kind;
+  }
+
+  public GET_ALLOWABLE_VALUES(): unknown[] | undefined {
+    return this._allowable_values;
+  }
+
+  // @ts-ignore : 'Command' found in JSON Spec
+  public toSeqJson(): VariableDeclaration {
+    let error;
+    //check if type ENUM has ENUM_NAME set
+    if (this.type === 'ENUM' && !this._enum_name) {
+      error = \`$$ERROR$$: 'enum_name' is required for ENUM type.\`;
+    }
+    // check if type ins't ENUM but has a ENUM_NAME set
+    if (this.type !== 'ENUM' && this._enum_name) {
+      error = \`$$ERROR$$: 'enum_name: \${this._enum_name}' is not required for non-ENUM type.\`;
+    }
+    // check if type is STRING but has allowable_ranges set
+    if (this.type === 'STRING' && this._allowable_ranges) {
+      error = \`$$ERROR$$: 'allowable_ranges' is not required for STRING type.\`;
+    }
+
+    return {
+      name: error ? error : this.name,
+      type: this.type,
+      ...(this._enum_name && { enum_name: this._enum_name }),
+      ...(this._allowable_ranges && {
+        allowable_ranges: this._allowable_ranges.map(range => {
+          return {
+            min: range.min,
+            max: range.max,
+          };
+        }),
+      }),
+      ...(this._allowable_values && { allowable_values: this._allowable_values }),
+    };
+  }
+
+  // @ts-ignore : 'VariableDeclaration: Request' found in JSON Spec
+  public static fromSeqJson(json: VariableDeclaration): Variable {
+    return new Variable({
+      name: json.name,
+      type: json.type,
+      ...(json.enum_name ? { enum_name: json.enum_name } : {}),
+      ...(json.allowable_ranges ? { allowable_ranges: json.allowable_ranges } : {}),
+      ...(json.allowable_values ? { allowable_values: json.allowable_values } : {}),
+    });
+  }
+
+  public toRefernceString(kind: 'LOCALS' | 'PARAMETERS' | 'UNKNOWN' = this.kind): string {
+    return \`\${kind}.\${this.name}\`;
+  }
+
+  public toEDSLString(): string {
+    const enumName = this._enum_name ? \`\\n.ENUM_NAME('\${this._enum_name}')\` : '';
+    const allowableRanges = this._allowable_ranges
+      ? \`\\n.ALLOWABLE_RANGES([\${this._allowable_ranges
+          .map(v => {
+            return \`{ min: \${v.min}, max: \${v.max} }\`;
+          })
+          .join(',')}])\`
+      : '';
+    const allowableValues = this._allowable_values ? \`\\n.ALLOWABLE_VALUES([\${this._allowable_values}])\` : '';
+
+    return \`VARIABLE('\${this.name}','\${this.type}')\${enumName}\${allowableRanges}\${allowableValues}\`;
+  }
+}
+
+export function VARIABLE(name: string, type: typeof VariableType[number]): Variable {
+  return Variable.new({ name, type });
+}
+
+/**
+ * Construct an object of parameters that can be used as arguments for commands
+ *
+ * @param locals: Variable[]
+ */
+export function BUILD_LOCALS(...locals: (Variable | VariableOptions)[]): Record<string, Variable> {
+  return buildVariable(locals, 'LOCALS');
+}
+
+/**
+ * Construct an object of parameters that can be used as arguments for commands
+ *
+ * @param locals: Variable[]
+ *
+ */
+export function BUILD_PARAMETERS(...parameters: (Variable | VariableOptions)[]): Record<string, Variable> {
+  return buildVariable(parameters, 'PARAMETERS');
+}
+
+/**
+ * Map the locals or parameters from the eDSL BUILD_LOCALS or BUILD_PARAMETERS
+ * to a SeqJSON local or parameter
+ *
+ * @param opt: Record<string, Variable>
+ */
+// @ts-ignore : 'VariableDeclaration: Request' found in JSON Spec
+export function MAP_VARIABLES(opt: Record<string, Variable>): [VariableDeclaration, ...VariableDeclaration[]] {
+  const variables = Object.values(opt);
+  return [variables[0], ...variables.slice(1)];
+}
+
+function buildVariable(
+  variables: (Variable | VariableOptions)[],
+  kind: 'LOCALS' | 'PARAMETERS',
+): Record<string, Variable> {
+  const map: Record<string, Variable> = {};
+
+  for (const varable of variables) {
+    if (varable instanceof Variable) {
+      varable.setKind(kind);
+      map[varable.name] = varable;
+    } else {
+      const options = varable;
+      const v = Variable.new({
+        name: options.name,
+        type: options.type,
+        ...(options.enum_name ? { enum_name: options.enum_name } : {}),
+        ...(options.allowable_ranges ? { allowable_ranges: options.allowable_ranges } : {}),
+        ...(options.allowable_values ? { allowable_values: options.allowable_values } : {}),
+      });
+      v.setKind(kind);
+      map[options.name] = v;
+    }
+  }
+
+  return map;
+}
+
+/**
+ * ---------------------------------
+ *        STEPS eDSL
+ * ---------------------------------
+ */
 
 // @ts-ignore : 'Args' found in JSON Spec
 export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
@@ -744,8 +1066,12 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
     };
   }
 
-  // @ts-ignore : 'Command' found in JSON Spec
-  public static fromSeqJson(json: Command): CommandStem {
+  public static fromSeqJson(
+    // @ts-ignore : 'Command' found in JSON Spec
+    json: Command,
+    localNames?: string[],
+    parameterNames?: string[],
+  ): CommandStem {
     const timeValue =
       json.time.type === TimingTypes.ABSOLUTE
         ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
@@ -757,7 +1083,7 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
 
     return CommandStem.new({
       stem: json.stem,
-      arguments: convertInterfacesToArgs(json.args),
+      arguments: convertInterfacesToArgs(json.args, localNames, parameterNames),
       metadata: json.metadata,
       models: json.models,
       description: json.description,
@@ -876,10 +1202,10 @@ export class ImmediateStem<A extends Args[] | { [argName: string]: any } = [] | 
   }
 
   // @ts-ignore : 'Command' found in JSON Spec
-  public static fromSeqJson(json: ImmediateCommand): ImmediateStem {
+  public static fromSeqJson(json: ImmediateCommand, localNames?: string[], parameterNames?: string[]): ImmediateStem {
     return ImmediateStem.new({
       stem: json.stem,
-      arguments: convertInterfacesToArgs(json.args),
+      arguments: convertInterfacesToArgs(json.args, localNames, parameterNames),
       metadata: json.metadata,
       description: json.description,
     });
@@ -1398,9 +1724,11 @@ export const STEPS = {
   GROUND_EVENT: GROUND_EVENT,
 };
 
-/*-----------------------------------
-		HW Commands
-	  ------------------------------------- */
+/**
+ * -----------------------------------
+ *        HW Commands
+ * -----------------------------------
+ */
 // @ts-ignore : 'HardwareCommand' found in JSON Spec
 export class HardwareStem implements HardwareCommand {
   public readonly stem: string;
@@ -1476,11 +1804,11 @@ export class HardwareStem implements HardwareCommand {
   }
 }
 
-/*
-	  ---------------------------------
-			  Time Utilities
-	  ---------------------------------
-	  */
+/**
+ *---------------------------------
+ *      Time Utilities
+ *---------------------------------
+ */
 
 export type DOY_STRING = string & { __brand: 'DOY_STRING' };
 export type HMS_STRING = string & { __brand: 'HMS_STRING' };
@@ -1680,11 +2008,11 @@ function commandsWithTimeValue<T extends TimingTypes>(
   };
 }
 
-/*
-	  ---------------------------------
-			  Utility Functions
-	  ---------------------------------
-	  */
+/**
+ * ---------------------------------
+ *      Utility Functions
+ * ---------------------------------
+ */
 
 // @ts-ignore : Used in generated code
 function sortCommandArguments(args: { [argName: string]: any }, order: string[]): { [argName: string]: any } {
@@ -1744,7 +2072,7 @@ function argumentsToString<A extends Args[] | { [argName: string]: any } = [] | 
  * @param interfaces
  */
 // @ts-ignore : \`Args\` found in JSON Spec
-function convertInterfacesToArgs(interfaces: Args): {} | [] {
+function convertInterfacesToArgs(interfaces: Args, localNames?: String[], parameterNames?: String[]): {} | [] {
   const args = interfaces.length === 0 ? [] : {};
 
   // Use to prevent a Remote property injection attack
@@ -1781,8 +2109,28 @@ function convertInterfacesToArgs(interfaces: Args): {} | [] {
         return { repeat_error: 'Remote property injection detected...' };
       } else if (arg.type === 'symbol') {
         if (validate(arg.name)) {
-          // @ts-ignore : 'SymbolArgument' found in JSON Spec
-          return { [arg.name]: { symbol: arg.value } };
+          // We dont know the TYPE value as that information is lost in seq json, but we don't need
+          // it here so we just use type: "INT" for the variable object. The variable will eventually
+          // become local.<name> or parameter.<name> for the toEDSLString()
+
+          let variable = Variable.new({ name: arg.value, type: 'INT' });
+          if (localNames && parameterNames) {
+            const variableKind = localNames.includes(arg.value)
+              ? 'LOCALS'
+              : parameterNames.includes(arg.value)
+              ? 'PARAMETERS'
+              : 'ERROR';
+            if (variableKind === 'ERROR') {
+              variable = Variable.new({
+                name: \`\${arg.value} //ERROR: Variable '\${arg.value}' is not defined as a local or parameter\`,
+                type: 'INT',
+              });
+              variable.setKind('UNKNOWN');
+            } else {
+              variable.setKind(variableKind);
+            }
+          }
+          return { [arg.name]: variable };
         }
         return { symbol_error: 'Remote property injection detected...' };
         // @ts-ignore : 'HexArgument' found in JSON Spec
@@ -1849,8 +2197,17 @@ function convertValueToObject(value: any, key: string): any {
     case 'boolean':
       return { type: 'boolean', value: value, name: key };
     default:
-      if (value instanceof Object && value.symbol && value.symbol === 'string') {
-        return { type: 'symbol', value: value, name: key };
+      if (
+        value instanceof Object &&
+        'name' in value &&
+        'type' in value &&
+        (value.type === 'FLOAT' ||
+          value.type === 'INT' ||
+          value.type === 'STRING' ||
+          value.type === 'UINT' ||
+          value.type === 'ENUM')
+      ) {
+        return { type: 'symbol', value: value.name, name: key };
       } else if (
         value instanceof Object &&
         value.hex &&
@@ -1858,6 +2215,12 @@ function convertValueToObject(value: any, key: string): any {
         new RegExp('^0x([0-9A-F])+$').test(value.hex)
       ) {
         return { type: 'hex', value: value, name: key };
+      } else {
+        return {
+          type: typeof value,
+          value: \`\${key} is an unknown value\`,
+          name: \`$$ERROR$$\`,
+        };
       }
   }
 }
@@ -1890,11 +2253,16 @@ function objectToString(obj: any, indentLevel: number = 1): string {
         indentLevel--;
         output += indent(\`],\`, indentLevel) + '\\n';
       } else if (typeof value === 'object') {
-        output += indent(\`\${key}:{\`, indentLevel) + '\\n';
-        indentLevel++;
-        print(value);
-        indentLevel--;
-        output += indent(\`},\`, indentLevel) + '\\n';
+        //value is a Local or Parameter
+        if (value instanceof Variable) {
+          output += indent(\`\${key}: \${value.toRefernceString()}\`, indentLevel) + ',\\n';
+        } else {
+          output += indent(\`\${key}:{\`, indentLevel) + '\\n';
+          indentLevel++;
+          print(value);
+          indentLevel--;
+          output += indent(\`},\`, indentLevel) + '\\n';
+        }
       } else {
         output += indent(\`\${key}: \${typeof value === 'string' ? \`'\${value}'\` : value},\`, indentLevel) + '\\n';
       }
@@ -2318,31 +2686,31 @@ export interface HardwareCommand {
 declare global {
 
 	interface ECHO_IMMEDIATE extends ImmediateStem<[ [{ 'echo_string': VarString<8, 1024> }] ]> {}
-	interface ECHO_STEP extends CommandStem<[ [{ 'echo_string': VarString<8, 1024> }] ]> {}
+	interface ECHO_STEP extends CommandStem<[ [{ 'echo_string': VarString<8, 1024>| VariableDeclaration }] ]> {}
 	function ECHO(...args: [{ 'echo_string': VarString<8, 1024> }]) : ECHO_IMMEDIATE
 
 	interface PREHEAT_OVEN_IMMEDIATE extends ImmediateStem<[ [{ 'temperature': U8 }] ]> {}
-	interface PREHEAT_OVEN_STEP extends CommandStem<[ [{ 'temperature': U8 }] ]> {}
+	interface PREHEAT_OVEN_STEP extends CommandStem<[ [{ 'temperature': U8| VariableDeclaration }] ]> {}
 	function PREHEAT_OVEN(...args: [{ 'temperature': U8 }]) : PREHEAT_OVEN_IMMEDIATE
 
 	interface THROW_BANANA_IMMEDIATE extends ImmediateStem<[ [{ 'distance': U8 }] ]> {}
-	interface THROW_BANANA_STEP extends CommandStem<[ [{ 'distance': U8 }] ]> {}
+	interface THROW_BANANA_STEP extends CommandStem<[ [{ 'distance': U8| VariableDeclaration }] ]> {}
 	function THROW_BANANA(...args: [{ 'distance': U8 }]) : THROW_BANANA_IMMEDIATE
 
 	interface GROW_BANANA_IMMEDIATE extends ImmediateStem<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
-	interface GROW_BANANA_STEP extends CommandStem<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
+	interface GROW_BANANA_STEP extends CommandStem<[ [{ 'quantity': U8| VariableDeclaration,'durationSecs': U8| VariableDeclaration }] ]> {}
 	function GROW_BANANA(...args: [{ 'quantity': U8,'durationSecs': U8 }]) : GROW_BANANA_IMMEDIATE
 
 	interface GrowBanana_IMMEDIATE extends ImmediateStem<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
-	interface GrowBanana_STEP extends CommandStem<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
+	interface GrowBanana_STEP extends CommandStem<[ [{ 'quantity': U8| VariableDeclaration,'durationSecs': U8| VariableDeclaration }] ]> {}
 	function GrowBanana(...args: [{ 'quantity': U8,'durationSecs': U8 }]) : GrowBanana_IMMEDIATE
 
 	interface PREPARE_LOAF_IMMEDIATE extends ImmediateStem<[ [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }] ]> {}
-	interface PREPARE_LOAF_STEP extends CommandStem<[ [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }] ]> {}
+	interface PREPARE_LOAF_STEP extends CommandStem<[ [{ 'tb_sugar': U8| VariableDeclaration,'gluten_free': ('FALSE' | 'TRUE')| VariableDeclaration }] ]> {}
 	function PREPARE_LOAF(...args: [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }]) : PREPARE_LOAF_IMMEDIATE
 
 	interface PEEL_BANANA_IMMEDIATE extends ImmediateStem<[ [{ 'peelDirection': ('fromStem' | 'fromTip') }] ]> {}
-	interface PEEL_BANANA_STEP extends CommandStem<[ [{ 'peelDirection': ('fromStem' | 'fromTip') }] ]> {}
+	interface PEEL_BANANA_STEP extends CommandStem<[ [{ 'peelDirection': ('fromStem' | 'fromTip')| VariableDeclaration }] ]> {}
 	function PEEL_BANANA(...args: [{ 'peelDirection': ('fromStem' | 'fromTip') }]) : PEEL_BANANA_IMMEDIATE
 
 
@@ -2366,7 +2734,7 @@ declare global {
 
 
 	interface PACKAGE_BANANA_IMMEDIATE extends ImmediateStem<[ [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }] ]> {}
-	interface PACKAGE_BANANA_STEP extends CommandStem<[ [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }] ]> {}
+	interface PACKAGE_BANANA_STEP extends CommandStem<[ [{ 'lot_number': U16| VariableDeclaration,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }>| VariableDeclaration }] ]> {}
 	function PACKAGE_BANANA(...args: [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]) : PACKAGE_BANANA_IMMEDIATE
 
 
@@ -2442,7 +2810,7 @@ function ECHO(...args: [{ 'echo_string': VarString<8, 1024> }]) {
     arguments: args
   }) as ECHO_IMMEDIATE;
 }
-function ECHO_STEP(...args: [{ 'echo_string': VarString<8, 1024> }]) {
+function ECHO_STEP(...args: [{ 'echo_string': VarString<8, 1024>| VariableDeclaration }]) {
   return CommandStem.new({
     stem: 'ECHO',
     arguments: sortCommandArguments(args, argumentOrders['ECHO'])
@@ -2460,7 +2828,7 @@ function PREHEAT_OVEN(...args: [{ 'temperature': U8 }]) {
     arguments: args
   }) as PREHEAT_OVEN_IMMEDIATE;
 }
-function PREHEAT_OVEN_STEP(...args: [{ 'temperature': U8 }]) {
+function PREHEAT_OVEN_STEP(...args: [{ 'temperature': U8| VariableDeclaration }]) {
   return CommandStem.new({
     stem: 'PREHEAT_OVEN',
     arguments: sortCommandArguments(args, argumentOrders['PREHEAT_OVEN'])
@@ -2478,7 +2846,7 @@ function THROW_BANANA(...args: [{ 'distance': U8 }]) {
     arguments: args
   }) as THROW_BANANA_IMMEDIATE;
 }
-function THROW_BANANA_STEP(...args: [{ 'distance': U8 }]) {
+function THROW_BANANA_STEP(...args: [{ 'distance': U8| VariableDeclaration }]) {
   return CommandStem.new({
     stem: 'THROW_BANANA',
     arguments: sortCommandArguments(args, argumentOrders['THROW_BANANA'])
@@ -2497,7 +2865,7 @@ function GROW_BANANA(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
     arguments: args
   }) as GROW_BANANA_IMMEDIATE;
 }
-function GROW_BANANA_STEP(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
+function GROW_BANANA_STEP(...args: [{ 'quantity': U8| VariableDeclaration,'durationSecs': U8| VariableDeclaration }]) {
   return CommandStem.new({
     stem: 'GROW_BANANA',
     arguments: sortCommandArguments(args, argumentOrders['GROW_BANANA'])
@@ -2516,7 +2884,7 @@ function GrowBanana(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
     arguments: args
   }) as GrowBanana_IMMEDIATE;
 }
-function GrowBanana_STEP(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
+function GrowBanana_STEP(...args: [{ 'quantity': U8| VariableDeclaration,'durationSecs': U8| VariableDeclaration }]) {
   return CommandStem.new({
     stem: 'GrowBanana',
     arguments: sortCommandArguments(args, argumentOrders['GrowBanana'])
@@ -2535,7 +2903,7 @@ function PREPARE_LOAF(...args: [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE
     arguments: args
   }) as PREPARE_LOAF_IMMEDIATE;
 }
-function PREPARE_LOAF_STEP(...args: [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }]) {
+function PREPARE_LOAF_STEP(...args: [{ 'tb_sugar': U8| VariableDeclaration,'gluten_free': ('FALSE' | 'TRUE')| VariableDeclaration }]) {
   return CommandStem.new({
     stem: 'PREPARE_LOAF',
     arguments: sortCommandArguments(args, argumentOrders['PREPARE_LOAF'])
@@ -2553,7 +2921,7 @@ function PEEL_BANANA(...args: [{ 'peelDirection': ('fromStem' | 'fromTip') }]) {
     arguments: args
   }) as PEEL_BANANA_IMMEDIATE;
 }
-function PEEL_BANANA_STEP(...args: [{ 'peelDirection': ('fromStem' | 'fromTip') }]) {
+function PEEL_BANANA_STEP(...args: [{ 'peelDirection': ('fromStem' | 'fromTip')| VariableDeclaration }]) {
   return CommandStem.new({
     stem: 'PEEL_BANANA',
     arguments: sortCommandArguments(args, argumentOrders['PEEL_BANANA'])
@@ -2600,7 +2968,7 @@ function PACKAGE_BANANA(...args: [{ 'lot_number': U16,'bundle': Array<{ 'bundle_
     arguments: args
   }) as PACKAGE_BANANA_IMMEDIATE;
 }
-function PACKAGE_BANANA_STEP(...args: [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]) {
+function PACKAGE_BANANA_STEP(...args: [{ 'lot_number': U16| VariableDeclaration,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }>| VariableDeclaration }]) {
   return CommandStem.new({
     stem: 'PACKAGE_BANANA',
     arguments: sortCommandArguments(args, argumentOrders['PACKAGE_BANANA'])
@@ -2677,6 +3045,6 @@ export const Hardwares = {
 		HDW_BLENDER_DUMP: HDW_BLENDER_DUMP,
 };
 
-Object.assign(globalThis, { A:A, R:R, E:E, C:Object.assign(Commands, STEPS), Sequence}, Hardwares, Immediates);
+Object.assign(globalThis, { A:A, R:R, E:E, C:Object.assign(Commands, STEPS), Sequence, VARIABLE, BUILD_LOCALS, BUILD_PARAMETERS, MAP_VARIABLES}, Hardwares, Immediates);
 "
 `;

--- a/sequencing-server/test/command-expansion.spec.ts
+++ b/sequencing-server/test/command-expansion.spec.ts
@@ -16,8 +16,8 @@ import {
 } from './testUtils/Expansion.js';
 import { removeMissionModel, uploadMissionModel } from './testUtils/MissionModel.js';
 import { createPlan, removePlan } from './testUtils/Plan.js';
-import {executeSimulation, removeSimulationArtifacts, updateSimulationBounds} from './testUtils/Simulation.js';
-import {waitMs} from "./testUtils/testUtils";
+import { executeSimulation, removeSimulationArtifacts, updateSimulationBounds } from './testUtils/Simulation.js';
+import { waitMs } from './testUtils/testUtils';
 
 let planId: number;
 let graphqlClient: GraphQLClient;
@@ -28,7 +28,11 @@ beforeEach(async () => {
   graphqlClient = new GraphQLClient(process.env['MERLIN_GRAPHQL_URL'] as string);
   missionModelId = await uploadMissionModel(graphqlClient);
   planId = await createPlan(graphqlClient, missionModelId);
-  await updateSimulationBounds(graphqlClient, {plan_id: planId, simulation_start_time:"2020-001T00:00:00Z", simulation_end_time:"2020-002T00:00:00Z" });
+  await updateSimulationBounds(graphqlClient, {
+    plan_id: planId,
+    simulation_start_time: '2020-001T00:00:00Z',
+    simulation_end_time: '2020-002T00:00:00Z',
+  });
   commandDictionaryId = await insertCommandDictionary(graphqlClient);
 });
 
@@ -122,7 +126,7 @@ describe('expansion', () => {
     await removeExpansionRun(graphqlClient, expansionRunPk);
     await removeSimulationArtifacts(graphqlClient, simulationArtifactPk);
     await removeExpansionSet(graphqlClient, expansionSetId);
-  });
+  }, 30000);
 
   it('should throw an error if an activity instance goes beyond the plan duration', async () => {
     /** Begin Setup*/
@@ -263,5 +267,5 @@ describe('expansion', () => {
     await removeExpansion(graphqlClient, expansionId);
     await removeExpansionSet(graphqlClient, expansionSetId);
     await removeExpansionRun(graphqlClient, expansionRunId);
-  }, 10000);
+  }, 30000);
 });


### PR DESCRIPTION
* **Tickets addressed:** Closes https://github.com/NASA-AMMOS/aerie/issues/706
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

I've noticed that implementing `Locals` and `Parameters` in Monaco using a custom worker can be tricky. Currently, it's not possible to define a variable inside a JavaScript object and use it elsewhere in the same object. Additionally, valid TypeScript is required for the TS runner to execute the user's code, so using a placeholder in the sequence and ignoring the error during SeqJson generation is not an option.

Below is not possible in TS
```ts
export default () =>
  Sequence.new({
    seqId: '',
    locals: [{ name: 'duration', type: 'FLOAT' }],
    parameters: [{ name: 'timeout', type: 'UINT' }],
    metadata: {},
    steps: [
      // Notice we use magic globals 'locals' and 'parameters' that bind to
      // the declared values in 'locals' and 'parameters' above.
      // This is just one idea.
      C.FSW_CMD_0({ arg0: locals.duration, arg1: parameters.timeout  })
    ],
  });
```

To work around these restrictions, I've implemented using `const` outside of the sequence object and created helper functions to make defining parameters and locals more manageable. These can be used like variables in the command arguments, and the eDSL will try to link everything together as best as possible. However, going from seqJSON to eDSL can be tricky, as all the data is not in the same place. To help with this, I've implemented more extensive error checking for going to and from seqJSON.

```ts
const LOCALS = BUILD_LOCALS(
    VARIABLE('temp','FLOAT')
  )
  
  const PARAMETERS = BUILD_PARAMETERS(
    VARIABLE('sugar','INT')
  )
  
  export default () =>
    Sequence.new({
      seqId: '',
      metadata: {},
      locals: MAP_VARIABLES(LOCALS),
      parameters: MAP_VARIABLES(PARAMETERS),
      steps: [
        C.PREHEAT_OVEN({
          temperature: LOCALS.temp
        }),
        C.PREPARE_LOAF({
          tb_sugar: PARAMETERS.sugar,
          gluten_free: 'FALSE',
        }),
      ],
    });
```



I've included examples of errors that may occur when converting between eDSL and seqJSON, which should make it easier to identify and fix any issues. Do you want to keep this version of the description?


### **eDSL to SeqJSON error checking**

```ts
const LOCALS = BUILD_LOCALS(
  VARIABLE('temperature','STRING').ENUM_NAME('TEMPERATURE_ARRAY'),
)

const PARAMETERS = BUILD_PARAMETERS(
  VARIABLE('arm_position','ENUM').ALLOWABLE_RANGES([{min: 1, max: 2}]),
  VARIABLE('arm_rotation','STRING').ALLOWABLE_RANGES([{min: 1, max: 2}])
)

export default () =>
  Sequence.new({
    seqId: '',
    metadata: {},
    locals: MAP_VARIABLES(LOCALS),
    parameters: MAP_VARIABLES(PARAMETERS),
    immediate_commands : [PREHEAT_OVEN({temperature : LOCALS.temptemperature})]
  });
```

Errors caught and displayed in SeqJSON
```json
{
  "id": "",
  "immediate_commands": [
    {
      "args": [
        {
          "name": "$$ERROR$$",
          "type": "undefined",
          "value": "temperature is an unknown value"
        }
      ],
      "stem": "PREHEAT_OVEN"
    }
  ],
  "locals": [
    {
      "enum_name": "TEMPERATURE_ARRAY",
      "name": "$$ERROR$$: 'enum_name: TEMPERATURE_ARRAY' is not required for non-ENUM type.",
      "type": "STRING"
    }
  ],
  "metadata": {},
  "parameters": [
    {
      "allowable_ranges": [
        {
          "max": 2,
          "min": 1
        }
      ],
      "name": "$$ERROR$$: 'enum_name' is required for ENUM type.",
      "type": "ENUM"
    },
    {
      "allowable_ranges": [
        {
          "max": 2,
          "min": 1
        }
      ],
      "name": "$$ERROR$$: 'allowable_ranges' is not required for STRING type.",
      "type": "STRING"
    }
  ]
}
```

### **From SeqJSON to eDSL Error checking**

```json
{
  "id": "",
  "metadata": {},
  "parameters": [
    {
      "name": "sugar",
      "type": "INT"
    }
  ],
  "steps": [
    {
      "args": [
        {
          "name": "tb_sugar",
          "type": "symbol",
          "value": "sugarrrrr"
        },
        {
          "name": "gluten_free",
          "type": "string",
          "value": "FALSE"
        }
      ],
      "stem": "PREPARE_LOAF",
      "time": {
        "type": "COMMAND_COMPLETE"
      },
      "type": "command"
    }
  ]
}
```

Errors caught and displayed in the eDSL
```ts
const PARAMETERS = BUILD_PARAMETERS(
  VARIABLE('sugar','INT')
)

export default () =>
  Sequence.new({
    seqId: '',
    metadata: {},
    parameters: MAP_VARIABLES(PARAMETERS),
    steps: [
      C.PREPARE_LOAF({
        tb_sugar: UNKNOWN.sugarrrrr, //ERROR:  variable 'sugarrrrr' is not defined as a local or parameter"
        gluten_free: 'FALSE',
      }),
    ],
  });
```


## Verification
Added new e2e test to check all the errors for `locals` and `parameters`. All pass

## Documentation
This is probably a good write up to include in the wiki

## Future work
Globals are next
