### PR TITLE
Add GH issue templates for bugs and features

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+Please help us process issues more efficiently by filing an issue using one of the following templates:
+
+https://github.com/NASA-AMMOS/aerie/issues/new/choose
+
+Thank you!

--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -1,0 +1,77 @@
+name: "\U0001F41E Bug Report"
+description: Report an issue with Aerie.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: dropdown
+    id: checked-for-duplicates
+    attributes:
+      label: Checked for duplicates
+      description: Have you checked for duplicate issue tickets?
+      options:
+        - "No - I haven't checked"
+        - "Yes - I've already checked"
+    validations:
+      required: true
+  - type: dropdown
+    id: is-regression
+    attributes:
+      label: Is this a regression?
+      options:
+        - "No - This is a new bug"
+        - "Yes - This worked in a previous version"
+    validations:
+      required: true
+  - type: textarea
+    id: bug-version
+    attributes:
+      label: Version
+      description: What version of Aerie are you observing this bug in?
+      placeholder: "1.4.0, 1.5.0, develop, etc."
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please describe how to reproduce the problem you ran into. If the description is vague (e.g. just a generic error message) and has no reproduction, it will receive a "needs reproduction" label. If no reproduction is provided within a reasonable time-frame, the issue will be closed.
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Please include browser console and server logs around the time this bug occurred. Optional if provided reproduction. Please try not to insert an image but copy paste the log text.
+      render: shell
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System Info
+      description: Please provide information on the environment you discovered this bug in.
+      render: shell
+      placeholder: Browsers, System, Binaries
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Select the severity of this issue.
+      options:
+        - Annoyance
+        - Blocking an upgrade
+        - Blocking all usage of Aerie
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.yml
@@ -1,0 +1,46 @@
+name: "Feature Request"
+description: Request a new Aerie feature.
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to request this feature! If your feature request is complex or substantial enough to warrant in-depth discussion, maintainers may close the issue and ask you to open a [Discussion](https://github.com/NASA-AMMOS/aerie/discussions).
+  - type: dropdown
+    id: checked-for-duplicates
+    attributes:
+      label: Checked for duplicates
+      description: Have you checked for duplicate issue tickets?
+      options:
+        - "No - I haven't checked"
+        - "Yes - I've already checked"
+    validations:
+      required: true
+  - type: dropdown
+    id: checked-alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered alternative solutions to your feature request?
+      options:
+        - "No - I haven't considered"
+        - "Yes - and alternatives don't suffice"
+    validations:
+      required: true
+  - type: textarea
+    id: related-problems
+    attributes:
+      label: Related problems
+      description: Is your feature request related to any problems? Please help us understand if so, including linking to any other issue tickets.
+      placeholder: Tell us the problems
+      value: "I'm frustrated when [...] happens as documented in issue-XYZ"
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature request
+      description: A clear and concise description of your request.
+      placeholder: Tell us what you want
+      value: "I need or want [...]"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Aerie UI
+    url: https://github.com/NASA-AMMOS/aerie-ui/issues/new/choose
+    about: Issues and feature requests for the main Aerie UI repo (not backend related).
+  - name: Aerie Docs
+    url: https://github.com/NASA-AMMOS/aerie-docs/issues/new/choose
+    about: Issues and feature requests for the Aerie Documentation
+  - name: Slack Chat
+    url: https://jpl.slack.com/archives/C0163E42UBF
+    about: Ask questions and discuss with other Aerie users in real time.


### PR DESCRIPTION
* **Tickets addressed:** Closes https://github.com/NASA-AMMOS/aerie/issues/652
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

Adds two basic GH issue templates for bugs and new features.

## Verification

Need to merge to see them. But you can see the [UI issue templates](https://github.com/NASA-AMMOS/aerie-ui/issues/new/choose) for example.

## Documentation

N/A

## Future work

N/A