### PR TITLE
Added Local and Parameters with TS 5

### DIFF
--- a/merlin-server/constraints-dsl-compiler/package-lock.json
+++ b/merlin-server/constraints-dsl-compiler/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@js-temporal/polyfill": "^0.4.0",
-        "@nasa-jpl/aerie-ts-user-code-runner": "^0.5.0",
+        "@nasa-jpl/aerie-ts-user-code-runner": "0.5.0",
         "prettier": "^2.6.2",
         "source-map": "^0.7.3",
         "typescript": "^4.5.5"

--- a/merlin-server/constraints-dsl-compiler/package.json
+++ b/merlin-server/constraints-dsl-compiler/package.json
@@ -10,7 +10,7 @@
     "generate-doc": "rm -rf build/docs; npx typedoc src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Constraints eDSL Documentation\" --readme none --gitRevision develop"
   },
   "dependencies": {
-    "@nasa-jpl/aerie-ts-user-code-runner": "^0.5.0",
+    "@nasa-jpl/aerie-ts-user-code-runner": "0.5.0",
     "@js-temporal/polyfill": "^0.4.0",
     "prettier": "^2.6.2",
     "source-map": "^0.7.3",

--- a/scheduler-worker/scheduling-dsl-compiler/package-lock.json
+++ b/scheduler-worker/scheduling-dsl-compiler/package-lock.json
@@ -7,7 +7,7 @@
       "name": "scheduling-dsl-compiler",
       "dependencies": {
         "@js-temporal/polyfill": "^0.4.0",
-        "@nasa-jpl/aerie-ts-user-code-runner": "^0.5.0",
+        "@nasa-jpl/aerie-ts-user-code-runner": "0.5.0",
         "source-map": "^0.7.3",
         "typescript": "^4.5.5"
       },

--- a/scheduler-worker/scheduling-dsl-compiler/package.json
+++ b/scheduler-worker/scheduling-dsl-compiler/package.json
@@ -8,7 +8,7 @@
     "generate-doc": "rm -rf build/docs; npx typedoc src/libs/scheduler-edsl-fluent-api.ts src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Scheduling eDSL Documentation\" --readme none --gitRevision develop"
   },
   "dependencies": {
-    "@nasa-jpl/aerie-ts-user-code-runner": "^0.5.0",
+    "@nasa-jpl/aerie-ts-user-code-runner": "0.5.0",
     "@js-temporal/polyfill": "^0.4.0",
     "source-map": "^0.7.3",
     "typescript": "^4.5.5"

--- a/sequencing-server/package-lock.json
+++ b/sequencing-server/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@js-temporal/polyfill": "~0.4.3",
         "@nasa-jpl/aerie-ampcs": "~1.0.1",
-        "@nasa-jpl/aerie-ts-user-code-runner": "~0.5.0",
+        "@nasa-jpl/aerie-ts-user-code-runner": "~0.6.0",
         "@nasa-jpl/seq-json-schema": "1.0.17",
         "body-parser": "~1.20.1",
         "dataloader": "~2.2.0",
@@ -22,7 +22,7 @@
         "piscina": "~3.2.0",
         "postgres-interval": "~4.0.0",
         "reserved-words": "~0.1.2",
-        "typescript": "~4.9.5",
+        "typescript": "^5",
         "winston": "~3.8.2"
       },
       "devDependencies": {
@@ -39,13 +39,13 @@
         "dotenv": "~16.0.3",
         "form-data": "~4.0.0",
         "jest": "~29.4.1",
-        "jest-circus": "~29.4.1",
-        "jest-extended": "~3.2.3",
-        "jest-html-reporters": "~3.1.1",
+        "jest-circus": "~29.5.0",
+        "jest-extended": "~3.2.4",
+        "jest-html-reporters": "~3.1.4",
         "node-fetch": "~3.3.0",
         "prettier": "~2.8.3",
         "supervisor": "~0.12.0",
-        "ts-jest": "~29.0.5",
+        "ts-jest": "~29.1.0",
         "ts-node": "~10.9.1"
       }
     },
@@ -752,16 +752,16 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.4.1.tgz",
-      "integrity": "sha512-m+XpwKSi3PPM9znm5NGS8bBReeAJJpSkL1OuFCqaMaJL2YX9YXLkkI+MBchMPwu+ZuM2rynL51sgfkQteQ1CKQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.5.0.tgz",
+      "integrity": "sha512-NEpkObxPwyw/XxZVLPmAGKE89IQRp4puc6IQRPru6JKd1M3fW9v1xM1AnzIJE65hbCkzQAdnL8P47e9hzhiYLQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^29.4.1",
-        "jest-util": "^29.4.1",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -816,72 +816,72 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.1.tgz",
-      "integrity": "sha512-pJ14dHGSQke7Q3mkL/UZR9ZtTOxqskZaC91NzamEH4dlKRt42W+maRBXiw/LWkdJe+P0f/zDR37+SPMplMRlPg==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.5.0.tgz",
+      "integrity": "sha512-5FXw2+wD29YU1d4I2htpRX7jYnAyTRjP2CsXQdo9SAM8g3ifxWPSV0HnClSn71xwctr0U3oZIIH+dtbfmnbXVQ==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/fake-timers": "^29.5.0",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
-        "jest-mock": "^29.4.1"
+        "jest-mock": "^29.5.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.4.1.tgz",
-      "integrity": "sha512-ZxKJP5DTUNF2XkpJeZIzvnzF1KkfrhEF6Rz0HGG69fHl6Bgx5/GoU3XyaeFYEjuuKSOOsbqD/k72wFvFxc3iTw==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.5.0.tgz",
+      "integrity": "sha512-PueDR2HGihN3ciUNGr4uelropW7rqUfTiOn+8u0leg/42UhblPxHkfoh0Ruu3I9Y1962P3u2DY4+h7GVTSVU6g==",
       "dev": true,
       "dependencies": {
-        "expect": "^29.4.1",
-        "jest-snapshot": "^29.4.1"
+        "expect": "^29.5.0",
+        "jest-snapshot": "^29.5.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.4.1.tgz",
-      "integrity": "sha512-w6YJMn5DlzmxjO00i9wu2YSozUYRBhIoJ6nQwpMYcBMtiqMGJm1QBzOf6DDgRao8dbtpDoaqLg6iiQTvv0UHhQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.5.0.tgz",
+      "integrity": "sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==",
       "dev": true,
       "dependencies": {
-        "jest-get-type": "^29.2.0"
+        "jest-get-type": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.1.tgz",
-      "integrity": "sha512-/1joI6rfHFmmm39JxNfmNAO3Nwm6Y0VoL5fJDy7H1AtWrD1CgRtqJbN9Ld6rhAkGO76qqp4cwhhxJ9o9kYjQMw==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.5.0.tgz",
+      "integrity": "sha512-9ARvuAAQcBwDAqOnglWq2zwNIRUDtk/SCkp/ToGEhFv5r86K21l+VEs0qNTaXtyiY0lEePl3kylijSYJQqdbDg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.4.1",
-        "jest-mock": "^29.4.1",
-        "jest-util": "^29.4.1"
+        "jest-message-util": "^29.5.0",
+        "jest-mock": "^29.5.0",
+        "jest-util": "^29.5.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.4.1.tgz",
-      "integrity": "sha512-znoK2EuFytbHH0ZSf2mQK2K1xtIgmaw4Da21R2C/NE/+NnItm5mPEFQmn8gmF3f0rfOlmZ3Y3bIf7bFj7DHxAA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.5.0.tgz",
+      "integrity": "sha512-S02y0qMWGihdzNbUiqSAiKSpSozSuHX5UYc7QbnHP+D9Lyw8DgGGCinrN9uSuHPeKgSSzvPom2q1nAtBvUsvPQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.4.1",
-        "@jest/expect": "^29.4.1",
-        "@jest/types": "^29.4.1",
-        "jest-mock": "^29.4.1"
+        "@jest/environment": "^29.5.0",
+        "@jest/expect": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "jest-mock": "^29.5.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -931,9 +931,9 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.0.tgz",
-      "integrity": "sha512-0E01f/gOZeNTG76i5eWWSupvSHaIINrTie7vCyjiYFKgzNdyEGd12BUv4oNBFHOqlHDbtoJi3HrQ38KCC90NsQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
       "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.25.16"
@@ -943,9 +943,9 @@
       }
     },
     "node_modules/@jest/source-map": {
-      "version": "29.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.2.0.tgz",
-      "integrity": "sha512-1NX9/7zzI0nqa6+kgpSdKPK+WU1p+SJk3TloWZf5MzPbxri9UEeXX5bWZAPCzbQcyuAzubcdUHA7hcNznmRqWQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.4.3.tgz",
+      "integrity": "sha512-qyt/mb6rLyd9j1jUts4EQncvS6Yy3PM9HghnNv86QBlV+zdL2inCdK1tuVlL+J+lpiw2BI67qXOrX3UurBqQ1w==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.15",
@@ -957,13 +957,13 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.4.1.tgz",
-      "integrity": "sha512-WRt29Lwt+hEgfN8QDrXqXGgCTidq1rLyFqmZ4lmJOpVArC8daXrZWkWjiaijQvgd3aOUj2fM8INclKHsQW9YyQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.5.0.tgz",
+      "integrity": "sha512-fGl4rfitnbfLsrfx1uUpDEESS7zM8JdgZgOCQuxQvL1Sn/I6ijeAVQWGfXI9zb1i9Mzo495cIpVZhA0yr60PkQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/console": "^29.5.0",
+        "@jest/types": "^29.5.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
@@ -987,26 +987,26 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.4.1.tgz",
-      "integrity": "sha512-5w6YJrVAtiAgr0phzKjYd83UPbCXsBRTeYI4BXokv9Er9CcrH9hfXL/crCvP2d2nGOcovPUnlYiLPFLZrkG5Hg==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.5.0.tgz",
+      "integrity": "sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@jridgewell/trace-mapping": "^0.3.15",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.4.1",
-        "jest-regex-util": "^29.2.0",
-        "jest-util": "^29.4.1",
+        "jest-haste-map": "^29.5.0",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.5.0",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
-        "write-file-atomic": "^5.0.0"
+        "write-file-atomic": "^4.0.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -1019,12 +1019,12 @@
       "dev": true
     },
     "node_modules/@jest/types": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.1.tgz",
-      "integrity": "sha512-zbrAXDUOnpJ+FMST2rV7QZOgec8rskg2zv8g2ajeqitp4tvZiyqTCYXANrKsM+ryj5o+LI+ZN2EgU9drrkiwSA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
+      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.0",
+        "@jest/schemas": "^29.4.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -1109,15 +1109,15 @@
       }
     },
     "node_modules/@nasa-jpl/aerie-ts-user-code-runner": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-ts-user-code-runner/-/aerie-ts-user-code-runner-0.5.0.tgz",
-      "integrity": "sha512-w029/vHut7A2HAiKHM6vQj+y/0eoW8yG5f/iUZKE+0bQvfiNOgQTtM/yqdgZ4s8gr5x1pQHpVjoB6n+MAb/TPw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-ts-user-code-runner/-/aerie-ts-user-code-runner-0.6.0.tgz",
+      "integrity": "sha512-l9akSO33rLNW08QL+lu69B/l8Eb9lEtaqmtptFazlpjy6q4CzNAlM74g+BhThNyOvUaErNH7cIWQL1ns3JpJeQ==",
       "dependencies": {
         "source-map": "^0.7.4",
         "stack-trace": "^1.0.0-pre1"
       },
       "peerDependencies": {
-        "typescript": "4.x"
+        "typescript": "4.x || 5.x"
       }
     },
     "node_modules/@nasa-jpl/seq-json-schema": {
@@ -1126,9 +1126,9 @@
       "integrity": "sha512-VTVoUWm0iDp1xysdtE6BV2VmXaRvvU3os8ecE/O3AFCPTJ8GWnMh1a46atjKonm7TqgvH4pUYyVWfMBip2u81A=="
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
-      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==",
+      "version": "0.25.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
+      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -2166,9 +2166,9 @@
       }
     },
     "node_modules/diff-sequences": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
-      "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
+      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2316,16 +2316,16 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.4.1.tgz",
-      "integrity": "sha512-OKrGESHOaMxK3b6zxIq9SOW8kEXztKff/Dvg88j4xIJxur1hspEbedVkR3GpHe5LO+WB2Qw7OWN0RMTdp6as5A==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.5.0.tgz",
+      "integrity": "sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==",
       "dev": true,
       "dependencies": {
-        "@jest/expect-utils": "^29.4.1",
-        "jest-get-type": "^29.2.0",
-        "jest-matcher-utils": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-util": "^29.4.1"
+        "@jest/expect-utils": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2486,12 +2486,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
-    },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
     "node_modules/fb-watchman": {
@@ -3178,28 +3172,29 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.4.1.tgz",
-      "integrity": "sha512-v02NuL5crMNY4CGPHBEflLzl4v91NFb85a+dH9a1pUNx6Xjggrd8l9pPy4LZ1VYNRXlb+f65+7O/MSIbLir6pA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.5.0.tgz",
+      "integrity": "sha512-gq/ongqeQKAplVxqJmbeUOJJKkW3dDNPY8PjhJ5G0lBRvu0e3EWGxGy5cI4LAGA7gV2UHCtWBI4EMXK8c9nQKA==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.4.1",
-        "@jest/expect": "^29.4.1",
-        "@jest/test-result": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/environment": "^29.5.0",
+        "@jest/expect": "^29.5.0",
+        "@jest/test-result": "^29.5.0",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.4.1",
-        "jest-matcher-utils": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-runtime": "^29.4.1",
-        "jest-snapshot": "^29.4.1",
-        "jest-util": "^29.4.1",
+        "jest-each": "^29.5.0",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-runtime": "^29.5.0",
+        "jest-snapshot": "^29.5.0",
+        "jest-util": "^29.5.0",
         "p-limit": "^3.1.0",
-        "pretty-format": "^29.4.1",
+        "pretty-format": "^29.5.0",
+        "pure-rand": "^6.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -3287,15 +3282,15 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.4.1.tgz",
-      "integrity": "sha512-uazdl2g331iY56CEyfbNA0Ut7Mn2ulAG5vUaEHXycf1L6IPyuImIxSz4F0VYBKi7LYIuxOwTZzK3wh5jHzASMw==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
+      "integrity": "sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.3.1",
-        "jest-get-type": "^29.2.0",
-        "pretty-format": "^29.4.1"
+        "diff-sequences": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3314,16 +3309,16 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.4.1.tgz",
-      "integrity": "sha512-QlYFiX3llJMWUV0BtWht/esGEz9w+0i7BHwODKCze7YzZzizgExB9MOfiivF/vVT0GSQ8wXLhvHXh3x2fVD4QQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.5.0.tgz",
+      "integrity": "sha512-HM5kIJ1BTnVt+DQZ2ALp3rzXEl+g726csObrW/jpEGl+CDSSQpOJJX2KE/vEg8cxcMXdyEPu6U4QX5eruQv5hA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.2.0",
-        "jest-util": "^29.4.1",
-        "pretty-format": "^29.4.1"
+        "jest-get-type": "^29.4.3",
+        "jest-util": "^29.5.0",
+        "pretty-format": "^29.5.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3347,9 +3342,9 @@
       }
     },
     "node_modules/jest-extended": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-3.2.3.tgz",
-      "integrity": "sha512-YcdjfFv3+N2AiWq4aG6gT/r1mfLtDKnbXs0hKXNlL/hf37TKQJTlh2zNwuMUYnvwKRRMtO/X9CfZU1EmOgUREA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-3.2.4.tgz",
+      "integrity": "sha512-lSEYhSmvXZG/7YXI7KO3LpiUiQ90gi5giwCJNDMMsX5a+/NZhdbQF2G4ALOBN+KcXVT3H6FPVPohAuMXooaLTQ==",
       "dev": true,
       "dependencies": {
         "jest-diff": "^29.0.0",
@@ -3368,29 +3363,29 @@
       }
     },
     "node_modules/jest-get-type": {
-      "version": "29.2.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
-      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.4.1.tgz",
-      "integrity": "sha512-imTjcgfVVTvg02khXL11NNLTx9ZaofbAWhilrMg/G8dIkp+HYCswhxf0xxJwBkfhWb3e8dwbjuWburvxmcr58w==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.5.0.tgz",
+      "integrity": "sha512-IspOPnnBro8YfVYSw6yDRKh/TiCdRngjxeacCps1cQ9cgVN6+10JUcuJ1EabrgYLOATsIAigxA0rLR9x/YlrSA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.2.0",
-        "jest-util": "^29.4.1",
-        "jest-worker": "^29.4.1",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.5.0",
+        "jest-worker": "^29.5.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -3402,12 +3397,11 @@
       }
     },
     "node_modules/jest-html-reporters": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/jest-html-reporters/-/jest-html-reporters-3.1.1.tgz",
-      "integrity": "sha512-ck8xmlBltsg62CD2VTBL5Fu3Pvq4viAhjakFlCt2dcmAZsKQ/P+mqCYLxXUV0HT2TROElIfi/tV5DdAgZYR3fQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jest-html-reporters/-/jest-html-reporters-3.1.4.tgz",
+      "integrity": "sha512-7lLrKDKDNBNDprd5lP241HRx2mRXb/XQOuYFxX/MxydgHtYRE/lEtK2+J5XLiNTs9JL/rUjWsWhIBOBs9j3wcg==",
       "dev": true,
       "dependencies": {
-        "fast-safe-stringify": "^2.1.1",
         "fs-extra": "^10.0.0",
         "open": "^8.0.3"
       }
@@ -3426,33 +3420,33 @@
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.4.1.tgz",
-      "integrity": "sha512-k5h0u8V4nAEy6lSACepxL/rw78FLDkBnXhZVgFneVpnJONhb2DhZj/Gv4eNe+1XqQ5IhgUcqj745UwH0HJmMnA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz",
+      "integrity": "sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.4.1",
-        "jest-get-type": "^29.2.0",
-        "pretty-format": "^29.4.1"
+        "jest-diff": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.1.tgz",
-      "integrity": "sha512-H4/I0cXUaLeCw6FM+i4AwCnOwHRgitdaUFOdm49022YD5nfyr8C/DrbXOBEyJaj+w/y0gGJ57klssOaUiLLQGQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
+      "integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.4.1",
+        "pretty-format": "^29.5.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -3461,14 +3455,14 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.1.tgz",
-      "integrity": "sha512-MwA4hQ7zBOcgVCVnsM8TzaFLVUD/pFWTfbkY953Y81L5ret3GFRZtmPmRFAjKQSdCKoJvvqOu6Bvfpqlwwb0dQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.5.0.tgz",
+      "integrity": "sha512-GqOzvdWDE4fAV2bWQLQCkujxYWL7RxjCnj71b5VhDAGOevB3qj3Ovg26A5NI84ZpODxyzaozXLOh2NCgkbvyaw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
-        "jest-util": "^29.4.1"
+        "jest-util": "^29.5.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3492,26 +3486,26 @@
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "29.2.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.2.0.tgz",
-      "integrity": "sha512-6yXn0kg2JXzH30cr2NlThF+70iuO/3irbaB4mh5WyqNIvLLP+B6sFdluO1/1RJmslyh/f9osnefECflHvTbwVA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.4.3.tgz",
+      "integrity": "sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-resolve": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.4.1.tgz",
-      "integrity": "sha512-j/ZFNV2lm9IJ2wmlq1uYK0Y/1PiyDq9g4HEGsNTNr3viRbJdV+8Lf1SXIiLZXFvyiisu0qUyIXGBnw+OKWkJwQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.5.0.tgz",
+      "integrity": "sha512-1TzxJ37FQq7J10jPtQjcc+MkCkE3GBpBecsSUWJ0qZNJpmg6m0D9/7II03yJulm3H/fvVjgqLh/k2eYg+ui52w==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.4.1",
+        "jest-haste-map": "^29.5.0",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.4.1",
-        "jest-validate": "^29.4.1",
+        "jest-util": "^29.5.0",
+        "jest-validate": "^29.5.0",
         "resolve": "^1.20.0",
         "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
