### PR TITLE
FixedDuration handling bug

### DIFF
--- a/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/services/SynchronousSchedulerAgent.java
+++ b/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/services/SynchronousSchedulerAgent.java
@@ -404,7 +404,10 @@ public record SynchronousSchedulerAgent(
                     .orElseThrow(() -> new Exception("Controllable Duration parameter was not an Int")),
                 Duration.MICROSECONDS);
           }
-        } else if (schedulerActType.getDurationType() instanceof DurationType.Uncontrollable s) {
+        } else if (
+            schedulerActType.getDurationType() instanceof DurationType.Uncontrollable
+            || schedulerActType.getDurationType() instanceof DurationType.Fixed
+        ) {
           // Do nothing
         } else {
           throw new Error("Unhandled variant of DurationType:" + schedulerActType.getDurationType());

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
@@ -2187,4 +2187,21 @@ public class SchedulingIntegrationTests {
 
     // If invalid typescript is generated, an exception will be thrown.
   }
+
+  @Test
+  void testSchedulerAgentDurationTypeHandling() {
+    runScheduler(
+        BANANANATION,
+        List.of(
+            new ActivityDirective(
+                Duration.ZERO,
+                "BananaNap",
+                Map.of(),
+                null,
+                true
+            )
+        ),
+        List.of(),
+        PLANNING_HORIZON);
+  }
 }


### PR DESCRIPTION
* **Tickets addressed:** none
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
fixes a bug where the synchronous scheduler agent didn't allow fixed duration activities in the initial plan.
Follow up from https://github.com/NASA-AMMOS/aerie/pull/858

## Verification
added a test

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
