### PR TITLE
Expanded sequence sorting

### DIFF
--- a/sequencing-server/src/defaultSeqBuilder.ts
+++ b/sequencing-server/src/defaultSeqBuilder.ts
@@ -56,7 +56,10 @@ export const defaultSeqBuilder: SeqBuilder = (
 
         // If we come across a relative command, convert it to absolute.
         if (command.relativeTime !== null && previousTime !== null) {
-          convertedCommands.push(command.absoluteTiming(previousTime.add(command.relativeTime)));
+          const absoluteCommand = command.absoluteTiming(previousTime.add(command.relativeTime));
+
+          convertedCommands.push(absoluteCommand);
+          previousTime = absoluteCommand.absoluteTime;
         } else {
           convertedCommands.push(command);
           previousTime = command.absoluteTime;

--- a/sequencing-server/src/defaultSeqBuilder.ts
+++ b/sequencing-server/src/defaultSeqBuilder.ts
@@ -7,11 +7,16 @@ export const defaultSeqBuilder: SeqBuilder = (
   seqMetadata,
   simulationDatasetId,
 ) => {
+  const convertedCommands: CommandStem<{} | []>[] = [];
+
   // A combined list of all the activity instance commands.
   let allCommands: CommandStem<{} | []>[] = [];
   let activityInstaceCount = 0;
   let planId;
+  // Keep track if we should try and sort the commands.
+  let shouldSort = true;
   let timeSorted = false;
+  let previousTime: Temporal.Instant | null = null;
 
   for (const ai of sortedActivityInstancesWithCommands) {
     // If errors, no associated Expansion
@@ -34,18 +39,46 @@ export const defaultSeqBuilder: SeqBuilder = (
         break;
       }
 
+      /**
+       * Look at the first command for each activity and check if it's relative, if so we shouldn't
+       * sort later. Also convert any relative commands to absolute.
+       */
+      for (const command of ai.commands) {
+        // If the command is epoch-relative, complete, or the first command and relative then short circuit and don't try and sort.
+        if (
+          command.epochTime !== null ||
+          (command.absoluteTime === null && command.epochTime === null && command.relativeTime === null) ||
+          (command.relativeTime !== null && ai.commands.indexOf(command) === 0)
+        ) {
+          shouldSort = false;
+          break;
+        }
+
+        // If we come across a relative command, convert it to absolute.
+        if (command.relativeTime !== null && previousTime !== null) {
+          convertedCommands.push(command.absoluteTiming(previousTime.add(command.relativeTime)));
+        } else {
+          convertedCommands.push(command);
+          previousTime = command.absoluteTime;
+        }
+      }
+
       allCommands = allCommands.concat(ai.commands);
       // Keep track of the number of times we add commands to the allCommands list.
       activityInstaceCount++;
     }
   }
 
-  // Now that we have all the commands for each activity instance, sort if there's > 1 activity instance.
-  if (activityInstaceCount > 1) {
-    const result = sortCommandsByTime(allCommands);
+  // Now that we have all the commands for each activity instance, sort if there's > 1 activity instance and we didn't short circuit above.
+  if (activityInstaceCount > 1 && shouldSort) {
+    timeSorted = true;
+    allCommands = convertedCommands.sort((a, b) => {
+      if (a.absoluteTime !== null && b.absoluteTime !== null) {
+        return Temporal.Instant.compare(a.absoluteTime, b.absoluteTime);
+      }
 
-    timeSorted = result.timeSorted;
-    allCommands = result.sortedCommands;
+      return 0;
+    });
   }
 
   return Sequence.new({
@@ -59,43 +92,3 @@ export const defaultSeqBuilder: SeqBuilder = (
     steps: allCommands,
   });
 };
-
-// Order commands by time in expanded sequences.
-function sortCommandsByTime(commands: CommandStem<{} | []>[]): {
-  sortedCommands: CommandStem<{} | []>[];
-  timeSorted: boolean;
-} {
-  const convertedCommands: CommandStem<{} | []>[] = [];
-
-  let previousTime: Temporal.Instant | null = null;
-
-  // If we have mixed time commands then we only sort if they're all absolute and relative.
-  for (const command of commands) {
-    // If the command is epoch-relative, complete, or the first command and relative then short circuit and don't try and sort.
-    if (
-      command.epochTime !== null ||
-      (command.absoluteTime === null && command.epochTime === null && command.relativeTime === null) ||
-      (command.relativeTime !== null && commands.indexOf(command) === 0)
-    ) {
-      return { sortedCommands: commands, timeSorted: false };
-    }
-
-    if (command.relativeTime !== null && previousTime !== null) {
-      convertedCommands.push(command.absoluteTiming(previousTime.add(command.relativeTime)));
-    } else {
-      convertedCommands.push(command);
-      previousTime = command.absoluteTime;
-    }
-  }
-
-  // The commands will all be absolute time at this point, so sort them.
-  convertedCommands.sort((a, b) => {
-    if (a.absoluteTime !== null && b.absoluteTime !== null) {
-      return Temporal.Instant.compare(a.absoluteTime, b.absoluteTime);
-    }
-
-    return 0;
-  });
-
-  return { sortedCommands: convertedCommands, timeSorted: true };
-}

--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -767,6 +767,7 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
       stem: this.stem,
       arguments: this.arguments,
       absoluteTime: absoluteTime,
+      metadata: this._metadata,
     });
   }
 