@@ -3566,32 +3560,31 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.4.1.tgz",
-      "integrity": "sha512-UXTMU9uKu2GjYwTtoAw5rn4STxWw/nadOfW7v1sx6LaJYa3V/iymdCLQM6xy3+7C6mY8GfX22vKpgxY171UIoA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.5.0.tgz",
+      "integrity": "sha512-1Hr6Hh7bAgXQP+pln3homOiEZtCDZFqwmle7Ew2j8OlbkIu6uE3Y/etJQG8MLQs3Zy90xrp2C0BRrtPHG4zryw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.4.1",
-        "@jest/fake-timers": "^29.4.1",
-        "@jest/globals": "^29.4.1",
-        "@jest/source-map": "^29.2.0",
-        "@jest/test-result": "^29.4.1",
-        "@jest/transform": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/environment": "^29.5.0",
+        "@jest/fake-timers": "^29.5.0",
+        "@jest/globals": "^29.5.0",
+        "@jest/source-map": "^29.4.3",
+        "@jest/test-result": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-mock": "^29.4.1",
-        "jest-regex-util": "^29.2.0",
-        "jest-resolve": "^29.4.1",
-        "jest-snapshot": "^29.4.1",
-        "jest-util": "^29.4.1",
-        "semver": "^7.3.5",
+        "jest-haste-map": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-mock": "^29.5.0",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.5.0",
+        "jest-snapshot": "^29.5.0",
+        "jest-util": "^29.5.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -3599,25 +3592,10 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-runtime/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-snapshot": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.4.1.tgz",
-      "integrity": "sha512-l4iV8EjGgQWVz3ee/LR9sULDk2pCkqb71bjvlqn+qp90lFwpnulHj4ZBT8nm1hA1C5wowXLc7MGnw321u0tsYA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.5.0.tgz",
+      "integrity": "sha512-x7Wolra5V0tt3wRs3/ts3S6ciSQVypgGQlJpz2rsdQYoUKxMxPNaoHMGJN6qAuPJqS+2iQ1ZUn5kl7HCyls84g==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -3626,23 +3604,22 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.4.1",
-        "@jest/transform": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/expect-utils": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
         "@types/babel__traverse": "^7.0.6",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.4.1",
+        "expect": "^29.5.0",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.4.1",
-        "jest-get-type": "^29.2.0",
-        "jest-haste-map": "^29.4.1",
-        "jest-matcher-utils": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-util": "^29.4.1",
+        "jest-diff": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.4.1",
+        "pretty-format": "^29.5.0",
         "semver": "^7.3.5"
       },
       "engines": {
@@ -3665,12 +3642,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.1.tgz",
-      "integrity": "sha512-bQy9FPGxVutgpN4VRc0hk6w7Hx/m6L53QxpDreTZgJd9gfx/AV2MjyPde9tGyZRINAUrSv57p2inGBu2dRLmkQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
+      "integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -3682,17 +3659,17 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.4.1.tgz",
-      "integrity": "sha512-qNZXcZQdIQx4SfUB/atWnI4/I2HUvhz8ajOSYUu40CSmf9U5emil8EDHgE7M+3j9/pavtk3knlZBDsgFvv/SWw==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.5.0.tgz",
+      "integrity": "sha512-pC26etNIi+y3HV8A+tUGr/lph9B18GnzSRAkPaaZJIE1eFdiYm6/CewuiJQ8/RlfHd1u/8Ioi8/sJ+CmbA+zAQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.2.0",
+        "jest-get-type": "^29.4.3",
         "leven": "^3.1.0",
-        "pretty-format": "^29.4.1"
+        "pretty-format": "^29.5.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3730,13 +3707,13 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.4.1.tgz",
-      "integrity": "sha512-O9doU/S1EBe+yp/mstQ0VpPwpv0Clgn68TkNwGxL6/usX/KUW9Arnn4ag8C3jc6qHcXznhsT5Na1liYzAsuAbQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.5.0.tgz",
+      "integrity": "sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.4.1",
+        "jest-util": "^29.5.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -4513,12 +4490,12 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.1.tgz",
-      "integrity": "sha512-dt/Z761JUVsrIKaY215o1xQJBGlSmTx/h4cSqXqjHLnU1+Kt+mavVE7UgqJJO5ukx5HjSswHfmXz4LjS2oIJfg==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
+      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.0",
+        "@jest/schemas": "^29.4.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -4571,6 +4548,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
+      "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
     },
     "node_modules/qs": {
       "version": "6.11.0",
@@ -5209,9 +5202,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "node_modules/ts-jest": {
-      "version": "29.0.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.5.tgz",
-      "integrity": "sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==",
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.0.tgz",
+      "integrity": "sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",
@@ -5234,7 +5227,7 @@
         "@jest/types": "^29.0.0",
         "babel-jest": "^29.0.0",
         "jest": "^29.0.0",
-        "typescript": ">=4.3"
+        "typescript": ">=4.3 <6"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -5348,15 +5341,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/universalify": {
@@ -5565,16 +5558,16 @@
       "dev": true
     },
     "node_modules/write-file-atomic": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
-      "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/xml-js": {
@@ -6196,16 +6189,16 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.4.1.tgz",
-      "integrity": "sha512-m+XpwKSi3PPM9znm5NGS8bBReeAJJpSkL1OuFCqaMaJL2YX9YXLkkI+MBchMPwu+ZuM2rynL51sgfkQteQ1CKQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.5.0.tgz",
+      "integrity": "sha512-NEpkObxPwyw/XxZVLPmAGKE89IQRp4puc6IQRPru6JKd1M3fW9v1xM1AnzIJE65hbCkzQAdnL8P47e9hzhiYLQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^29.4.1",
-        "jest-util": "^29.4.1",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0",
         "slash": "^3.0.0"
       }
     },
@@ -6246,60 +6239,60 @@
       }
     },
     "@jest/environment": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.1.tgz",
-      "integrity": "sha512-pJ14dHGSQke7Q3mkL/UZR9ZtTOxqskZaC91NzamEH4dlKRt42W+maRBXiw/LWkdJe+P0f/zDR37+SPMplMRlPg==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.5.0.tgz",
+      "integrity": "sha512-5FXw2+wD29YU1d4I2htpRX7jYnAyTRjP2CsXQdo9SAM8g3ifxWPSV0HnClSn71xwctr0U3oZIIH+dtbfmnbXVQ==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/fake-timers": "^29.5.0",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
-        "jest-mock": "^29.4.1"
+        "jest-mock": "^29.5.0"
       }
     },
     "@jest/expect": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.4.1.tgz",
-      "integrity": "sha512-ZxKJP5DTUNF2XkpJeZIzvnzF1KkfrhEF6Rz0HGG69fHl6Bgx5/GoU3XyaeFYEjuuKSOOsbqD/k72wFvFxc3iTw==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.5.0.tgz",
+      "integrity": "sha512-PueDR2HGihN3ciUNGr4uelropW7rqUfTiOn+8u0leg/42UhblPxHkfoh0Ruu3I9Y1962P3u2DY4+h7GVTSVU6g==",
       "dev": true,
       "requires": {
-        "expect": "^29.4.1",
-        "jest-snapshot": "^29.4.1"
+        "expect": "^29.5.0",
+        "jest-snapshot": "^29.5.0"
       }
     },
     "@jest/expect-utils": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.4.1.tgz",
-      "integrity": "sha512-w6YJMn5DlzmxjO00i9wu2YSozUYRBhIoJ6nQwpMYcBMtiqMGJm1QBzOf6DDgRao8dbtpDoaqLg6iiQTvv0UHhQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.5.0.tgz",
+      "integrity": "sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^29.2.0"
+        "jest-get-type": "^29.4.3"
       }
     },
     "@jest/fake-timers": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.1.tgz",
-      "integrity": "sha512-/1joI6rfHFmmm39JxNfmNAO3Nwm6Y0VoL5fJDy7H1AtWrD1CgRtqJbN9Ld6rhAkGO76qqp4cwhhxJ9o9kYjQMw==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.5.0.tgz",
+      "integrity": "sha512-9ARvuAAQcBwDAqOnglWq2zwNIRUDtk/SCkp/ToGEhFv5r86K21l+VEs0qNTaXtyiY0lEePl3kylijSYJQqdbDg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.4.1",
-        "jest-mock": "^29.4.1",
-        "jest-util": "^29.4.1"
+        "jest-message-util": "^29.5.0",
+        "jest-mock": "^29.5.0",
+        "jest-util": "^29.5.0"
       }
     },
     "@jest/globals": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.4.1.tgz",
-      "integrity": "sha512-znoK2EuFytbHH0ZSf2mQK2K1xtIgmaw4Da21R2C/NE/+NnItm5mPEFQmn8gmF3f0rfOlmZ3Y3bIf7bFj7DHxAA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.5.0.tgz",
+      "integrity": "sha512-S02y0qMWGihdzNbUiqSAiKSpSozSuHX5UYc7QbnHP+D9Lyw8DgGGCinrN9uSuHPeKgSSzvPom2q1nAtBvUsvPQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.4.1",
-        "@jest/expect": "^29.4.1",
-        "@jest/types": "^29.4.1",
-        "jest-mock": "^29.4.1"
+        "@jest/environment": "^29.5.0",
+        "@jest/expect": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "jest-mock": "^29.5.0"
       }
     },
     "@jest/reporters": {
@@ -6335,18 +6328,18 @@
       }
     },
     "@jest/schemas": {
-      "version": "29.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.0.tgz",
-      "integrity": "sha512-0E01f/gOZeNTG76i5eWWSupvSHaIINrTie7vCyjiYFKgzNdyEGd12BUv4oNBFHOqlHDbtoJi3HrQ38KCC90NsQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
       "dev": true,
       "requires": {
         "@sinclair/typebox": "^0.25.16"
       }
     },
     "@jest/source-map": {
-      "version": "29.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.2.0.tgz",
-      "integrity": "sha512-1NX9/7zzI0nqa6+kgpSdKPK+WU1p+SJk3TloWZf5MzPbxri9UEeXX5bWZAPCzbQcyuAzubcdUHA7hcNznmRqWQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.4.3.tgz",
+      "integrity": "sha512-qyt/mb6rLyd9j1jUts4EQncvS6Yy3PM9HghnNv86QBlV+zdL2inCdK1tuVlL+J+lpiw2BI67qXOrX3UurBqQ1w==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.15",
@@ -6355,13 +6348,13 @@
       }
     },
     "@jest/test-result": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.4.1.tgz",
-      "integrity": "sha512-WRt29Lwt+hEgfN8QDrXqXGgCTidq1rLyFqmZ4lmJOpVArC8daXrZWkWjiaijQvgd3aOUj2fM8INclKHsQW9YyQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.5.0.tgz",
+      "integrity": "sha512-fGl4rfitnbfLsrfx1uUpDEESS7zM8JdgZgOCQuxQvL1Sn/I6ijeAVQWGfXI9zb1i9Mzo495cIpVZhA0yr60PkQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/console": "^29.5.0",
+        "@jest/types": "^29.5.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
@@ -6379,26 +6372,26 @@
       }
     },
     "@jest/transform": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.4.1.tgz",
-      "integrity": "sha512-5w6YJrVAtiAgr0phzKjYd83UPbCXsBRTeYI4BXokv9Er9CcrH9hfXL/crCvP2d2nGOcovPUnlYiLPFLZrkG5Hg==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.5.0.tgz",
+      "integrity": "sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@jridgewell/trace-mapping": "^0.3.15",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.4.1",
-        "jest-regex-util": "^29.2.0",
-        "jest-util": "^29.4.1",
+        "jest-haste-map": "^29.5.0",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.5.0",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
-        "write-file-atomic": "^5.0.0"
+        "write-file-atomic": "^4.0.2"
       },
       "dependencies": {
         "convert-source-map": {
@@ -6410,12 +6403,12 @@
       }
     },
     "@jest/types": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.1.tgz",
-      "integrity": "sha512-zbrAXDUOnpJ+FMST2rV7QZOgec8rskg2zv8g2ajeqitp4tvZiyqTCYXANrKsM+ryj5o+LI+ZN2EgU9drrkiwSA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
+      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
       "dev": true,
       "requires": {
-        "@jest/schemas": "^29.4.0",
+        "@jest/schemas": "^29.4.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -6485,9 +6478,9 @@
       }
     },
     "@nasa-jpl/aerie-ts-user-code-runner": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-ts-user-code-runner/-/aerie-ts-user-code-runner-0.5.0.tgz",
-      "integrity": "sha512-w029/vHut7A2HAiKHM6vQj+y/0eoW8yG5f/iUZKE+0bQvfiNOgQTtM/yqdgZ4s8gr5x1pQHpVjoB6n+MAb/TPw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-ts-user-code-runner/-/aerie-ts-user-code-runner-0.6.0.tgz",
+      "integrity": "sha512-l9akSO33rLNW08QL+lu69B/l8Eb9lEtaqmtptFazlpjy6q4CzNAlM74g+BhThNyOvUaErNH7cIWQL1ns3JpJeQ==",
       "requires": {
         "source-map": "^0.7.4",
         "stack-trace": "^1.0.0-pre1"
@@ -6499,9 +6492,9 @@
       "integrity": "sha512-VTVoUWm0iDp1xysdtE6BV2VmXaRvvU3os8ecE/O3AFCPTJ8GWnMh1a46atjKonm7TqgvH4pUYyVWfMBip2u81A=="
     },
     "@sinclair/typebox": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
-      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==",
+      "version": "0.25.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
+      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -7335,9 +7328,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
-      "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
+      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
       "dev": true
     },
     "dotenv": {
@@ -7445,16 +7438,16 @@
       "dev": true
     },
     "expect": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.4.1.tgz",
-      "integrity": "sha512-OKrGESHOaMxK3b6zxIq9SOW8kEXztKff/Dvg88j4xIJxur1hspEbedVkR3GpHe5LO+WB2Qw7OWN0RMTdp6as5A==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.5.0.tgz",
+      "integrity": "sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==",
       "dev": true,
       "requires": {
-        "@jest/expect-utils": "^29.4.1",
-        "jest-get-type": "^29.2.0",
-        "jest-matcher-utils": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-util": "^29.4.1"
+        "@jest/expect-utils": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0"
       }
     },
     "express": {
@@ -7589,12 +7582,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
-    },
-    "fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
     "fb-watchman": {
@@ -8093,28 +8080,29 @@
       }
     },
     "jest-circus": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.4.1.tgz",
-      "integrity": "sha512-v02NuL5crMNY4CGPHBEflLzl4v91NFb85a+dH9a1pUNx6Xjggrd8l9pPy4LZ1VYNRXlb+f65+7O/MSIbLir6pA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.5.0.tgz",
+      "integrity": "sha512-gq/ongqeQKAplVxqJmbeUOJJKkW3dDNPY8PjhJ5G0lBRvu0e3EWGxGy5cI4LAGA7gV2UHCtWBI4EMXK8c9nQKA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.4.1",
-        "@jest/expect": "^29.4.1",
-        "@jest/test-result": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/environment": "^29.5.0",
+        "@jest/expect": "^29.5.0",
+        "@jest/test-result": "^29.5.0",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.4.1",
-        "jest-matcher-utils": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-runtime": "^29.4.1",
-        "jest-snapshot": "^29.4.1",
-        "jest-util": "^29.4.1",
+        "jest-each": "^29.5.0",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-runtime": "^29.5.0",
+        "jest-snapshot": "^29.5.0",
+        "jest-util": "^29.5.0",
         "p-limit": "^3.1.0",
-        "pretty-format": "^29.4.1",
+        "pretty-format": "^29.5.0",
+        "pure-rand": "^6.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       }
@@ -8170,15 +8158,15 @@
       }
     },
     "jest-diff": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.4.1.tgz",
-      "integrity": "sha512-uazdl2g331iY56CEyfbNA0Ut7Mn2ulAG5vUaEHXycf1L6IPyuImIxSz4F0VYBKi7LYIuxOwTZzK3wh5jHzASMw==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
+      "integrity": "sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.3.1",
-        "jest-get-type": "^29.2.0",
-        "pretty-format": "^29.4.1"
+        "diff-sequences": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
       }
     },
     "jest-docblock": {
@@ -8191,16 +8179,16 @@
       }
     },
     "jest-each": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.4.1.tgz",
-      "integrity": "sha512-QlYFiX3llJMWUV0BtWht/esGEz9w+0i7BHwODKCze7YzZzizgExB9MOfiivF/vVT0GSQ8wXLhvHXh3x2fVD4QQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.5.0.tgz",
+      "integrity": "sha512-HM5kIJ1BTnVt+DQZ2ALp3rzXEl+g726csObrW/jpEGl+CDSSQpOJJX2KE/vEg8cxcMXdyEPu6U4QX5eruQv5hA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.2.0",
-        "jest-util": "^29.4.1",
-        "pretty-format": "^29.4.1"
+        "jest-get-type": "^29.4.3",
+        "jest-util": "^29.5.0",
+        "pretty-format": "^29.5.0"
       }
     },
     "jest-environment-node": {
@@ -8218,9 +8206,9 @@
       }
     },
     "jest-extended": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-3.2.3.tgz",
-      "integrity": "sha512-YcdjfFv3+N2AiWq4aG6gT/r1mfLtDKnbXs0hKXNlL/hf37TKQJTlh2zNwuMUYnvwKRRMtO/X9CfZU1EmOgUREA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-3.2.4.tgz",
+      "integrity": "sha512-lSEYhSmvXZG/7YXI7KO3LpiUiQ90gi5giwCJNDMMsX5a+/NZhdbQF2G4ALOBN+KcXVT3H6FPVPohAuMXooaLTQ==",
       "dev": true,
       "requires": {
         "jest-diff": "^29.0.0",
@@ -8228,38 +8216,37 @@
       }
     },
     "jest-get-type": {
-      "version": "29.2.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
-      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.4.1.tgz",
-      "integrity": "sha512-imTjcgfVVTvg02khXL11NNLTx9ZaofbAWhilrMg/G8dIkp+HYCswhxf0xxJwBkfhWb3e8dwbjuWburvxmcr58w==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.5.0.tgz",
+      "integrity": "sha512-IspOPnnBro8YfVYSw6yDRKh/TiCdRngjxeacCps1cQ9cgVN6+10JUcuJ1EabrgYLOATsIAigxA0rLR9x/YlrSA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.2.0",
-        "jest-util": "^29.4.1",
-        "jest-worker": "^29.4.1",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.5.0",
+        "jest-worker": "^29.5.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       }
     },
     "jest-html-reporters": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/jest-html-reporters/-/jest-html-reporters-3.1.1.tgz",
