### PR TITLE
ParametricDuration annotation

### DIFF
--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/DownloadBananaActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/DownloadBananaActivity.java
@@ -1,0 +1,44 @@
+package gov.nasa.jpl.aerie.banananation.activities;
+
+import gov.nasa.jpl.aerie.banananation.Mission;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.ParametricDuration;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Parameter;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
+
+/**
+ * Internet technology has come a long way.
+ *
+ * @subsystem fruit
+ * @contact Jane Doe
+ */
+@ActivityType("DownloadBanana")
+public final class DownloadBananaActivity {
+
+  public enum ConnectionType {
+    DSL,
+    FiberOptic,
+    DietaryFiberOptic
+  }
+
+  @Parameter
+  public ConnectionType connection = ConnectionType.DSL;
+
+  @ParametricDuration
+  public Duration duration() {
+    return switch (this.connection) {
+      case DSL -> Duration.HOUR;
+      case FiberOptic -> Duration.of(10, Duration.MINUTE);
+      case DietaryFiberOptic -> Duration.MINUTE;
+    };
+  }
+
+  @EffectModel
+  public void run(final Mission mission) {
+    delay(duration());
+    mission.fruit.add(1);
+  }
+}

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
@@ -17,6 +17,7 @@
 @WithActivityType(DecomposingActivity.GrandchildActivity.class)
 @WithActivityType(DecomposingSpawnActivity.DecomposingSpawnParentActivity.class)
 @WithActivityType(DecomposingSpawnActivity.DecomposingSpawnChildActivity.class)
+@WithActivityType(DownloadBananaActivity.class)
 @WithActivityType(BakeBananaBreadActivity.class)
 @WithActivityType(BananaNapActivity.class)
 @WithActivityType(DurationParameterActivity.class)
@@ -32,6 +33,7 @@ import gov.nasa.jpl.aerie.banananation.activities.ChangeProducerActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ControllableDurationActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DecomposingActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DecomposingSpawnActivity;
+import gov.nasa.jpl.aerie.banananation.activities.DownloadBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DurationParameterActivity;
 import gov.nasa.jpl.aerie.banananation.activities.GrowBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.LineCountBananaActivity;

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -12,7 +12,6 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
 import com.squareup.javapoet.WildcardTypeName;
-import gov.nasa.jpl.aerie.contrib.serialization.mappers.RecordValueMapper;
 import gov.nasa.jpl.aerie.merlin.framework.ActivityMapper;
 import gov.nasa.jpl.aerie.merlin.framework.EmptyInputType;
 import gov.nasa.jpl.aerie.merlin.framework.ModelActions;
@@ -24,7 +23,6 @@ import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityTypeRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.EffectModelRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.InputTypeRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.MissionModelRecord;
-import gov.nasa.jpl.aerie.merlin.processor.metamodel.TypeRule;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.model.InputType;
@@ -40,24 +38,18 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
-import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.processing.Generated;
 import javax.annotation.processing.Messager;
 import javax.lang.model.element.Modifier;
