### PR TITLE
Add additional Hasura metadata env vars

### DIFF
--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -113,13 +113,17 @@ This document provides detailed information about environment variables for each
 
 ## Hasura
 
-| Name                           | Description                                                   | Type     |
-| ------------------------------ | ------------------------------------------------------------- | -------- |
-| `AERIE_MERLIN_DATABASE_URL`    | Url of the Merlin Postgres database.                          | `string` |
-| `AERIE_SCHEDULER_DATABASE_URL` | Url of the scheduler Postgres database.                       | `string` |
-| `AERIE_UI_DATABASE_URL`        | Url of the UI Postgres database                               | `string` |
-| `HASURA_GRAPHQL_ADMIN_SECRET`  | The admin secret for Hasura which gives admin access if used. | `string` |
-| `HASURA_GRAPHQL_JWT_SECRET`    | The JWT secret for JSON web token auth. Also in Gateway.      | `string` |
+| Name                            | Description                                                   | Type     |
+| ------------------------------- | ------------------------------------------------------------- | -------- |
+| `AERIE_MERLIN_DATABASE_URL`     | Url of the Merlin Postgres database.                          | `string` |
+| `AERIE_MERLIN_URL`              | Url of the Merlin service.                                    | `string` |
+| `AERIE_SCHEDULER_DATABASE_URL`  | Url of the scheduler Postgres database.                       | `string` |
+| `AERIE_SCHEDULER_URL`           | Url of the scheduler service.                                 | `string` |
+| `AERIE_SEQUENCING_DATABASE_URL` | Url of the sequencing Postgres database.                      | `string` |
+| `AERIE_SEQUENCING_URL`          | Url of the sequencing service.                                | `string` |
+| `AERIE_UI_DATABASE_URL`         | Url of the UI Postgres database                               | `string` |
+| `HASURA_GRAPHQL_ADMIN_SECRET`   | The admin secret for Hasura which gives admin access if used. | `string` |
+| `HASURA_GRAPHQL_JWT_SECRET`     | The JWT secret for JSON web token auth. Also in Gateway.      | `string` |
 
 Additionally, Hasura provides documentation on it's own environment variables you can use to fine-tune your deployment:
 

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -140,8 +140,11 @@ services:
     depends_on: ["postgres"]
     environment:
       AERIE_MERLIN_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_merlin"
+      AERIE_MERLIN_URL: "http://aerie_merlin:27183"
       AERIE_SCHEDULER_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_scheduler"
+      AERIE_SCHEDULER_URL: "http://aerie_scheduler:27185"
       AERIE_SEQUENCING_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_sequencing"
+      AERIE_SEQUENCING_URL: "http://aerie_sequencing:27184"
       AERIE_UI_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_ui"
       HASURA_GRAPHQL_ADMIN_SECRET: "${HASURA_GRAPHQL_ADMIN_SECRET}"
       HASURA_GRAPHQL_DEV_MODE: "true"

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -2,107 +2,133 @@ actions:
   - name: addExternalDataset
     definition:
       kind: synchronous
-      handler: http://aerie_merlin:27183/addExternalDataset
+      handler: "{{AERIE_MERLIN_URL}}/addExternalDataset"
+      timeout: 300
   - name: extendExternalDataset
     definition:
       kind: synchronous
-      handler: http://aerie_merlin:27183/extendExternalDataset
+      handler: "{{AERIE_MERLIN_URL}}/extendExternalDataset"
+      timeout: 300
   - name: uploadDictionary
     definition:
       kind: synchronous
-      handler: http://aerie_sequencing:27184/put-dictionary
+      handler: "{{AERIE_SEQUENCING_URL}}/put-dictionary"
+      timeout: 300
   - name: addCommandExpansionTypeScript
     definition:
       kind: synchronous
-      handler: http://aerie_sequencing:27184/command-expansion/put-expansion
+      handler: "{{AERIE_SEQUENCING_URL}}/command-expansion/put-expansion"
+      timeout: 300
   - name: createExpansionSet
     definition:
       kind: synchronous
-      handler: http://aerie_sequencing:27184/command-expansion/put-expansion-set
+      handler: "{{AERIE_SEQUENCING_URL}}/command-expansion/put-expansion-set"
+      timeout: 300
   - name: expandAllActivities
     definition:
       kind: synchronous
-      handler: http://aerie_sequencing:27184/command-expansion/expand-all-activity-instances
+      handler: "{{AERIE_SEQUENCING_URL}}/command-expansion/expand-all-activity-instances"
+      timeout: 300
   - name: getEdslForSeqJson
     definition:
       kind: synchronous
