### PR TITLE
Remove empty transaction from claimSimulationDataset

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -198,12 +198,6 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
     try (final var claimSimulationAction = new ClaimSimulationAction(connection)) {
         claimSimulationAction.apply(datasetId);
     }
-
-    try (final var transactionContext = new TransactionContext(connection)) {
-      transactionContext.commit();
-    } catch (final SQLException ex) {
-      throw new DatabaseException(String.format("Failed to create partitions for simulation dataset id %s", datasetId), ex);
-    }
   }
 
   private static void cancelSimulation(

--- a/sequencing-server/test/testUtils/Simulation.ts
+++ b/sequencing-server/test/testUtils/Simulation.ts
@@ -48,7 +48,7 @@ export async function executeSimulation(
     );
     const status = simulationRes.simulate.status;
     if (status === 'failed') {
-      throw new Error(simulationRes.simulate.reason.message);
+      throw new Error(JSON.stringify(simulationRes.simulate.reason));
     }
     if (status !== 'pending' && status !== 'incomplete') {
       const getSimulationRes = await graphqlClient.request(


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
#723 removed the only remaining action wrapped in this transaction context - so now this transaction context is empty and can safely be deleted.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I'm relying on end-to-end tests that run simulation to verify this change.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No existing documentation should be affected by this change.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
#687 is still desirable - although after #723 and this PR, there are fewer moving parts between claiming and starting a simulation