### PR TITLE
Add @FixedDuration annotation

### DIFF
--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/RipenBananaActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/RipenBananaActivity.java
@@ -5,22 +5,26 @@ import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
-import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.*;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 
 /**
- * Nap time [banana style]!!!!
- * This activity has no effect :)
+ * Monke is patient.
+ *
+ * Waits two days for bananas to ripen. Ripeness is not modelled.
  *
  * @subsystem fruit
  * @contact Jane Doe
  */
-@ActivityType("BananaNap")
-public final class BananaNapActivity {
+@ActivityType("RipenBanana")
+public final class RipenBananaActivity {
+
   @ActivityType.FixedDuration
-  public static final Duration DURATION = Duration.HOUR;
+  public static Duration duration() {
+    return Duration.of(48, Duration.HOUR);
+  }
 
   @EffectModel
   public void run(final Mission mission) {
-    delay(DURATION);
+    delay(duration());
   }
 }

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
@@ -21,6 +21,7 @@
 @WithActivityType(BananaNapActivity.class)
 @WithActivityType(DurationParameterActivity.class)
 @WithActivityType(ControllableDurationActivity.class)
+@WithActivityType(RipenBananaActivity.class)
 
 package gov.nasa.jpl.aerie.banananation;
 
@@ -37,6 +38,7 @@ import gov.nasa.jpl.aerie.banananation.activities.LineCountBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ParameterTestActivity;
 import gov.nasa.jpl.aerie.banananation.activities.PeelBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.PickBananaActivity;
+import gov.nasa.jpl.aerie.banananation.activities.RipenBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ThrowBananaActivity;
 import gov.nasa.jpl.aerie.contrib.serialization.rulesets.BasicValueMappers;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.MissionModel;

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -298,8 +298,11 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                                       DurationType.class,
                                                       activityTypeRecord
                                                           .effectModel()
-                                                          .flatMap(EffectModelRecord::durationParameter)
-                                                          .map(durationParameter -> CodeBlock.of("controllable(\"$L\")", durationParameter))
+                                                          .map($ -> {
+                                                            if ($.durationParameter().isPresent()) return CodeBlock.of("controllable(\"$L\")", $.durationParameter().get());
+                                                            else if ($.fixedDurationExpr().isPresent()) return CodeBlock.of("fixed($L.$L)", activityTypeRecord.fullyQualifiedClass(), $.fixedDurationExpr().get());
+                                                            else return CodeBlock.of("uncontrollable()");
+                                                          })
                                                           .orElse(CodeBlock.of("uncontrollable()"))))
                             .reduce((x, y) -> x.add("$L", y.build()))
                             .orElse(CodeBlock.builder()).build())

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ActivityTypeRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ActivityTypeRecord.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public record ActivityTypeRecord(
+    String fullyQualifiedClass,
     String name,
     InputTypeRecord inputType,
     Optional<EffectModelRecord> effectModel

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
@@ -9,6 +9,7 @@ public record EffectModelRecord(
     String methodName,
     ActivityType.Executor executor,
     Optional<TypeMirror> returnType,
-    Optional<String> durationParameter
+    Optional<String> durationParameter,
+    Optional<String> fixedDurationExpr
 ) {
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/ActivityType.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/ActivityType.java
@@ -27,6 +27,26 @@ public @interface ActivityType {
     Executor value() default Executor.Threaded;
   }
 
+  /**
+   * Apply to the effect model when the activity has a parameter that sets the activity's duration.
+   *
+   * Apply like the following:
+   *
+   * <pre>{@code
+   * @ActivityType("ControllableDurationActivity")
+   * public record ControllableDurationActivity(Duration duration) {
+   *
+   *   @EffectModel
+   *   @ActivityType.ControllableDuration(parameterName = "duration")
+   *   public void run(Mission mission) {
+   *     delay(duration);
+   *   }
+   * }
+   * }</pre>
+   *
+   * Keep in mind that it is not enough for the activity duration to be *determined* by the duration parameter.
+   * They must be exactly equal as above.
+   */
   @Retention(RetentionPolicy.CLASS)
   @Target(ElementType.METHOD)
   @interface ControllableDuration {
@@ -40,6 +60,38 @@ public @interface ActivityType {
    * that returns {@link Duration}. For correctness, it is recommended that you use the field or method
    * in the effect model to ensure that the duration is what you say it is - the duration is verified
    * by the scheduler, but only after a (potentially expensive) simulation.
+   *
+   * Apply either like the following on a static field:
+   *
+   * <pre>{@code
+   * @ActivityType("FixedDurationActivity")
+   * public record FixedDurationActivity() {
+   *   @FixedDuration
+   *   public static final Duration DURATION = Duration.HOUR;
+   *
+   *   @EffectModel
+   *   public void run(Mission mission) {
+   *     delay(DURATION);
+   *   }
+   * }
+   * }</pre>
+   *
+   * Or like the following on a static method:
+   *
+   * <pre>{@code
+   * @ActivityType("FixedDurationActivity")
+   * public record FixedDurationActivity() {
+   *   @FixedDuration
+   *   public static Duration duration() {
+   *     return Duration.HOUR;
+   *   }
+   *
+   *   @EffectModel
+   *   public void run(Mission mission) {
+   *     delay(duration());
+   *   }
+   * }
+   * }</pre>
    *
    * This annotation is optional, but it is highly recommended if applicable. The scheduler will assume
    * your activity has an uncontrollable variable duration if no duration annotation is present, which

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/ActivityType.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/ActivityType.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.framework.annotations;
 
 import gov.nasa.jpl.aerie.merlin.framework.ActivityMapper;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -31,4 +32,20 @@ public @interface ActivityType {
   @interface ControllableDuration {
     String parameterName();
   }
+
+  /**
+   * Use when an activity has a constant statically-known duration.
+   *
+   * Apply to either a static {@link Duration} field or a static no-arg method
+   * that returns {@link Duration}. For correctness, it is recommended that you use the field or method
+   * in the effect model to ensure that the duration is what you say it is - the duration is verified
+   * by the scheduler, but only after a (potentially expensive) simulation.
+   *
+   * This annotation is optional, but it is highly recommended if applicable. The scheduler will assume
+   * your activity has an uncontrollable variable duration if no duration annotation is present, which
+   * will cause extra simulations in scheduling.
+   */
+  @Retention(RetentionPolicy.CLASS)
+  @Target({ ElementType.FIELD, ElementType.METHOD })
+  @interface FixedDuration {}
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/DurationType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/DurationType.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.protocol.types;
 public sealed interface DurationType {
   record Controllable(String parameterName) implements DurationType {}
   record Uncontrollable() implements DurationType {}
+  record Fixed(Duration duration) implements DurationType {}
 
   static DurationType uncontrollable() {
     return new Uncontrollable();
@@ -10,5 +11,9 @@ public sealed interface DurationType {
 
   static DurationType controllable(final String parameterName) {
     return new Controllable(parameterName);
+  }
+
+  static DurationType fixed(final Duration duration) {
+    return new Fixed(duration);
   }
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/ActivityCreationTemplate.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/ActivityCreationTemplate.java
@@ -389,7 +389,7 @@ public class ActivityCreationTemplate extends ActivityExpression implements Expr
           null,
           true));
     } else {
-     throw new UnsupportedOperationException("Duration type other than Uncontrollable and Controllable are not suppoerted");
+     throw new UnsupportedOperationException("Duration types other than Uncontrollable, Controllable, and Fixed are not supported: " + this.type.getDurationType());
     }
   }
 

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -21,7 +21,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
 
@@ -233,7 +232,7 @@ public class SimulationFacade implements AutoCloseable{
       final var durationType = activity.getType().getDurationType();
       if (durationType instanceof DurationType.Controllable dt) {
         arguments.put(dt.parameterName(), SerializedValue.of(activity.duration().in(Duration.MICROSECONDS)));
-      } else if (durationType instanceof DurationType.Uncontrollable) {
+      } else if (durationType instanceof DurationType.Uncontrollable || durationType instanceof DurationType.Fixed) {
         // If an activity has already been simulated, it will have a duration, even if its DurationType is Uncontrollable.
       } else {
         throw new Error("Unhandled variant of DurationType: " + durationType);

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/FixedDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/FixedDurationTest.java
@@ -1,0 +1,101 @@
+package gov.nasa.jpl.aerie.scheduler;
+
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.constraints.tree.SpansFromWindows;
+import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
+import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate;
+import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
+import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.TimeAnchor;
+import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.TimeExpression;
+import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.TimeExpressionRelativeFixed;
+import gov.nasa.jpl.aerie.scheduler.goals.CoexistenceGoal;
+import gov.nasa.jpl.aerie.scheduler.goals.RecurrenceGoal;
+import gov.nasa.jpl.aerie.scheduler.model.*;
+import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
+import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FixedDurationTest {
+
+  PlanningHorizon planningHorizon;
+  Problem problem;
+  Plan plan;
+
+  @BeforeEach
+  void setUp(){
+    planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochDays(3));
+    MissionModel<?> bananaMissionModel = SimulationUtility.getBananaMissionModel();
+    problem = new Problem(bananaMissionModel, planningHorizon, new SimulationFacade(planningHorizon, bananaMissionModel), SimulationUtility.getBananaSchedulerModel());
+    plan = makeEmptyPlan();
+  }
+
+  /** constructs an empty plan with the test model/horizon **/
+  private PlanInMemory makeEmptyPlan() {
+    return new PlanInMemory();
+  }
+
+  @Test
+  public void testFieldAnnotation(){
+
+    final var fixedDurationActivityTemplate = new ActivityCreationTemplate.Builder()
+        .ofType(problem.getActivityType("BananaNap"))
+        .withTimingPrecision(Duration.of(500, Duration.MILLISECOND))
+        .build();
+
+    final var start = TimeExpression.atStart();
+    final var coexistence = new CoexistenceGoal.Builder()
+        .thereExistsOne(fixedDurationActivityTemplate)
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(planningHorizon.getHor(), true)))
+        .forEach(new SpansFromWindows(new WindowsWrapperExpression(new Windows(false).set(Interval.between(1, 2, Duration.MINUTE), true))))
+        .startsAt(start)
+        .named("FixedCoexistenceGoal")
+        .aliasForAnchors("its a me")
+        .build();
+
+
+    problem.setGoals(List.of(coexistence));
+
+    final var solver = new PrioritySolver(problem);
+    final var plan = solver.getNextSolution().get();
+    solver.printEvaluation();
+    assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT1M"), planningHorizon.fromStart("PT1H1M"), problem.getActivityType("BananaNap")));
+  }
+
+
+  @Test
+  public void testMethodAnnotation(){
+
+    final var fixedDurationActivityTemplate = new ActivityCreationTemplate.Builder()
+        .ofType(problem.getActivityType("RipenBanana"))
+        .withTimingPrecision(Duration.of(500, Duration.MILLISECOND))
+        .build();
+
+    final var start = TimeExpression.atStart();
+    final var coexistence = new CoexistenceGoal.Builder()
+        .thereExistsOne(fixedDurationActivityTemplate)
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(planningHorizon.getHor(), true)))
+        .forEach(new SpansFromWindows(new WindowsWrapperExpression(new Windows(false).set(Interval.between(1, 2, Duration.MINUTE), true))))
+        .startsAt(start)
+        .named("FixedCoexistenceGoal")
+        .aliasForAnchors("its a me")
+        .build();
+
+
+    problem.setGoals(List.of(coexistence));
+
+    final var solver = new PrioritySolver(problem);
+    final var plan = solver.getNextSolution().get();
+    solver.printEvaluation();
+    assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT1M"), planningHorizon.fromStart("P2DT1M"), problem.getActivityType("RipenBanana")));
+  }
+
+}

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/FixedDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/FixedDurationTest.java
@@ -6,14 +6,9 @@ import gov.nasa.jpl.aerie.constraints.tree.SpansFromWindows;
 import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
-import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate;
-import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
-import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.TimeAnchor;
 import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.TimeExpression;
-import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.TimeExpressionRelativeFixed;
 import gov.nasa.jpl.aerie.scheduler.goals.CoexistenceGoal;
-import gov.nasa.jpl.aerie.scheduler.goals.RecurrenceGoal;
 import gov.nasa.jpl.aerie.scheduler.model.*;
 import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
 import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
@@ -28,19 +23,12 @@ public class FixedDurationTest {
 
   PlanningHorizon planningHorizon;
   Problem problem;
-  Plan plan;
 
   @BeforeEach
   void setUp(){
     planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochDays(3));
     MissionModel<?> bananaMissionModel = SimulationUtility.getBananaMissionModel();
     problem = new Problem(bananaMissionModel, planningHorizon, new SimulationFacade(planningHorizon, bananaMissionModel), SimulationUtility.getBananaSchedulerModel());
-    plan = makeEmptyPlan();
-  }
-
-  /** constructs an empty plan with the test model/horizon **/
-  private PlanInMemory makeEmptyPlan() {
-    return new PlanInMemory();
   }
 
   @Test

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUtility.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUtility.java
@@ -136,5 +136,11 @@ public class TestUtility {
   public static Instant timeFromEpochSeconds(int seconds){
     return timeFromEpochMillis(seconds * 1000L);
   }
+  public static Instant timeFromEpochHours(int hours) {
+    return timeFromEpochSeconds(hours * 60 * 60);
+  }
+  public static Instant timeFromEpochDays(int days) {
+    return timeFromEpochHours(days * 24);
+  }
 
 }

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
@@ -400,7 +400,7 @@ public class SchedulingIntegrationTests {
     final var growBananas = planByActivityType.get("GrowBanana");
     assertEquals(1, biteBananas.size());
     assertEquals(2, growBananas.size());
-    final var iterator = growBananas.iterator();
+    final var iterator = growBananas.stream().sorted(Comparator.comparing(ActivityDirective::startOffset)).iterator();
     iterator.next();
     final var created = iterator.next();
 


### PR DESCRIPTION
* **Tickets addressed:** closes #831 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This allows modellers to differentiate uncontrollable duration activities into dynamic and static durations. If the activity has a fixed statically known duration, they can apply the `FixedDuration` annotation to a static field or static factory method in the activity class which tells the scheduler the duration of the activity.

Currently the scheduler resimulates $2n+1$ times per goal where $n$ is the number of uncontrollable duration activities placed. For `FixedDuration` activities this is reduced to just $1$, same as `ControllableDuration`.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
- I modified `BananaNap` to use a fixed duration field, and added a test that the scheduler can place it correctly.
- I added `RipenBanana` which is pretty much the same as `BananaNap`, but uses the annotation on a static method instead of a field, and added a similar test.
- Fixed another integration test for window references in coexistence goal that was slightly changed by this.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
- [x] Doc comments on duration annoations
- [ ] Real docs

## Future work
<!-- What next steps can we anticipate from here, if any? -->