-      "integrity": "sha512-ck8xmlBltsg62CD2VTBL5Fu3Pvq4viAhjakFlCt2dcmAZsKQ/P+mqCYLxXUV0HT2TROElIfi/tV5DdAgZYR3fQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jest-html-reporters/-/jest-html-reporters-3.1.4.tgz",
+      "integrity": "sha512-7lLrKDKDNBNDprd5lP241HRx2mRXb/XQOuYFxX/MxydgHtYRE/lEtK2+J5XLiNTs9JL/rUjWsWhIBOBs9j3wcg==",
       "dev": true,
       "requires": {
-        "fast-safe-stringify": "^2.1.1",
         "fs-extra": "^10.0.0",
         "open": "^8.0.3"
       }
@@ -8275,43 +8262,43 @@
       }
     },
     "jest-matcher-utils": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.4.1.tgz",
-      "integrity": "sha512-k5h0u8V4nAEy6lSACepxL/rw78FLDkBnXhZVgFneVpnJONhb2DhZj/Gv4eNe+1XqQ5IhgUcqj745UwH0HJmMnA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz",
+      "integrity": "sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.4.1",
-        "jest-get-type": "^29.2.0",
-        "pretty-format": "^29.4.1"
+        "jest-diff": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
       }
     },
     "jest-message-util": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.1.tgz",
-      "integrity": "sha512-H4/I0cXUaLeCw6FM+i4AwCnOwHRgitdaUFOdm49022YD5nfyr8C/DrbXOBEyJaj+w/y0gGJ57klssOaUiLLQGQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
+      "integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.4.1",
+        "pretty-format": "^29.5.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       }
     },
     "jest-mock": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.1.tgz",
-      "integrity": "sha512-MwA4hQ7zBOcgVCVnsM8TzaFLVUD/pFWTfbkY953Y81L5ret3GFRZtmPmRFAjKQSdCKoJvvqOu6Bvfpqlwwb0dQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.5.0.tgz",
+      "integrity": "sha512-GqOzvdWDE4fAV2bWQLQCkujxYWL7RxjCnj71b5VhDAGOevB3qj3Ovg26A5NI84ZpODxyzaozXLOh2NCgkbvyaw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
-        "jest-util": "^29.4.1"
+        "jest-util": "^29.5.0"
       }
     },
     "jest-pnp-resolver": {
@@ -8322,23 +8309,23 @@
       "requires": {}
     },
     "jest-regex-util": {
-      "version": "29.2.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.2.0.tgz",
-      "integrity": "sha512-6yXn0kg2JXzH30cr2NlThF+70iuO/3irbaB4mh5WyqNIvLLP+B6sFdluO1/1RJmslyh/f9osnefECflHvTbwVA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.4.3.tgz",
+      "integrity": "sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.4.1.tgz",
-      "integrity": "sha512-j/ZFNV2lm9IJ2wmlq1uYK0Y/1PiyDq9g4HEGsNTNr3viRbJdV+8Lf1SXIiLZXFvyiisu0qUyIXGBnw+OKWkJwQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.5.0.tgz",
+      "integrity": "sha512-1TzxJ37FQq7J10jPtQjcc+MkCkE3GBpBecsSUWJ0qZNJpmg6m0D9/7II03yJulm3H/fvVjgqLh/k2eYg+ui52w==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.4.1",
+        "jest-haste-map": "^29.5.0",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.4.1",
-        "jest-validate": "^29.4.1",
+        "jest-util": "^29.5.0",
+        "jest-validate": "^29.5.0",
         "resolve": "^1.20.0",
         "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
@@ -8384,51 +8371,39 @@
       }
     },
     "jest-runtime": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.4.1.tgz",
-      "integrity": "sha512-UXTMU9uKu2GjYwTtoAw5rn4STxWw/nadOfW7v1sx6LaJYa3V/iymdCLQM6xy3+7C6mY8GfX22vKpgxY171UIoA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.5.0.tgz",
+      "integrity": "sha512-1Hr6Hh7bAgXQP+pln3homOiEZtCDZFqwmle7Ew2j8OlbkIu6uE3Y/etJQG8MLQs3Zy90xrp2C0BRrtPHG4zryw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.4.1",
-        "@jest/fake-timers": "^29.4.1",
-        "@jest/globals": "^29.4.1",
-        "@jest/source-map": "^29.2.0",
-        "@jest/test-result": "^29.4.1",
-        "@jest/transform": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/environment": "^29.5.0",
+        "@jest/fake-timers": "^29.5.0",
+        "@jest/globals": "^29.5.0",
+        "@jest/source-map": "^29.4.3",
+        "@jest/test-result": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-mock": "^29.4.1",
-        "jest-regex-util": "^29.2.0",
-        "jest-resolve": "^29.4.1",
-        "jest-snapshot": "^29.4.1",
-        "jest-util": "^29.4.1",
-        "semver": "^7.3.5",
+        "jest-haste-map": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-mock": "^29.5.0",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.5.0",
+        "jest-snapshot": "^29.5.0",
+        "jest-util": "^29.5.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "jest-snapshot": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.4.1.tgz",
-      "integrity": "sha512-l4iV8EjGgQWVz3ee/LR9sULDk2pCkqb71bjvlqn+qp90lFwpnulHj4ZBT8nm1hA1C5wowXLc7MGnw321u0tsYA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.5.0.tgz",
+      "integrity": "sha512-x7Wolra5V0tt3wRs3/ts3S6ciSQVypgGQlJpz2rsdQYoUKxMxPNaoHMGJN6qAuPJqS+2iQ1ZUn5kl7HCyls84g==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
@@ -8437,23 +8412,22 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.4.1",
-        "@jest/transform": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/expect-utils": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
         "@types/babel__traverse": "^7.0.6",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.4.1",
+        "expect": "^29.5.0",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.4.1",
-        "jest-get-type": "^29.2.0",
-        "jest-haste-map": "^29.4.1",
-        "jest-matcher-utils": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-util": "^29.4.1",
+        "jest-diff": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.4.1",
+        "pretty-format": "^29.5.0",
         "semver": "^7.3.5"
       },
       "dependencies": {
@@ -8469,12 +8443,12 @@
       }
     },
     "jest-util": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.1.tgz",
-      "integrity": "sha512-bQy9FPGxVutgpN4VRc0hk6w7Hx/m6L53QxpDreTZgJd9gfx/AV2MjyPde9tGyZRINAUrSv57p2inGBu2dRLmkQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
+      "integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -8483,17 +8457,17 @@
       }
     },
     "jest-validate": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.4.1.tgz",
-      "integrity": "sha512-qNZXcZQdIQx4SfUB/atWnI4/I2HUvhz8ajOSYUu40CSmf9U5emil8EDHgE7M+3j9/pavtk3knlZBDsgFvv/SWw==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.5.0.tgz",
+      "integrity": "sha512-pC26etNIi+y3HV8A+tUGr/lph9B18GnzSRAkPaaZJIE1eFdiYm6/CewuiJQ8/RlfHd1u/8Ioi8/sJ+CmbA+zAQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.5.0",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.2.0",
+        "jest-get-type": "^29.4.3",
         "leven": "^3.1.0",
-        "pretty-format": "^29.4.1"
+        "pretty-format": "^29.5.0"
       },
       "dependencies": {
         "camelcase": {
@@ -8521,13 +8495,13 @@
       }
     },
     "jest-worker": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.4.1.tgz",
-      "integrity": "sha512-O9doU/S1EBe+yp/mstQ0VpPwpv0Clgn68TkNwGxL6/usX/KUW9Arnn4ag8C3jc6qHcXznhsT5Na1liYzAsuAbQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.5.0.tgz",
+      "integrity": "sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "jest-util": "^29.4.1",
+        "jest-util": "^29.5.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       }
@@ -9099,12 +9073,12 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.1.tgz",
-      "integrity": "sha512-dt/Z761JUVsrIKaY215o1xQJBGlSmTx/h4cSqXqjHLnU1+Kt+mavVE7UgqJJO5ukx5HjSswHfmXz4LjS2oIJfg==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
+      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
       "dev": true,
       "requires": {
-        "@jest/schemas": "^29.4.0",
+        "@jest/schemas": "^29.4.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -9140,6 +9114,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true
+    },
+    "pure-rand": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
+      "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
       "dev": true
     },
     "qs": {
@@ -9625,9 +9605,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "ts-jest": {
-      "version": "29.0.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.5.tgz",
-      "integrity": "sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==",
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.0.tgz",
+      "integrity": "sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -9699,9 +9679,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
     "universalify": {
       "version": "2.0.0",
@@ -9856,9 +9836,9 @@
       "dev": true
     },
     "write-file-atomic": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
-      "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4",

--- a/sequencing-server/package.json
+++ b/sequencing-server/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@js-temporal/polyfill": "~0.4.3",
     "@nasa-jpl/aerie-ampcs": "~1.0.1",
-    "@nasa-jpl/aerie-ts-user-code-runner": "~0.5.0",
+    "@nasa-jpl/aerie-ts-user-code-runner": "~0.6.0",
     "@nasa-jpl/seq-json-schema": "1.0.17",
     "body-parser": "~1.20.1",
     "dataloader": "~2.2.0",
@@ -32,7 +32,7 @@
     "piscina": "~3.2.0",
     "postgres-interval": "~4.0.0",
     "reserved-words": "~0.1.2",
-    "typescript": "~4.9.5",
+    "typescript": "^5",
     "winston": "~3.8.2"
   },
   "devDependencies": {
@@ -49,13 +49,13 @@
     "dotenv": "~16.0.3",
     "form-data": "~4.0.0",
     "jest": "~29.4.1",
-    "jest-circus": "~29.4.1",
-    "jest-extended": "~3.2.3",
-    "jest-html-reporters": "~3.1.1",
+    "jest-circus": "~29.5.0",
+    "jest-extended": "~3.2.4",
+    "jest-html-reporters": "~3.1.4",
     "node-fetch": "~3.3.0",
     "prettier": "~2.8.3",
     "supervisor": "~0.12.0",
-    "ts-jest": "~29.0.5",
+    "ts-jest": "~29.1.0",
     "ts-node": "~10.9.1"
   },
   "overrides": {

--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
@@ -10,6 +10,12 @@ import {
   Ground_Event,
   Ground_Block,
   ImmediateStem,
+    FLOAT,
+    INT,
+    UINT,
+    STRING,
+    ENUM,
+    Variable
 } from './CommandEDSLPreface';
 
 describe('Command', () => {
@@ -160,6 +166,78 @@ describe('Command', () => {
           '})',
       );
     });
+
+    it('should convert to EDSL string from Variable', () => {
+      const float = Variable.new(FLOAT('float_name', {allowable_ranges : [{min: 0, max : 1}], allowable_values : [1,3], sc_name : 'Mission Control'}));
+      expect(float.toSeqJson()).toEqual({
+        allowable_ranges: [
+          {
+            "max": 1,
+            "min": 0
+          }
+        ],
+        allowable_values: [
+          1,
+          3
+        ],
+        sc_name : 'Mission Control',
+        name: "float_name",
+        type: "FLOAT"
+      });
+
+      const int = Variable.new(INT('int_name', {allowable_ranges : [{min: 2, max : 10}], allowable_values : [1,3], sc_name : 'Mission Control 2'}));
+      expect(int.toSeqJson()).toEqual({
+        allowable_ranges: [
+          {
+            "max": 10,
+            "min": 2
+          }
+        ],
+        allowable_values: [
+          1,
+          3
+        ],
+        sc_name : 'Mission Control 2',
+        name: "int_name",
+        type: "INT"
+      });
+
+      const uint = Variable.new(UINT('uint_name'));
+      expect(uint.toSeqJson()).toEqual({ name: 'uint_name', type: 'UINT' });
+
+      const string = Variable.new(STRING('string_name', {allowable_values : [5,12,43], sc_name : 'Mission Control 3'}));
+      expect(string.toSeqJson()).toEqual({ name: 'string_name', type: 'STRING' , allowable_values: [
+          5,
+          12,
+          43
+        ],sc_name : 'Mission Control 3'});
+
+      const enumm = Variable.new(ENUM('enum_name','ENUM_NAME', {allowable_ranges : [{min: 20, max : 100}], allowable_values : [1,30], sc_name : 'Mission Control 20'}));
+      expect(enumm.toSeqJson()).toEqual({ name: 'enum_name', enum_name : 'ENUM_NAME', type: 'ENUM', allowable_ranges: [
+          {
+            "max": 100,
+            "min": 20
+          }
+        ],
+        allowable_values: [
+          1,
+          30
+        ], sc_name : 'Mission Control 20' });
+    });
+
+    it('should convert to EDSL string from Command with Local/Parameter arguments', () => {
+      const local = Variable.new(FLOAT('temp'));
+      const command = CommandStem.new({
+        arguments: [{ temperature: local }],
+        stem: 'PREHEAT_OVEN',
+      });
+      expect(command.toSeqJson()).toEqual({
+        args: [{ name: 'temperature', type: 'symbol', value: 'temp' }],
+        stem: 'PREHEAT_OVEN',
+        time: { type: 'COMMAND_COMPLETE' },
+        type: 'command',
+      });
+    });
   });
 });
 