-      handler: http://aerie_sequencing:27184/seqjson/get-edsl-for-seqjson
+      handler: "{{AERIE_SEQUENCING_URL}}/seqjson/get-edsl-for-seqjson"
+      timeout: 300
   - name: getEdslForSeqJsonBulk
     definition:
       kind: synchronous
-      handler: http://aerie_sequencing:27184/seqjson/bulk-get-edsl-for-seqjson
+      handler: "{{AERIE_SEQUENCING_URL}}/seqjson/bulk-get-edsl-for-seqjson"
+      timeout: 300
   - name: getModelEffectiveArguments
     definition:
       kind: ""
-      handler: http://aerie_merlin:27183/getModelEffectiveArguments
+      handler: "{{AERIE_MERLIN_URL}}/getModelEffectiveArguments"
+      timeout: 300
   - name: getActivityEffectiveArguments
     definition:
       kind: ""
-      handler: http://aerie_merlin:27183/getActivityEffectiveArguments
+      handler: "{{AERIE_MERLIN_URL}}/getActivityEffectiveArguments"
+      timeout: 300
   - name: getActivityTypeScript
     definition:
       kind: ""
-      handler: http://aerie_sequencing:27184/get-activity-typescript
+      handler: "{{AERIE_SEQUENCING_URL}}/get-activity-typescript"
+      timeout: 300
   - name: getCommandTypeScript
     definition:
       kind: ""
-      handler: http://aerie_sequencing:27184/get-command-typescript
+      handler: "{{AERIE_SEQUENCING_URL}}/get-command-typescript"
+      timeout: 300
   - name: getSequenceSeqJson
     definition:
       kind: ""
-      handler: http://aerie_sequencing:27184/seqjson/get-seqjson-for-seqid-and-simulation-dataset
+      handler: "{{AERIE_SEQUENCING_URL}}/seqjson/get-seqjson-for-seqid-and-simulation-dataset"
+      timeout: 300
   - name: getSequenceSeqJsonBulk
     definition:
       kind: ""
-      handler: http://aerie_sequencing:27184/seqjson/bulk-get-seqjson-for-seqid-and-simulation-dataset
+      handler: "{{AERIE_SEQUENCING_URL}}/seqjson/bulk-get-seqjson-for-seqid-and-simulation-dataset"
+      timeout: 300
   - name: getUserSequenceSeqJson
     definition:
       kind: ""
-      handler: http://aerie_sequencing:27184/seqjson/get-seqjson-for-sequence-standalone
+      handler: "{{AERIE_SEQUENCING_URL}}/seqjson/get-seqjson-for-sequence-standalone"
+      timeout: 300
   - name: getUserSequenceSeqJsonBulk
     definition:
       kind: ""
-      handler: http://aerie_sequencing:27184/seqjson/bulk-get-seqjson-for-sequence-standalone
+      handler: "{{AERIE_SEQUENCING_URL}}/seqjson/bulk-get-seqjson-for-sequence-standalone"
+      timeout: 300
   - name: resourceTypes
     definition:
       kind: ""
-      handler: http://aerie_merlin:27183/resourceTypes
+      handler: "{{AERIE_MERLIN_URL}}/resourceTypes"
+      timeout: 300
   - name: schedule
     definition:
       kind: ""
-      handler: http://aerie_scheduler:27185/schedule
+      handler: "{{AERIE_SCHEDULER_URL}}/schedule"
+      timeout: 300
   - name: schedulingDslTypescript
     definition:
       kind: ""
-      handler: http://aerie_scheduler:27185/schedulingDslTypescript
+      handler: "{{AERIE_SCHEDULER_URL}}/schedulingDslTypescript"
+      timeout: 300
   - name: constraintsDslTypescript
     definition:
       kind: ""
-      handler: http://aerie_merlin:27183/constraintsDslTypescript
+      handler: "{{AERIE_MERLIN_URL}}/constraintsDslTypescript"
+      timeout: 300
   - name: simulate
     definition:
       kind: ""
-      handler: http://aerie_merlin:27183/getSimulationResults
+      handler: "{{AERIE_MERLIN_URL}}/getSimulationResults"
+      timeout: 300
   - name: resourceSamples
     definition:
       kind: ""
-      handler: http://aerie_merlin:27183/resourceSamples
+      handler: "{{AERIE_MERLIN_URL}}/resourceSamples"
+      timeout: 300
   - name: constraintViolations
     definition:
       kind: ""
-      handler: http://aerie_merlin:27183/constraintViolations
+      handler: "{{AERIE_MERLIN_URL}}/constraintViolations"
+      timeout: 300
   - name: validateActivityArguments
     definition:
       kind: ""