@@ -775,6 +776,7 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
       stem: this.stem,
       arguments: this.arguments,
       epochTime: epochTime,
+      metadata: this._metadata,
     });
   }
 
@@ -783,6 +785,7 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
       stem: this.stem,
       arguments: this.arguments,
       relativeTime: relativeTime,
+      metadata: this._metadata,
     });
   }
 

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -770,6 +770,7 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
       stem: this.stem,
       arguments: this.arguments,
       absoluteTime: absoluteTime,
+      metadata: this._metadata,
     });
   }
 
@@ -778,6 +779,7 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
       stem: this.stem,
       arguments: this.arguments,
       epochTime: epochTime,
+      metadata: this._metadata,
     });
   }
 
@@ -786,6 +788,7 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
       stem: this.stem,
       arguments: this.arguments,
       relativeTime: relativeTime,
+      metadata: this._metadata,
     });
   }
 

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -2783,7 +2783,7 @@ describe('sequence generation', () => {
       /** Begin Setup */
       const expansionId1 = await insertExpansion(
         graphqlClient,
-        'GrowBanana',
+        'PickBanana',
         `
     export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
       return [
@@ -2814,7 +2814,7 @@ describe('sequence generation', () => {
 
       // Create Activity Directives
       const [activityId1, activityId2] = await Promise.all([
-        insertActivityDirective(graphqlClient, planId, 'GrowBanana'),
+        insertActivityDirective(graphqlClient, planId, 'PickBanana'),
         insertActivityDirective(graphqlClient, planId, 'GrowBanana', '30 minutes'),
       ]);
 
@@ -2866,13 +2866,6 @@ describe('sequence generation', () => {
         timeSorted: true,
       });
 
-      /**
-        A\`2023-091T08:00:00.000\`.ADD_WATER,
-        R\`04:00:00.000\`.PICK_BANANA,
-        A\`2023-091T10:00:00.000\`.ADD_WATER,
-        R\`04:00:00.000\`.GROW_BANANA
-        */
-
       expect(getSequenceSeqJsonResponse.seqJson.steps).toEqual([
         {
           type: 'command',
@@ -2886,14 +2879,14 @@ describe('sequence generation', () => {
           stem: 'ADD_WATER',
           time: { tag: '2023-091T10:00:00.000', type: TimingTypes.ABSOLUTE },
           args: [],
-          metadata: { simulatedActivityId: simulatedActivityId1 },
+          metadata: { simulatedActivityId: simulatedActivityId2 },
         },
         {
           type: 'command',
           stem: 'PICK_BANANA',
           time: { tag: '2023-091T12:00:00.000', type: TimingTypes.ABSOLUTE },
           args: [],
-          metadata: { simulatedActivityId: simulatedActivityId2 },
+          metadata: { simulatedActivityId: simulatedActivityId1 },
         },
         {
           type: 'command',

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -2779,6 +2779,149 @@ describe('sequence generation', () => {
       /** End Cleanup */
     }, 30000);
 
+    it('should sort expanded commands correctly with relative and absolute times for multiple activities', async () => {
+      /** Begin Setup */
+      const expansionId1 = await insertExpansion(
+        graphqlClient,
+        'GrowBanana',
+        `
+    export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
+      return [
+        A\`2023-091T08:00:00.000\`.ADD_WATER,
+        R\`04:00:00.000\`.PICK_BANANA,
+      ];
+    }
+    `,
+      );
+
+      const expansionId2 = await insertExpansion(
+        graphqlClient,
+        'GrowBanana',
+        `
+    export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
+      return [
+        A\`2023-091T10:00:00.000\`.ADD_WATER,
+        R\`04:00:00.000\`.GROW_BANANA({ quantity: 10, durationSecs: 7200 })
+      ];
+    }
+    `,
+      );
+      // Create Expansion Set
+      const expansionSetId = await insertExpansionSet(graphqlClient, commandDictionaryId, missionModelId, [
+        expansionId1,
+        expansionId2,
+      ]);
+
+      // Create Activity Directives
+      const [activityId1, activityId2] = await Promise.all([
+        insertActivityDirective(graphqlClient, planId, 'GrowBanana'),
+        insertActivityDirective(graphqlClient, planId, 'GrowBanana', '30 minutes'),
+      ]);
+
+      // Simulate Plan
+      const simulationArtifactPk = await executeSimulation(graphqlClient, planId);
+      // Expand Plan to Sequence Fragments
+      const expansionRunPk = await expand(graphqlClient, expansionSetId, simulationArtifactPk.simulationDatasetId);
+      // Create Sequence
+      const sequencePk = await insertSequence(graphqlClient, {
+        seqId: 'test00000',
+        simulationDatasetId: simulationArtifactPk.simulationDatasetId,
+      });
+      // Link Activity Instances to Sequence
+      await Promise.all([
+        linkActivityInstance(graphqlClient, sequencePk, activityId1),
+        linkActivityInstance(graphqlClient, sequencePk, activityId2),
+      ]);
+
+      // Get the simulated activity ids
+      const [simulatedActivityId1, simulatedActivityId2] = await Promise.all([
+        convertActivityDirectiveIdToSimulatedActivityId(
+          graphqlClient,
+          simulationArtifactPk.simulationDatasetId,
+          activityId1,
+        ),
+        convertActivityDirectiveIdToSimulatedActivityId(
+          graphqlClient,
+          simulationArtifactPk.simulationDatasetId,
+          activityId2,
+        ),
+      ]);
+      /** End Setup */
+
+      // Retrieve seqJson
+      const getSequenceSeqJsonResponse = await getSequenceSeqJson(
+        graphqlClient,
+        'test00000',
+        simulationArtifactPk.simulationDatasetId,
+      );
+
+      if (getSequenceSeqJsonResponse.status !== FallibleStatus.SUCCESS) {
+        throw getSequenceSeqJsonResponse.errors;
+      }
+
+      expect(getSequenceSeqJsonResponse.seqJson.id).toBe('test00000');
+      expect(getSequenceSeqJsonResponse.seqJson.metadata).toEqual({
+        planId: planId,
+        simulationDatasetId: simulationArtifactPk.simulationDatasetId,
+        timeSorted: true,
+      });
+
+      /**
+        A\`2023-091T08:00:00.000\`.ADD_WATER,
+        R\`04:00:00.000\`.PICK_BANANA,
+        A\`2023-091T10:00:00.000\`.ADD_WATER,
+        R\`04:00:00.000\`.GROW_BANANA
+        */
+
+      expect(getSequenceSeqJsonResponse.seqJson.steps).toEqual([
+        {
+          type: 'command',
+          stem: 'ADD_WATER',
+          time: { tag: '2023-091T08:00:00.000', type: TimingTypes.ABSOLUTE },
+          args: [],
+          metadata: { simulatedActivityId: simulatedActivityId1 },
+        },
+        {
+          type: 'command',
+          stem: 'ADD_WATER',
+          time: { tag: '2023-091T10:00:00.000', type: TimingTypes.ABSOLUTE },
+          args: [],
+          metadata: { simulatedActivityId: simulatedActivityId1 },
+        },
+        {
+          type: 'command',
+          stem: 'PICK_BANANA',
+          time: { tag: '2023-091T12:00:00.000', type: TimingTypes.ABSOLUTE },
+          args: [],
+          metadata: { simulatedActivityId: simulatedActivityId2 },
+        },
+        {
+          type: 'command',
+          stem: 'GROW_BANANA',
+          time: { tag: '2023-091T14:00:00.000', type: TimingTypes.ABSOLUTE },
+          args: [
+            { value: 10, name: 'quantity', type: 'number' },
+            { value: 7200, name: 'durationSecs', type: 'number' },
+          ],
+          metadata: { simulatedActivityId: simulatedActivityId2 },
+        },
+      ]);
+
+      /** Begin Cleanup */
+      await removeSequence(graphqlClient, sequencePk);
+      await removeExpansionRun(graphqlClient, expansionRunPk);
+      await removeSimulationArtifacts(graphqlClient, simulationArtifactPk);
+      await Promise.all([
+        removeActivityDirective(graphqlClient, activityId1, planId),
+        removeActivityDirective(graphqlClient, activityId2, planId),
+      ]);
+      await removeExpansionSet(graphqlClient, expansionSetId);
+      await removeExpansionRun(graphqlClient, expansionRunPk);
+      await removeExpansion(graphqlClient, expansionId1);
+      await removeExpansion(graphqlClient, expansionId2);
+      /** End Cleanup */
+    }, 30000);
+
     it('should not sort expansions if there is only one activity instance', async () => {
       /** Begin Setup */
       const expansionId = await insertExpansion(

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -2754,14 +2754,14 @@ describe('sequence generation', () => {
         {
           type: 'command',
           stem: 'PICK_BANANA',
-          time: { tag: '04:00:00.000', type: TimingTypes.COMMAND_RELATIVE },
+          time: { tag: '2023-091T12:19:00.000', type: TimingTypes.ABSOLUTE },
           args: [],
           metadata: { simulatedActivityId: simulatedActivityId1 },
         },
         {
           type: 'command',
           stem: 'PICK_BANANA',
-          time: { tag: '04:00:00.000', type: TimingTypes.COMMAND_RELATIVE },
+          time: { tag: '2023-091T12:19:00.000', type: TimingTypes.ABSOLUTE },
           args: [],
           metadata: { simulatedActivityId: simulatedActivityId2 },
         },


### PR DESCRIPTION
Closes #866 
Closes https://github.com/NASA-AMMOS/aerie/issues/879

* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Adds a new `timeSorted` flag to the sequence metadata and adds sorting if every command is `EPOCH_RELATIVE`.

## Verification
Updated existing tests and added new tests.

## Documentation
NA

## Future work
Possibly more sorting behavior? Hopefully this catches all of the valid cases.