@@ -231,9 +309,15 @@ describe('Sequence', () => {
     });
 
     it('should convert with commands', () => {
+      const local = Variable.new(FLOAT('temp'));
+      local.setKind('locals')
+      const parameter = Variable.new(ENUM('duration', 'POSSIBLE_DURATION'));
+      parameter.setKind('parameters')
       const sequence = Sequence.new({
         seqId: 'test',
         metadata: {},
+        locals: [local],
+        parameters: [parameter],
         steps: [
           CommandStem.new({
             stem: 'TEST',
@@ -251,6 +335,17 @@ describe('Sequence', () => {
           }).METADATA({
             author: 'XXXXXXXXXXXXXXXXXXXXXXXXXX',
           }),
+          CommandStem.new({
+            stem: 'TEST',
+            arguments: {
+              temperature: local,
+              duration: parameter,
+            },
+
+            absoluteTime: doyToInstant('2021-001T00:00:00.000' as DOY_STRING),
+          }).METADATA({
+            author: 'ZZZZ',
+          }),
         ],
       });
 
@@ -258,7 +353,13 @@ describe('Sequence', () => {
   Sequence.new({
     seqId: 'test',
     metadata: {},
-    steps: [
+    locals: [
+      FLOAT('temp')
+    ],
+    parameters: [
+      ENUM('duration', 'POSSIBLE_DURATION')
+    ],
+    steps: ({ locals, parameters }) => ([
       A\`2020-001T00:00:00.000\`.TEST('string', 0, true),
       A\`2020-001T00:00:00.000\`.TEST({
         string: 'string',
@@ -268,7 +369,14 @@ describe('Sequence', () => {
       .METADATA({
         author: 'XXXXXXXXXXXXXXXXXXXXXXXXXX',
       }),
-    ],
+      A\`2021-001T00:00:00.000\`.TEST({
+        temperature: locals.temp,
+        duration: parameters.duration,
+      })
+      .METADATA({
+        author: 'ZZZZ',
+      }),
+    ]),
   });`);
     });
 

--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -7,6 +7,91 @@ export enum TimingTypes {
   COMMAND_COMPLETE = 'COMMAND_COMPLETE',
 }
 
+export enum VariableType {
+  FLOAT = 'FLOAT',
+  INT = 'INT',
+  STRING = 'STRING',
+  UINT = 'UINT',
+  ENUM = 'ENUM'
+}
+
+export type VariableOptions = {
+  name: string;
+  type: VariableType;
+  enum_name?: string | undefined;
+  allowable_values?: unknown[] | undefined;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  allowable_ranges?: VariableRange[] | undefined;
+  sc_name?: string | undefined;
+};
+// @ts-ignore : 'VariableDeclaration' found in JSON Spec
+export interface INT<N extends string> extends VariableDeclaration {
+  name: N;
+  type: VariableType.INT;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  allowable_ranges?: VariableRange[] | undefined;
+  allowable_values?: unknown[] | undefined;
+  sc_name?: string | undefined;
+}
+
+// @ts-ignore : 'VariableDeclaration' found in JSON Spec
+export interface UINT<N extends string> extends VariableDeclaration {
+  name: N;
+  type: VariableType.UINT;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  allowable_ranges?: VariableRange[] | undefined;
+  allowable_values?: unknown[] | undefined;
+  sc_name?: string | undefined;
+}
+
+// @ts-ignore : 'VariableDeclaration' found in JSON Spec
+export interface FLOAT<N extends string> extends VariableDeclaration {
+  name: N;
+  type: VariableType.FLOAT;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  allowable_ranges?: VariableRange[] | undefined;
+  allowable_values?: unknown[] | undefined;
+  sc_name?: string | undefined;
+}
+
+// @ts-ignore : 'VariableDeclaration' found in JSON Spec
+export interface STRING<N extends string> extends VariableDeclaration {
+  name: N;
+  type: VariableType.STRING;
+  allowable_values?: unknown[] | undefined;
+  sc_name?: string | undefined;
+}
+
+// @ts-ignore : 'VariableDeclaration' found in JSON Spec
+export interface ENUM<N extends string, E extends string> extends VariableDeclaration {
+  name: N;
+  enum_name: E;
+  type: VariableType.ENUM;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  allowable_ranges?: VariableRange[] | undefined;
+  allowable_values?: unknown[] | undefined;
+  sc_name?: string | undefined;
+}
+
+export type SequenceOptions = {
+  seqId: string;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  metadata: Metadata;
+
+  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+  locals?: [VariableDeclaration, ...VariableDeclaration[]];
+  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+  parameters?: [VariableDeclaration, ...VariableDeclaration[]];
+  // @ts-ignore : 'Step' found in JSON Spec
+  steps?: Step[];
+  // @ts-ignore : 'Request' found in JSON Spec
+  requests?: Request[];
+  // @ts-ignore : 'ImmediateCommand' found in JSON Spec
+  immediate_commands?: ImmediateCommand[];
+  // @ts-ignore : 'HardwareCommand' found in JSON Spec
+  hardware_commands?: HardwareCommand[];
+};
+
 // @ts-ignore : 'Args' found in JSON Spec
 export type CommandOptions<A extends Args[] | { [argName: string]: any } = [] | {}> = {
   stem: string;
@@ -75,25 +160,6 @@ export type GroundOptions = {
 
 export type Arrayable<T> = T | Arrayable<T>[];
 
-export interface SequenceOptions {
-  seqId: string;
-  // @ts-ignore : 'Metadata' found in JSON Spec
-  metadata: Metadata;
-
-  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-  locals?: [VariableDeclaration, ...VariableDeclaration[]];
-  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-  parameters?: [VariableDeclaration, ...VariableDeclaration[]];
-  // @ts-ignore : 'Step' found in JSON Spec
-  steps?: Step[];
-  // @ts-ignore : 'Request' found in JSON Spec
-  requests?: Request[];
-  // @ts-ignore : 'ImmediateCommand' found in JSON Spec
-  immediate_commands?: ImmediateCommand[];
-  // @ts-ignore : 'HardwareCommand' found in JSON Spec
-  hardware_commands?: HardwareCommand[];
-}
-
 declare global {
   // @ts-ignore : 'SeqJson' found in JSON Spec
   class Sequence implements SeqJson {
@@ -115,27 +181,42 @@ declare global {
     public readonly hardware_commands?: HardwareCommand[];
     [k: string]: unknown;
 
-    public static new(
-      opts:
-        | {
-            seqId: string;
-            // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-            locals?: [VariableDeclaration, ...VariableDeclaration[]];
-            // @ts-ignore : 'Metadata' found in JSON Spec
-            metadata: Metadata;
-            // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-            parameters?: [VariableDeclaration, ...VariableDeclaration[]];
+    public static new<
+        // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+        const Locals extends ReadonlyArray<VariableDeclaration>,
+        // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+        const Parameters extends ReadonlyArray<VariableDeclaration>,
+    >(
+        opts:
+            | {
+          seqId: string;
+          // @ts-ignore : 'Metadata' found in JSON Spec
+          metadata: Metadata;
+          locals?: Locals;
+          parameters?: Parameters;
+          steps: // @ts-ignore : 'Step' found in JSON Spec
+              | Step[]
+              | ((opts: {
+            /*Fancy way to map our array of objects to an object with name as key and type as value
+             * this needs to be inlined instead of extracted to a helper type alias so that monaco won't hide the underlying type behind the alias
+             */
+            locals: { [Index in Locals[number] as Index['name']]: Index['type'] };
+            parameters: { [Index in Parameters[number] as Index['name']]: Index['type'] };
             // @ts-ignore : 'Step' found in JSON Spec
-            steps?: Step[];
-            // @ts-ignore : 'Request' found in JSON Spec
-            requests?: Request[];
-            // @ts-ignore : 'ImmediateCommand' found in JSON Spec
-            immediate_commands?: ImmediateCommand[];
-            // @ts-ignore : 'HardwareCommand' found in JSON Spec
-            hardware_commands?: HardwareCommand[];
-          }
-        // @ts-ignore : 'SeqJson' found in JSON Spec
-        | SeqJson,
+          }) => Step[]);
+          // @ts-ignore : 'ImmediateCommand' found in JSON Spec
+          immediate_commands?: ImmediateCommand[];
+          // @ts-ignore : 'HardwareCommand' found in JSON Spec
+          hardware_commands?: HardwareCommand[];
+          // @ts-ignore : 'Request' found in JSON Spec
+          requests?: Request[] | ((opts : {
+            locals: { [Index in Locals[number] as Index['name']]: Index['type'] };
+            parameters: { [Index in Parameters[number] as Index['name']]: Index['type'] };
+            // @ts-ignore : 'Step' found in JSON Spec
+          }) => Request[]);
+        }
+            // @ts-ignore : 'SeqJson' found in JSON Spec
+            | SeqJson,
     ): Sequence;
 
     // @ts-ignore : 'SeqJson' found in JSON Spec
@@ -214,11 +295,6 @@ declare global {
     public GET_DESCRIPTION(): Description | undefined;
   }
 
-  const STEPS: {
-    GROUND_BLOCK: typeof GROUND_BLOCK;
-    GROUND_EVENT: typeof GROUND_EVENT;
-  };
-
   type Context = {};
   type ExpansionReturn = Arrayable<CommandStem>;
 
@@ -237,6 +313,69 @@ declare global {
   type F<BitLength extends 32 | 64> = number;
   type F32 = F<32>;
   type F64 = F<64>;
+
+  function INT<const N extends string>(name: N): INT<N>;
+  function INT<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): INT<N>;
+  function INT<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals?: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): INT<N>;
+
+  function UINT<const N extends string>(name: N): UINT<N>;
+  function UINT<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): UINT<N>;
+  function UINT<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals?: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): UINT<N>;
+
+  function FLOAT<const N extends string>(name: N): FLOAT<N>;
+  function FLOAT<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): FLOAT<N>;
+  function FLOAT<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals?: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): FLOAT<N>;
+
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  function STRING<const N extends string>(name: N): STRING<N>;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  function STRING<const N extends string>(
+      name: N,
+      optionals: { allowable_values?: unknown[]; sc_name?: string },
+  ): STRING<N>;
+  function STRING<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals?: { allowable_values?: unknown[]; sc_name?: string },
+  ): STRING<N>;
+
+  function ENUM<const N extends string, const E extends string>(name: N, enum_name: E): ENUM<N, E>;
+  function ENUM<const N extends string, const E extends string>(
+      name: N,
+      enum_name: E,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): ENUM<N, E>;
+  function ENUM<const N extends string, const E extends string>(
+      name: N,
+      enum_name: E,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals?: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): ENUM<N, E>;
 
   // @ts-ignore : 'Commands' found in generated code
   function A(...args: [TemplateStringsArray, ...string[]]): typeof Commands & typeof STEPS;
@@ -263,11 +402,12 @@ declare global {
   const C: typeof Commands & typeof STEPS;
 }
 
-/*
-		  ---------------------------------
-					  Sequence eDSL
-		  ---------------------------------
-		  */
+/**
+ *  ---------------------------------
+ * 			 Sequence eDSL
+ * ---------------------------------
+ */
+
 // @ts-ignore : 'SeqJson' found in JSON Spec
 export class Sequence implements SeqJson {
   public readonly id: string;
@@ -304,8 +444,97 @@ export class Sequence implements SeqJson {
     this.immediate_commands = opts.immediate_commands ?? undefined;
     this.hardware_commands = opts.hardware_commands ?? undefined;
   }
-  public static new(opts: SequenceOptions): Sequence {
-    return new Sequence(opts);
+
+  public static new<
+      // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+      const Locals extends ReadonlyArray<VariableDeclaration>,
+      // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+      const Parameters extends ReadonlyArray<VariableDeclaration>,
+  >(
+      opts:
+          | {
+        seqId: string;
+        // @ts-ignore : 'Metadata' found in JSON Spec
+        metadata: Metadata;
+        locals?: Locals;
+        parameters?: Parameters;
+        steps: // @ts-ignore : 'Step' found in JSON Spec
+            | Step[]
+            | ((opts: {
+          /*Fancy way to map our array of objects to an object with name as key and type as value
+           * this needs to be inlined instead of extracted to a helper type alias so that monaco won't hide the underlying type behind the alias
+           */
+          locals: { [Index in Locals[number] as Index['name']]: Index['type'] };
+          parameters: { [Index in Parameters[number] as Index['name']]: Index['type'] };
+          // @ts-ignore : 'Step' found in JSON Spec
+        }) => Step[]);
+        // @ts-ignore : 'ImmediateCommand' found in JSON Spec
+        immediate_commands?: ImmediateCommand[];
+        // @ts-ignore : 'HardwareCommand' found in JSON Spec
+        hardware_commands?: HardwareCommand[];
+        // @ts-ignore : 'Request' found in JSON Spec
+        requests?: Request[] | ((opts : {
+          locals: { [Index in Locals[number] as Index['name']]: Index['type'] };
+          parameters: { [Index in Parameters[number] as Index['name']]: Index['type'] };
+          // @ts-ignore : 'Step' found in JSON Spec
+        }) => Request[]);
+      }
+          // @ts-ignore : 'SeqJson' found in JSON Spec
+          | SeqJson,
+  ): Sequence {
+    if ('id' in opts) {
+      // @ts-ignore : 'SeqJson' found in JSON Spec
+      return new Sequence(opts as SeqJson);
+    } else {
+      /** Forcing the correct type for the undefined case */
+      const seqId = 'id' in opts ? opts.id : opts.seqId;
+      const metadata = opts.metadata;
+      const immediate_commands = opts.immediate_commands;
+      const hardware_commands = opts.hardware_commands;
+
+      const locals = opts.locals ?? ([] as unknown as Locals);
+      const parameters = opts.parameters ?? ([] as unknown as Parameters);
+
+      // @ts-ignore
+      const localsMap = locals.reduce((acc, declaration) => {
+        /* ts ignore here because we're very much NOT doing what we're telling TS we are, but it makes for good UX
+         * we're not actually passing the type property of the declaration, but the whole declaration
+         * This ensures we get a readable type in the steps function
+         */
+        // @ts-ignore
+        const variable = Variable.new({ name: declaration.name, type: declaration.type });
+        variable.setKind('locals');
+        acc[declaration.name] = variable;
+        return acc;
+      }, {} as { [Index in Locals[number] as Index['name']]: Index['type'] });
+
+      // @ts-ignore
+      const parametersMap = parameters.reduce((acc, declaration) => {
+        // ts ignore here because we're very much NOT doing what we're telling TS we are, but it makes for good UX
+        // @ts-ignore
+        const variable = Variable.new({ name: declaration.name, type: declaration.type });
+        variable.setKind('parameters');
+        acc[declaration.name] = variable;
+        return acc;
+      }, {} as { [Index in Parameters[number] as Index['name']]: Index['type'] });
+
+      const steps =
+          typeof opts.steps === 'function' ? opts.steps({ locals: localsMap, parameters: parametersMap }) : opts.steps;
+
+      const requests =
+          typeof opts.requests === 'function' ? opts.requests({ locals: localsMap, parameters: parametersMap }) : opts.requests;
+
+      return new Sequence({
+        seqId,
+        metadata,
+        locals: locals.length !== 0 ? [locals[0], ...locals.slice(1)] : undefined,
+        parameters: parameters.length !== 0 ? [parameters[0], ...parameters.slice(1)] : undefined,
+        steps,
+        immediate_commands,
+        hardware_commands,
+        requests
+      } as SequenceOptions);
+    }
   }
 
   // @ts-ignore : 'SeqJson' found in JSON Spec
@@ -321,9 +550,31 @@ export class Sequence implements SeqJson {
               return step;
             }),
           }
-        : {}),
-      ...(this.locals ? { locals: this.locals } : {}),
-      ...(this.parameters ? { parameters: this.parameters } : {}),
+          : {}),
+      ...(this.locals
+          ? {
+            locals: [
+              Variable.isVariable(this.locals[0]) ? Variable.new(this.locals[0]).toSeqJson() : this.locals[0],
+              ...this.locals.slice(1).map(local => {
+                if (Variable.isVariable(local)) return Variable.new(local).toSeqJson();
+                return local;
+              }),
+            ],
+          }
+          : {}),
+      ...(this.parameters
+          ? {
+            parameters: [
+              Variable.isVariable(this.parameters[0])
+                  ? Variable.new(this.parameters[0]).toSeqJson()
+                  : this.parameters[0],
+              ...this.parameters.slice(1).map(parameter => {
+                if (Variable.isVariable(parameter)) return Variable.new(parameter).toSeqJson();
+                return parameter;
+              }),
+            ],
+          }
+          : {}),
       ...(this.requests
         ? {
             requests: this.requests.map(request => {
@@ -401,37 +652,56 @@ export class Sequence implements SeqJson {
     // [C.ADD_WATER]
     const metadataString = Object.keys(this.metadata).length == 0 ? `{}` : `${objectToString(this.metadata)}`;
 
-    const localsString = this.locals ? `[\n${indent(this.locals.map(l => objectToString(l)).join(',\n'), 1)}\n]` : '';
+    const localsString = this.locals
+        ? '[\n' +
+        indent(
+            this.locals
+                .map(local => {
+                  if (local instanceof Variable) {
+                    return local.toEDSLString();
+                  } else if (Variable.isVariable(local)) {
+                    return Variable.new(local).toEDSLString();
+                  }
+                  return objectToString(local);
+                })
+                .join('\n'),
+            1,
+        ) +
+        '\n]'
+        : '';
+    //ex.
+    // `locals: [
+    //	ENUM('duration','WHEEL_DURATION'),
+    //  ]`;
 
     const parameterString = this.parameters
-      ? `[\n${indent(this.parameters.map(l => objectToString(l)).join(',\n'), 1)}\n]`
-      : '';
+        ? '[\n' +
+        indent(
+            this.parameters
+                .map(parameter => {
+                  if (parameter instanceof Variable) {
+                    return parameter.toEDSLString();
+                  } else if (Variable.isVariable(parameter)) {
+                    return Variable.new(parameter).toEDSLString();
+                  }
+                  return objectToString(parameter);
+                })
+                .join('\n'),
+            1,
+        ) +
+        '\n]'
+        : '';
     //ex.
     // `parameters: [
-    //   {
-    //     allowable_ranges: [
-    //       {
-    //         max: 3600,
-    //         min: 1,
-    //       },
-    //     ],
-    //     name: 'duration',
-    //     type: 'UINT',
-    //   }
-    // ]`;
+    //	FLOAT('duration', { sc_name : 'test'}),
+    //  ]`;
 
     const hardwareString = this.hardware_commands
       ? `[\n${indent(this.hardware_commands.map(h => (h as HardwareStem).toEDSLString()).join(',\n'), 1)}\n]`
       : '';
     //ex.
     // hardware_commands: [
-    //   {
-    //     description: 'FIRE THE PYROS',
-    //     metadata:{
-    //       author: 'rrgoetz',
-    //     },
-    //     stem: 'HDW_PYRO_ENGINE',
-    //   }
+    //   HWD_PYRO_BURN,
     // ],
 
     const immediateString =
@@ -451,18 +721,7 @@ export class Sequence implements SeqJson {
           '\n]'
         : '';
     //ex.
-    // immediate_commands: [
-    //   {
-    //     args: [
-    //       {
-    //         name: 'direction',
-    //         type: 'string',
-    //         value: 'FromStem',
-    //       },
-    //     ],
-    //     stem: 'PEEL_BANANA',
-    //   }
-    // ]
+    // immediate_commands: [ADD_WATER]
 
     const requestString = this.requests
       ? `[\n${indent(
@@ -522,39 +781,66 @@ export class Sequence implements SeqJson {
     }*/
 
     return (
-      `export default () =>\n` +
-      `${indent(`Sequence.new({`, 1)}\n` +
-      `${indent(`seqId: '${this.id}'`, 2)},\n` +
-      `${indent(`metadata: ${metadataString}`, 2)},\n` +
-      `${localsString.length !== 0 ? `${indent(`locals: ${localsString}`, 2)},\n` : ''}` +
-      `${parameterString.length !== 0 ? `${indent(`parameters: ${parameterString}`, 2)},\n` : ''}` +
-      `${commandsString.length !== 0 ? `${indent(`steps: ${commandsString}`, 2)},\n` : ''}` +
-      `${hardwareString.length !== 0 ? `${indent(`hardware_commands: ${hardwareString}`, 2)},\n` : ''}` +
-      `${immediateString.length !== 0 ? `${indent(`immediate_commands: ${immediateString}`, 2)},\n` : ''}` +
-      `${requestString.length !== 0 ? `${indent(`requests: ${requestString}`, 2)},\n` : ''}` +
-      `${indent(`});`, 1)}`
+        `export default () =>\n` +
+        `${indent(`Sequence.new({`, 1)}\n` +
+        `${indent(`seqId: '${this.id}'`, 2)},\n` +
+        `${indent(`metadata: ${metadataString}`, 2)},\n` +
+        `${localsString.length !== 0 ? `${indent(`locals: ${localsString}`, 2)},\n` : ''}` +
+        `${parameterString.length !== 0 ? `${indent(`parameters: ${parameterString}`, 2)},\n` : ''}` +
+        `${
+            commandsString.length !== 0 ? `${indent(`steps: ({ locals, parameters }) => (${commandsString}`, 2)}),\n` : ''
+        }` +
+        `${hardwareString.length !== 0 ? `${indent(`hardware_commands: ${hardwareString}`, 2)},\n` : ''}` +
+        `${immediateString.length !== 0 ? `${indent(`immediate_commands: ${immediateString}`, 2)},\n` : ''}` +
+        `${requestString.length !== 0 ? `${indent(`requests: ({ locals, parameters }) => (${requestString}`, 2)}),\n` : ''}` +
+        `${indent(`});`, 1)}`
     );
   }
 
   // @ts-ignore : 'Args' found in JSON Spec
   public static fromSeqJson(json: SeqJson): Sequence {
+    // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+    const localNames = json.locals !== undefined ? json.locals.map( (local : VariableDeclaration) => local.name) : []
+    // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+    const parameterNames = json.locals !== undefined ? json.parameters.map( (parameter : VariableDeclaration) => parameter.name) : []
+
     return Sequence.new({
-      seqId: json.id,
+      id: json.id,
       metadata: json.metadata,
       // @ts-ignore : 'Step' found in JSON Spec
       ...(json.steps
         ? {
             // @ts-ignore : 'Step' found in JSON Spec
             steps: json.steps.map((c: Step) => {
-              if (c.type === 'command') return CommandStem.fromSeqJson(c as CommandStem);
+              if (c.type === 'command') return CommandStem.fromSeqJson(c as CommandStem, localNames, parameterNames);
               else if (c.type === 'ground_block') return Ground_Block.fromSeqJson(c as Ground_Block);
               else if (c.type === 'ground_event') return Ground_Event.fromSeqJson(c as Ground_Event);
               return c;
             }),
           }
-        : {}),
-      ...(json.locals ? { locals: json.locals } : {}),
-      ...(json.parameters ? { parameters: json.parameters } : {}),
+          : {}),
+      ...(json.locals
+          ? {
+            locals: [
+              Variable.fromSeqJson(json.locals[0], 'locals'),
+              // @ts-ignore : 'l: Request' found in JSON Spec
+              ...json.locals.slice(1).map(l => {
+                return Variable.fromSeqJson(l, 'locals');
+              }),
+            ],
+          }
+          : {}),
+      ...(json.parameters
+          ? {
+            parameters: [
+              Variable.fromSeqJson(json.parameters[0], 'parameters'),
+              // @ts-ignore : 'l: Request' found in JSON Spec
+              ...json.parameters.slice(1).map(p => {
+                return Variable.fromSeqJson(p, 'parameters');
+              }),
+            ],
+          }
+          : {}),
       ...(json.requests
         ? {
             // @ts-ignore : 'r: Request' found in JSON Spec
@@ -568,7 +854,7 @@ export class Sequence implements SeqJson {
                 ...(r.metadata ? { metadata: r.metadata } : {}),
                 steps: [
                   r.steps[0].type === 'command'
-                    ? CommandStem.fromSeqJson(r.steps[0] as CommandStem)
+                    ? CommandStem.fromSeqJson(r.steps[0] as CommandStem,localNames, parameterNames)
                     : r.steps[0].type === 'ground_block'
                     ? // @ts-ignore : 'GroundBlock' found in JSON Spec
                       Ground_Block.fromSeqJson(r.steps[0] as GroundBlock)
@@ -578,7 +864,7 @@ export class Sequence implements SeqJson {
                     : r.steps[0],
                   // @ts-ignore : 'step : Step' found in JSON Spec
                   ...r.steps.slice(1).map(step => {
-                    if (step.type === 'command') return CommandStem.fromSeqJson(step as CommandStem);
+                    if (step.type === 'command') return CommandStem.fromSeqJson(step as CommandStem, localNames, parameterNames);
                     else if (step.type === 'ground_block') return Ground_Block.fromSeqJson(step as Ground_Block);
                     else if (step.type === 'ground_event') return Ground_Event.fromSeqJson(step as Ground_Event);
                     return step;
@@ -597,16 +883,278 @@ export class Sequence implements SeqJson {
       ...(json.hardware_commands
         ? // @ts-ignore : 'HardwareCommand' found in JSON Spec
           { hardware_commands: json.hardware_commands.map((h: HardwareCommand) => HardwareStem.fromSeqJson(h)) }
-        : {}),
-    });
+          : {}),
+      // @ts-ignore : 'SeqJson' found in JSON Spec
+    } as SeqJson);
   }
 }
 
-/*
-	  ---------------------------------
-				  STEPS eDSL
-	  ---------------------------------
-	  */
+/**
+ * ----------------------------------------
+ * 			Local and Parameters
+ * ----------------------------------------
+ */
+
+//@ts-ignore : 'VariableDeclaration: Request' found in JSON Spec
+export class Variable implements VariableDeclaration {
+  name: string;
+  type: VariableType;
+
+  [k: string]: unknown;
+  private kind: 'locals' | 'parameters' | 'unknown' = 'locals';
+  private readonly _enum_name?: string | undefined;
+  // @ts-ignore : 'VariableRange: Request' found in JSON Spec
+  private readonly _allowable_ranges?: VariableRange[] | undefined;
+  private readonly _allowable_values?: unknown[] | undefined;
+  private readonly _sc_name?: string | undefined;
+
+  constructor(opts: VariableOptions) {
+    this.name = opts.name;
+    this.type = opts.type;
+
+    this._enum_name = opts.enum_name ?? undefined;
+    this._allowable_ranges = opts.allowable_ranges ?? undefined;
+    this._allowable_values = opts.allowable_values ?? undefined;
+    this._sc_name = opts.sc_name ?? undefined;
+  }
+
+  public static new(opts: VariableOptions): Variable {
+    return new Variable(opts);
+  }
+
+  public static isVariable(obj: any): obj is Variable {
+    return obj && typeof obj === 'object' && obj.hasOwnProperty('name') && obj.hasOwnProperty('type');
+  }
+
+  public setKind(kind: 'locals' | 'parameters' | 'unknown') {
+    this.kind = kind;
+  }
+
+  // @ts-ignore : 'Command' found in JSON Spec
+  public toSeqJson(): VariableDeclaration {
+    let error;
+    //check if type ENUM has ENUM_NAME set
+    if (this.type === 'ENUM' && !this._enum_name) {
+      error = `$$ERROR$$: 'enum_name' is required for ENUM type.`;
+    }
+    // check if type ins't ENUM but has a ENUM_NAME set
+    if (this.type !== 'ENUM' && this._enum_name) {
+      error = `$$ERROR$$: 'enum_name: ${this._enum_name}' is not required for non-ENUM type.`;
+    }
+    // check if type is STRING but has allowable_ranges set
+    if (this.type === 'STRING' && this._allowable_ranges) {
+      error = `$$ERROR$$: 'allowable_ranges' is not required for STRING type.`;
+    }
+
+    return {
+      name: error ? error : this.name,
+      type: this.type,
+      ...(this._enum_name && { enum_name: this._enum_name }),
+      ...(this._allowable_ranges && {
+        allowable_ranges: this._allowable_ranges.map(range => {
+          return {
+            min: range.min,
+            max: range.max,
+          };
+        }),
+      }),
+      ...(this._allowable_values && { allowable_values: this._allowable_values }),
+      ...(this._sc_name && { sc_name: this._sc_name })
+    };
+  }
+
+  // @ts-ignore : 'VariableDeclaration: Request' found in JSON Spec
+  public static fromSeqJson(json: VariableDeclaration, kind: 'locals' | 'parameters' | 'unknown'): Variable {
+    const variable = new Variable({
+      name: json.name,
+      type: json.type as VariableType,
+      ...(json.enum_name ? { enum_name: json.enum_name } : {}),
+      ...(json.allowable_ranges ? { allowable_ranges: json.allowable_ranges } : {}),
+      ...(json.allowable_values ? { allowable_values: json.allowable_values } : {}),
+      ...(json.sc_name ? { sc_name: json.sc_name } : {}),
+    });
+    variable.setKind(kind);
+    return variable;
+  }
+
+  public toReferenceString(): string {
+    return `${this.kind}.${this.name}`;
+  }
+
+  public toEDSLString(): string {
+    const types = ['FLOAT', 'UINT', 'INT', 'STRING', 'ENUM'];
+    const type = types.includes(this.type) ? this.type : 'UNKNOWN';
+    switch (type) {
+      case 'FLOAT':
+      case 'UINT':
+      case 'INT':
+        return `${type}('${this.name}'${
+            this._allowable_ranges || this._allowable_values || this._sc_name
+                ? ', ' +
+                objectToString({
+                  ...(this._allowable_ranges ? { allowable_ranges: this._allowable_ranges } : {}),
+                  ...(this._allowable_values ? { allowable_values: this._allowable_values } : {}),
+                  ...(this._sc_name ? { sc_name: this._sc_name } : {}),
+                }) +
+                ')'
+                : ')'
+        }`;
+      case 'STRING':
+        return `${type}('${this.name}'${
+            this._allowable_ranges || this._allowable_values || this._sc_name
+                ? ', ' +
+                objectToString({
+                  ...(this._allowable_values ? { allowable_values: this._allowable_values } : {}),
+                  ...(this._sc_name ? { sc_name: this._sc_name } : {}),
+                }) +
+                ')'
+                : ')'
+        }`;
+      case 'ENUM':
+        return `${type}('${this.name}', '${this._enum_name}'${
+            this._allowable_ranges || this._allowable_values || this._sc_name
+                ? ', ' +
+                objectToString({
+                  ...(this._allowable_ranges ? { allowable_ranges: this._allowable_ranges } : {}),
+                  ...(this._allowable_values ? { allowable_values: this._allowable_values } : {}),
+                  ...(this._sc_name ? { sc_name: this._sc_name } : {}),
+                }) +
+                ')'
+                : ')'
+        }`;
+      default:
+        return `${type}(${this.name}${this._enum_name ? ', ' + this._enum_name : ''}${
+            this._allowable_ranges || this._allowable_values || this._sc_name
+                ? ', ' +
+                objectToString({
+                  ...(this._allowable_ranges ? { allowable_ranges: this._allowable_ranges } : {}),
+                  ...(this._allowable_values ? { allowable_values: this._allowable_values } : {}),
+                  ...(this._sc_name ? { sc_name: this._sc_name } : {}),
+                })
+                : ''
+        })`;
+    }
+  }
+}
+
+export function INT<N extends string>(name: N): INT<N>;
+export function INT<N extends string>(
+    name: N,
+    optionals: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): INT<N>;
+export function INT<N extends string>(
+    name: N,
+    optionals?: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): INT<N> {
+  const { allowable_ranges, allowable_values, sc_name } = optionals || {};
+  return { name, type: VariableType.INT, allowable_ranges, allowable_values, sc_name };
+}
+
+export function UINT<N extends string>(name: N): UINT<N>;
+export function UINT<N extends string>(
+    name: N,
+    optionals: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): UINT<N>;
+export function UINT<N extends string>(
+    name: N,
+    optionals?: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): UINT<N> {
+  const { allowable_ranges, allowable_values, sc_name } = optionals || {};
+  return { name, type: VariableType.UINT, allowable_ranges, allowable_values, sc_name };
+}
+
+export function FLOAT<N extends string>(name: N): FLOAT<N>;
+export function FLOAT<N extends string>(
+    name: N,
+    optionals: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): FLOAT<N>;
+export function FLOAT<N extends string>(
+    name: N,
+    optionals?: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): FLOAT<N> {
+  const { allowable_ranges, allowable_values, sc_name } = optionals || {};
+  return { name, type: VariableType.FLOAT, allowable_ranges, allowable_values, sc_name };
+}
+
+export function STRING<N extends string>(name: N): STRING<N>;
+export function STRING<N extends string>(
+    name: N,
+    optionals: {
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): STRING<N>;
+export function STRING<N extends string>(
+    name: N,
+    optionals?: {
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): STRING<N> {
+  const { allowable_values, sc_name } = optionals || {};
+  return { name, type: VariableType.STRING, allowable_values, sc_name };
+}
+
+export function ENUM<const N extends string, const E extends string>(name: N, enum_name: E): ENUM<N, E>;
+export function ENUM<const N extends string, const E extends string>(
+    name: N,
+    enum_name: E,
+    optionals?: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): ENUM<N, E>;
+export function ENUM<const N extends string, const E extends string>(
+    name: N,
+    enum_name: E,
+    optionals?: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): ENUM<N, E> {
+  const { allowable_ranges, allowable_values, sc_name } = optionals || {};
+  return { name, enum_name, type: VariableType.ENUM, allowable_ranges, allowable_values, sc_name };
+}
+
+/**
+ * ---------------------------------
+ *        STEPS eDSL
+ * ---------------------------------
+ */
 
 // @ts-ignore : 'Args' found in JSON Spec
 export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
@@ -741,8 +1289,12 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
     };
   }
 
-  // @ts-ignore : 'Command' found in JSON Spec
-  public static fromSeqJson(json: Command): CommandStem {
+  public static fromSeqJson(
+      // @ts-ignore : 'Command' found in JSON Spec
+      json: Command,
+      localNames?: string[],
+      parameterNames?: string[],
+  ): CommandStem {
     const timeValue =
       json.time.type === TimingTypes.ABSOLUTE
         ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
@@ -754,7 +1306,7 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
 
     return CommandStem.new({
       stem: json.stem,
-      arguments: convertInterfacesToArgs(json.args),
+      arguments: convertInterfacesToArgs(json.args, localNames, parameterNames),
       metadata: json.metadata,
       models: json.models,
       description: json.description,
@@ -876,10 +1428,10 @@ export class ImmediateStem<A extends Args[] | { [argName: string]: any } = [] | 
   }
 
   // @ts-ignore : 'Command' found in JSON Spec
-  public static fromSeqJson(json: ImmediateCommand): ImmediateStem {
+  public static fromSeqJson(json: ImmediateCommand, localNames?: string[], parameterNames?: string[]): ImmediateStem {
     return ImmediateStem.new({
       stem: json.stem,
-      arguments: convertInterfacesToArgs(json.args),
+      arguments: convertInterfacesToArgs(json.args, localNames, parameterNames),
       metadata: json.metadata,
       description: json.description,
     });
@@ -1398,9 +1950,11 @@ export const STEPS = {
   GROUND_EVENT: GROUND_EVENT,
 };
 
-/*-----------------------------------
-		HW Commands
-	  ------------------------------------- */
+/**
+ * -----------------------------------
+ *        HW Commands
+ * -----------------------------------
+ */
 // @ts-ignore : 'HardwareCommand' found in JSON Spec
 export class HardwareStem implements HardwareCommand {
   public readonly stem: string;
@@ -1476,11 +2030,11 @@ export class HardwareStem implements HardwareCommand {
   }
 }
 
-/*
-	  ---------------------------------
-			  Time Utilities
-	  ---------------------------------
-	  */
+/**
+ *---------------------------------
+ *      Time Utilities
+ *---------------------------------
+ */
 
 export type DOY_STRING = string & { __brand: 'DOY_STRING' };
 export type HMS_STRING = string & { __brand: 'HMS_STRING' };
@@ -1680,11 +2234,11 @@ function commandsWithTimeValue<T extends TimingTypes>(
   };
 }
 
-/*
-	  ---------------------------------
-			  Utility Functions
-	  ---------------------------------
-	  */
+/**
+ * ---------------------------------
+ *      Utility Functions
+ * ---------------------------------
+ */
 
 // @ts-ignore : Used in generated code
 function sortCommandArguments(args: { [argName: string]: any }, order: string[]): { [argName: string]: any } {
@@ -1744,7 +2298,7 @@ function argumentsToString<A extends Args[] | { [argName: string]: any } = [] | 
  * @param interfaces
  */
 // @ts-ignore : `Args` found in JSON Spec
-function convertInterfacesToArgs(interfaces: Args): {} | [] {
+function convertInterfacesToArgs(interfaces: Args, localNames?: String[], parameterNames?: String[]): {} | [] {
   const args = interfaces.length === 0 ? [] : {};
 
   // Use to prevent a Remote property injection attack
@@ -1755,50 +2309,65 @@ function convertInterfacesToArgs(interfaces: Args): {} | [] {
   };
 
   const convertedArgs = interfaces.map(
-    (
-      // @ts-ignore : found in JSON Spec
-      arg: StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument | RepeatArgument,
-    ) => {
-      // @ts-ignore : 'RepeatArgument' found in JSON Spec
-      if (arg.type === 'repeat') {
-        if (validate(arg.name)) {
-          // @ts-ignore : 'RepeatArgument' found in JSON Spec
-          return {
-            [arg.name]: arg.value.map(
-              (
-                // @ts-ignore : found in JSON Spec
-                repeatArgBundle: (StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument)[],
-              ) =>
-                repeatArgBundle.reduce((obj, item) => {
-                  if (validate(item.name)) {
-                    obj[item.name] = item.value;
-                  }
-                  return obj;
-                }, {}),
-            ),
-          };
-        }
-        return { repeat_error: 'Remote property injection detected...' };
-      } else if (arg.type === 'symbol') {
-        if (validate(arg.name)) {
-          // @ts-ignore : 'SymbolArgument' found in JSON Spec
-          return { [arg.name]: { symbol: arg.value } };
-        }
-        return { symbol_error: 'Remote property injection detected...' };
-        // @ts-ignore : 'HexArgument' found in JSON Spec
-      } else if (arg.type === 'hex') {
-        if (validate(arg.name)) {
+      (
+          // @ts-ignore : found in JSON Spec
+          arg: StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument | RepeatArgument,
+      ) => {
+        // @ts-ignore : 'RepeatArgument' found in JSON Spec
+        if (arg.type === 'repeat') {
+          if (validate(arg.name)) {
+            // @ts-ignore : 'RepeatArgument' found in JSON Spec
+            return {
+              [arg.name]: arg.value.map(
+                  (
+                      // @ts-ignore : found in JSON Spec
+                      repeatArgBundle: (StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument)[],
+                  ) =>
+                      repeatArgBundle.reduce((obj, item) => {
+                        if (validate(item.name)) {
+                          obj[item.name] = item.value;
+                        }
+                        return obj;
+                      }, {}),
+              ),
+            };
+          }
+          return { repeat_error: 'Remote property injection detected...' };
+        } else if (arg.type === 'symbol') {
+          if (validate(arg.name)) {
+            /**
+             * We don't have access to the actual type of the variable, as it's not included in
+             * the sequential JSON. However, we don't need the type at this point in the code. Instead,
+             * we create a variable object with a default type of "INT". Later on in the code, the
+             * variable will be used to generate "local.<name>" or "parameter.<name>" syntax in the toEDSLString() method.
+             */
+            let variable = Variable.new({ name: arg.value, type: VariableType.INT });
+            if (localNames && localNames.includes(arg.value)) {
+              variable.setKind('locals');
+            } else if (parameterNames && parameterNames.includes(arg.value)) {
+              variable.setKind('parameters');
+            } else {
+              const errorMsg = `Variable '${arg.value}' is not defined as a local or parameter`;
+              variable = Variable.new({ name: `${arg.value} //ERROR: ${errorMsg}`, type: VariableType.INT });
+              variable.setKind('unknown');
+            }
+            return { [arg.name]: variable };
+          }
+          return { symbol_error: 'Remote property injection detected...' };
           // @ts-ignore : 'HexArgument' found in JSON Spec
-          return { [arg.name]: { hex: arg.value } };
+        } else if (arg.type === 'hex') {
+          if (validate(arg.name)) {
+            // @ts-ignore : 'HexArgument' found in JSON Spec
+            return { [arg.name]: { hex: arg.value } };
+          }
+          return { hex_error: 'Remote property injection detected...' };
+        } else {
+          if (validate(arg.name)) {
+            return { [arg.name]: arg.value };
+          }
+          return { error: 'Remote property injection detected...' };
         }
-        return { hex_error: 'Remote property injection detected...' };
-      } else {
-        if (validate(arg.name)) {
-          return { [arg.name]: arg.value };
-        }
-        return { error: 'Remote property injection detected...' };
-      }
-    },
+      },
   );
 
   for (const key in convertedArgs) {
@@ -1849,15 +2418,30 @@ function convertValueToObject(value: any, key: string): any {
     case 'boolean':
       return { type: 'boolean', value: value, name: key };
     default:
-      if (value instanceof Object && value.symbol && value.symbol === 'string') {
-        return { type: 'symbol', value: value, name: key };
+      if (
+          value instanceof Object &&
+          'name' in value &&
+          'type' in value &&
+          (value.type === 'FLOAT' ||
+              value.type === 'INT' ||
+              value.type === 'STRING' ||
+              value.type === 'UINT' ||
+              value.type === 'ENUM')
+      ) {
+        return { type: 'symbol', value: value.name, name: key };
       } else if (
-        value instanceof Object &&
-        value.hex &&
-        value.hex === 'string' &&
-        new RegExp('^0x([0-9A-F])+$').test(value.hex)
+          value instanceof Object &&
+          value.hex &&
+          value.hex === 'string' &&
+          new RegExp('^0x([0-9A-F])+$').test(value.hex)
       ) {
         return { type: 'hex', value: value, name: key };
+      } else {
+        return {
+          type: typeof value,
+          value: `${key} is an unknown value`,
+          name: `$$ERROR$$`,
+        };
       }
   }
 }
@@ -1890,11 +2474,16 @@ function objectToString(obj: any, indentLevel: number = 1): string {
         indentLevel--;
         output += indent(`],`, indentLevel) + '\n';
       } else if (typeof value === 'object') {
-        output += indent(`${key}:{`, indentLevel) + '\n';
-        indentLevel++;
-        print(value);
-        indentLevel--;
-        output += indent(`},`, indentLevel) + '\n';
+        //value is a Local or Parameter
+        if (value instanceof Variable) {
+          output += indent(`${key}: ${value.toReferenceString()}`, indentLevel) + ',\n';
+        } else {
+          output += indent(`${key}:{`, indentLevel) + '\n';
+          indentLevel++;
+          print(value);
+          indentLevel--;
+          output += indent(`},`, indentLevel) + '\n';
+        }
       } else {
         output += indent(`${key}: ${typeof value === 'string' ? `'${value}'` : value},`, indentLevel) + '\n';
       }

--- a/sequencing-server/src/lib/codegen/CommandTypeCodegen.ts
+++ b/sequencing-server/src/lib/codegen/CommandTypeCodegen.ts
@@ -57,7 +57,7 @@ export const Hardwares = {\n${dictionary.hwCommands
     .map(hwCommands => `\t\t${hwCommands.stem}: ${hwCommands.stem},\n`)
     .join('')}};
 
-Object.assign(globalThis, { A:A, R:R, E:E, C:Object.assign(Commands, STEPS), Sequence}, Hardwares, Immediates);
+Object.assign(globalThis, { A:A, R:R, E:E, C:Object.assign(Commands, STEPS), Sequence, FLOAT, UINT,INT, STRING, ENUM}, Hardwares, Immediates);
 `;
 
   return {
@@ -139,7 +139,9 @@ function ${fswCommandName}(...args: [{ ${argsWithType.map(arg => arg.name + ': '
     arguments: args
   }) as ${fswCommandName}_IMMEDIATE;
 }
-function ${fswCommandName}_STEP(...args: [{ ${argsWithType.map(arg => arg.name + ': ' + arg.type).join(',')} }]) {
+function ${fswCommandName}_STEP(...args: [{ ${argsWithType
+    .map(arg => arg.name + ': ' + arg.type + `${argumentTypeToVariable(arg.type)}`)
+    .join(',')} }]) {
   return CommandStem.new({
     stem: '${fswCommandName}',
     arguments: sortCommandArguments(args, argumentOrders['${fswCommandName}'])
@@ -151,7 +153,7 @@ function ${fswCommandName}_STEP(...args: [{ ${argsWithType.map(arg => arg.name +
     .map(arg => arg.name + ': ' + arg.type)
     .join(',')} }] ]> {}
 \tinterface ${fswCommandName}_STEP extends CommandStem<[ [{ ${argsWithType
-    .map(arg => arg.name + ': ' + arg.type)
+    .map(arg => arg.name + ': ' + arg.type + `${argumentTypeToVariable(arg.type)}`)
     .join(',')} }] ]> {}
 \tfunction ${fswCommandName}(...args: [{ ${argsWithType
     .map(arg => arg.name + ': ' + arg.type)
@@ -163,6 +165,25 @@ function ${fswCommandName}_STEP(...args: [{ ${argsWithType.map(arg => arg.name +
   };
 }
 
+/**
+ * Match the argument types in the command dictionary with the corresponding variable types
+ * for both local and parameter in the seqjson specification.
+ */
+function argumentTypeToVariable(argumentType : string) : string{
+  if (argumentType.startsWith('F')) {
+    return "| 'FLOAT'";
+  } else if (argumentType.startsWith('I')) {
+    return "| 'INT'";
+  } else if (argumentType.startsWith('U')) {
+    return "| 'UINT'";
+  } else if (argumentType.startsWith('VarString')) {
+    return "| 'STRING'";
+  } else if (argumentType.startsWith('(')) {
+    return "| 'ENUM'";
+  } else {
+    return ''
+  }
+}
 function generateHwCommandCode(hwCommand: ampcs.HwCommand): { value: string; interfaces: string } {
   const needsUnderscore =
     /^\d/.test(hwCommand.stem) ||

--- a/sequencing-server/src/routes/seqjson.ts
+++ b/sequencing-server/src/routes/seqjson.ts
@@ -215,7 +215,7 @@ seqjsonRouter.post('/get-seqjson-for-seqid-and-simulation-dataset', async (req, 
     }
     return {
       ...ai,
-      commands: row.commands?.map(CommandStem.fromSeqJson) ?? null,
+      commands: row.commands?.map(c => CommandStem.fromSeqJson(c)) ?? null,
       errors: row.errors,
     };
   });
@@ -374,7 +374,7 @@ seqjsonRouter.post('/bulk-get-seqjson-for-seqid-and-simulation-dataset', async (
         }
         return {
           ...ai,
-          commands: row.commands?.map(CommandStem.fromSeqJson) ?? null,
+          commands: row.commands?.map(c => CommandStem.fromSeqJson(c)) ?? null,
           errors: row.errors,
         };
       });

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -10,6 +10,91 @@ export enum TimingTypes {
   COMMAND_COMPLETE = 'COMMAND_COMPLETE',
 }
 
+export enum VariableType {
+  FLOAT = 'FLOAT',
+  INT = 'INT',
+  STRING = 'STRING',
+  UINT = 'UINT',
+  ENUM = 'ENUM'
+}
+
+export type VariableOptions = {
+  name: string;
+  type: VariableType;
+  enum_name?: string | undefined;
+  allowable_values?: unknown[] | undefined;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  allowable_ranges?: VariableRange[] | undefined;
+  sc_name?: string | undefined;
+};
+// @ts-ignore : 'VariableDeclaration' found in JSON Spec
+export interface INT<N extends string> extends VariableDeclaration {
+  name: N;
+  type: VariableType.INT;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  allowable_ranges?: VariableRange[] | undefined;
+  allowable_values?: unknown[] | undefined;
+  sc_name?: string | undefined;
+}
+
+// @ts-ignore : 'VariableDeclaration' found in JSON Spec
+export interface UINT<N extends string> extends VariableDeclaration {
+  name: N;
+  type: VariableType.UINT;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  allowable_ranges?: VariableRange[] | undefined;
+  allowable_values?: unknown[] | undefined;
+  sc_name?: string | undefined;
+}
+
+// @ts-ignore : 'VariableDeclaration' found in JSON Spec
+export interface FLOAT<N extends string> extends VariableDeclaration {
+  name: N;
+  type: VariableType.FLOAT;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  allowable_ranges?: VariableRange[] | undefined;
+  allowable_values?: unknown[] | undefined;
+  sc_name?: string | undefined;
+}
+
+// @ts-ignore : 'VariableDeclaration' found in JSON Spec
+export interface STRING<N extends string> extends VariableDeclaration {
+  name: N;
+  type: VariableType.STRING;
+  allowable_values?: unknown[] | undefined;
+  sc_name?: string | undefined;
+}
+
+// @ts-ignore : 'VariableDeclaration' found in JSON Spec
+export interface ENUM<N extends string, E extends string> extends VariableDeclaration {
+  name: N;
+  enum_name: E;
+  type: VariableType.ENUM;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  allowable_ranges?: VariableRange[] | undefined;
+  allowable_values?: unknown[] | undefined;
+  sc_name?: string | undefined;
+}
+
+export type SequenceOptions = {
+  seqId: string;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  metadata: Metadata;
+
+  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+  locals?: [VariableDeclaration, ...VariableDeclaration[]];
+  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+  parameters?: [VariableDeclaration, ...VariableDeclaration[]];
+  // @ts-ignore : 'Step' found in JSON Spec
+  steps?: Step[];
+  // @ts-ignore : 'Request' found in JSON Spec
+  requests?: Request[];
+  // @ts-ignore : 'ImmediateCommand' found in JSON Spec
+  immediate_commands?: ImmediateCommand[];
+  // @ts-ignore : 'HardwareCommand' found in JSON Spec
+  hardware_commands?: HardwareCommand[];
+};
+
 // @ts-ignore : 'Args' found in JSON Spec
 export type CommandOptions<A extends Args[] | { [argName: string]: any } = [] | {}> = {
   stem: string;
@@ -78,25 +163,6 @@ export type GroundOptions = {
 
 export type Arrayable<T> = T | Arrayable<T>[];
 
-export interface SequenceOptions {
-  seqId: string;
-  // @ts-ignore : 'Metadata' found in JSON Spec
-  metadata: Metadata;
-
-  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-  locals?: [VariableDeclaration, ...VariableDeclaration[]];
-  // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-  parameters?: [VariableDeclaration, ...VariableDeclaration[]];
-  // @ts-ignore : 'Step' found in JSON Spec
-  steps?: Step[];
-  // @ts-ignore : 'Request' found in JSON Spec
-  requests?: Request[];
-  // @ts-ignore : 'ImmediateCommand' found in JSON Spec
-  immediate_commands?: ImmediateCommand[];
-  // @ts-ignore : 'HardwareCommand' found in JSON Spec
-  hardware_commands?: HardwareCommand[];
-}
-
 declare global {
   // @ts-ignore : 'SeqJson' found in JSON Spec
   class Sequence implements SeqJson {
@@ -118,27 +184,42 @@ declare global {
     public readonly hardware_commands?: HardwareCommand[];
     [k: string]: unknown;
 
-    public static new(
-      opts:
-        | {
-            seqId: string;
-            // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-            locals?: [VariableDeclaration, ...VariableDeclaration[]];
-            // @ts-ignore : 'Metadata' found in JSON Spec
-            metadata: Metadata;
-            // @ts-ignore : 'VariableDeclaration' found in JSON Spec
-            parameters?: [VariableDeclaration, ...VariableDeclaration[]];
+    public static new<
+        // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+        const Locals extends ReadonlyArray<VariableDeclaration>,
+        // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+        const Parameters extends ReadonlyArray<VariableDeclaration>,
+    >(
+        opts:
+            | {
+          seqId: string;
+          // @ts-ignore : 'Metadata' found in JSON Spec
+          metadata: Metadata;
+          locals?: Locals;
+          parameters?: Parameters;
+          steps: // @ts-ignore : 'Step' found in JSON Spec
+              | Step[]
+              | ((opts: {
+            /*Fancy way to map our array of objects to an object with name as key and type as value
+             * this needs to be inlined instead of extracted to a helper type alias so that monaco won't hide the underlying type behind the alias
+             */
+            locals: { [Index in Locals[number] as Index['name']]: Index['type'] };
+            parameters: { [Index in Parameters[number] as Index['name']]: Index['type'] };
             // @ts-ignore : 'Step' found in JSON Spec
-            steps?: Step[];
-            // @ts-ignore : 'Request' found in JSON Spec
-            requests?: Request[];
-            // @ts-ignore : 'ImmediateCommand' found in JSON Spec
-            immediate_commands?: ImmediateCommand[];
-            // @ts-ignore : 'HardwareCommand' found in JSON Spec
-            hardware_commands?: HardwareCommand[];
-          }
-        // @ts-ignore : 'SeqJson' found in JSON Spec
-        | SeqJson,
+          }) => Step[]);
+          // @ts-ignore : 'ImmediateCommand' found in JSON Spec
+          immediate_commands?: ImmediateCommand[];
+          // @ts-ignore : 'HardwareCommand' found in JSON Spec
+          hardware_commands?: HardwareCommand[];
+          // @ts-ignore : 'Request' found in JSON Spec
+          requests?: Request[] | ((opts : {
+            locals: { [Index in Locals[number] as Index['name']]: Index['type'] };
+            parameters: { [Index in Parameters[number] as Index['name']]: Index['type'] };
+            // @ts-ignore : 'Step' found in JSON Spec
+          }) => Request[]);
+        }
+            // @ts-ignore : 'SeqJson' found in JSON Spec
+            | SeqJson,
     ): Sequence;
 
     // @ts-ignore : 'SeqJson' found in JSON Spec
@@ -217,11 +298,6 @@ declare global {
     public GET_DESCRIPTION(): Description | undefined;
   }
 
-  const STEPS: {
-    GROUND_BLOCK: typeof GROUND_BLOCK;
-    GROUND_EVENT: typeof GROUND_EVENT;
-  };
-
   type Context = {};
   type ExpansionReturn = Arrayable<CommandStem>;
 
@@ -240,6 +316,69 @@ declare global {
   type F<BitLength extends 32 | 64> = number;
   type F32 = F<32>;
   type F64 = F<64>;
+
+  function INT<const N extends string>(name: N): INT<N>;
+  function INT<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): INT<N>;
+  function INT<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals?: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): INT<N>;
+
+  function UINT<const N extends string>(name: N): UINT<N>;
+  function UINT<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): UINT<N>;
+  function UINT<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals?: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): UINT<N>;
+
+  function FLOAT<const N extends string>(name: N): FLOAT<N>;
+  function FLOAT<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): FLOAT<N>;
+  function FLOAT<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals?: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): FLOAT<N>;
+
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  function STRING<const N extends string>(name: N): STRING<N>;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  function STRING<const N extends string>(
+      name: N,
+      optionals: { allowable_values?: unknown[]; sc_name?: string },
+  ): STRING<N>;
+  function STRING<const N extends string>(
+      name: N,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals?: { allowable_values?: unknown[]; sc_name?: string },
+  ): STRING<N>;
+
+  function ENUM<const N extends string, const E extends string>(name: N, enum_name: E): ENUM<N, E>;
+  function ENUM<const N extends string, const E extends string>(
+      name: N,
+      enum_name: E,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): ENUM<N, E>;
+  function ENUM<const N extends string, const E extends string>(
+      name: N,
+      enum_name: E,
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      optionals?: { allowable_ranges?: VariableRange[]; allowable_values?: unknown[]; sc_name?: string },
+  ): ENUM<N, E>;
 
   // @ts-ignore : 'Commands' found in generated code
   function A(...args: [TemplateStringsArray, ...string[]]): typeof Commands & typeof STEPS;
@@ -266,11 +405,12 @@ declare global {
   const C: typeof Commands & typeof STEPS;
 }
 
-/*
-		  ---------------------------------
-					  Sequence eDSL
-		  ---------------------------------
-		  */
+/**
+ *  ---------------------------------
+ * 			 Sequence eDSL
+ * ---------------------------------
+ */
+
 // @ts-ignore : 'SeqJson' found in JSON Spec
 export class Sequence implements SeqJson {
   public readonly id: string;
@@ -307,8 +447,97 @@ export class Sequence implements SeqJson {
     this.immediate_commands = opts.immediate_commands ?? undefined;
     this.hardware_commands = opts.hardware_commands ?? undefined;
   }
-  public static new(opts: SequenceOptions): Sequence {
-    return new Sequence(opts);
+
+  public static new<
+      // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+      const Locals extends ReadonlyArray<VariableDeclaration>,
+      // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+      const Parameters extends ReadonlyArray<VariableDeclaration>,
+  >(
+      opts:
+          | {
+        seqId: string;
+        // @ts-ignore : 'Metadata' found in JSON Spec
+        metadata: Metadata;
+        locals?: Locals;
+        parameters?: Parameters;
+        steps: // @ts-ignore : 'Step' found in JSON Spec
+            | Step[]
+            | ((opts: {
+          /*Fancy way to map our array of objects to an object with name as key and type as value
+           * this needs to be inlined instead of extracted to a helper type alias so that monaco won't hide the underlying type behind the alias
+           */
+          locals: { [Index in Locals[number] as Index['name']]: Index['type'] };
+          parameters: { [Index in Parameters[number] as Index['name']]: Index['type'] };
+          // @ts-ignore : 'Step' found in JSON Spec
+        }) => Step[]);
+        // @ts-ignore : 'ImmediateCommand' found in JSON Spec
+        immediate_commands?: ImmediateCommand[];
+        // @ts-ignore : 'HardwareCommand' found in JSON Spec
+        hardware_commands?: HardwareCommand[];
+        // @ts-ignore : 'Request' found in JSON Spec
+        requests?: Request[] | ((opts : {
+          locals: { [Index in Locals[number] as Index['name']]: Index['type'] };
+          parameters: { [Index in Parameters[number] as Index['name']]: Index['type'] };
+          // @ts-ignore : 'Step' found in JSON Spec
+        }) => Request[]);
+      }
+          // @ts-ignore : 'SeqJson' found in JSON Spec
+          | SeqJson,
+  ): Sequence {
+    if ('id' in opts) {
+      // @ts-ignore : 'SeqJson' found in JSON Spec
+      return new Sequence(opts as SeqJson);
+    } else {
+      /** Forcing the correct type for the undefined case */
+      const seqId = 'id' in opts ? opts.id : opts.seqId;
+      const metadata = opts.metadata;
+      const immediate_commands = opts.immediate_commands;
+      const hardware_commands = opts.hardware_commands;
+
+      const locals = opts.locals ?? ([] as unknown as Locals);
+      const parameters = opts.parameters ?? ([] as unknown as Parameters);
+
+      // @ts-ignore
+      const localsMap = locals.reduce((acc, declaration) => {
+        /* ts ignore here because we're very much NOT doing what we're telling TS we are, but it makes for good UX
+         * we're not actually passing the type property of the declaration, but the whole declaration
+         * This ensures we get a readable type in the steps function
+         */
+        // @ts-ignore
+        const variable = Variable.new({ name: declaration.name, type: declaration.type });
+        variable.setKind('locals');
+        acc[declaration.name] = variable;
+        return acc;
+      }, {} as { [Index in Locals[number] as Index['name']]: Index['type'] });
+
+      // @ts-ignore
+      const parametersMap = parameters.reduce((acc, declaration) => {
+        // ts ignore here because we're very much NOT doing what we're telling TS we are, but it makes for good UX
+        // @ts-ignore
+        const variable = Variable.new({ name: declaration.name, type: declaration.type });
+        variable.setKind('parameters');
+        acc[declaration.name] = variable;
+        return acc;
+      }, {} as { [Index in Parameters[number] as Index['name']]: Index['type'] });
+
+      const steps =
+          typeof opts.steps === 'function' ? opts.steps({ locals: localsMap, parameters: parametersMap }) : opts.steps;
+
+      const requests =
+          typeof opts.requests === 'function' ? opts.requests({ locals: localsMap, parameters: parametersMap }) : opts.requests;
+
+      return new Sequence({
+        seqId,
+        metadata,
+        locals: locals.length !== 0 ? [locals[0], ...locals.slice(1)] : undefined,
+        parameters: parameters.length !== 0 ? [parameters[0], ...parameters.slice(1)] : undefined,
+        steps,
+        immediate_commands,
+        hardware_commands,
+        requests
+      } as SequenceOptions);
+    }
   }
 
   // @ts-ignore : 'SeqJson' found in JSON Spec
@@ -324,9 +553,31 @@ export class Sequence implements SeqJson {
               return step;
             }),
           }
-        : {}),
-      ...(this.locals ? { locals: this.locals } : {}),
-      ...(this.parameters ? { parameters: this.parameters } : {}),
+          : {}),
+      ...(this.locals
+          ? {
+            locals: [
+              Variable.isVariable(this.locals[0]) ? Variable.new(this.locals[0]).toSeqJson() : this.locals[0],
+              ...this.locals.slice(1).map(local => {
+                if (Variable.isVariable(local)) return Variable.new(local).toSeqJson();
+                return local;
+              }),
+            ],
+          }
+          : {}),
+      ...(this.parameters
+          ? {
+            parameters: [
+              Variable.isVariable(this.parameters[0])
+                  ? Variable.new(this.parameters[0]).toSeqJson()
+                  : this.parameters[0],
+              ...this.parameters.slice(1).map(parameter => {
+                if (Variable.isVariable(parameter)) return Variable.new(parameter).toSeqJson();
+                return parameter;
+              }),
+            ],
+          }
+          : {}),
       ...(this.requests
         ? {
             requests: this.requests.map(request => {
@@ -404,37 +655,56 @@ export class Sequence implements SeqJson {
     // [C.ADD_WATER]
     const metadataString = Object.keys(this.metadata).length == 0 ? \`{}\` : \`\${objectToString(this.metadata)}\`;
 
-    const localsString = this.locals ? \`[\\n\${indent(this.locals.map(l => objectToString(l)).join(',\\n'), 1)}\\n]\` : '';
+    const localsString = this.locals
+        ? '[\\n' +
+        indent(
+            this.locals
+                .map(local => {
+                  if (local instanceof Variable) {
+                    return local.toEDSLString();
+                  } else if (Variable.isVariable(local)) {
+                    return Variable.new(local).toEDSLString();
+                  }
+                  return objectToString(local);
+                })
+                .join('\\n'),
+            1,
+        ) +
+        '\\n]'
+        : '';
+    //ex.
+    // \`locals: [
+    //	ENUM('duration','WHEEL_DURATION'),
+    //  ]\`;
 
     const parameterString = this.parameters
-      ? \`[\\n\${indent(this.parameters.map(l => objectToString(l)).join(',\\n'), 1)}\\n]\`
-      : '';
+        ? '[\\n' +
+        indent(
+            this.parameters
+                .map(parameter => {
+                  if (parameter instanceof Variable) {
+                    return parameter.toEDSLString();
+                  } else if (Variable.isVariable(parameter)) {
+                    return Variable.new(parameter).toEDSLString();
+                  }
+                  return objectToString(parameter);
+                })
+                .join('\\n'),
+            1,
+        ) +
+        '\\n]'
+        : '';
     //ex.
     // \`parameters: [
-    //   {
-    //     allowable_ranges: [
-    //       {
-    //         max: 3600,
-    //         min: 1,
-    //       },
-    //     ],
-    //     name: 'duration',
-    //     type: 'UINT',
-    //   }
-    // ]\`;
+    //	FLOAT('duration', { sc_name : 'test'}),
+    //  ]\`;
 
     const hardwareString = this.hardware_commands
       ? \`[\\n\${indent(this.hardware_commands.map(h => (h as HardwareStem).toEDSLString()).join(',\\n'), 1)}\\n]\`
       : '';
     //ex.
     // hardware_commands: [
-    //   {
-    //     description: 'FIRE THE PYROS',
-    //     metadata:{
-    //       author: 'rrgoetz',
-    //     },
-    //     stem: 'HDW_PYRO_ENGINE',
-    //   }
+    //   HWD_PYRO_BURN,
     // ],
 
     const immediateString =
@@ -454,18 +724,7 @@ export class Sequence implements SeqJson {
           '\\n]'
         : '';
     //ex.
-    // immediate_commands: [
-    //   {
-    //     args: [
-    //       {
-    //         name: 'direction',
-    //         type: 'string',
-    //         value: 'FromStem',
-    //       },
-    //     ],
-    //     stem: 'PEEL_BANANA',
-    //   }
-    // ]
+    // immediate_commands: [ADD_WATER]
 
     const requestString = this.requests
       ? \`[\\n\${indent(
@@ -525,39 +784,66 @@ export class Sequence implements SeqJson {
     }*/
 
     return (
-      \`export default () =>\\n\` +
-      \`\${indent(\`Sequence.new({\`, 1)}\\n\` +
-      \`\${indent(\`seqId: '\${this.id}'\`, 2)},\\n\` +
-      \`\${indent(\`metadata: \${metadataString}\`, 2)},\\n\` +
-      \`\${localsString.length !== 0 ? \`\${indent(\`locals: \${localsString}\`, 2)},\\n\` : ''}\` +
-      \`\${parameterString.length !== 0 ? \`\${indent(\`parameters: \${parameterString}\`, 2)},\\n\` : ''}\` +
-      \`\${commandsString.length !== 0 ? \`\${indent(\`steps: \${commandsString}\`, 2)},\\n\` : ''}\` +
-      \`\${hardwareString.length !== 0 ? \`\${indent(\`hardware_commands: \${hardwareString}\`, 2)},\\n\` : ''}\` +
-      \`\${immediateString.length !== 0 ? \`\${indent(\`immediate_commands: \${immediateString}\`, 2)},\\n\` : ''}\` +
-      \`\${requestString.length !== 0 ? \`\${indent(\`requests: \${requestString}\`, 2)},\\n\` : ''}\` +
-      \`\${indent(\`});\`, 1)}\`
+        \`export default () =>\\n\` +
+        \`\${indent(\`Sequence.new({\`, 1)}\\n\` +
+        \`\${indent(\`seqId: '\${this.id}'\`, 2)},\\n\` +
+        \`\${indent(\`metadata: \${metadataString}\`, 2)},\\n\` +
+        \`\${localsString.length !== 0 ? \`\${indent(\`locals: \${localsString}\`, 2)},\\n\` : ''}\` +
+        \`\${parameterString.length !== 0 ? \`\${indent(\`parameters: \${parameterString}\`, 2)},\\n\` : ''}\` +
+        \`\${
+            commandsString.length !== 0 ? \`\${indent(\`steps: ({ locals, parameters }) => (\${commandsString}\`, 2)}),\\n\` : ''
+        }\` +
+        \`\${hardwareString.length !== 0 ? \`\${indent(\`hardware_commands: \${hardwareString}\`, 2)},\\n\` : ''}\` +
+        \`\${immediateString.length !== 0 ? \`\${indent(\`immediate_commands: \${immediateString}\`, 2)},\\n\` : ''}\` +
+        \`\${requestString.length !== 0 ? \`\${indent(\`requests: ({ locals, parameters }) => (\${requestString}\`, 2)}),\\n\` : ''}\` +
+        \`\${indent(\`});\`, 1)}\`
     );
   }
 
   // @ts-ignore : 'Args' found in JSON Spec
   public static fromSeqJson(json: SeqJson): Sequence {
+    // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+    const localNames = json.locals !== undefined ? json.locals.map( (local : VariableDeclaration) => local.name) : []
+    // @ts-ignore : 'VariableDeclaration' found in JSON Spec
+    const parameterNames = json.locals !== undefined ? json.parameters.map( (parameter : VariableDeclaration) => parameter.name) : []
+
     return Sequence.new({
-      seqId: json.id,
+      id: json.id,
       metadata: json.metadata,
       // @ts-ignore : 'Step' found in JSON Spec
       ...(json.steps
         ? {
             // @ts-ignore : 'Step' found in JSON Spec
             steps: json.steps.map((c: Step) => {
-              if (c.type === 'command') return CommandStem.fromSeqJson(c as CommandStem);
+              if (c.type === 'command') return CommandStem.fromSeqJson(c as CommandStem, localNames, parameterNames);
               else if (c.type === 'ground_block') return Ground_Block.fromSeqJson(c as Ground_Block);
               else if (c.type === 'ground_event') return Ground_Event.fromSeqJson(c as Ground_Event);
               return c;
             }),
           }
-        : {}),
-      ...(json.locals ? { locals: json.locals } : {}),
-      ...(json.parameters ? { parameters: json.parameters } : {}),
+          : {}),
+      ...(json.locals
+          ? {
+            locals: [
+              Variable.fromSeqJson(json.locals[0], 'locals'),
+              // @ts-ignore : 'l: Request' found in JSON Spec
+              ...json.locals.slice(1).map(l => {
+                return Variable.fromSeqJson(l, 'locals');
+              }),
+            ],
+          }
+          : {}),
+      ...(json.parameters
+          ? {
+            parameters: [
+              Variable.fromSeqJson(json.parameters[0], 'parameters'),
+              // @ts-ignore : 'l: Request' found in JSON Spec
+              ...json.parameters.slice(1).map(p => {
+                return Variable.fromSeqJson(p, 'parameters');
+              }),
+            ],
+          }
+          : {}),
       ...(json.requests
         ? {
             // @ts-ignore : 'r: Request' found in JSON Spec
@@ -571,7 +857,7 @@ export class Sequence implements SeqJson {
                 ...(r.metadata ? { metadata: r.metadata } : {}),
                 steps: [
                   r.steps[0].type === 'command'
-                    ? CommandStem.fromSeqJson(r.steps[0] as CommandStem)
+                    ? CommandStem.fromSeqJson(r.steps[0] as CommandStem,localNames, parameterNames)
                     : r.steps[0].type === 'ground_block'
                     ? // @ts-ignore : 'GroundBlock' found in JSON Spec
                       Ground_Block.fromSeqJson(r.steps[0] as GroundBlock)
@@ -581,7 +867,7 @@ export class Sequence implements SeqJson {
                     : r.steps[0],
                   // @ts-ignore : 'step : Step' found in JSON Spec
                   ...r.steps.slice(1).map(step => {
-                    if (step.type === 'command') return CommandStem.fromSeqJson(step as CommandStem);
+                    if (step.type === 'command') return CommandStem.fromSeqJson(step as CommandStem, localNames, parameterNames);
                     else if (step.type === 'ground_block') return Ground_Block.fromSeqJson(step as Ground_Block);
                     else if (step.type === 'ground_event') return Ground_Event.fromSeqJson(step as Ground_Event);
                     return step;
@@ -600,16 +886,278 @@ export class Sequence implements SeqJson {
       ...(json.hardware_commands
         ? // @ts-ignore : 'HardwareCommand' found in JSON Spec
           { hardware_commands: json.hardware_commands.map((h: HardwareCommand) => HardwareStem.fromSeqJson(h)) }
-        : {}),
-    });
+          : {}),
+      // @ts-ignore : 'SeqJson' found in JSON Spec
+    } as SeqJson);
   }
 }
 
-/*
-	  ---------------------------------
-				  STEPS eDSL
-	  ---------------------------------
-	  */
+/**
+ * ----------------------------------------
+ * 			Local and Parameters
+ * ----------------------------------------
+ */
+
+//@ts-ignore : 'VariableDeclaration: Request' found in JSON Spec
+export class Variable implements VariableDeclaration {
+  name: string;
+  type: VariableType;
+
+  [k: string]: unknown;
+  private kind: 'locals' | 'parameters' | 'unknown' = 'locals';
+  private readonly _enum_name?: string | undefined;
+  // @ts-ignore : 'VariableRange: Request' found in JSON Spec
+  private readonly _allowable_ranges?: VariableRange[] | undefined;
+  private readonly _allowable_values?: unknown[] | undefined;
+  private readonly _sc_name?: string | undefined;
+
+  constructor(opts: VariableOptions) {
+    this.name = opts.name;
+    this.type = opts.type;
+
+    this._enum_name = opts.enum_name ?? undefined;
+    this._allowable_ranges = opts.allowable_ranges ?? undefined;
+    this._allowable_values = opts.allowable_values ?? undefined;
+    this._sc_name = opts.sc_name ?? undefined;
+  }
+
+  public static new(opts: VariableOptions): Variable {
+    return new Variable(opts);
+  }
+
+  public static isVariable(obj: any): obj is Variable {
+    return obj && typeof obj === 'object' && obj.hasOwnProperty('name') && obj.hasOwnProperty('type');
+  }
+
+  public setKind(kind: 'locals' | 'parameters' | 'unknown') {
+    this.kind = kind;
+  }
+
+  // @ts-ignore : 'Command' found in JSON Spec
+  public toSeqJson(): VariableDeclaration {
+    let error;
+    //check if type ENUM has ENUM_NAME set
+    if (this.type === 'ENUM' && !this._enum_name) {
+      error = \`$$ERROR$$: 'enum_name' is required for ENUM type.\`;
+    }
+    // check if type ins't ENUM but has a ENUM_NAME set
+    if (this.type !== 'ENUM' && this._enum_name) {
+      error = \`$$ERROR$$: 'enum_name: \${this._enum_name}' is not required for non-ENUM type.\`;
+    }
+    // check if type is STRING but has allowable_ranges set
+    if (this.type === 'STRING' && this._allowable_ranges) {
+      error = \`$$ERROR$$: 'allowable_ranges' is not required for STRING type.\`;
+    }
+
+    return {
+      name: error ? error : this.name,
+      type: this.type,
+      ...(this._enum_name && { enum_name: this._enum_name }),
+      ...(this._allowable_ranges && {
+        allowable_ranges: this._allowable_ranges.map(range => {
+          return {
+            min: range.min,
+            max: range.max,
+          };
+        }),
+      }),
+      ...(this._allowable_values && { allowable_values: this._allowable_values }),
+      ...(this._sc_name && { sc_name: this._sc_name })
+    };
+  }
+
+  // @ts-ignore : 'VariableDeclaration: Request' found in JSON Spec
+  public static fromSeqJson(json: VariableDeclaration, kind: 'locals' | 'parameters' | 'unknown'): Variable {
+    const variable = new Variable({
+      name: json.name,
+      type: json.type as VariableType,
+      ...(json.enum_name ? { enum_name: json.enum_name } : {}),
+      ...(json.allowable_ranges ? { allowable_ranges: json.allowable_ranges } : {}),
+      ...(json.allowable_values ? { allowable_values: json.allowable_values } : {}),
+      ...(json.sc_name ? { sc_name: json.sc_name } : {}),
+    });
+    variable.setKind(kind);
+    return variable;
+  }
+
+  public toReferenceString(): string {
+    return \`\${this.kind}.\${this.name}\`;
+  }
+
+  public toEDSLString(): string {
+    const types = ['FLOAT', 'UINT', 'INT', 'STRING', 'ENUM'];
+    const type = types.includes(this.type) ? this.type : 'UNKNOWN';
+    switch (type) {
+      case 'FLOAT':
+      case 'UINT':
+      case 'INT':
+        return \`\${type}('\${this.name}'\${
+            this._allowable_ranges || this._allowable_values || this._sc_name
+                ? ', ' +
+                objectToString({
+                  ...(this._allowable_ranges ? { allowable_ranges: this._allowable_ranges } : {}),
+                  ...(this._allowable_values ? { allowable_values: this._allowable_values } : {}),
+                  ...(this._sc_name ? { sc_name: this._sc_name } : {}),
+                }) +
+                ')'
+                : ')'
+        }\`;
+      case 'STRING':
+        return \`\${type}('\${this.name}'\${
+            this._allowable_ranges || this._allowable_values || this._sc_name
+                ? ', ' +
+                objectToString({
+                  ...(this._allowable_values ? { allowable_values: this._allowable_values } : {}),
+                  ...(this._sc_name ? { sc_name: this._sc_name } : {}),
+                }) +
+                ')'
+                : ')'
+        }\`;
+      case 'ENUM':
+        return \`\${type}('\${this.name}', '\${this._enum_name}'\${
+            this._allowable_ranges || this._allowable_values || this._sc_name
+                ? ', ' +
+                objectToString({
+                  ...(this._allowable_ranges ? { allowable_ranges: this._allowable_ranges } : {}),
+                  ...(this._allowable_values ? { allowable_values: this._allowable_values } : {}),
+                  ...(this._sc_name ? { sc_name: this._sc_name } : {}),
+                }) +
+                ')'
+                : ')'
+        }\`;
+      default:
+        return \`\${type}(\${this.name}\${this._enum_name ? ', ' + this._enum_name : ''}\${
+            this._allowable_ranges || this._allowable_values || this._sc_name
+                ? ', ' +
+                objectToString({
+                  ...(this._allowable_ranges ? { allowable_ranges: this._allowable_ranges } : {}),
+                  ...(this._allowable_values ? { allowable_values: this._allowable_values } : {}),
+                  ...(this._sc_name ? { sc_name: this._sc_name } : {}),
+                })
+                : ''
+        })\`;
+    }
+  }
+}
+
+export function INT<N extends string>(name: N): INT<N>;
+export function INT<N extends string>(
+    name: N,
+    optionals: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): INT<N>;
+export function INT<N extends string>(
+    name: N,
+    optionals?: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): INT<N> {
+  const { allowable_ranges, allowable_values, sc_name } = optionals || {};
+  return { name, type: VariableType.INT, allowable_ranges, allowable_values, sc_name };
+}
+
+export function UINT<N extends string>(name: N): UINT<N>;
+export function UINT<N extends string>(
+    name: N,
+    optionals: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): UINT<N>;
+export function UINT<N extends string>(
+    name: N,
+    optionals?: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): UINT<N> {
+  const { allowable_ranges, allowable_values, sc_name } = optionals || {};
+  return { name, type: VariableType.UINT, allowable_ranges, allowable_values, sc_name };
+}
+
+export function FLOAT<N extends string>(name: N): FLOAT<N>;
+export function FLOAT<N extends string>(
+    name: N,
+    optionals: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): FLOAT<N>;
+export function FLOAT<N extends string>(
+    name: N,
+    optionals?: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): FLOAT<N> {
+  const { allowable_ranges, allowable_values, sc_name } = optionals || {};
+  return { name, type: VariableType.FLOAT, allowable_ranges, allowable_values, sc_name };
+}
+
+export function STRING<N extends string>(name: N): STRING<N>;
+export function STRING<N extends string>(
+    name: N,
+    optionals: {
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): STRING<N>;
+export function STRING<N extends string>(
+    name: N,
+    optionals?: {
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): STRING<N> {
+  const { allowable_values, sc_name } = optionals || {};
+  return { name, type: VariableType.STRING, allowable_values, sc_name };
+}
+
+export function ENUM<const N extends string, const E extends string>(name: N, enum_name: E): ENUM<N, E>;
+export function ENUM<const N extends string, const E extends string>(
+    name: N,
+    enum_name: E,
+    optionals?: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): ENUM<N, E>;
+export function ENUM<const N extends string, const E extends string>(
+    name: N,
+    enum_name: E,
+    optionals?: {
+      // @ts-ignore : 'VariableRange' found in JSON Spec
+      allowable_ranges?: VariableRange[];
+      allowable_values?: unknown[];
+      sc_name?: string;
+    },
+): ENUM<N, E> {
+  const { allowable_ranges, allowable_values, sc_name } = optionals || {};
+  return { name, enum_name, type: VariableType.ENUM, allowable_ranges, allowable_values, sc_name };
+}
+
+/**
+ * ---------------------------------
+ *        STEPS eDSL
+ * ---------------------------------
+ */
 
 // @ts-ignore : 'Args' found in JSON Spec
 export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
@@ -744,8 +1292,12 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
     };
   }
 
-  // @ts-ignore : 'Command' found in JSON Spec
-  public static fromSeqJson(json: Command): CommandStem {
+  public static fromSeqJson(
+      // @ts-ignore : 'Command' found in JSON Spec
+      json: Command,
+      localNames?: string[],
+      parameterNames?: string[],
+  ): CommandStem {
     const timeValue =
       json.time.type === TimingTypes.ABSOLUTE
         ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
@@ -757,7 +1309,7 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
 
     return CommandStem.new({
       stem: json.stem,
-      arguments: convertInterfacesToArgs(json.args),
+      arguments: convertInterfacesToArgs(json.args, localNames, parameterNames),
       metadata: json.metadata,
       models: json.models,
       description: json.description,
@@ -879,10 +1431,10 @@ export class ImmediateStem<A extends Args[] | { [argName: string]: any } = [] | 
   }
 
   // @ts-ignore : 'Command' found in JSON Spec
-  public static fromSeqJson(json: ImmediateCommand): ImmediateStem {
+  public static fromSeqJson(json: ImmediateCommand, localNames?: string[], parameterNames?: string[]): ImmediateStem {
     return ImmediateStem.new({
       stem: json.stem,
-      arguments: convertInterfacesToArgs(json.args),
+      arguments: convertInterfacesToArgs(json.args, localNames, parameterNames),
       metadata: json.metadata,
       description: json.description,
     });
@@ -1401,9 +1953,11 @@ export const STEPS = {
   GROUND_EVENT: GROUND_EVENT,
 };
 
-/*-----------------------------------
-		HW Commands
-	  ------------------------------------- */
+/**
+ * -----------------------------------
+ *        HW Commands
+ * -----------------------------------
+ */
 // @ts-ignore : 'HardwareCommand' found in JSON Spec
 export class HardwareStem implements HardwareCommand {
   public readonly stem: string;
@@ -1479,11 +2033,11 @@ export class HardwareStem implements HardwareCommand {
   }
 }
 
-/*
-	  ---------------------------------
-			  Time Utilities
-	  ---------------------------------
-	  */
+/**
+ *---------------------------------
+ *      Time Utilities
+ *---------------------------------
+ */
 
 export type DOY_STRING = string & { __brand: 'DOY_STRING' };
 export type HMS_STRING = string & { __brand: 'HMS_STRING' };
@@ -1683,11 +2237,11 @@ function commandsWithTimeValue<T extends TimingTypes>(
   };
 }
 
-/*
-	  ---------------------------------
-			  Utility Functions
-	  ---------------------------------
-	  */
+/**
+ * ---------------------------------
+ *      Utility Functions
+ * ---------------------------------
+ */
 
 // @ts-ignore : Used in generated code
 function sortCommandArguments(args: { [argName: string]: any }, order: string[]): { [argName: string]: any } {
@@ -1747,7 +2301,7 @@ function argumentsToString<A extends Args[] | { [argName: string]: any } = [] | 
  * @param interfaces
  */
 // @ts-ignore : \`Args\` found in JSON Spec
-function convertInterfacesToArgs(interfaces: Args): {} | [] {
+function convertInterfacesToArgs(interfaces: Args, localNames?: String[], parameterNames?: String[]): {} | [] {
   const args = interfaces.length === 0 ? [] : {};
 
   // Use to prevent a Remote property injection attack
@@ -1758,50 +2312,65 @@ function convertInterfacesToArgs(interfaces: Args): {} | [] {
   };
 
   const convertedArgs = interfaces.map(
-    (
-      // @ts-ignore : found in JSON Spec
-      arg: StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument | RepeatArgument,
-    ) => {
-      // @ts-ignore : 'RepeatArgument' found in JSON Spec
-      if (arg.type === 'repeat') {
-        if (validate(arg.name)) {
-          // @ts-ignore : 'RepeatArgument' found in JSON Spec
-          return {
-            [arg.name]: arg.value.map(
-              (
-                // @ts-ignore : found in JSON Spec
-                repeatArgBundle: (StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument)[],
-              ) =>
-                repeatArgBundle.reduce((obj, item) => {
-                  if (validate(item.name)) {
-                    obj[item.name] = item.value;
-                  }
-                  return obj;
-                }, {}),
-            ),
-          };
-        }
-        return { repeat_error: 'Remote property injection detected...' };
-      } else if (arg.type === 'symbol') {
-        if (validate(arg.name)) {
-          // @ts-ignore : 'SymbolArgument' found in JSON Spec
-          return { [arg.name]: { symbol: arg.value } };
-        }
-        return { symbol_error: 'Remote property injection detected...' };
-        // @ts-ignore : 'HexArgument' found in JSON Spec
-      } else if (arg.type === 'hex') {
-        if (validate(arg.name)) {
+      (
+          // @ts-ignore : found in JSON Spec
+          arg: StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument | RepeatArgument,
+      ) => {
+        // @ts-ignore : 'RepeatArgument' found in JSON Spec
+        if (arg.type === 'repeat') {
+          if (validate(arg.name)) {
+            // @ts-ignore : 'RepeatArgument' found in JSON Spec
+            return {
+              [arg.name]: arg.value.map(
+                  (
+                      // @ts-ignore : found in JSON Spec
+                      repeatArgBundle: (StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument)[],
+                  ) =>
+                      repeatArgBundle.reduce((obj, item) => {
+                        if (validate(item.name)) {
+                          obj[item.name] = item.value;
+                        }
+                        return obj;
+                      }, {}),
+              ),
+            };
+          }
+          return { repeat_error: 'Remote property injection detected...' };
+        } else if (arg.type === 'symbol') {
+          if (validate(arg.name)) {
+            /**
+             * We don't have access to the actual type of the variable, as it's not included in
+             * the sequential JSON. However, we don't need the type at this point in the code. Instead,
+             * we create a variable object with a default type of "INT". Later on in the code, the
+             * variable will be used to generate "local.<name>" or "parameter.<name>" syntax in the toEDSLString() method.
+             */
+            let variable = Variable.new({ name: arg.value, type: VariableType.INT });
+            if (localNames && localNames.includes(arg.value)) {
+              variable.setKind('locals');
+            } else if (parameterNames && parameterNames.includes(arg.value)) {
+              variable.setKind('parameters');
+            } else {
+              const errorMsg = \`Variable '\${arg.value}' is not defined as a local or parameter\`;
+              variable = Variable.new({ name: \`\${arg.value} //ERROR: \${errorMsg}\`, type: VariableType.INT });
+              variable.setKind('unknown');
+            }
+            return { [arg.name]: variable };
+          }
+          return { symbol_error: 'Remote property injection detected...' };
           // @ts-ignore : 'HexArgument' found in JSON Spec
-          return { [arg.name]: { hex: arg.value } };
+        } else if (arg.type === 'hex') {
+          if (validate(arg.name)) {
+            // @ts-ignore : 'HexArgument' found in JSON Spec
+            return { [arg.name]: { hex: arg.value } };
+          }
+          return { hex_error: 'Remote property injection detected...' };
+        } else {
+          if (validate(arg.name)) {
+            return { [arg.name]: arg.value };
+          }
+          return { error: 'Remote property injection detected...' };
         }
-        return { hex_error: 'Remote property injection detected...' };
-      } else {
-        if (validate(arg.name)) {
-          return { [arg.name]: arg.value };
-        }
-        return { error: 'Remote property injection detected...' };
-      }
-    },
+      },
   );
 
   for (const key in convertedArgs) {
@@ -1852,15 +2421,30 @@ function convertValueToObject(value: any, key: string): any {
     case 'boolean':
       return { type: 'boolean', value: value, name: key };
     default:
-      if (value instanceof Object && value.symbol && value.symbol === 'string') {
-        return { type: 'symbol', value: value, name: key };
+      if (
+          value instanceof Object &&
+          'name' in value &&
+          'type' in value &&
+          (value.type === 'FLOAT' ||
+              value.type === 'INT' ||
+              value.type === 'STRING' ||
+              value.type === 'UINT' ||
+              value.type === 'ENUM')
+      ) {
+        return { type: 'symbol', value: value.name, name: key };
       } else if (
-        value instanceof Object &&
-        value.hex &&
-        value.hex === 'string' &&
-        new RegExp('^0x([0-9A-F])+$').test(value.hex)
+          value instanceof Object &&
+          value.hex &&
+          value.hex === 'string' &&
+          new RegExp('^0x([0-9A-F])+$').test(value.hex)
       ) {
         return { type: 'hex', value: value, name: key };
+      } else {
+        return {
+          type: typeof value,
+          value: \`\${key} is an unknown value\`,
+          name: \`$$ERROR$$\`,
+        };
       }
   }
 }
@@ -1893,11 +2477,16 @@ function objectToString(obj: any, indentLevel: number = 1): string {
         indentLevel--;
         output += indent(\`],\`, indentLevel) + '\\n';
       } else if (typeof value === 'object') {
-        output += indent(\`\${key}:{\`, indentLevel) + '\\n';
-        indentLevel++;
-        print(value);
-        indentLevel--;
-        output += indent(\`},\`, indentLevel) + '\\n';
+        //value is a Local or Parameter
+        if (value instanceof Variable) {
+          output += indent(\`\${key}: \${value.toReferenceString()}\`, indentLevel) + ',\\n';
+        } else {
+          output += indent(\`\${key}:{\`, indentLevel) + '\\n';
+          indentLevel++;
+          print(value);
+          indentLevel--;
+          output += indent(\`},\`, indentLevel) + '\\n';
+        }
       } else {
         output += indent(\`\${key}: \${typeof value === 'string' ? \`'\${value}'\` : value},\`, indentLevel) + '\\n';
       }
@@ -2321,31 +2910,31 @@ export interface HardwareCommand {
 declare global {
 
 	interface ECHO_IMMEDIATE extends ImmediateStem<[ [{ 'echo_string': VarString<8, 1024> }] ]> {}
-	interface ECHO_STEP extends CommandStem<[ [{ 'echo_string': VarString<8, 1024> }] ]> {}
+	interface ECHO_STEP extends CommandStem<[ [{ 'echo_string': VarString<8, 1024>| 'STRING' }] ]> {}
 	function ECHO(...args: [{ 'echo_string': VarString<8, 1024> }]) : ECHO_IMMEDIATE
 
 	interface PREHEAT_OVEN_IMMEDIATE extends ImmediateStem<[ [{ 'temperature': U8 }] ]> {}
-	interface PREHEAT_OVEN_STEP extends CommandStem<[ [{ 'temperature': U8 }] ]> {}
+	interface PREHEAT_OVEN_STEP extends CommandStem<[ [{ 'temperature': U8| 'UINT' }] ]> {}
 	function PREHEAT_OVEN(...args: [{ 'temperature': U8 }]) : PREHEAT_OVEN_IMMEDIATE
 
 	interface THROW_BANANA_IMMEDIATE extends ImmediateStem<[ [{ 'distance': U8 }] ]> {}
-	interface THROW_BANANA_STEP extends CommandStem<[ [{ 'distance': U8 }] ]> {}
+	interface THROW_BANANA_STEP extends CommandStem<[ [{ 'distance': U8| 'UINT' }] ]> {}
 	function THROW_BANANA(...args: [{ 'distance': U8 }]) : THROW_BANANA_IMMEDIATE
 
 	interface GROW_BANANA_IMMEDIATE extends ImmediateStem<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
-	interface GROW_BANANA_STEP extends CommandStem<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
+	interface GROW_BANANA_STEP extends CommandStem<[ [{ 'quantity': U8| 'UINT','durationSecs': U8| 'UINT' }] ]> {}
 	function GROW_BANANA(...args: [{ 'quantity': U8,'durationSecs': U8 }]) : GROW_BANANA_IMMEDIATE
 
 	interface GrowBanana_IMMEDIATE extends ImmediateStem<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
-	interface GrowBanana_STEP extends CommandStem<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
+	interface GrowBanana_STEP extends CommandStem<[ [{ 'quantity': U8| 'UINT','durationSecs': U8| 'UINT' }] ]> {}
 	function GrowBanana(...args: [{ 'quantity': U8,'durationSecs': U8 }]) : GrowBanana_IMMEDIATE
 
 	interface PREPARE_LOAF_IMMEDIATE extends ImmediateStem<[ [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }] ]> {}
-	interface PREPARE_LOAF_STEP extends CommandStem<[ [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }] ]> {}
+	interface PREPARE_LOAF_STEP extends CommandStem<[ [{ 'tb_sugar': U8| 'UINT','gluten_free': ('FALSE' | 'TRUE')| 'ENUM' }] ]> {}
 	function PREPARE_LOAF(...args: [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }]) : PREPARE_LOAF_IMMEDIATE
 
 	interface PEEL_BANANA_IMMEDIATE extends ImmediateStem<[ [{ 'peelDirection': ('fromStem' | 'fromTip') }] ]> {}
-	interface PEEL_BANANA_STEP extends CommandStem<[ [{ 'peelDirection': ('fromStem' | 'fromTip') }] ]> {}
+	interface PEEL_BANANA_STEP extends CommandStem<[ [{ 'peelDirection': ('fromStem' | 'fromTip')| 'ENUM' }] ]> {}
 	function PEEL_BANANA(...args: [{ 'peelDirection': ('fromStem' | 'fromTip') }]) : PEEL_BANANA_IMMEDIATE
 
 
@@ -2369,7 +2958,7 @@ declare global {
 
 
 	interface PACKAGE_BANANA_IMMEDIATE extends ImmediateStem<[ [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }] ]> {}
-	interface PACKAGE_BANANA_STEP extends CommandStem<[ [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }] ]> {}
+	interface PACKAGE_BANANA_STEP extends CommandStem<[ [{ 'lot_number': U16| 'UINT','bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }] ]> {}
 	function PACKAGE_BANANA(...args: [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]) : PACKAGE_BANANA_IMMEDIATE
 
 
@@ -2445,7 +3034,7 @@ function ECHO(...args: [{ 'echo_string': VarString<8, 1024> }]) {
     arguments: args
   }) as ECHO_IMMEDIATE;
 }
-function ECHO_STEP(...args: [{ 'echo_string': VarString<8, 1024> }]) {
+function ECHO_STEP(...args: [{ 'echo_string': VarString<8, 1024>| 'STRING' }]) {
   return CommandStem.new({
     stem: 'ECHO',
     arguments: sortCommandArguments(args, argumentOrders['ECHO'])
@@ -2463,7 +3052,7 @@ function PREHEAT_OVEN(...args: [{ 'temperature': U8 }]) {
     arguments: args
   }) as PREHEAT_OVEN_IMMEDIATE;
 }
-function PREHEAT_OVEN_STEP(...args: [{ 'temperature': U8 }]) {
+function PREHEAT_OVEN_STEP(...args: [{ 'temperature': U8| 'UINT' }]) {
   return CommandStem.new({
     stem: 'PREHEAT_OVEN',
     arguments: sortCommandArguments(args, argumentOrders['PREHEAT_OVEN'])
@@ -2481,7 +3070,7 @@ function THROW_BANANA(...args: [{ 'distance': U8 }]) {
     arguments: args
   }) as THROW_BANANA_IMMEDIATE;
 }
-function THROW_BANANA_STEP(...args: [{ 'distance': U8 }]) {
+function THROW_BANANA_STEP(...args: [{ 'distance': U8| 'UINT' }]) {
   return CommandStem.new({
     stem: 'THROW_BANANA',
     arguments: sortCommandArguments(args, argumentOrders['THROW_BANANA'])
@@ -2500,7 +3089,7 @@ function GROW_BANANA(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
     arguments: args
   }) as GROW_BANANA_IMMEDIATE;
 }
-function GROW_BANANA_STEP(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
+function GROW_BANANA_STEP(...args: [{ 'quantity': U8| 'UINT','durationSecs': U8| 'UINT' }]) {
   return CommandStem.new({
     stem: 'GROW_BANANA',
     arguments: sortCommandArguments(args, argumentOrders['GROW_BANANA'])
@@ -2519,7 +3108,7 @@ function GrowBanana(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
     arguments: args
   }) as GrowBanana_IMMEDIATE;
 }
-function GrowBanana_STEP(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
+function GrowBanana_STEP(...args: [{ 'quantity': U8| 'UINT','durationSecs': U8| 'UINT' }]) {
   return CommandStem.new({
     stem: 'GrowBanana',
     arguments: sortCommandArguments(args, argumentOrders['GrowBanana'])
@@ -2538,7 +3127,7 @@ function PREPARE_LOAF(...args: [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE
     arguments: args
   }) as PREPARE_LOAF_IMMEDIATE;
 }
-function PREPARE_LOAF_STEP(...args: [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }]) {
+function PREPARE_LOAF_STEP(...args: [{ 'tb_sugar': U8| 'UINT','gluten_free': ('FALSE' | 'TRUE')| 'ENUM' }]) {
   return CommandStem.new({
     stem: 'PREPARE_LOAF',
     arguments: sortCommandArguments(args, argumentOrders['PREPARE_LOAF'])
@@ -2556,7 +3145,7 @@ function PEEL_BANANA(...args: [{ 'peelDirection': ('fromStem' | 'fromTip') }]) {
     arguments: args
   }) as PEEL_BANANA_IMMEDIATE;
 }
-function PEEL_BANANA_STEP(...args: [{ 'peelDirection': ('fromStem' | 'fromTip') }]) {
+function PEEL_BANANA_STEP(...args: [{ 'peelDirection': ('fromStem' | 'fromTip')| 'ENUM' }]) {
   return CommandStem.new({
     stem: 'PEEL_BANANA',
     arguments: sortCommandArguments(args, argumentOrders['PEEL_BANANA'])
@@ -2603,7 +3192,7 @@ function PACKAGE_BANANA(...args: [{ 'lot_number': U16,'bundle': Array<{ 'bundle_
     arguments: args
   }) as PACKAGE_BANANA_IMMEDIATE;
 }
-function PACKAGE_BANANA_STEP(...args: [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]) {
+function PACKAGE_BANANA_STEP(...args: [{ 'lot_number': U16| 'UINT','bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]) {
   return CommandStem.new({
     stem: 'PACKAGE_BANANA',
     arguments: sortCommandArguments(args, argumentOrders['PACKAGE_BANANA'])
@@ -2680,6 +3269,6 @@ export const Hardwares = {
 		HDW_BLENDER_DUMP: HDW_BLENDER_DUMP,
 };
 
-Object.assign(globalThis, { A:A, R:R, E:E, C:Object.assign(Commands, STEPS), Sequence}, Hardwares, Immediates);
+Object.assign(globalThis, { A:A, R:R, E:E, C:Object.assign(Commands, STEPS), Sequence, FLOAT, UINT,INT, STRING, ENUM}, Hardwares, Immediates);
 "
 `;

--- a/sequencing-server/test/command-expansion.spec.ts
+++ b/sequencing-server/test/command-expansion.spec.ts
@@ -103,7 +103,7 @@ describe('expansion', () => {
         await insertExpansionSet(graphqlClient, commandDictionaryId, missionModelId, [groundEventExpansion]),
       ).toThrow();
     } catch (e) {}
-  });
+  }, 30000);
 
   it('should allow an activity type and command to have the same name', async () => {
     const expansionSetId = await insertExpansionSet(graphqlClient, commandDictionaryId, missionModelId, [expansionId]);
@@ -122,7 +122,7 @@ describe('expansion', () => {
     await removeExpansionRun(graphqlClient, expansionRunPk);
     await removeSimulationArtifacts(graphqlClient, simulationArtifactPk);
     await removeExpansionSet(graphqlClient, expansionSetId);
-  });
+  }, 30000);
 
   it('should throw an error if an activity instance goes beyond the plan duration', async () => {
     /** Begin Setup*/
@@ -187,7 +187,7 @@ describe('expansion', () => {
     await removeExpansion(graphqlClient, expansionId);
     await removeExpansionSet(graphqlClient, expansionSetId);
     await removeExpansionRun(graphqlClient, expansionRunId);
-  });
+  }, 30000);
 
   it('start_offset undefined regression', async () => {
     /** Begin Setup*/
@@ -263,5 +263,5 @@ describe('expansion', () => {
     await removeExpansion(graphqlClient, expansionId);
     await removeExpansionSet(graphqlClient, expansionSetId);
     await removeExpansionRun(graphqlClient, expansionRunId);
-  }, 10000);
+  }, 30000);
 });

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -3530,7 +3530,7 @@ describe('user sequence to seqjson', () => {
               immediate_commands: [
                 PEEL_BANANA({peelDirection: 'fromStem'})
               ],
-              requests: [
+              requests: ({ locals, parameters }) => ([
                 {
                   name: 'power',
                   steps: [
@@ -3564,7 +3564,7 @@ describe('user sequence to seqjson', () => {
                     author: 'rrgoet',
                   },
                 }
-              ],
+              ]),
             });
           `,
       },

--- a/sequencing-server/tsconfig.json
+++ b/sequencing-server/tsconfig.json
@@ -9,6 +9,7 @@
     "lib": [
       "esnext"
     ],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "ignoreDeprecations": "5.0"
   }
 }


### PR DESCRIPTION
* **Tickets addressed:** Closes https://github.com/NASA-AMMOS/aerie/issues/706
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Leveraging the new TS 5 feature that @jdylanstewart figured out `local` and `parameters` work a lot better. 
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters

```ts
export default () =>
  Sequence.new({
    seqId: '',
    metadata: {},
    locals: [
      UINT('temperature')
    ],
    parameters: [
      UINT('sugarAmount')
    ],
    steps: ({ locals, parameters }) => ([
      A`2025-358T12:01:59.000`.PREHEAT_OVEN({
        temperature: locals.temperature,
      }),
      C.PREPARE_LOAF({
        tb_sugar: parameters.sugarAmount,
        gluten_free: 'FALSE',
      }),
    ]),
  });
```

There is also type checking between defined `local` and `parameters` and when you use them as argument parameters.

```ts
locals : [FLOAT("temperature")]
...
C.PREPARE_LOAF({
        tb_sugar: 360,
        gluten_free: locals.temperature <----ERROR: Temperature isn't a boolean
      }),
```


I've included examples of errors that may occur when converting between SeqJson to eDSL, which should make it easier to identify and fix any issues. 


### **From SeqJSON to eDSL Error checking**

```json

  "steps": [
    {
      "args": [
        {
          "name": "tb_sugar",
          "type": "symbol",
          "value": "sugarrrrr"
        },
        {
          "name": "gluten_free",
          "type": "string",
          "value": "FALSE"
        }
      ],
      "stem": "PREPARE_LOAF",
      "time": {
        "type": "COMMAND_COMPLETE"
      },
      "type": "command"
    }
  ]

```

Errors caught and displayed in the eDSL
```ts
      C.PREPARE_LOAF({
        tb_sugar: UNKNOWN.sugarrrrr, //ERROR:  variable 'sugarrrrr' is not defined as a local or parameter"
        gluten_free: 'FALSE',
 
)



```


## Verification
Added new e2e test to check all the errors for `locals` and `parameters`. All pass

## Documentation
This is probably a good write-up to include in the wiki

## Future work
Globals are next