### PR TITLE
Assign zero duration to activities with no effect model

### DIFF
--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -296,7 +296,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                                             else if ($.parametricDuration().isPresent()) return CodeBlock.of("parametric($$ -> (new $L().new InputMapper()).instantiate($$).$L())", activityTypeRecord.inputType().mapper().name, $.parametricDuration().get());
                                                             else return CodeBlock.of("uncontrollable()");
                                                           })
-                                                          .orElse(CodeBlock.of("uncontrollable()"))))
+                                                          .orElse(CodeBlock.of("fixed($T.ZERO)", ClassName.get(Duration.class)))))
                             .reduce((x, y) -> x.add("$L", y.build()))
                             .orElse(CodeBlock.builder()).build())
                     .addStatement("return result")


### PR DESCRIPTION
* **Tickets addressed:** inspired by #908 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
For activities that have no effect model, we should default to assigning `FixedDuration(ZERO)` instead of uncontrollable.

## Verification
Banananananation's ParameterTest activity's generated code was changed by this PR. Given that we have tests for FixedDuration, and tests that use ParameterTest, I'm satisfied not adding any new tests.