-      handler: http://aerie_merlin:27183/validateActivityArguments
+      handler: "{{AERIE_MERLIN_URL}}/validateActivityArguments"
+      timeout: 300
   - name: validateModelArguments
     definition:
       kind: ""
-      handler: http://aerie_merlin:27183/validateModelArguments
+      handler: "{{AERIE_MERLIN_URL}}/validateModelArguments"
+      timeout: 300
   - name: validatePlan
     definition:
       kind: ""
-      handler: http://aerie_merlin:27183/validatePlan
+      handler: "{{AERIE_MERLIN_URL}}/validatePlan"
+      timeout: 300
 custom_types:
   enums:
     - name: MerlinSimulationStatus

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_mission_model.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_mission_model.yaml
@@ -52,8 +52,8 @@ event_triggers:
   retry_conf:
     interval_sec: 10
     num_retries: 0
-    timeout_sec: 60
-  webhook: http://aerie_merlin:27183/refreshActivityTypes
+    timeout_sec: 300
+  webhook: "{{AERIE_MERLIN_URL}}/refreshActivityTypes"
 - definition:
     enable_manual: false
     insert:
@@ -71,5 +71,5 @@ event_triggers:
   retry_conf:
     interval_sec: 10
     num_retries: 0
-    timeout_sec: 60
-  webhook: http://aerie_merlin:27183/refreshModelParameters
+    timeout_sec: 300
+  webhook: "{{AERIE_MERLIN_URL}}/refreshModelParameters"

--- a/deployment/kubernetes/hasura-deployment.yaml
+++ b/deployment/kubernetes/hasura-deployment.yaml
@@ -21,10 +21,16 @@ spec:
           env:
             - name: AERIE_MERLIN_DATABASE_URL
               value: postgres://aerie:aerie@postgres:5432/aerie_merlin
+            - name: AERIE_MERLIN_URL
+              value: http://aerie_merlin:27183
             - name: AERIE_SCHEDULER_DATABASE_URL
               value: postgres://aerie:aerie@postgres:5432/aerie_scheduler
+            - name: AERIE_SCHEDULER_URL
+              value: http://aerie_scheduler:27185
             - name: AERIE_SEQUENCING_DATABASE_URL
               value: postgres://aerie:aerie@postgres:5432/aerie_sequencing
+            - name: AERIE_SEQUENCING_URL
+              value: http://aerie_sequencing:27184
             - name: AERIE_UI_DATABASE_URL
               value: postgres://aerie:aerie@postgres:5432/aerie_ui
             - name: HASURA_GRAPHQL_ADMIN_SECRET

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,8 +217,11 @@ services:
     depends_on: ["postgres"]
     environment:
       AERIE_MERLIN_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_merlin"
+      AERIE_MERLIN_URL: "http://aerie_merlin:27183"
       AERIE_SCHEDULER_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_scheduler"
+      AERIE_SCHEDULER_URL: "http://aerie_scheduler:27185"
       AERIE_SEQUENCING_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_sequencing"
+      AERIE_SEQUENCING_URL: "http://aerie_sequencing:27184"
       AERIE_UI_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_ui"
       HASURA_GRAPHQL_ADMIN_SECRET: "${HASURA_GRAPHQL_ADMIN_SECRET}"
       HASURA_GRAPHQL_DEV_MODE: "true"

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -214,8 +214,11 @@ services:
     depends_on: ['postgres']
     environment:
       AERIE_MERLIN_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_merlin'
+      AERIE_MERLIN_URL: "http://aerie_merlin:27183"
       AERIE_SCHEDULER_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_scheduler'
+      AERIE_SCHEDULER_URL: "http://aerie_scheduler:27185"
       AERIE_SEQUENCING_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_sequencing'
+      AERIE_SEQUENCING_URL: "http://aerie_sequencing:27184"
       AERIE_UI_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_ui'
       HASURA_GRAPHQL_ADMIN_SECRET: "${HASURA_GRAPHQL_ADMIN_SECRET}"
       HASURA_GRAPHQL_DEV_MODE: 'true'


### PR DESCRIPTION
* **Tickets addressed:** Closes https://github.com/NASA-AMMOS/aerie/issues/903
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

- Adds three additional Hasura environment variables for specifying service URLs in actions and events.
- Add default timeout of 300 seconds for actions and events. Created a feature request in Hasrua (https://github.com/hasura/graphql-engine/issues/9630) to add support for numeric env vars.

## Verification

All actions and events should still work.

## Documentation

Environment variables document updated.

## Future work

If Hasura supports numeric env vars we can add the timeout as an env var in the future.
Will merge the UI test docker-compose after this is merged (https://github.com/NASA-AMMOS/aerie-ui/pull/631).