-import javax.lang.model.element.RecordComponentElement;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -301,6 +293,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                                           .map($ -> {
                                                             if ($.durationParameter().isPresent()) return CodeBlock.of("controllable(\"$L\")", $.durationParameter().get());
                                                             else if ($.fixedDurationExpr().isPresent()) return CodeBlock.of("fixed($L.$L)", activityTypeRecord.fullyQualifiedClass(), $.fixedDurationExpr().get());
+                                                            else if ($.parametricDuration().isPresent()) return CodeBlock.of("parametric($$ -> (new $L().new InputMapper()).instantiate($$).$L())", activityTypeRecord.inputType().mapper().name, $.parametricDuration().get());
                                                             else return CodeBlock.of("uncontrollable()");
                                                           })
                                                           .orElse(CodeBlock.of("uncontrollable()"))))

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
@@ -10,6 +10,7 @@ public record EffectModelRecord(
     ActivityType.Executor executor,
     Optional<TypeMirror> returnType,
     Optional<String> durationParameter,
-    Optional<String> fixedDurationExpr
+    Optional<String> fixedDurationExpr,
+    Optional<String> parametricDuration
 ) {
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/ActivityType.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/ActivityType.java
@@ -45,7 +45,7 @@ public @interface ActivityType {
    * }</pre>
    *
    * Keep in mind that it is not enough for the activity duration to be *determined* by the duration parameter.
-   * They must be exactly equal as above.
+   * They must be exactly equal as above. If that is not true, use {@link ParametricDuration} instead.
    */
   @Retention(RetentionPolicy.CLASS)
   @Target(ElementType.METHOD)
@@ -100,4 +100,38 @@ public @interface ActivityType {
   @Retention(RetentionPolicy.CLASS)
   @Target({ ElementType.FIELD, ElementType.METHOD })
   @interface FixedDuration {}
+
+  /**
+   * Use when an activity's duration is indirectly determined only by its arguments.
+   *
+   * Apply to a getter method that returns this activity's duration. For correctness, it is recommended
+   * that you use the getter in the effect model to ensure the duration is what you say it is. Apply like this:
+   *
+   * <pre>{@code
+   * @ActivityType("ParametricDurationActivity")
+   * public record ParametricDurationActivity(boolean goFast) {
+   *   @ParametricDuration
+   *   public Duration duration() {
+   *     if (goFast) {
+   *       return Duration.MINUTE;
+   *     } else {
+   *       return Duration.HOUR;
+   *     }
+   *   }
+   *
+   *   @EffectModel
+   *   public void run(Mission mission) {
+   *     // ...
+   *     delay(duration);
+   *     // ...
+   *   }
+   * }
+   * }</pre>
+   *
+   * If the duration of the activity is exactly equal to one of the arguments, it is recommended to use the
+   * {@link ControllableDuration} annotation instead.
+   */
+  @Retention(RetentionPolicy.CLASS)
+  @Target(ElementType.METHOD)
+  @interface ParametricDuration {}
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/DurationType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/DurationType.java
@@ -1,9 +1,12 @@
 package gov.nasa.jpl.aerie.merlin.protocol.types;
 
+import java.util.Map;
+
 public sealed interface DurationType {
   record Controllable(String parameterName) implements DurationType {}
   record Uncontrollable() implements DurationType {}
   record Fixed(Duration duration) implements DurationType {}
+  record Parametric(ThrowingDurationFunction durationFunction) implements DurationType {}
 
   static DurationType uncontrollable() {
     return new Uncontrollable();
@@ -15,5 +18,13 @@ public sealed interface DurationType {
 
   static DurationType fixed(final Duration duration) {
     return new Fixed(duration);
+  }
+
+  static DurationType parametric(final ThrowingDurationFunction durationFunction) {
+    return new Parametric(durationFunction);
+  }
+
+  interface ThrowingDurationFunction {
+    Duration apply(final Map<String, SerializedValue> arguments) throws InstantiationException;
   }
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -232,7 +232,11 @@ public class SimulationFacade implements AutoCloseable{
       final var durationType = activity.getType().getDurationType();
       if (durationType instanceof DurationType.Controllable dt) {
         arguments.put(dt.parameterName(), SerializedValue.of(activity.duration().in(Duration.MICROSECONDS)));
-      } else if (durationType instanceof DurationType.Uncontrollable || durationType instanceof DurationType.Fixed) {
+      } else if (
+          durationType instanceof DurationType.Uncontrollable
+          || durationType instanceof DurationType.Fixed
+          || durationType instanceof DurationType.Parametric
+      ) {
         // If an activity has already been simulated, it will have a duration, even if its DurationType is Uncontrollable.
       } else {
         throw new Error("Unhandled variant of DurationType: " + durationType);

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/ParametricDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/ParametricDurationTest.java
@@ -1,0 +1,92 @@
+package gov.nasa.jpl.aerie.scheduler;
+
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.constraints.tree.SpansFromWindows;
+import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
+import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate;
+import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.TimeAnchor;
+import gov.nasa.jpl.aerie.scheduler.constraints.timeexpressions.TimeExpression;
+import gov.nasa.jpl.aerie.scheduler.goals.CoexistenceGoal;
+import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
+import gov.nasa.jpl.aerie.scheduler.model.Problem;
+import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
+import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ParametricDurationTest {
+
+  PlanningHorizon planningHorizon;
+  Problem problem;
+
+  @BeforeEach
+  void setUp(){
+    planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochDays(3));
+    MissionModel<?> bananaMissionModel = SimulationUtility.getBananaMissionModel();
+    problem = new Problem(bananaMissionModel, planningHorizon, new SimulationFacade(planningHorizon, bananaMissionModel), SimulationUtility.getBananaSchedulerModel());
+  }
+
+  @Test
+  public void testStartConstraint() {
+
+    final var parameterizedDurationActivityTemplate = new ActivityCreationTemplate.Builder()
+        .ofType(problem.getActivityType("DownloadBanana"))
+        .withArgument("connection", SerializedValue.of("DietaryFiberOptic"))
+        .withTimingPrecision(Duration.of(500, Duration.MILLISECOND))
+        .build();
+
+    final var start = TimeExpression.atStart();
+    final var coexistence = new CoexistenceGoal.Builder()
+        .thereExistsOne(parameterizedDurationActivityTemplate)
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(planningHorizon.getHor(), true)))
+        .forEach(new SpansFromWindows(new WindowsWrapperExpression(new Windows(false).set(Interval.between(1, 3, Duration.MINUTE), true))))
+        .startsAt(start)
+        .named("ParamDurationCoexistenceGoal")
+        .aliasForAnchors("its a me")
+        .build();
+
+
+    problem.setGoals(List.of(coexistence));
+
+    final var solver = new PrioritySolver(problem);
+    final var plan = solver.getNextSolution().get();
+    solver.printEvaluation();
+    assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT1M"), planningHorizon.fromStart("PT2M"), problem.getActivityType("DownloadBanana")));
+  }
+
+  @Test
+  public void testEndConstraint() {
+
+    final var parameterizedDurationActivityTemplate = new ActivityCreationTemplate.Builder()
+        .ofType(problem.getActivityType("DownloadBanana"))
+        .withArgument("connection", SerializedValue.of("FiberOptic"))
+        .withTimingPrecision(Duration.of(500, Duration.MILLISECOND))
+        .build();
+
+    final var coexistence = new CoexistenceGoal.Builder()
+        .thereExistsOne(parameterizedDurationActivityTemplate)
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(planningHorizon.getHor(), true)))
+        .forEach(new SpansFromWindows(new WindowsWrapperExpression(new Windows(false).set(Interval.between(10, 13, Duration.MINUTE), true))))
+        .endsBeforeEnd()
+        .startsAt(TimeExpression.offsetByBeforeStart(Duration.of(8, Duration.MINUTE)))
+        .named("ParamDurationCoexistenceGoal")
+        .aliasForAnchors("its a me")
+        .build();
+
+
+    problem.setGoals(List.of(coexistence));
+
+    final var solver = new PrioritySolver(problem);
+    final var plan = solver.getNextSolution().get();
+    solver.printEvaluation();
+    assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT2M"), planningHorizon.fromStart("PT12M"), problem.getActivityType("DownloadBanana")));
+  }
+}

--- a/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/services/SynchronousSchedulerAgent.java
+++ b/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/services/SynchronousSchedulerAgent.java
@@ -407,6 +407,7 @@ public record SynchronousSchedulerAgent(
         } else if (
             schedulerActType.getDurationType() instanceof DurationType.Uncontrollable
             || schedulerActType.getDurationType() instanceof DurationType.Fixed
+            || schedulerActType.getDurationType() instanceof DurationType.Parametric
         ) {
           // Do nothing
         } else {

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
@@ -2188,6 +2188,7 @@ public class SchedulingIntegrationTests {
     // If invalid typescript is generated, an exception will be thrown.
   }
 
+  // Tests that the scheduler can handle an initial plan with various duration annotated activities.
   @Test
   void testSchedulerAgentDurationTypeHandling() {
     runScheduler(
@@ -2197,6 +2198,13 @@ public class SchedulingIntegrationTests {
                 Duration.ZERO,
                 "BananaNap",
                 Map.of(),
+                null,
+                true
+            ),
+            new ActivityDirective(
+                Duration.SECOND,
+                "DownloadBanana",
+                Map.of("connection", SerializedValue.of("DietaryFiberOptic")),
                 null,
                 true
             )


### PR DESCRIPTION
* **Tickets addressed:** closes #904 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Adds a `ParametricDuration` annotation which is apply to a duration getter method. During root finding, the scheduler will create an instance of the original activity type class and call the annotated method, rather than simulating. This means that there are now uses of root finding that don't simulate.

## Verification
Added a `DownloadBanana` activity for testing, added a couple tests for timing constraints.

## Future work
- [ ] docs incoming
