### PR TITLE
Changed constraint violation api to return a list of violations rathe…

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/ConstraintType.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/ConstraintType.java
@@ -2,6 +2,6 @@ package gov.nasa.jpl.aerie.constraints.model;
 
 // This will go away with https://github.com/NASA-AMMOS/aerie/issues/892 when there's only 1 type of constraint.
 public enum ConstraintType {
-  MODEL,
-  PLAN
+  model,
+  plan
 }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/ConstraintType.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/ConstraintType.java
@@ -1,0 +1,7 @@
+package gov.nasa.jpl.aerie.constraints.model;
+
+// This will go away with https://github.com/NASA-AMMOS/aerie/issues/892 when there's only 1 type of constraint.
+public enum ConstraintType {
+  MODEL,
+  PLAN
+}

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/Violation.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/Violation.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import java.util.stream.StreamSupport;
 
 public final class Violation {
+  public final String constraintName;
   public final Long constraintId;
   public final ConstraintType constraintType;
   public final List<Long> activityInstanceIds;
@@ -16,7 +17,8 @@ public final class Violation {
   public final List<Interval> violationWindows;
   public final List<Interval> gaps;
 
-  public Violation(final Long constraintId, final ConstraintType constraintType, final List<Long> activityInstanceIds, final List<String> resourceNames, final Windows violationWindows) {
+  public Violation(final String constraintName, final Long constraintId, final ConstraintType constraintType, final List<Long> activityInstanceIds, final List<String> resourceNames, final Windows violationWindows) {
+    this.constraintName = constraintName;
     this.constraintId = constraintId;
     this.constraintType = constraintType;
     this.activityInstanceIds = new ArrayList<>(activityInstanceIds);
@@ -36,10 +38,11 @@ public final class Violation {
   }
 
   public Violation(final Windows violationWindows) {
-    this(null, null, new ArrayList<>(), new ArrayList<>(), violationWindows);
+    this(null, null, null, new ArrayList<>(), new ArrayList<>(), violationWindows);
   }
 
-  public Violation(final Long constraintId, final ConstraintType constraintType, final List<Long> activityInstanceIds, final List<String> resourceNames, final List<Interval> intervals, final List<Interval> gaps) {
+  public Violation(final String constraintName, final Long constraintId, final ConstraintType constraintType, final List<Long> activityInstanceIds, final List<String> resourceNames, final List<Interval> intervals, final List<Interval> gaps) {
+    this.constraintName = constraintName;
     this.constraintId = constraintId;
     this.constraintType = constraintType;
     this.activityInstanceIds = new ArrayList<>(activityInstanceIds);
@@ -49,7 +52,7 @@ public final class Violation {
   }
 
   public Violation(final Violation other) {
-    this(other.constraintId, other.constraintType, other.activityInstanceIds, other.resourceNames, other.violationWindows, other.gaps);
+    this(other.constraintName, other.constraintId, other.constraintType, other.activityInstanceIds, other.resourceNames, other.violationWindows, other.gaps);
   }
 
   public void addActivityId(final long activityId) {

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/Violation.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/Violation.java
@@ -9,12 +9,16 @@ import java.util.Objects;
 import java.util.stream.StreamSupport;
 
 public final class Violation {
+  public final Long constraintId;
+  public final ConstraintType constraintType;
   public final List<Long> activityInstanceIds;
   public final List<String> resourceNames;
   public final List<Interval> violationWindows;
   public final List<Interval> gaps;
 
-  public Violation(final List<Long> activityInstanceIds, final List<String> resourceNames, final Windows violationWindows) {
+  public Violation(final Long constraintId, final ConstraintType constraintType, final List<Long> activityInstanceIds, final List<String> resourceNames, final Windows violationWindows) {
+    this.constraintId = constraintId;
+    this.constraintType = constraintType;
     this.activityInstanceIds = new ArrayList<>(activityInstanceIds);
     this.resourceNames = new ArrayList<>(resourceNames);
     this.violationWindows = new ArrayList<>(violationWindows.size());
@@ -32,10 +36,12 @@ public final class Violation {
   }
 
   public Violation(final Windows violationWindows) {
-    this(new ArrayList<>(), new ArrayList<>(), violationWindows);
+    this(null, null, new ArrayList<>(), new ArrayList<>(), violationWindows);
   }
 
-  public Violation(final List<Long> activityInstanceIds, final List<String> resourceNames, final List<Interval> intervals, final List<Interval> gaps) {
+  public Violation(final Long constraintId, final ConstraintType constraintType, final List<Long> activityInstanceIds, final List<String> resourceNames, final List<Interval> intervals, final List<Interval> gaps) {
+    this.constraintId = constraintId;
+    this.constraintType = constraintType;
     this.activityInstanceIds = new ArrayList<>(activityInstanceIds);
     this.resourceNames = List.copyOf(resourceNames);
     this.violationWindows = List.copyOf(intervals);
@@ -43,7 +49,7 @@ public final class Violation {
   }
 
   public Violation(final Violation other) {
-    this(other.activityInstanceIds, other.resourceNames, other.violationWindows, other.gaps);
+    this(other.constraintId, other.constraintType, other.activityInstanceIds, other.resourceNames, other.violationWindows, other.gaps);
   }
 
   public void addActivityId(final long activityId) {

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.constraints.tree;
 
 import gov.nasa.jpl.aerie.constraints.InputMismatchException;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
+import gov.nasa.jpl.aerie.constraints.model.ConstraintType;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
@@ -661,7 +662,7 @@ public class ASTTests {
         Map.of()
     );
 
-    final var violation = new Violation(List.of(), List.of(), new Windows(interval(4, 6, SECONDS), true));
+    final var violation = new Violation(1L, ConstraintType.MODEL, List.of(), List.of(), new Windows(interval(4, 6, SECONDS), true));
     final var result = new ForEachActivityViolations(
         "TypeA",
         "act",
@@ -675,8 +676,8 @@ public class ASTTests {
     // We expect two violations because there are two activities of TypeA
     // The details of the violation will be the same, since we are using a supplier
     final var expected = List.of(
-        new Violation(List.of(1L, 2L), List.of(), new Windows(interval(4, 6, SECONDS), true)),
-        new Violation(List.of(3L, 2L), List.of(), new Windows(interval(4, 6, SECONDS), true)));
+        new Violation(1L, ConstraintType.MODEL, List.of(1L, 2L), List.of(), new Windows(interval(4, 6, SECONDS), true)),
+        new Violation(1L, ConstraintType.MODEL, List.of(3L, 2L), List.of(), new Windows(interval(4, 6, SECONDS), true)));
 
     assertEquivalent(expected, result);
   }
@@ -727,6 +728,8 @@ public class ASTTests {
     final var result = new ViolationsOfWindows(new Supplier<>(windows)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = List.of(new Violation(
+        1L,
+        ConstraintType.MODEL,
         List.of(),
         List.of(),
         List.of(Interval.between(5, 6, SECONDS)),

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -662,7 +662,7 @@ public class ASTTests {
         Map.of()
     );
 
-    final var violation = new Violation(1L, ConstraintType.MODEL, List.of(), List.of(), new Windows(interval(4, 6, SECONDS), true));
+    final var violation = new Violation("Constraint Test", 1L, ConstraintType.model, List.of(), List.of(), new Windows(interval(4, 6, SECONDS), true));
     final var result = new ForEachActivityViolations(
         "TypeA",
         "act",
@@ -676,8 +676,8 @@ public class ASTTests {
     // We expect two violations because there are two activities of TypeA
     // The details of the violation will be the same, since we are using a supplier
     final var expected = List.of(
-        new Violation(1L, ConstraintType.MODEL, List.of(1L, 2L), List.of(), new Windows(interval(4, 6, SECONDS), true)),
-        new Violation(1L, ConstraintType.MODEL, List.of(3L, 2L), List.of(), new Windows(interval(4, 6, SECONDS), true)));
+        new Violation("Constraint Test", 1L, ConstraintType.model, List.of(1L, 2L), List.of(), new Windows(interval(4, 6, SECONDS), true)),
+        new Violation("Constraint Test", 1L, ConstraintType.model, List.of(3L, 2L), List.of(), new Windows(interval(4, 6, SECONDS), true)));
 
     assertEquivalent(expected, result);
   }
@@ -728,8 +728,9 @@ public class ASTTests {
     final var result = new ViolationsOfWindows(new Supplier<>(windows)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = List.of(new Violation(
+        "Constraint Test",
         1L,
-        ConstraintType.MODEL,
+        ConstraintType.model,
         List.of(),
         List.of(),
         List.of(Interval.between(5, 6, SECONDS)),

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -259,7 +259,7 @@ type ResourceSamplesResponse {
 }
 
 type ConstraintViolationsResponse {
-  constraintViolations: ConstraintViolations!
+  violations: ConstraintViolations!
 }
 
 scalar ResourceSchema

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -128,6 +128,7 @@ public final class ResponseSerializers {
   public static JsonValue serializeConstraintViolation(final Violation violation) {
     return Json
         .createObjectBuilder()
+        .add("id", violation.constraintId)
         .add("associations", Json
             .createObjectBuilder()
             .add("activityInstanceIds", serializeIterable(Json::createValue, violation.activityInstanceIds))
@@ -135,6 +136,7 @@ public final class ResponseSerializers {
             .build())
         .add("windows", serializeIterable(ResponseSerializers::serializeInterval, violation.violationWindows))
         .add("gaps", serializeIterable(ResponseSerializers::serializeInterval, violation.gaps))
+        .add("type", violation.constraintType.name())
         .build();
   }
 
@@ -228,12 +230,14 @@ public final class ResponseSerializers {
         .build();
   }
 
-  public static JsonValue serializeConstraintViolations(final Map<String, List<Violation>> violations) {
+  public static JsonValue serializeConstraintViolations(final List<Violation> violations) {
+    final var builder = Json.createArrayBuilder();
+
+    for (final var violation : violations) builder.add(serializeConstraintViolation(violation));
+
     return Json
         .createObjectBuilder()
-        .add("constraintViolations", serializeMap(
-            v -> serializeIterable(ResponseSerializers::serializeConstraintViolation, v),
-            violations))
+        .add("constraintViolations", builder.build())
         .build();
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -238,7 +238,7 @@ public final class ResponseSerializers {
 
     return Json
         .createObjectBuilder()
-        .add("constraintViolations", builder.build())
+        .add("violations", builder.build())
         .build();
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -128,7 +128,8 @@ public final class ResponseSerializers {
   public static JsonValue serializeConstraintViolation(final Violation violation) {
     return Json
         .createObjectBuilder()
-        .add("id", violation.constraintId)
+        .add("constraintId", violation.constraintId)
+        .add("constraintName", violation.constraintName)
         .add("associations", Json
             .createObjectBuilder()
             .add("activityInstanceIds", serializeIterable(Json::createValue, violation.activityInstanceIds))

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
@@ -118,7 +118,7 @@ public final class InMemoryPlanRepository implements PlanRepository {
   }
 
   @Override
-  public Map<String, Constraint> getAllConstraintsInPlan(final PlanId planId) {
+  public Map<Long, Constraint> getAllConstraintsInPlan(final PlanId planId) {
     return Map.of();
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/Constraint.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/Constraint.java
@@ -1,4 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.models;
 
-public record Constraint (String name, String description, String definition) {
+import gov.nasa.jpl.aerie.constraints.model.ConstraintType;
+
+public record Constraint (String name, String description, String definition, ConstraintType type) {
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/MissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/MissionModelRepository.java
@@ -17,7 +17,7 @@ public interface MissionModelRepository {
     // Queries
     Map<String, MissionModelJar> getAllMissionModels();
     MissionModelJar getMissionModel(String id) throws NoSuchMissionModelException;
-    Map<String, Constraint> getConstraints(String missionModelId) throws NoSuchMissionModelException;
+    Map<Long, Constraint> getConstraints(String missionModelId) throws NoSuchMissionModelException;
     Map<String, ActivityType> getActivityTypes(String missionModelId) throws NoSuchMissionModelException;
 
     // Mutations

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
@@ -33,7 +33,7 @@ public interface PlanRepository {
   long getPlanRevision(PlanId planId) throws NoSuchPlanException;
   RevisionData getPlanRevisionData(PlanId planId) throws NoSuchPlanException;
 
-  Map<String, Constraint> getAllConstraintsInPlan(PlanId planId) throws NoSuchPlanException;
+  Map<Long, Constraint> getAllConstraintsInPlan(PlanId planId) throws NoSuchPlanException;
 
   long addExternalDataset(PlanId planId, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
   void extendExternalDataset(DatasetId datasetId, ProfileSet profileSet) throws NoSuchPlanDatasetException;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresMissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresMissionModelRepository.java
@@ -71,7 +71,7 @@ public final class PostgresMissionModelRepository implements MissionModelReposit
                     r.name(),
                     r.description(),
                     r.definition(),
-                    ConstraintType.MODEL)));
+                    ConstraintType.model)));
       }
     } catch (final SQLException ex) {
       throw new DatabaseException(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresMissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresMissionModelRepository.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.constraints.model.ConstraintType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Resource;
@@ -57,7 +58,7 @@ public final class PostgresMissionModelRepository implements MissionModelReposit
   }
 
   @Override
-  public Map<String, Constraint> getConstraints(final String missionModelId) throws NoSuchMissionModelException {
+  public Map<Long, Constraint> getConstraints(final String missionModelId) throws NoSuchMissionModelException {
     try (final var connection = this.dataSource.getConnection()) {
       try (final var getModelConstraintsAction = new GetModelConstraintsAction(connection)) {
         return getModelConstraintsAction
@@ -65,11 +66,12 @@ public final class PostgresMissionModelRepository implements MissionModelReposit
             .orElseThrow(NoSuchMissionModelException::new)
             .stream()
             .collect(Collectors.toMap(
-                ConstraintRecord::name,
+                ConstraintRecord::id,
                 r -> new Constraint(
                     r.name(),
                     r.description(),
-                    r.definition())));
+                    r.definition(),
+                    ConstraintType.MODEL)));
       }
     } catch (final SQLException ex) {
       throw new DatabaseException(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -192,7 +192,7 @@ public final class PostgresPlanRepository implements PlanRepository {
                     r.name(),
                     r.description(),
                     r.definition(),
-                    ConstraintType.PLAN)));
+                    ConstraintType.plan)));
       }
     } catch (final SQLException ex) {
       throw new DatabaseException(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.jpl.aerie.constraints.model.ConstraintType;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityDirective;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -178,7 +179,7 @@ public final class PostgresPlanRepository implements PlanRepository {
   }
 
   @Override
-  public Map<String, Constraint> getAllConstraintsInPlan(final PlanId planId) throws NoSuchPlanException {
+  public Map<Long, Constraint> getAllConstraintsInPlan(final PlanId planId) throws NoSuchPlanException {
     try (final var connection = this.dataSource.getConnection()) {
       try (final var getPlanConstraintsAction = new GetPlanConstraintsAction(connection)) {
         return getPlanConstraintsAction
@@ -186,11 +187,12 @@ public final class PostgresPlanRepository implements PlanRepository {
             .orElseThrow(() -> new NoSuchPlanException(planId))
             .stream()
             .collect(Collectors.toMap(
-                ConstraintRecord::name,
+                ConstraintRecord::id,
                 r -> new Constraint(
                     r.name(),
                     r.description(),
-                    r.definition())));
+                    r.definition(),
+                    ConstraintType.PLAN)));
       }
     } catch (final SQLException ex) {
       throw new DatabaseException(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -118,21 +118,17 @@ public final class GetSimulationResultsAction {
     return samples;
   }
 
-  public Map<String, List<Violation>> getViolations(final PlanId planId)
+  public List<Violation> getViolations(final PlanId planId)
   throws NoSuchPlanException, MissionModelService.NoSuchMissionModelException
   {
     final var plan = this.planService.getPlanForValidation(planId);
     final var revisionData = this.planService.getPlanRevisionData(planId);
 
-    final var constraintCode = new HashMap<String, Constraint>();
+    final var constraintCode = new HashMap<Long, Constraint>();
 
     try {
-      this.missionModelService.getConstraints(plan.missionModelId).forEach(
-          (name, constraint) -> constraintCode.put("model/" + name, constraint)
-      );
-      this.planService.getConstraintsForPlan(planId).forEach(
-          (name, constraint) -> constraintCode.put("plan/" + name, constraint)
-      );
+      constraintCode.putAll(this.missionModelService.getConstraints(plan.missionModelId));
+      constraintCode.putAll(this.planService.getConstraintsForPlan(planId));
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       throw new RuntimeException("Assumption falsified -- mission model for existing plan does not exist");
     }
@@ -204,7 +200,7 @@ public final class GetSimulationResultsAction {
         realProfiles,
         discreteProfiles);
 
-    final var violations = new HashMap<String, List<Violation>>();
+    final var violations = new ArrayList<Violation>();
     for (final var entry : constraintCode.entrySet()) {
 
       // Pipeline switch
@@ -247,14 +243,14 @@ public final class GetSimulationResultsAction {
       final var names = new HashSet<String>();
       expression.extractResources(names);
       final var resourceNames = new ArrayList<>(names);
-      final var violationEventsWithNames = new ArrayList<Violation>();
-      violationEvents.forEach(violation -> violationEventsWithNames.add(new Violation(
+
+      violationEvents.forEach(violation -> violations.add(new Violation(
+          entry.getKey(),
+          entry.getValue().type(),
           violation.activityInstanceIds,
           resourceNames,
           violation.violationWindows,
           violation.gaps)));
-
-      violations.put(entry.getKey(), violationEventsWithNames);
     }
 
     return violations;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -245,6 +245,7 @@ public final class GetSimulationResultsAction {
       final var resourceNames = new ArrayList<>(names);
 
       violationEvents.forEach(violation -> violations.add(new Violation(
+          entry.getValue().name(),
           entry.getKey(),
           entry.getValue().type(),
           violation.activityInstanceIds,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -62,7 +62,7 @@ public final class LocalMissionModelService implements MissionModelService {
   }
 
   @Override
-  public Map<String, Constraint> getConstraints(final String missionModelId) throws NoSuchMissionModelException {
+  public Map<Long, Constraint> getConstraints(final String missionModelId) throws NoSuchMissionModelException {
     try {
       return this.missionModelRepository.getConstraints(missionModelId);
     } catch (final MissionModelRepository.NoSuchMissionModelException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
@@ -41,7 +41,7 @@ public final class LocalPlanService implements PlanService {
   }
 
   @Override
-  public Map<String, Constraint> getConstraintsForPlan(final PlanId planId) throws NoSuchPlanException {
+  public Map<Long, Constraint> getConstraintsForPlan(final PlanId planId) throws NoSuchPlanException {
     return this.planRepository.getAllConstraintsInPlan(planId);
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -23,7 +23,7 @@ public interface MissionModelService {
   MissionModelJar getMissionModelById(String missionModelId)
   throws NoSuchMissionModelException;
 
-  Map<String, Constraint> getConstraints(String missionModelId)
+  Map<Long, Constraint> getConstraints(String missionModelId)
   throws NoSuchMissionModelException;
 
   Map<String, ValueSchema> getResourceSchemas(String missionModelId)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
@@ -20,7 +20,7 @@ public interface PlanService {
   Plan getPlanForValidation(PlanId planId) throws NoSuchPlanException;
   RevisionData getPlanRevisionData(PlanId planId) throws NoSuchPlanException;
 
-  Map<String, Constraint> getConstraintsForPlan(PlanId planId) throws NoSuchPlanException;
+  Map<Long, Constraint> getConstraintsForPlan(PlanId planId) throws NoSuchPlanException;
 
   long addExternalDataset(PlanId planId, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
   void extendExternalDataset(DatasetId datasetId, ProfileSet profileSet) throws NoSuchPlanDatasetException;

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -115,7 +115,7 @@ public final class StubMissionModelService implements MissionModelService {
   }
 
   @Override
-  public Map<String, Constraint> getConstraints(final String missionModelId) throws NoSuchMissionModelException {
+  public Map<Long, Constraint> getConstraints(final String missionModelId) throws NoSuchMissionModelException {
     return Map.of();
   }
 

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
@@ -77,7 +77,7 @@ public final class StubPlanService implements PlanService {
   }
 
   @Override
-  public Map<String, Constraint> getConstraintsForPlan(final PlanId planId)
+  public Map<Long, Constraint> getConstraintsForPlan(final PlanId planId)
   throws NoSuchPlanException {
     return Map.of();
   }


### PR DESCRIPTION
…r than a map of constraint names and types to violations

* **Tickets addressed:** Closes #897 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Previously the constraint violation API was returning a list of violations keyed by constraint name and type (model or plan). This PR updates the API to return a list of violation objects where those objects have a constraint id and constraint type property.

Here's a sample return:
```
{
  "data": {
    "checkConstraintsResponse": {
      "violationsMap": [
        {
          "associations": {
            "activityInstanceIds": [],
            "resourceIds": [
              "/fruit"
            ]
          },
          "gaps": [
            {
              "end": 0,
              "start": "-9223372036854775808"
            },
            {
              "end": "9223372036854775807",
              "start": 604800000000
            }
          ],
          "id": 1,
          "type": "PLAN",
          "windows": [
            {
              "end": 604800000000,
              "start": 0
            }
          ]
        }
      ]
    }
  }
}
```

## Verification
Updated existing tests.

## Documentation
I'm not sure if this API is documented, but if it is I can change that.

## Future work
A UI ticket to consume the new API changes.
