### PR TITLE
Add ACTIVE and LOAD to eDSL

### DIFF
--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
@@ -9,6 +9,8 @@ import {
   TimingTypes,
   Ground_Event,
   Ground_Block,
+    LoadStep,
+    ActivateStep,
   ImmediateStem,
     FLOAT,
     INT,
@@ -40,40 +42,92 @@ describe('Command', () => {
     it('should handle absolute time tagged commands', () => {
       const command = CommandStem.new({
         stem: 'TEST',
-        arguments: ['string', 0, true],
+        arguments: [{type: 'string', value: 'string' }, {type: 'number', value: 0 }, { type: 'boolean', value: true }],
         absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
       });
 
-      expect(command.toEDSLString()).toEqual("A`2020-001T00:00:00.000`.TEST('string', 0, true)");
+      expect(command.toEDSLString()).toEqual(`A\`2020-001T00:00:00.000\`.TEST([
+  {
+    type: 'string',
+    value: 'string',
+  },
+  {
+    type: 'number',
+    value: 0,
+  },
+  {
+    type: 'boolean',
+    value: true,
+  },
+])`);
     });
 
     it('should handle relative time tagged commands', () => {
       const command = CommandStem.new({
         stem: 'TEST',
-        arguments: ['string', 0, true],
+        arguments: [{type: 'string', value: 'string' }, {type: 'number', value: 0 }, { type: 'boolean', value: true }],
         relativeTime: hmsToDuration('00:00:00.000' as HMS_STRING),
       });
 
-      expect(command.toEDSLString()).toEqual("R`00:00:00.000`.TEST('string', 0, true)");
+      expect(command.toEDSLString()).toEqual(`R\`00:00:00.000\`.TEST([
+  {
+    type: 'string',
+    value: 'string',
+  },
+  {
+    type: 'number',
+    value: 0,
+  },
+  {
+    type: 'boolean',
+    value: true,
+  },
+])`);
     });
 
     it('should handle epoch relative time tagged commands', () => {
       const command = CommandStem.new({
         stem: 'TEST',
-        arguments: ['string', 0, true],
+        arguments: [{type: 'string', value: 'string' }, {type: 'number', value: 0 }, { type: 'boolean', value: true }],
         epochTime: hmsToDuration('00:00:00.000' as HMS_STRING),
       });
 
-      expect(command.toEDSLString()).toEqual("E`00:00:00.000`.TEST('string', 0, true)");
+      expect(command.toEDSLString()).toEqual(`E\`00:00:00.000\`.TEST([
+  {
+    type: 'string',
+    value: 'string',
+  },
+  {
+    type: 'number',
+    value: 0,
+  },
+  {
+    type: 'boolean',
+    value: true,
+  },
+])`);
     });
 
     it('should handle command complete commands', () => {
       const command = CommandStem.new({
         stem: 'TEST',
-        arguments: ['string', 0, true],
+        arguments: [{type: 'string', value: 'string' }, {type: 'number', value: 0 }, { type: 'boolean', value: true }],
       });
 
-      expect(command.toEDSLString()).toEqual("C.TEST('string', 0, true)");
+      expect(command.toEDSLString()).toEqual(`C.TEST([
+  {
+    type: 'string',
+    value: 'string',
+  },
+  {
+    type: 'number',
+    value: 0,
+  },
+  {
+    type: 'boolean',
+    value: true,
+  },
+])`);
     });
 
     it('should handle commands without arguments', () => {
@@ -95,11 +149,24 @@ describe('Command', () => {
     it('should convert to EDSL string with array arguments', () => {
       const command = CommandStem.new({
         stem: 'TEST',
-        arguments: ['string', 0, true],
+        arguments: [{type: 'string', value: 'string' }, {type: 'number', value: 0 }, { type: 'boolean', value: true }],
         absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
       });
 
-      expect(command.toEDSLString()).toEqual("A`2020-001T00:00:00.000`.TEST('string', 0, true)");
+      expect(command.toEDSLString()).toEqual(`A\`2020-001T00:00:00.000\`.TEST([
+  {
+    type: 'string',
+    value: 'string',
+  },
+  {
+    type: 'number',
+    value: 0,
+  },
+  {
+    type: 'boolean',
+    value: true,
+  },
+])`);
     });
 
     it('should convert to EDSL string with named arguments', () => {
@@ -127,20 +194,18 @@ describe('Command', () => {
         metadata: { author: 'Emery' },
       });
 
-      expect(groundEvent.toEDSLString()).toEqual(
-        "A`2020-001T00:00:00.000`.GROUND_EVENT('Ground Event Name')\n" +
-          '.ARGUMENTS([\n' +
-          '  {\n' +
-          "    name: 'name',\n" +
-          "    type: 'string',\n" +
-          "    value: 'hello',\n" +
-          '  }\n' +
-          '])\n' +
-          ".DESCRIPTION('ground event description')\n" +
-          '.METADATA({\n' +
-          "  author: 'Emery',\n" +
-          '})',
-      );
+      expect(groundEvent.toEDSLString()).toEqual(`A\`2020-001T00:00:00.000\`.GROUND_EVENT('Ground Event Name')
+  .ARGUMENTS([
+    {
+      name: 'name',
+      type: 'string',
+      value: 'hello',
+    },
+  ])
+  .DESCRIPTION('ground event description')
+  .METADATA({
+    author: 'Emery',
+  })`);
     });
 
     it('should convert to EDSL string from ground block', () => {
@@ -151,20 +216,92 @@ describe('Command', () => {
         metadata: { author: 'Jasmine' },
       });
 
-      expect(groundBlock.toEDSLString()).toEqual(
-        "C.GROUND_BLOCK('Ground Block Name')\n" +
-          '.ARGUMENTS([\n' +
-          '  {\n' +
-          "    name: 'turnOff',\n" +
-          "    type: 'boolean',\n" +
-          '    value: false,\n' +
-          '  }\n' +
-          '])\n' +
-          ".DESCRIPTION('ground block description')\n" +
-          '.METADATA({\n' +
-          "  author: 'Jasmine',\n" +
-          '})',
-      );
+      expect(groundBlock.toEDSLString()).toEqual(`C.GROUND_BLOCK('Ground Block Name')
+  .ARGUMENTS([
+    {
+      name: 'turnOff',
+      type: 'boolean',
+      value: false,
+    },
+  ])
+  .DESCRIPTION('ground block description')
+  .METADATA({
+    author: 'Jasmine',
+  })`);
+    });
+
+    it('should convert to EDSL string from Activate', () => {
+      const activateStep = ActivateStep.new({
+        sequence: 'test0001',
+        args: [{ name: 'turnOff', type: 'boolean', value: false }],
+        description: 'ground block description',
+        metadata: { author: 'Ryan' },
+        engine : 45,
+        epoch : "epoch1",
+        models : [{
+          offset: '00:00:00.000',
+          value: '1.234',
+          variable: 'model_var_float',
+        },]
+      });
+
+      expect(activateStep.toEDSLString()).toEqual(`C.ACTIVATE('test0001')
+  .ARGUMENTS([
+    {
+      name: 'turnOff',
+      type: 'boolean',
+      value: false,
+    },
+  ])
+  .DESCRIPTION('ground block description')
+  .ENGINE(45)
+  .EPOCH('epoch1')
+  .METADATA({
+    author: 'Ryan',
+  })
+  .MODELS([
+    {
+      offset: '00:00:00.000',
+      value: '1.234',
+      variable: 'model_var_float',
+    }
+  ])`);
+    });
+
+    it('should convert to EDSL string from Load', () => {
+      const loadStep = LoadStep.new({
+        sequence: 'test0001',
+        args: [{ name: 'turnOff', type: 'boolean', value: false }],
+        description: 'ground block description',
+        metadata: { author: 'Ryan' },
+        engine : 45,
+        epoch : "epoch1",
+        models : [{
+          offset: '00:00:00.000',
+          value: '1.234',
+          variable: 'model_var_float',
+        },]
+      });
+
+      expect(loadStep.toEDSLString()).toEqual(`C.LOAD('test0001')
+  .ARGUMENTS([
+    {
+      name: 'turnOff',
+      type: 'boolean',
+      value: false,
+    },
+  ])
+  .DESCRIPTION('ground block description')
+  .ENGINE(45)
+  .EPOCH('epoch1')\t  .METADATA({
+    author: 'Ryan',
+  })./  .MODELS([
+    {
+      offset: '00:00:00.000',
+      value: '1.234',
+      variable: 'model_var_float',
+    }
+  ])`);
     });
 
     it('should convert to EDSL string from Variable', () => {
@@ -360,22 +497,26 @@ describe('Sequence', () => {
       ENUM('duration', 'POSSIBLE_DURATION')
     ],
     steps: ({ locals, parameters }) => ([
-      A\`2020-001T00:00:00.000\`.TEST('string', 0, true),
+      A\`2020-001T00:00:00.000\`.TEST([
+          'string',
+          0,
+          true,
+      ]),
       A\`2020-001T00:00:00.000\`.TEST({
         string: 'string',
         number: 0,
         boolean: true,
       })
-      .METADATA({
-        author: 'XXXXXXXXXXXXXXXXXXXXXXXXXX',
-      }),
+        .METADATA({
+          author: 'XXXXXXXXXXXXXXXXXXXXXXXXXX',
+        }),
       A\`2021-001T00:00:00.000\`.TEST({
         temperature: locals.temp,
         duration: parameters.duration,
       })
-      .METADATA({
-        author: 'ZZZZ',
-      }),
+        .METADATA({
+          author: 'ZZZZ',
+        }),
     ]),
   });`);
     });
@@ -410,25 +551,26 @@ describe('Sequence', () => {
         seqId: 'Immediate',
         metadata: {},
         immediate_commands: [
-          ImmediateStem.new({ stem: 'SMASH_BANANA', arguments: ['AGRESSIVE'] })
+          ImmediateStem.new({ stem: 'SMASH_BANANA', arguments: { behavior : 'AGRESSIVE'} })
             .DESCRIPTION('Hulk smash banannas')
             .METADATA({ author: 'An Avenger' }),
         ],
       });
 
-      expect(sequence.toEDSLString()).toEqual(
-        'export default () =>\n' +
-          '  Sequence.new({\n' +
-          "    seqId: 'Immediate',\n" +
-          '    metadata: {},\n' +
-          '    immediate_commands: [\n' +
-          "      SMASH_BANANA('AGRESSIVE')\n" +
-          "      .DESCRIPTION('Hulk smash banannas')\n" +
-          '      .METADATA({\n' +
-          "        author: 'An Avenger',\n" +
-          '      }),\n' +
-          '    ],\n' +
-          '  });',
+      expect(sequence.toEDSLString()).toEqual(`export default () =>
+  Sequence.new({
+    seqId: 'Immediate',
+    metadata: {},
+    immediate_commands: [
+      SMASH_BANANA({
+        behavior: 'AGRESSIVE',
+      })
+        .DESCRIPTION('Hulk smash banannas')
+        .METADATA({
+          author: 'An Avenger',
+        }),
+    ],
+  });`
       );
     });
   });

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -3,6 +3,10 @@
 exports[`should return command types 1`] = `
 "/** START Preface */
 
+/**-----------------------------
+ *            ENUMS
+ * -----------------------------
+ */
 export enum TimingTypes {
   ABSOLUTE = 'ABSOLUTE',
   COMMAND_RELATIVE = 'COMMAND_RELATIVE',
@@ -18,15 +22,18 @@ export enum VariableType {
   ENUM = 'ENUM'
 }
 
-export type VariableOptions = {
-  name: string;
-  type: VariableType;
-  enum_name?: string | undefined;
-  allowable_values?: unknown[] | undefined;
-  // @ts-ignore : 'VariableRange' found in JSON Spec
-  allowable_ranges?: VariableRange[] | undefined;
-  sc_name?: string | undefined;
-};
+enum StepType {
+  Command = 'command',
+  GroundBlock = 'ground_block',
+  GroundEvent = 'ground_event',
+  Activate = 'activate',
+  Load = 'load'
+}
+
+/**-----------------------------
+ *      eDSL Interfaces
+ * -----------------------------
+ */
 // @ts-ignore : 'VariableDeclaration' found in JSON Spec
 export interface INT<N extends string> extends VariableDeclaration {
   name: N;
@@ -75,6 +82,21 @@ export interface ENUM<N extends string, E extends string> extends VariableDeclar
   allowable_values?: unknown[] | undefined;
   sc_name?: string | undefined;
 }
+
+/**-----------------------------
+ *      eDSL Options types
+ * -----------------------------
+ */
+
+export type VariableOptions = {
+  name: string;
+  type: VariableType;
+  enum_name?: string | undefined;
+  allowable_values?: unknown[] | undefined;
+  // @ts-ignore : 'VariableRange' found in JSON Spec
+  allowable_ranges?: VariableRange[] | undefined;
+  sc_name?: string | undefined;
+};
 
 export type SequenceOptions = {
   seqId: string;
@@ -161,7 +183,37 @@ export type GroundOptions = {
   | {}
 );
 
+export type ActivateLoadOptions = {
+  sequence: string;
+  // @ts-ignore : 'Args' found in JSON Spec
+  args?: Args | undefined;
+  description?: string | undefined;
+  engine?: number | undefined;
+  epoch?: string | undefined;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  metadata?: Metadata | undefined;
+  // @ts-ignore : 'Model' found in JSON Spec
+  models?: Model[] | undefined;
+} & (
+    | {
+  absoluteTime: Temporal.Instant;
+}
+    | {
+  epochTime: Temporal.Duration;
+}
+    | {
+  relativeTime: Temporal.Duration;
+}
+    // CommandComplete
+    | {}
+    );
+
 export type Arrayable<T> = T | Arrayable<T>[];
+
+/**-----------------------------
+ *      GLOBAL eDSL Declarations
+ * -----------------------------
+ */
 
 declare global {
   // @ts-ignore : 'SeqJson' found in JSON Spec
@@ -548,7 +600,13 @@ export class Sequence implements SeqJson {
       ...(this.steps
         ? {
             steps: this.steps.map(step => {
-              if (step instanceof CommandStem || step instanceof Ground_Block || step instanceof Ground_Event)
+              if (
+                  step instanceof CommandStem ||
+                  step instanceof Ground_Block ||
+                  step instanceof Ground_Event ||
+                  step instanceof ActivateStep ||
+                  step instanceof LoadStep
+              )
                 return step.toSeqJson();
               return step;
             }),
@@ -587,7 +645,7 @@ export class Sequence implements SeqJson {
                   request.steps[0] instanceof CommandStem ||
                   request.steps[0] instanceof Ground_Block ||
                   request.steps[0] instanceof Ground_Event
-                    ? request.steps[0].toSeqJson()
+                      ? request.steps[0].toSeqJson()
                     : request.steps[0],
                   // @ts-ignore : 'step' found in JSON Spec
                   ...request.steps.slice(1).map(step => {
@@ -636,24 +694,30 @@ export class Sequence implements SeqJson {
 
   public toEDSLString(): string {
     const commandsString =
-      this.steps && this.steps.length > 0
-        ? '[\\n' +
-          indent(
-            this.steps
-              .map(step => {
-                if (step instanceof CommandStem || step instanceof Ground_Block || step instanceof Ground_Event) {
-                  return step.toEDSLString() + ',';
-                }
-                return objectToString(step) + ',';
-              })
-              .join('\\n'),
-            1,
-          ) +
-          '\\n]'
-        : '';
+        this.steps && this.steps.length > 0
+            ? '[\\n' +
+            indent(
+                this.steps
+                    .map(step => {
+                      if (
+                          step instanceof CommandStem ||
+                          step instanceof Ground_Block ||
+                          step instanceof Ground_Event ||
+                          step instanceof ActivateStep ||
+                          step instanceof LoadStep
+                      ) {
+                        return step.toEDSLString() + ',';
+                      }
+                      return argumentsToString(step) + ',';
+                    })
+                    .join('\\n'),
+                1,
+            ) +
+            '\\n]'
+            : '';
     //ex.
     // [C.ADD_WATER]
-    const metadataString = Object.keys(this.metadata).length == 0 ? \`{}\` : \`\${objectToString(this.metadata)}\`;
+    const metadataString = Object.keys(this.metadata).length == 0 ? \`{}\` : \`\${argumentsToString(this.metadata)}\`;
 
     const localsString = this.locals
         ? '[\\n' +
@@ -665,9 +729,9 @@ export class Sequence implements SeqJson {
                   } else if (Variable.isVariable(local)) {
                     return Variable.new(local).toEDSLString();
                   }
-                  return objectToString(local);
+                  return argumentsToString(local);
                 })
-                .join('\\n'),
+                .join(',\\n'),
             1,
         ) +
         '\\n]'
@@ -687,9 +751,9 @@ export class Sequence implements SeqJson {
                   } else if (Variable.isVariable(parameter)) {
                     return Variable.new(parameter).toEDSLString();
                   }
-                  return objectToString(parameter);
+                  return argumentsToString(parameter);
                 })
-                .join('\\n'),
+                .join(',\\n'),
             1,
         ) +
         '\\n]'
@@ -708,56 +772,56 @@ export class Sequence implements SeqJson {
     // ],
 
     const immediateString =
-      this.immediate_commands && this.immediate_commands.length > 0
-        ? '[\\n' +
-          indent(
-            this.immediate_commands
-              .map(command => {
-                if (command instanceof ImmediateStem) {
-                  return command.toEDSLString() + ',';
-                }
-                return objectToString(command) + ',';
-              })
-              .join('\\n'),
-            1,
-          ) +
-          '\\n]'
-        : '';
+        this.immediate_commands && this.immediate_commands.length > 0
+            ? '[\\n' +
+            indent(
+                this.immediate_commands
+                    .map(command => {
+                      if (command instanceof ImmediateStem) {
+                        return command.toEDSLString() + ',';
+                      }
+                      return argumentsToString(command) + ',';
+                    })
+                    .join('\\n'),
+                1,
+            ) +
+            '\\n]'
+            : '';
     //ex.
     // immediate_commands: [ADD_WATER]
 
     const requestString = this.requests
-      ? \`[\\n\${indent(
-          this.requests
-            .map(r => {
-              return (
-                \`{\\n\` +
-                indent(
-                  \`name: '\${r.name}',\\n\` +
-                    \`steps: [\\n\${indent(
-                      r.steps
-                        // @ts-ignore : 's: Step' found in JSON Spec
-                        .map(s => {
-                          if (s instanceof CommandStem || s instanceof Ground_Block || s instanceof Ground_Event) {
-                            return s.toEDSLString() + ',';
-                          }
-                          return objectToString(s) + ',';
-                        })
-                        .join('\\n'),
-                      1,
-                    )}\\n],\` +
-                    \`\\ntype: '\${r.type}',\` +
-                    \`\${r.description ? \`\\ndescription: '\${r.description}',\` : ''}\` +
-                    \`\${r.ground_epoch ? \`\\nground_epoch: \${objectToString(r.ground_epoch)},\` : ''}\` +
-                    \`\${r.time ? \`\\ntime: \${objectToString(r.time)},\` : ''}\` +
-                    \`\${r.metadata ? \`\\nmetadata: \${objectToString(r.metadata)},\` : ''}\`,
-                  1,
-                ) +
-                \`\\n}\`
-              );
-            })
-            .join(',\\n'),
-          1,
+        ? \`[\\n\${indent(
+            this.requests
+                .map(r => {
+                  return (
+                      \`{\\n\` +
+                      indent(
+                          \`name: '\${r.name}',\\n\` +
+                          \`steps: [\\n\${indent(
+                              r.steps
+                                  // @ts-ignore : 's: Step' found in JSON Spec
+                                  .map(s => {
+                                    if (s instanceof CommandStem || s instanceof Ground_Block || s instanceof Ground_Event || s instanceof ActivateStep || s instanceof  LoadStep) {
+                                      return s.toEDSLString() + ',';
+                                    }
+                                    return argumentsToString(s) + ',';
+                                  })
+                                  .join('\\n'),
+                              1,
+                          )}\\n],\` +
+                          \`\\ntype: '\${r.type}',\` +
+                          \`\${r.description ? \`\\ndescription: '\${r.description}',\` : ''}\` +
+                          \`\${r.ground_epoch ? \`\\nground_epoch: \${argumentsToString(r.ground_epoch)},\` : ''}\` +
+                          \`\${r.time ? \`\\ntime: \${argumentsToString(r.time)},\` : ''}\` +
+                          \`\${r.metadata ? \`\\nmetadata: \${argumentsToString(r.metadata)},\` : ''}\`,
+                          1,
+                      ) +
+                      \`\\n}\`
+                  );
+                })
+                .join(',\\n'),
+            1,
         )}\\n]\`
       : '';
     //ex.
@@ -814,11 +878,21 @@ export class Sequence implements SeqJson {
       ...(json.steps
         ? {
             // @ts-ignore : 'Step' found in JSON Spec
-            steps: json.steps.map((c: Step) => {
-              if (c.type === 'command') return CommandStem.fromSeqJson(c as CommandStem, localNames, parameterNames);
-              else if (c.type === 'ground_block') return Ground_Block.fromSeqJson(c as Ground_Block);
-              else if (c.type === 'ground_event') return Ground_Event.fromSeqJson(c as Ground_Event);
-              return c;
+            steps: json.steps.map((step: Step) => {
+              switch (step.type){
+                case StepType.Command:
+                  return CommandStem.fromSeqJson(step as CommandStem, localNames, parameterNames);
+                case StepType.GroundBlock:
+                  return Ground_Block.fromSeqJson(step as Ground_Block)
+                case StepType.GroundEvent:
+                  return Ground_Event.fromSeqJson(step as Ground_Event)
+                case StepType.Activate:
+                  return ActivateStep.fromSeqJson(step as ActivateStep)
+                case StepType.Load:
+                  return LoadStep.fromSeqJson(step as LoadStep)
+                default:
+                  return step;
+              }
             }),
           }
           : {}),
@@ -856,21 +930,37 @@ export class Sequence implements SeqJson {
                 ...(r.time ? { time: r.time } : {}),
                 ...(r.metadata ? { metadata: r.metadata } : {}),
                 steps: [
-                  r.steps[0].type === 'command'
-                    ? CommandStem.fromSeqJson(r.steps[0] as CommandStem,localNames, parameterNames)
-                    : r.steps[0].type === 'ground_block'
-                    ? // @ts-ignore : 'GroundBlock' found in JSON Spec
-                      Ground_Block.fromSeqJson(r.steps[0] as GroundBlock)
-                    : r.steps[0].type === 'ground_event'
-                    ? // @ts-ignore : 'GroundEvent' found in JSON Spec
-                      Ground_Event.fromSeqJson(r.steps[0] as GroundEvent)
-                    : r.steps[0],
+                  r.steps[0].type === StepType.Command
+                      ? CommandStem.fromSeqJson(r.steps[0] as CommandStem,localNames, parameterNames)
+                  : r.steps[0].type === StepType.GroundBlock
+                      // @ts-ignore : 'GroundBlock' found in JSON Spec
+                      ? Ground_Block.fromSeqJson(r.steps[0] as GroundBlock)
+                  : r.steps[0].type === StepType.GroundEvent
+                      // @ts-ignore : 'GroundEvent' found in JSON Spec
+                      ? Ground_Event.fromSeqJson(r.steps[0] as GroundEvent)
+                  : r.steps[0].type === StepType.Activate
+                      // @ts-ignore : 'GroundBlock' found in JSON Spec
+                      ? ActivateStep.fromSeqJson(r.steps[0] as ActivateStep)
+                  : r.steps[0].type === StepType.Load
+                      // @ts-ignore : 'GroundBlock' found in JSON Spec
+                      ? LoadStep.fromSeqJson(r.steps[0] as LoadStep)
+                  : r.steps[0],
                   // @ts-ignore : 'step : Step' found in JSON Spec
                   ...r.steps.slice(1).map(step => {
-                    if (step.type === 'command') return CommandStem.fromSeqJson(step as CommandStem, localNames, parameterNames);
-                    else if (step.type === 'ground_block') return Ground_Block.fromSeqJson(step as Ground_Block);
-                    else if (step.type === 'ground_event') return Ground_Event.fromSeqJson(step as Ground_Event);
-                    return step;
+                    switch (step.type){
+                      case StepType.Command:
+                        return CommandStem.fromSeqJson(step as CommandStem, localNames, parameterNames);
+                      case StepType.GroundBlock:
+                        return Ground_Block.fromSeqJson(step as Ground_Block)
+                      case StepType.GroundEvent:
+                        return Ground_Event.fromSeqJson(step as Ground_Event)
+                      case StepType.Activate:
+                        return ActivateStep.fromSeqJson(step as ActivateStep)
+                      case StepType.Load:
+                        return LoadStep.fromSeqJson(step as LoadStep)
+                      default:
+                        return step;
+                    }
                   }),
                 ],
               };
@@ -994,7 +1084,7 @@ export class Variable implements VariableDeclaration {
         return \`\${type}('\${this.name}'\${
             this._allowable_ranges || this._allowable_values || this._sc_name
                 ? ', ' +
-                objectToString({
+                argumentsToString({
                   ...(this._allowable_ranges ? { allowable_ranges: this._allowable_ranges } : {}),
                   ...(this._allowable_values ? { allowable_values: this._allowable_values } : {}),
                   ...(this._sc_name ? { sc_name: this._sc_name } : {}),
@@ -1006,7 +1096,7 @@ export class Variable implements VariableDeclaration {
         return \`\${type}('\${this.name}'\${
             this._allowable_ranges || this._allowable_values || this._sc_name
                 ? ', ' +
-                objectToString({
+                argumentsToString({
                   ...(this._allowable_values ? { allowable_values: this._allowable_values } : {}),
                   ...(this._sc_name ? { sc_name: this._sc_name } : {}),
                 }) +
@@ -1017,7 +1107,7 @@ export class Variable implements VariableDeclaration {
         return \`\${type}('\${this.name}', '\${this._enum_name}'\${
             this._allowable_ranges || this._allowable_values || this._sc_name
                 ? ', ' +
-                objectToString({
+                argumentsToString({
                   ...(this._allowable_ranges ? { allowable_ranges: this._allowable_ranges } : {}),
                   ...(this._allowable_values ? { allowable_values: this._allowable_values } : {}),
                   ...(this._sc_name ? { sc_name: this._sc_name } : {}),
@@ -1029,7 +1119,7 @@ export class Variable implements VariableDeclaration {
         return \`\${type}(\${this.name}\${this._enum_name ? ', ' + this._enum_name : ''}\${
             this._allowable_ranges || this._allowable_values || this._sc_name
                 ? ', ' +
-                objectToString({
+                argumentsToString({
                   ...(this._allowable_ranges ? { allowable_ranges: this._allowable_ranges } : {}),
                   ...(this._allowable_values ? { allowable_values: this._allowable_values } : {}),
                   ...(this._sc_name ? { sc_name: this._sc_name } : {}),
@@ -1159,7 +1249,7 @@ export function ENUM<const N extends string, const E extends string>(
  * ---------------------------------
  */
 
-// @ts-ignore : 'Args' found in JSON Spec
+  // @ts-ignore : 'Args' found in JSON Spec
 export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
   public readonly arguments: A;
   public readonly absoluteTime: Temporal.Instant | null = null;
@@ -1177,7 +1267,7 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
   private readonly _metadata?: Metadata | undefined;
   // @ts-ignore : 'Description' found in JSON Spec
   private readonly _description?: Description | undefined;
-  public readonly type: 'command' = 'command';
+  public readonly type: 'command' = StepType.Command;
 
   private constructor(opts: CommandOptions<A>) {
     this.stem = opts.stem;
@@ -1277,13 +1367,14 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
     return {
       args: convertArgsToInterfaces(this.arguments),
       stem: this.stem,
+      // prettier-ignore
       time:
-        this.absoluteTime !== null
-          ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this.absoluteTime) }
+          this.absoluteTime !== null
+              ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this.absoluteTime) }
           : this.epochTime !== null
-          ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this.epochTime) }
+              ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this.epochTime) }
           : this.relativeTime !== null
-          ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this.relativeTime) }
+              ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this.relativeTime) }
           : { type: TimingTypes.COMMAND_COMPLETE },
       type: this.type,
       ...(this._metadata ? { metadata: this._metadata } : {}),
@@ -1298,13 +1389,14 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
       localNames?: string[],
       parameterNames?: string[],
   ): CommandStem {
+    // prettier-ignore
     const timeValue =
-      json.time.type === TimingTypes.ABSOLUTE
-        ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
+        json.time.type === TimingTypes.ABSOLUTE
+            ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
         : json.time.type === TimingTypes.COMMAND_RELATIVE
-        ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
+            ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : json.time.type === TimingTypes.EPOCH_RELATIVE
-        ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : {};
 
     return CommandStem.new({
@@ -1346,25 +1438,25 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
 
   public toEDSLString(): string {
     const timeString = this.absoluteTime
-      ? \`A\\\`\${instantToDoy(this.absoluteTime)}\\\`\`
-      : this.epochTime
-      ? \`E\\\`\${durationToHms(this.epochTime)}\\\`\`
-      : this.relativeTime
-      ? \`R\\\`\${durationToHms(this.relativeTime)}\\\`\`
-      : 'C';
+        ? \`A\\\`\${instantToDoy(this.absoluteTime)}\\\`\`
+        : this.epochTime
+            ? \`E\\\`\${durationToHms(this.epochTime)}\\\`\`
+            : this.relativeTime
+                ? \`R\\\`\${durationToHms(this.relativeTime)}\\\`\`
+                : 'C';
 
     const argsString = Object.keys(this.arguments).length === 0 ? '' : \`(\${argumentsToString(this.arguments)})\`;
 
     const metadata =
-      this._metadata && Object.keys(this._metadata).length !== 0
-        ? \`\\n.METADATA(\${objectToString(this._metadata)})\`
-        : '';
+        this._metadata && Object.keys(this._metadata).length !== 0
+            ? "\\n"+indent(\`.METADATA(\${argumentsToString(this._metadata)})\`,1)
+            : '';
     const description =
-      this._description && this._description.length !== 0 ? \`\\n.DESCRIPTION('\${this._description}')\` : '';
+        this._description && this._description.length !== 0 ? "\\n"+indent(\`.DESCRIPTION('\${this._description}')\`,1) : '';
     const models =
-      this._models && Object.keys(this._models).length !== 0
-        ? \`\\n.MODELS([\\n\${this._models.map(m => indent(objectToString(m))).join(',\\n')}\\n])\`
-        : '';
+        this._models && Object.keys(this._models).length !== 0
+            ? "\\n"+indent(\`.MODELS([\\n\${this._models.map(m => indent(argumentsToString(m))).join(',\\n')}\\n])\`,1)
+            : '';
     return \`\${timeString}.\${this.stem}\${argsString}\${description}\${metadata}\${models}\`;
   }
 }
@@ -1444,48 +1536,14 @@ export class ImmediateStem<A extends Args[] | { [argName: string]: any } = [] | 
     const argsString = Object.keys(this.arguments).length === 0 ? '' : \`(\${argumentsToString(this.arguments)})\`;
 
     const metadata =
-      this._metadata && Object.keys(this._metadata).length !== 0
-        ? \`\\n.METADATA(\${objectToString(this._metadata)})\`
-        : '';
+        this._metadata && Object.keys(this._metadata).length !== 0
+            ? "\\n"+indent(\`.METADATA(\${argumentsToString(this._metadata)})\`,1)
+            : '';
     const description =
-      this._description && this._description.length !== 0 ? \`\\n.DESCRIPTION('\${this._description}')\` : '';
+        this._description && this._description.length !== 0 ? "\\n"+indent(\`.DESCRIPTION('\${this._description}')\`,1) : '';
 
     return \`\${this.stem}\${argsString}\${description}\${metadata}\`;
   }
-}
-
-//The function takes an object of arguments and converts them into the Args type. It does this by looping through the
-// values and pushing a new argument type to the result array depending on the type of the value.
-// If the value is an array, it will create a RepeatArgument type and recursively call on the values of the array.
-// the function returns the result array of argument types -
-// StringArgument, NumberArgument, BooleanArgument, SymbolArgument, HexArgument, and RepeatArgument.
-// @ts-ignore : 'Args' found in JSON Spec
-function convertArgsToInterfaces(args: { [argName: string]: any }): Args {
-  // @ts-ignore : 'Args' found in JSON Spec
-  let result: Args = [];
-  if (args['length'] === 0) {
-    return result;
-  }
-
-  const values = Array.isArray(args) ? args[0] : args;
-
-  for (let key in values) {
-    let value = values[key];
-    if (Array.isArray(value)) {
-      // @ts-ignore : 'RepeatArgument' found in JSON Spec
-      let repeatArg: RepeatArgument = {
-        value: value.map(arg => {
-          return convertRepeatArgs(arg);
-        }),
-        type: 'repeat',
-        name: key,
-      };
-      result.push(repeatArg);
-    } else {
-      result = result.concat(convertValueToObject(value, key));
-    }
-  }
-  return result;
 }
 
 // @ts-ignore : 'GroundBlock' found in JSON Spec
@@ -1493,7 +1551,7 @@ export class Ground_Block implements GroundBlock {
   name: string;
   // @ts-ignore : 'Time' found in JSON Spec
   time!: Time;
-  type: 'ground_block' = 'ground_block';
+  type: 'ground_block' = StepType.GroundBlock;
 
   private readonly _absoluteTime: Temporal.Instant | null = null;
   private readonly _epochTime: Temporal.Duration | null = null;
@@ -1641,13 +1699,14 @@ export class Ground_Block implements GroundBlock {
   public toSeqJson(): GroundBlock {
     return {
       name: this.name,
+      // prettier-ignore
       time:
-        this._absoluteTime !== null
-          ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
+          this._absoluteTime !== null
+              ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
           : this._epochTime !== null
-          ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
+              ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
           : this._relativeTime !== null
-          ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
+              ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
           : { type: TimingTypes.COMMAND_COMPLETE },
       ...(this._args ? { args: this._args } : {}),
       ...(this._description ? { description: this._description } : {}),
@@ -1659,13 +1718,14 @@ export class Ground_Block implements GroundBlock {
 
   // @ts-ignore : 'GroundBlock' found in JSON Spec
   public static fromSeqJson(json: GroundBlock): Ground_Block {
+    // prettier-ignore
     const timeValue =
-      json.time.type === TimingTypes.ABSOLUTE
-        ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
+        json.time.type === TimingTypes.ABSOLUTE
+            ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
         : json.time.type === TimingTypes.COMMAND_RELATIVE
-        ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
+            ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : json.time.type === TimingTypes.EPOCH_RELATIVE
-        ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : {};
 
     return Ground_Block.new({
@@ -1680,31 +1740,28 @@ export class Ground_Block implements GroundBlock {
 
   public toEDSLString(): string {
     const timeString = this._absoluteTime
-      ? \`A\\\`\${instantToDoy(this._absoluteTime)}\\\`\`
-      : this._epochTime
-      ? \`E\\\`\${durationToHms(this._epochTime)}\\\`\`
-      : this._relativeTime
-      ? \`R\\\`\${durationToHms(this._relativeTime)}\\\`\`
-      : 'C';
+        ? \`A\\\`\${instantToDoy(this._absoluteTime)}\\\`\`
+        : this._epochTime
+            ? \`E\\\`\${durationToHms(this._epochTime)}\\\`\`
+            : this._relativeTime
+                ? \`R\\\`\${durationToHms(this._relativeTime)}\\\`\`
+                : 'C';
 
     const args =
-      this._args && Object.keys(this._args).length !== 0
-        ? // @ts-ignore : 'A : Args' found in JSON Spec
-          \`\\n.ARGUMENTS([\\n\${this._args.map(a => indent(objectToString(a))).join(',\\n')}\\n])\`
-        : '';
+        this._args && Object.keys(this._args).length !== 0 ? "\\n"+indent(\`.ARGUMENTS(\${argumentsToString(this._args)})\`,1) : '';
 
     const metadata =
-      this._metadata && Object.keys(this._metadata).length !== 0
-        ? \`\\n.METADATA(\${objectToString(this._metadata)})\`
-        : '';
+        this._metadata && Object.keys(this._metadata).length !== 0
+            ? "\\n"+indent(\`.METADATA(\${argumentsToString(this._metadata)})\`,1)
+            : '';
 
     const description =
-      this._description && this._description.length !== 0 ? \`\\n.DESCRIPTION('\${this._description}')\` : '';
+        this._description && this._description.length !== 0 ? "\\n"+indent(\`.DESCRIPTION('\${this._description}')\`,1) : '';
 
     const models =
-      this._models && Object.keys(this._models).length !== 0
-        ? \`\\n.MODELS([\\n\${this._models.map(m => indent(objectToString(m))).join(',\\n')}\\n])\`
-        : '';
+        this._models && Object.keys(this._models).length !== 0
+            ? "\\n"+indent(\`.MODELS([\\n\${this._models.map(m => indent(argumentsToString(m))).join(',\\n')}\\n])\`,1)
+            : '';
 
     return \`\${timeString}.GROUND_BLOCK('\${this.name}')\${args}\${description}\${metadata}\${models}\`;
   }
@@ -1723,7 +1780,7 @@ export class Ground_Event implements GroundEvent {
   name: string;
   // @ts-ignore : 'Time' found in JSON Spec
   time!: Time;
-  type: 'ground_event' = 'ground_event';
+  type: 'ground_event' = StepType.GroundEvent;
 
   private readonly _absoluteTime: Temporal.Instant | null = null;
   private readonly _epochTime: Temporal.Duration | null = null;
@@ -1872,13 +1929,13 @@ export class Ground_Event implements GroundEvent {
     return {
       name: this.name,
       time:
-        this._absoluteTime !== null
-          ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
-          : this._epochTime !== null
-          ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
-          : this._relativeTime !== null
-          ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
-          : { type: TimingTypes.COMMAND_COMPLETE },
+          this._absoluteTime !== null
+              ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
+              : this._epochTime !== null
+                  ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
+                  : this._relativeTime !== null
+                      ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
+                      : { type: TimingTypes.COMMAND_COMPLETE },
       ...(this._args ? { args: this._args } : {}),
       ...(this._description ? { description: this._description } : {}),
       ...(this._metadata ? { metadata: this._metadata } : {}),
@@ -1889,13 +1946,14 @@ export class Ground_Event implements GroundEvent {
 
   // @ts-ignore : 'GroundEvent' found in JSON Spec
   public static fromSeqJson(json: GroundEvent): Ground_Event {
+    // prettier-ignore
     const timeValue =
-      json.time.type === TimingTypes.ABSOLUTE
-        ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
+        json.time.type === TimingTypes.ABSOLUTE
+            ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
         : json.time.type === TimingTypes.COMMAND_RELATIVE
-        ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
+            ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : json.time.type === TimingTypes.EPOCH_RELATIVE
-        ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : {};
 
     return Ground_Event.new({
@@ -1910,31 +1968,28 @@ export class Ground_Event implements GroundEvent {
 
   public toEDSLString(): string {
     const timeString = this._absoluteTime
-      ? \`A\\\`\${instantToDoy(this._absoluteTime)}\\\`\`
-      : this._epochTime
-      ? \`E\\\`\${durationToHms(this._epochTime)}\\\`\`
-      : this._relativeTime
-      ? \`R\\\`\${durationToHms(this._relativeTime)}\\\`\`
-      : 'C';
+        ? \`A\\\`\${instantToDoy(this._absoluteTime)}\\\`\`
+        : this._epochTime
+            ? \`E\\\`\${durationToHms(this._epochTime)}\\\`\`
+            : this._relativeTime
+                ? \`R\\\`\${durationToHms(this._relativeTime)}\\\`\`
+                : 'C';
 
     const args =
-      this._args && Object.keys(this._args).length !== 0
-        ? // @ts-ignore : 'A : Args' found in JSON Spec
-          \`\\n.ARGUMENTS([\\n\${this._args.map(a => indent(objectToString(a))).join(',\\n')}\\n])\`
-        : '';
+        this._args && Object.keys(this._args).length !== 0 ? \`\\n\`+indent(\`.ARGUMENTS(\${argumentsToString(this._args)})\`,1) : '';
 
     const metadata =
-      this._metadata && Object.keys(this._metadata).length !== 0
-        ? \`\\n.METADATA(\${objectToString(this._metadata)})\`
-        : '';
+        this._metadata && Object.keys(this._metadata).length !== 0
+            ? '\\n'+indent(\`.METADATA(\${argumentsToString(this._metadata)})\`,1)
+            : '';
 
     const description =
-      this._description && this._description.length !== 0 ? \`\\n.DESCRIPTION('\${this._description}')\` : '';
+        this._description && this._description.length !== 0 ? "\\n"+indent(\`.DESCRIPTION('\${this._description}')\`,1) : '';
 
     const models =
-      this._models && Object.keys(this._models).length !== 0
-        ? \`\\n.MODELS([\\n\${this._models.map(m => indent(objectToString(m))).join(',\\n')}\\n])\`
-        : '';
+        this._models && Object.keys(this._models).length !== 0
+            ? "\\n"+indent(\`.MODELS([\\n\${this._models.map(m => indent(argumentsToString(m))).join(',\\n')}\\n])\`,1)
+            : '';
 
     return \`\${timeString}.GROUND_EVENT('\${this.name}')\${args}\${description}\${metadata}\${models}\`;
   }
@@ -1948,9 +2003,597 @@ function GROUND_EVENT(name: string) {
   return new Ground_Event({ name: name });
 }
 
+// @ts-ignore : 'Activate' found in JSON Spec
+export class ActivateStep implements Activate {
+  sequence: string;
+  // @ts-ignore : 'Time' found in JSON Spec
+  time!: Time;
+  type: 'activate' = StepType.Activate;
+
+  private readonly _absoluteTime: Temporal.Instant | null = null;
+  private readonly _epochTime: Temporal.Duration | null = null;
+  private readonly _relativeTime: Temporal.Duration | null = null;
+
+  // @ts-ignore : 'Args' found in JSON Spec
+  private readonly _args?: Args | undefined;
+  private readonly _description?: string | undefined;
+  private readonly _engine?: number | undefined;
+  private readonly _epoch?: string | undefined;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  private readonly _metadata?: Metadata | undefined;
+  // @ts-ignore : 'Model' found in JSON Spec
+  private readonly _models?: Model[] | undefined;
+
+  constructor(opts: ActivateLoadOptions) {
+    this.sequence = opts.sequence;
+
+    this._args = opts.args ?? undefined;
+    this._description = opts.description ?? undefined;
+    this._engine = opts.engine ?? undefined;
+    this._epoch = opts.epoch ?? undefined;
+    this._metadata = opts.metadata ?? undefined;
+    this._models = opts.models ?? undefined;
+
+    if ('absoluteTime' in opts) {
+      this._absoluteTime = opts.absoluteTime;
+    } else if ('epochTime' in opts) {
+      this._epochTime = opts.epochTime;
+    } else if ('relativeTime' in opts) {
+      this._relativeTime = opts.relativeTime;
+    }
+  }
+
+  public static new(opts: ActivateLoadOptions): ActivateStep {
+    return new ActivateStep(opts);
+  }
+
+  public absoluteTiming(absoluteTime: Temporal.Instant): ActivateStep {
+    return new ActivateStep({
+      sequence: this.sequence,
+      absoluteTime: absoluteTime,
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._engine ? { engine: this._engine } : {}),
+      ...(this._epoch ? { epoch: this._epoch } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+    });
+  }
+
+  public epochTiming(epochTime: Temporal.Duration): ActivateStep {
+    return new ActivateStep({
+      sequence: this.sequence,
+      epochTime: epochTime,
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._engine ? { engine: this._engine } : {}),
+      ...(this._epoch ? { epoch: this._epoch } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+    });
+  }
+
+  public relativeTiming(relativeTime: Temporal.Duration): ActivateStep {
+    return new ActivateStep({
+      sequence: this.sequence,
+      relativeTime: relativeTime,
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._engine ? { engine: this._engine } : {}),
+      ...(this._epoch ? { epoch: this._epoch } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+    });
+  }
+
+  // @ts-ignore : 'Args' found in JSON Spec
+  public ARGUMENTS(args: Args): ActivateStep {
+    return ActivateStep.new({
+      sequence: this.sequence,
+      args: args,
+      ...(this._description && { description: this._description }),
+      ...(this._engine && { engine: this._engine }),
+      ...(this._epoch && { epoch: this._epoch }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._models && { models: this._models }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Args' found in JSON Spec
+  public GET_ARGUMENTS(): Args | undefined {
+    return this._args;
+  }
+
+  public DESCRIPTION(description: string): ActivateStep {
+    return ActivateStep.new({
+      sequence: this.sequence,
+      description: description,
+      ...(this._args && { args: this._args }),
+      ...(this._engine && { engine: this._engine }),
+      ...(this._epoch && { epoch: this._epoch }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._models && { models: this._models }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  public GET_DESCRIPTION(): string | undefined {
+    return this._description;
+  }
+
+  public ENGINE(engine: number): ActivateStep {
+    return ActivateStep.new({
+      sequence: this.sequence,
+      engine: engine,
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      ...(this._epoch && { epoch: this._epoch }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._models && { models: this._models }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  public GET_ENGINE(): number | undefined {
+    return this._engine;
+  }
+
+  public EPOCH(epoch: string): ActivateStep {
+    return ActivateStep.new({
+      sequence: this.sequence,
+      epoch: epoch,
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      ...(this._engine && { engine: this._engine }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._models && { models: this._models }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  public GET_EPOCH(): string | undefined {
+    return this._epoch;
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public METADATA(metadata: Metadata): ActivateStep {
+    return ActivateStep.new({
+      sequence: this.sequence,
+      metadata: metadata,
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      ...(this._engine && { engine: this._engine }),
+      ...(this._epoch && { epoch: this._epoch }),
+      ...(this._models && { models: this._models }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public GET_METADATA(): Metadata | undefined {
+    return this._metadata;
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public MODELS(models: Model[]): ActivateStep {
+    return ActivateStep.new({
+      sequence: this.sequence,
+      models: models,
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      ...(this._engine && { engine: this._engine }),
+      ...(this._epoch && { epoch: this._epoch }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public GET_MODELS(): Model[] | undefined {
+    return this._models;
+  }
+
+  // @ts-ignore : 'Activate' found in JSON Spec
+  public toSeqJson(): Activate {
+    return {
+      sequence: this.sequence,
+      time:
+          this._absoluteTime !== null
+              ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
+              : this._epochTime !== null
+                  ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
+                  : this._relativeTime !== null
+                      ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
+                      : { type: TimingTypes.COMMAND_COMPLETE },
+      type: this.type,
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._engine ? { engine: this._engine } : {}),
+      ...(this._epoch ? { epoch: this._epoch } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      ...(this._absoluteTime ? { absoluteTime: this._absoluteTime } : {}),
+      ...(this._epochTime ? { epochTime: this._epochTime } : {}),
+      ...(this._relativeTime ? { relativeTime: this._relativeTime } : {}),
+    };
+  }
+
+  // @ts-ignore : 'Activate' found in JSON Spec
+  public static fromSeqJson(json: Activate): ActivateStep {
+    // prettier-ignore
+    const timeValue =
+        json.time.type === TimingTypes.ABSOLUTE
+            ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
+        : json.time.type === TimingTypes.COMMAND_RELATIVE
+            ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
+        : json.time.type === TimingTypes.EPOCH_RELATIVE
+            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+        : {};
+
+    return ActivateStep.new({
+      sequence: json.sequence,
+      ...timeValue,
+      ...(json.args ? { args: json.args } : {}),
+      ...(json.description ? { description: json.description } : {}),
+      ...(json.engine ? { engine: json.engine } : {}),
+      ...(json.epoch ? { epoch: json.epoch } : {}),
+      ...(json.metadata ? { metadata: json.metadata } : {}),
+      ...(json.models ? { model: json.models } : {}),
+    });
+  }
+
+  public toEDSLString(): string {
+    const timeString = this._absoluteTime
+        ? \`A\\\`\${instantToDoy(this._absoluteTime)}\\\`\`
+        : this._epochTime
+            ? \`E\\\`\${durationToHms(this._epochTime)}\\\`\`
+            : this._relativeTime
+                ? \`R\\\`\${durationToHms(this._relativeTime)}\\\`\`
+                : 'C';
+
+    const args =
+        this._args && Object.keys(this._args).length !== 0 ? "\\n"+indent(\`.ARGUMENTS(\${argumentsToString(this._args)})\`,1) : '';
+
+    const description =
+        this._description && this._description.length !== 0 ? "\\n"+indent(\`.DESCRIPTION('\${this._description}')\`,1) : '';
+
+    const epoch = this._epoch ? "\\n"+indent(\`.EPOCH('\${this._epoch}')\`,1) : '';
+
+    const engine = this._engine ? "\\n"+indent(\`.ENGINE(\${this._engine})\`,1) : '';
+
+    const metadata =
+        this._metadata && Object.keys(this._metadata).length !== 0
+            ? "\\n"+indent(\`.METADATA(\${argumentsToString(this._metadata)})\`)
+            : '';
+
+    const models =
+        this._models && Object.keys(this._models).length !== 0
+            ? "\\n"+indent(\`.MODELS([\\n\${this._models.map(m => indent(argumentsToString(m))).join(',\\n')}\\n])\`,1)
+            : '';
+
+    return \`\${timeString}.ACTIVATE('\${this.sequence}')\${args}\${description}\${engine}\${epoch}\${metadata}\${models}\`;
+  }
+}
+
+/**
+ * This is a ACTIVATE step
+ *
+ */
+function ACTIVATE(sequence: string): ActivateStep {
+  return new ActivateStep({ sequence: sequence });
+}
+
+// @ts-ignore : 'Load' found in JSON Spec
+export class LoadStep implements Load {
+  sequence: string;
+  // @ts-ignore : 'Time' found in JSON Spec
+  time!: Time;
+  type: 'load' = StepType.Load;
+
+  private readonly _absoluteTime: Temporal.Instant | null = null;
+  private readonly _epochTime: Temporal.Duration | null = null;
+  private readonly _relativeTime: Temporal.Duration | null = null;
+
+  // @ts-ignore : 'Args' found in JSON Spec
+  private readonly _args?: Args | undefined;
+  private readonly _description?: string | undefined;
+  private readonly _engine?: number | undefined;
+  private readonly _epoch?: string | undefined;
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  private readonly _metadata?: Metadata | undefined;
+  // @ts-ignore : 'Model' found in JSON Spec
+  private readonly _models?: Model[] | undefined;
+
+  constructor(opts: ActivateLoadOptions) {
+    this.sequence = opts.sequence;
+
+    this._args = opts.args ?? undefined;
+    this._description = opts.description ?? undefined;
+    this._engine = opts.engine ?? undefined;
+    this._epoch = opts.epoch ?? undefined;
+    this._metadata = opts.metadata ?? undefined;
+    this._models = opts.models ?? undefined;
+
+    if ('absoluteTime' in opts) {
+      this._absoluteTime = opts.absoluteTime;
+    } else if ('epochTime' in opts) {
+      this._epochTime = opts.epochTime;
+    } else if ('relativeTime' in opts) {
+      this._relativeTime = opts.relativeTime;
+    }
+  }
+
+  public static new(opts: ActivateLoadOptions): LoadStep {
+    return new LoadStep(opts);
+  }
+
+  public absoluteTiming(absoluteTime: Temporal.Instant): LoadStep {
+    return new LoadStep({
+      sequence: this.sequence,
+      absoluteTime: absoluteTime,
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._engine ? { engine: this._engine } : {}),
+      ...(this._epoch ? { epoch: this._epoch } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+    });
+  }
+
+  public epochTiming(epochTime: Temporal.Duration): LoadStep {
+    return new LoadStep({
+      sequence: this.sequence,
+      epochTime: epochTime,
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._engine ? { engine: this._engine } : {}),
+      ...(this._epoch ? { epoch: this._epoch } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+    });
+  }
+
+  public relativeTiming(relativeTime: Temporal.Duration): LoadStep {
+    return new LoadStep({
+      sequence: this.sequence,
+      relativeTime: relativeTime,
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._engine ? { engine: this._engine } : {}),
+      ...(this._epoch ? { epoch: this._epoch } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+    });
+  }
+
+  // @ts-ignore : 'Args' found in JSON Spec
+  public ARGUMENTS(args: Args): LoadStep {
+    return LoadStep.new({
+      sequence: this.sequence,
+      args: args,
+      ...(this._description && { description: this._description }),
+      ...(this._engine && { engine: this._engine }),
+      ...(this._epoch && { epoch: this._epoch }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._models && { models: this._models }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Args' found in JSON Spec
+  public GET_ARGUMENTS(): Args | undefined {
+    return this._args;
+  }
+
+  public DESCRIPTION(description: string): LoadStep {
+    return LoadStep.new({
+      sequence: this.sequence,
+      description: description,
+      ...(this._args && { args: this._args }),
+      ...(this._engine && { engine: this._engine }),
+      ...(this._epoch && { epoch: this._epoch }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._models && { models: this._models }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  public GET_DESCRIPTION(): string | undefined {
+    return this._description;
+  }
+
+  public ENGINE(engine: number): LoadStep {
+    return LoadStep.new({
+      sequence: this.sequence,
+      engine: engine,
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      ...(this._epoch && { epoch: this._epoch }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._models && { models: this._models }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  public GET_ENGINE(): number | undefined {
+    return this._engine;
+  }
+
+  public EPOCH(epoch: string): LoadStep {
+    return LoadStep.new({
+      sequence: this.sequence,
+      epoch: epoch,
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      ...(this._engine && { engine: this._engine }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._models && { models: this._models }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  public GET_EPOCH(): string | undefined {
+    return this._epoch;
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public METADATA(metadata: Metadata): LoadStep {
+    return LoadStep.new({
+      sequence: this.sequence,
+      metadata: metadata,
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      ...(this._engine && { engine: this._engine }),
+      ...(this._epoch && { epoch: this._epoch }),
+      ...(this._models && { models: this._models }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Metadata' found in JSON Spec
+  public GET_METADATA(): Metadata | undefined {
+    return this._metadata;
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public MODELS(models: Model[]): LoadStep {
+    return LoadStep.new({
+      sequence: this.sequence,
+      models: models,
+      ...(this._args && { args: this._args }),
+      ...(this._description && { description: this._description }),
+      ...(this._engine && { engine: this._engine }),
+      ...(this._epoch && { epoch: this._epoch }),
+      ...(this._metadata && { metadata: this._metadata }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
+    });
+  }
+
+  // @ts-ignore : 'Model' found in JSON Spec
+  public GET_MODELS(): Model[] | undefined {
+    return this._models;
+  }
+
+  // @ts-ignore : 'Load' found in JSON Spec
+  public toSeqJson(): Load {
+    return {
+      sequence: this.sequence,
+      time:
+          this._absoluteTime !== null
+              ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
+              : this._epochTime !== null
+                  ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
+                  : this._relativeTime !== null
+                      ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
+                      : { type: TimingTypes.COMMAND_COMPLETE },
+      type: this.type,
+      ...(this._args ? { args: this._args } : {}),
+      ...(this._description ? { description: this._description } : {}),
+      ...(this._engine ? { engine: this._engine } : {}),
+      ...(this._epoch ? { epoch: this._epoch } : {}),
+      ...(this._metadata ? { metadata: this._metadata } : {}),
+      ...(this._models ? { model: this._models } : {}),
+      ...(this._absoluteTime ? { absoluteTime: this._absoluteTime } : {}),
+      ...(this._epochTime ? { epochTime: this._epochTime } : {}),
+      ...(this._relativeTime ? { relativeTime: this._relativeTime } : {}),
+    };
+  }
+
+  // @ts-ignore : 'Activate' found in JSON Spec
+  public static fromSeqJson(json: Load): LoadStep {
+    // prettier-ignore
+    const timeValue =
+        json.time.type === TimingTypes.ABSOLUTE
+            ? { absoluteTime: doyToInstant(json.time.tag as DOY_STRING) }
+        : json.time.type === TimingTypes.COMMAND_RELATIVE
+            ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
+        : json.time.type === TimingTypes.EPOCH_RELATIVE
+            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+        : {};
+
+    return LoadStep.new({
+      sequence: json.sequence,
+      ...timeValue,
+      ...(json.args ? { args: json.args } : {}),
+      ...(json.description ? { description: json.description } : {}),
+      ...(json.engine ? { engine: json.engine } : {}),
+      ...(json.epoch ? { epoch: json.epoch } : {}),
+      ...(json.metadata ? { metadata: json.metadata } : {}),
+      ...(json.models ? { model: json.models } : {}),
+    });
+  }
+
+  public toEDSLString(): string {
+    const timeString = this._absoluteTime
+        ? \`A\\\`\${instantToDoy(this._absoluteTime)}\\\`\`
+        : this._epochTime
+            ? \`E\\\`\${durationToHms(this._epochTime)}\\\`\`
+            : this._relativeTime
+                ? \`R\\\`\${durationToHms(this._relativeTime)}\\\`\`
+                : 'C';
+
+    const args =
+        this._args && Object.keys(this._args).length !== 0 ? "\\n"+indent(\`.ARGUMENTS(\${argumentsToString(this._args)})\`,1) : '';
+
+    const description =
+        this._description && this._description.length !== 0 ? "\\n"+indent(\`.DESCRIPTION('\${this._description}')\`,1) : '';
+
+    const epoch = this._epoch ? "\\n"+indent(\`.EPOCH('\${this._epoch}')\`,1) : '';
+
+    const engine = this._engine ? "\\n"+indent(\`.ENGINE(\${this._engine})\`,1) : '';
+
+    const metadata =
+        this._metadata && Object.keys(this._metadata).length !== 0
+            ? "\\t"+indent(\`.METADATA(\${argumentsToString(this._metadata)})\`,1)
+            : '';
+
+    const models =
+        this._models && Object.keys(this._models).length !== 0
+            ? "./"+indent(\`.MODELS([\\n\${this._models.map(m => indent(argumentsToString(m))).join(',\\n')}\\n])\`,1)
+            : '';
+
+    return \`\${timeString}.LOAD('\${this.sequence}')\${args}\${description}\${engine}\${epoch}\${metadata}\${models}\`;
+  }
+}
+
+/**
+ * This is a LOAD step
+ *
+ */
+function LOAD(sequence: string): LoadStep {
+  return new LoadStep({ sequence: sequence });
+}
+
 export const STEPS = {
   GROUND_BLOCK: GROUND_BLOCK,
   GROUND_EVENT: GROUND_EVENT,
+  ACTIVATE: ACTIVATE,
+  LOAD: LOAD,
 };
 
 /**
@@ -2023,11 +2666,11 @@ export class HardwareStem implements HardwareCommand {
 
   public toEDSLString(): string {
     const metadata =
-      this._metadata && Object.keys(this._metadata).length !== 0
-        ? \`\\n.METADATA(\${objectToString(this._metadata)})\`
-        : '';
+        this._metadata && Object.keys(this._metadata).length !== 0
+            ? \`\\n.METADATA(\${argumentsToString(this._metadata)})\`
+            : '';
     const description =
-      this._description && this._description.length !== 0 ? \`\\n.DESCRIPTION('\${this._description}')\` : '';
+        this._description && this._description.length !== 0 ? \`\\n.DESCRIPTION('\${this._description}')\` : '';
 
     return \`\${this.stem}\${description}\${metadata}\`;
   }
@@ -2275,20 +2918,40 @@ function indent(text: string, numTimes: number = 1, char: string = '  '): string
     .join('\\n');
 }
 
-// @ts-ignore : 'Args' found in JSON Spec
-function argumentsToString<A extends Args[] | { [argName: string]: any } = [] | {}>(args: A): string {
-  if (Array.isArray(args)) {
-    const argStrings = args.map(arg => {
-      if (typeof arg === 'string') {
-        return \`'\${arg}'\`;
-      }
-      return arg.toString();
-    });
-
-    return argStrings.join(', ');
-  } else {
-    return objectToString(args);
+/** The function takes an object of arguments and converts them into the Args type. It does this by looping through the
+ * values and pushing a new argument type to the result array depending on the type of the value.
+ * If the value is an array, it will create a RepeatArgument type and recursively call on the values of the array.
+ * the function returns the result array of argument types -
+ * StringArgument, NumberArgument, BooleanArgument, SymbolArgument, HexArgument, and RepeatArgument.
+ * @param args
+ */
+//@ts-ignore : 'Args' found in JSON Spec
+function convertArgsToInterfaces(args: { [argName: string]: any }): Args {
+  // @ts-ignore : 'Args' found in JSON Spec
+  let result: Args = [];
+  if (args['length'] === 0) {
+    return result;
   }
+
+  const values = Array.isArray(args) ? args[0] : args;
+
+  for (let key in values) {
+    let value = values[key];
+    if (Array.isArray(value)) {
+      // @ts-ignore : 'RepeatArgument' found in JSON Spec
+      let repeatArg: RepeatArgument = {
+        value: value.map(arg => {
+          return convertRepeatArgs(arg);
+        }),
+        type: 'repeat',
+        name: key,
+      };
+      result.push(repeatArg);
+    } else {
+      result = result.concat(convertValueToObject(value, key));
+    }
+  }
+  return result;
 }
 
 /**
@@ -2314,21 +2977,24 @@ function convertInterfacesToArgs(interfaces: Args, localNames?: String[], parame
   const convertedArgs = interfaces.map(
       (
           // @ts-ignore : found in JSON Spec
-          arg: StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument | RepeatArgument,
+          arg: StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument | RepeatArgument,index
       ) => {
+
+        const argName = arg.name !== undefined ? arg.name : \`arg\${index}\`
         // @ts-ignore : 'RepeatArgument' found in JSON Spec
         if (arg.type === 'repeat') {
-          if (validate(arg.name)) {
+          if (validate(argName)) {
             // @ts-ignore : 'RepeatArgument' found in JSON Spec
             return {
-              [arg.name]: arg.value.map(
+              [argName]: arg.value.map(
                   (
                       // @ts-ignore : found in JSON Spec
                       repeatArgBundle: (StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument)[],
                   ) =>
-                      repeatArgBundle.reduce((obj, item) => {
-                        if (validate(item.name)) {
-                          obj[item.name] = item.value;
+                      repeatArgBundle.reduce((obj, item,index) => {
+                        const argName = item.name !== undefined ? item.name : \`repeat\${index}\`
+                        if (validate(argName)) {
+                          obj[argName] = item.value;
                         }
                         return obj;
                       }, {}),
@@ -2337,7 +3003,7 @@ function convertInterfacesToArgs(interfaces: Args, localNames?: String[], parame
           }
           return { repeat_error: 'Remote property injection detected...' };
         } else if (arg.type === 'symbol') {
-          if (validate(arg.name)) {
+          if (validate(argName)) {
             /**
              * We don't have access to the actual type of the variable, as it's not included in
              * the sequential JSON. However, we don't need the type at this point in the code. Instead,
@@ -2354,19 +3020,19 @@ function convertInterfacesToArgs(interfaces: Args, localNames?: String[], parame
               variable = Variable.new({ name: \`\${arg.value} //ERROR: \${errorMsg}\`, type: VariableType.INT });
               variable.setKind('unknown');
             }
-            return { [arg.name]: variable };
+            return { [argName]: variable };
           }
           return { symbol_error: 'Remote property injection detected...' };
           // @ts-ignore : 'HexArgument' found in JSON Spec
         } else if (arg.type === 'hex') {
-          if (validate(arg.name)) {
+          if (validate(argName)) {
             // @ts-ignore : 'HexArgument' found in JSON Spec
-            return { [arg.name]: { hex: arg.value } };
+            return { [argName]: { hex: arg.value } };
           }
           return { hex_error: 'Remote property injection detected...' };
         } else {
-          if (validate(arg.name)) {
-            return { [arg.name]: arg.value };
+          if (validate(argName)) {
+            return { [argName]: arg.value };
           }
           return { error: 'Remote property injection detected...' };
         }
@@ -2457,24 +3123,16 @@ function convertValueToObject(value: any, key: string): any {
  * @param obj
  * @param indentLevel
  */
-function objectToString(obj: any, indentLevel: number = 1): string {
+// @ts-ignore : 'Args' found in JSON Spec
+function argumentsToString<A extends Args[] | { [argName: string]: any } = [] | {}>(args: A): string {
   let output = '';
-
-  const print = (obj: any) => {
+  function printObject(obj : any, indentLevel : number){
     Object.keys(obj).forEach(key => {
       const value = obj[key];
 
       if (Array.isArray(value)) {
         output += indent(\`\${key}: [\`, indentLevel) + '\\n';
-        indentLevel++;
-        value.forEach((item: any) => {
-          output += indent(\`{\`, indentLevel) + '\\n';
-          indentLevel++;
-          print(item);
-          indentLevel--;
-          output += indent(\`},\`, indentLevel) + '\\n';
-        });
-        indentLevel--;
+        printArray(value,indentLevel+1);
         output += indent(\`],\`, indentLevel) + '\\n';
       } else if (typeof value === 'object') {
         //value is a Local or Parameter
@@ -2482,22 +3140,53 @@ function objectToString(obj: any, indentLevel: number = 1): string {
           output += indent(\`\${key}: \${value.toReferenceString()}\`, indentLevel) + ',\\n';
         } else {
           output += indent(\`\${key}:{\`, indentLevel) + '\\n';
-          indentLevel++;
-          print(value);
-          indentLevel--;
+          printValue(value,indentLevel+1);
           output += indent(\`},\`, indentLevel) + '\\n';
         }
       } else {
         output += indent(\`\${key}: \${typeof value === 'string' ? \`'\${value}'\` : value},\`, indentLevel) + '\\n';
       }
     });
+  }
+
+  function printArray(array : any[], indentLevel : number){
+    array.forEach((item: any) => {
+      if (Array.isArray(item)) {
+        output += indent(\`[\`, indentLevel) + '\\n';
+      } else if (typeof item === 'object') {
+        output += indent(\`{\`, indentLevel) + '\\n';
+      }
+      printValue(item,indentLevel+1);
+      if (Array.isArray(item)) {
+        output += indent(\`],\`, indentLevel) + '\\n';
+      } else if (typeof item === 'object') {
+        output += indent(\`},\`, indentLevel) + '\\n';
+      }
+    });
+  }
+  function printValue(value: any, indentLevel : number) {
+    if (Array.isArray(value)) {
+      printArray(value,indentLevel)
+    } else if (typeof value === 'object') {
+      printObject(value,indentLevel)
+    } else {
+      output += indent(\`\${typeof value === 'string' ? \`'\${value}'\` : value},\`, indentLevel) + '\\n';
+    }
   };
 
-  output += '{\\n';
-  print(obj);
-  output += \`}\`;
+  if (Array.isArray(args)) {
+    output += '[\\n';
+  } else {
+    output += '{\\n';
+  }
+  printValue(args,1);
+  if (Array.isArray(args)) {
+    output += ']';
+  } else {
+    output += '}';
+  }
 
-  return output;
+  return output
 }
 
 /** END Preface */

--- a/sequencing-server/test/command-expansion.spec.ts
+++ b/sequencing-server/test/command-expansion.spec.ts
@@ -349,16 +349,16 @@ describe('expansion', () => {
     },
     steps: ({ locals, parameters }) => ([
       A\`2023-091T10:00:00.000\`.ADD_WATER
-      .METADATA({
-        simulatedActivityId: ${simulatedActivityId},
-      }),
+        .METADATA({
+          simulatedActivityId: ${simulatedActivityId},
+        }),
       R\`04:00:00.000\`.GROW_BANANA({
         quantity: 10,
         durationSecs: 7200,
       })
-      .METADATA({
-        simulatedActivityId: ${simulatedActivityId},
-      }),
+        .METADATA({
+          simulatedActivityId: ${simulatedActivityId},
+        }),
     ]),
   });`);
 


### PR DESCRIPTION
Closes https://github.com/NASA-AMMOS/aerie/issues/644 
Closes https://github.com/NASA-AMMOS/aerie/issues/643

* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The last 2 `Steps` have been added to the eDSL. This finishes all 5 steps that can be provided in a sequence.

```ts
export type Step = Activate | Command | GroundBlock | GroundEvent | Load;
```

```ts
export default () =>
  Sequence.new({
    seqId: '',
    metadata: {},
    steps: [
      C.BAKE_BREAD,
      C.ACTIVATE('/eng1003.a'),
      C.LOAD('/test00012.b'),
      C.GROUND_BLOCK('Ground Block'),
      C.GROUND_EVENT('Ground_Event'),
    ]
  });
```


## Verification
Updated the e2e testing 

## Documentation
none

## Future work
Probably make add a request eDSL