### PR TITLE
Add parsed command dict db col

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -13,18 +13,11 @@ interface Fallible {
 }
 
 type Mutation {
-  addExternalDataset(
-    planId: Int!
-    datasetStart: String!
-    profileSet: ProfileSet!
-  ): AddExternalDatasetResponse
+  addExternalDataset(planId: Int!, datasetStart: String!, profileSet: ProfileSet!): AddExternalDatasetResponse
 }
 
 type Mutation {
-  extendExternalDataset(
-    datasetId: Int!
-    profileSet: ProfileSet!
-  ): AddExternalDatasetResponse
+  extendExternalDataset(datasetId: Int!, profileSet: ProfileSet!): AddExternalDatasetResponse
 }
 
 type Mutation {
@@ -40,26 +33,16 @@ type Mutation {
   ): AddCommandExpansionResponse
 }
 
-type Mutation{
-  createExpansionSet(
-    commandDictionaryId: Int!
-    missionModelId: Int!
-    expansionIds: [Int!]!
-  ): ExpansionSetResponse
+type Mutation {
+  createExpansionSet(commandDictionaryId: Int!, missionModelId: Int!, expansionIds: [Int!]!): ExpansionSetResponse
 }
 
-type Mutation{
-  expandAllActivities(
-    expansionSetId: Int!
-    simulationDatasetId: Int!
-  ): ExpandAllActivitiesResponse
+type Mutation {
+  expandAllActivities(expansionSetId: Int!, simulationDatasetId: Int!): ExpandAllActivitiesResponse
 }
 
 type Query {
-  getModelEffectiveArguments(
-    missionModelId: ID!
-    modelArguments: ModelArguments!
-  ): EffectiveArgumentsResponse
+  getModelEffectiveArguments(missionModelId: ID!, modelArguments: ModelArguments!): EffectiveArgumentsResponse
 }
 
 type Query {
@@ -71,59 +54,39 @@ type Query {
 }
 
 type Query {
-  getActivityTypeScript(
-    missionModelId: Int!
-    activityTypeName: String!
-  ): DslTypescriptResponse
+  getActivityTypeScript(missionModelId: Int!, activityTypeName: String!): DslTypescriptResponse
 }
 
 type Query {
-  getCommandTypeScript(
-    commandDictionaryId: Int!
-  ): DslTypescriptResponse
+  getCommandTypeScript(commandDictionaryId: Int!): DslTypescriptResponse
 }
 
 type Query {
-  resourceTypes(
-    missionModelId: ID!
-  ): [ResourceType!]!
+  resourceTypes(missionModelId: ID!): [ResourceType!]!
 }
 
 type Query {
-  schedule(
-    specificationId: Int!
-  ): SchedulingResponse
+  schedule(specificationId: Int!): SchedulingResponse
 }
 
 type Query {
-  schedulingDslTypescript(
-    missionModelId: Int!
-  ): DslTypescriptResponse
+  schedulingDslTypescript(missionModelId: Int!): DslTypescriptResponse
 }
 
 type Query {
-  constraintsDslTypescript(
-    missionModelId: ID!,
-    planId: Int
-  ): DslTypescriptResponse
+  constraintsDslTypescript(missionModelId: ID!, planId: Int): DslTypescriptResponse
 }
 
 type Query {
-  simulate(
-    planId: Int!
-  ): MerlinSimulationResponse
+  simulate(planId: Int!): MerlinSimulationResponse
 }
 
 type Query {
-  resourceSamples(
-    planId: Int!
-  ): ResourceSamplesResponse
+  resourceSamples(planId: Int!): ResourceSamplesResponse
 }
 
 type Query {
-  constraintViolations(
-    planId: Int!
-  ): ConstraintViolationsResponse
+  constraintViolations(planId: Int!): ConstraintViolationsResponse
 }
 
 type Query {
@@ -135,23 +98,16 @@ type Query {
 }
 
 type Query {
-  validateModelArguments(
-    missionModelId: ID!
-    modelArguments: ModelArguments!
-  ): ValidationResponse
+  validateModelArguments(missionModelId: ID!, modelArguments: ModelArguments!): ValidationResponse
 }
 
 type Query {
-  validatePlan(
-    planId: Int!
-  ): ValidationResponse
+  validatePlan(planId: Int!): ValidationResponse
 }
 
 type Query {
-  getSequenceSeqJson(
-    seqId: String!
-    simulationDatasetId: Int!
-  ): GetSeqJsonResponse! @deprecated(reason: "Use bulk query getSequenceSeqJsonBulk instead")
+  getSequenceSeqJson(seqId: String!, simulationDatasetId: Int!): GetSeqJsonResponse!
+    @deprecated(reason: "Use bulk query getSequenceSeqJsonBulk instead")
 }
 
 input GetSequenceSeqJsonsInput {
@@ -160,16 +116,12 @@ input GetSequenceSeqJsonsInput {
 }
 
 type Query {
-  getSequenceSeqJsonBulk(
-    inputs: [GetSequenceSeqJsonsInput!]!
-  ): [GetSeqJsonResponse!]!
+  getSequenceSeqJsonBulk(inputs: [GetSequenceSeqJsonsInput!]!): [GetSeqJsonResponse!]!
 }
 
 type Query {
-  getUserSequenceSeqJson(
-    commandDictionaryID: Int!
-    edslBody: String!
-  ): GetSeqJsonResponse! @deprecated(reason: "Use bulk query getUserSequenceSeqJsonBulk instead")
+  getUserSequenceSeqJson(commandDictionaryID: Int!, edslBody: String!): GetSeqJsonResponse!
+    @deprecated(reason: "Use bulk query getUserSequenceSeqJsonBulk instead")
 }
 
 input GetUserSequenceSeqJsonBulkInput {
@@ -178,9 +130,7 @@ input GetUserSequenceSeqJsonBulkInput {
 }
 
 type Query {
-  getUserSequenceSeqJsonBulk(
-    inputs: [GetUserSequenceSeqJsonBulkInput!]!
-  ): [GetSeqJsonResponse!]!
+  getUserSequenceSeqJsonBulk(inputs: [GetUserSequenceSeqJsonBulkInput!]!): [GetSeqJsonResponse!]!
 }
 
 type GetSeqJsonResponse implements Fallible {
@@ -190,15 +140,12 @@ type GetSeqJsonResponse implements Fallible {
 }
 
 type Query {
-  getEdslForSeqJson(
-    seqJson: SequenceSeqJson!
-  ): String! @deprecated(reason: "Use bulk query getEdslForSeqJsonBulk instead")
+  getEdslForSeqJson(seqJson: SequenceSeqJson!): String!
+    @deprecated(reason: "Use bulk query getEdslForSeqJsonBulk instead")
 }
 
 type Query {
-  getEdslForSeqJsonBulk(
-    seqJsons: [SequenceSeqJson!]!
-  ): [String!]!
+  getEdslForSeqJsonBulk(seqJsons: [SequenceSeqJson!]!): [String!]!
 }
 
 enum MerlinSimulationStatus {
@@ -263,7 +210,7 @@ enum DslTypescriptResponseStatus {
 }
 
 type TypescriptFile {
-  filePath: String,
+  filePath: String
   content: String
 }
 
@@ -272,6 +219,7 @@ type CommandDictionaryResponse {
   command_types_typescript_path: String!
   mission: String!
   version: String!
+  parsed_json: CommandDictionary!
   created_at: String!
 }
 
@@ -294,8 +242,6 @@ type ExpandedActivityInstance {
   commands: [CommandSeqJson!]
   errors: [UserCodeError!]!
 }
-
-
 
 type UserCodeError implements Error {
   message: String!
@@ -337,5 +283,7 @@ scalar CommandArgumentsSeqJson
 scalar CommandSeqJson
 
 scalar SequenceSeqJson
+
+scalar CommandDictionary
 
 scalar Any

--- a/deployment/hasura/migrations/AerieSequencing/4_add_parsed_json/down.sql
+++ b/deployment/hasura/migrations/AerieSequencing/4_add_parsed_json/down.sql
@@ -1,0 +1,6 @@
+comment on column command_dictionary.parsed_json is null;
+
+alter table command_dictionary
+  drop column parsed_json;
+
+call migrations.mark_migration_rolled_back('4');

--- a/deployment/hasura/migrations/AerieSequencing/4_add_parsed_json/up.sql
+++ b/deployment/hasura/migrations/AerieSequencing/4_add_parsed_json/up.sql
@@ -1,0 +1,7 @@
+alter table command_dictionary
+  add column parsed_json jsonb not null;
+
+comment on column command_dictionary.parsed_json is e''
+  'The XML that has been parsed and converted to JSON';
+
+call migrations.mark_migration_applied('4');

--- a/sequencing-server/sql/sequencing/applied_migrations.sql
+++ b/sequencing-server/sql/sequencing/applied_migrations.sql
@@ -6,3 +6,4 @@ call migrations.mark_migration_applied('0');
 call migrations.mark_migration_applied('1');
 call migrations.mark_migration_applied('2');
 call migrations.mark_migration_applied('3');
+call migrations.mark_migration_applied('4');

--- a/sequencing-server/sql/sequencing/tables/command_dictionary.sql
+++ b/sequencing-server/sql/sequencing/tables/command_dictionary.sql
@@ -4,6 +4,7 @@ create table command_dictionary (
   command_types_typescript_path text not null,
   mission text not null,
   version text not null,
+  parsed_json jsonb not null,
 
   created_at timestamptz not null default now(),
 
@@ -23,5 +24,7 @@ comment on column command_dictionary.mission is e''
   'A human-meaningful identifier for the mission described by the command dictionary';
 comment on column command_dictionary.version is e''
   'A human-meaningful version qualifier.';
+comment on column command_dictionary.parsed_json is e''
+  'The XML that has been parsed and converted to JSON';
 comment on constraint command_dictionary_natural_key on command_dictionary is e''
   'There an only be one command dictionary of a given version for a given mission.';

--- a/sequencing-server/src/app.ts
+++ b/sequencing-server/src/app.ts
@@ -127,7 +127,7 @@ app.post('/put-dictionary', async (req, res, next) => {
     values ($1, $2, $3, $4)
     on conflict (mission, version) do update
       set command_types_typescript_path = $1, parsed_json = $4
-    returning id, command_types_typescript_path, mission, version, parsed_json, created_at, updated_at;
+    returning id, command_types_typescript_path, mission, version, parsed_json, created_at;
   `;
 
   const { rows } = await db.query(sqlExpression, [

--- a/sequencing-server/src/app.ts
+++ b/sequencing-server/src/app.ts
@@ -123,17 +123,18 @@ app.post('/put-dictionary', async (req, res, next) => {
   logger.info(`command-lib generated - path: ${commandDictionaryPath}`);
 
   const sqlExpression = `
-    insert into command_dictionary (command_types_typescript_path, mission, version)
-    values ($1, $2, $3)
+    insert into command_dictionary (command_types_typescript_path, mission, version, parsed_json)
+    values ($1, $2, $3, $4)
     on conflict (mission, version) do update
-      set command_types_typescript_path = $1
-    returning id, command_types_typescript_path, mission, version, created_at;
+      set command_types_typescript_path = $1, parsed_json = $4
+    returning id, command_types_typescript_path, mission, version, parsed_json, created_at, updated_at;
   `;
 
   const { rows } = await db.query(sqlExpression, [
     commandDictionaryPath,
     parsedDictionary.header.mission_name,
     parsedDictionary.header.version,
+    parsedDictionary,
   ]);
 
   if (rows.length < 1) {

--- a/sequencing-server/test/batchLoaders/expansionSetBatchLoader.spec.ts
+++ b/sequencing-server/test/batchLoaders/expansionSetBatchLoader.spec.ts
@@ -15,7 +15,7 @@ beforeAll(async () => {
     headers: { 'x-hasura-admin-secret': process.env['HASURA_GRAPHQL_ADMIN_SECRET'] as string },
   });
   missionModelId = await uploadMissionModel(graphqlClient);
-  commandDictionaryId = await insertCommandDictionary(graphqlClient);
+  commandDictionaryId = (await insertCommandDictionary(graphqlClient)).id;
   expansionId = await insertExpansion(
     graphqlClient,
     'ParameterTest',

--- a/sequencing-server/test/command-dictionary.spec.ts
+++ b/sequencing-server/test/command-dictionary.spec.ts
@@ -1,5 +1,6 @@
+import * as ampcs from '@nasa-jpl/aerie-ampcs';
 import { GraphQLClient } from 'graphql-request';
-import { insertCommandDictionary } from './testUtils/CommandDictionary.js';
+import { commandDictionaryString, insertCommandDictionary } from './testUtils/CommandDictionary.js';
 
 let graphqlClient: GraphQLClient;
 
@@ -11,6 +12,15 @@ beforeEach(async () => {
 
 describe('upload command dictionary', () => {
   it('should upload a command dictionary and all of the fields should be populated correctly', async () => {
-    expect(await insertCommandDictionary(graphqlClient)).toBeDefined();
+    // During the test we use a uuid for the mission so there's no conflicting command dictionaries.
+    const { command_types_typescript_path, mission, parsed_json } = await insertCommandDictionary(graphqlClient);
+
+    expect(command_types_typescript_path).toBe(
+      `/usr/src/app/sequencing_file_store/${mission}/command_lib.${mission}.ts`,
+    );
+
+    expect(parsed_json).toStrictEqual(
+      ampcs.parse(commandDictionaryString.replace(/(Banana Nation|1.0.0.0)/g, mission)),
+    );
   }, 30000);
 });

--- a/sequencing-server/test/command-dictionary.spec.ts
+++ b/sequencing-server/test/command-dictionary.spec.ts
@@ -1,0 +1,16 @@
+import { GraphQLClient } from 'graphql-request';
+import { insertCommandDictionary } from './testUtils/CommandDictionary.js';
+
+let graphqlClient: GraphQLClient;
+
+beforeEach(async () => {
+  graphqlClient = new GraphQLClient(process.env['MERLIN_GRAPHQL_URL'] as string, {
+    headers: { 'x-hasura-admin-secret': process.env['HASURA_GRAPHQL_ADMIN_SECRET'] as string },
+  });
+});
+
+describe('upload command dictionary', () => {
+  it('should upload a command dictionary and all of the fields should be populated correctly', async () => {
+    expect(await insertCommandDictionary(graphqlClient)).toBeDefined();
+  }, 30000);
+});

--- a/sequencing-server/test/command-expansion.spec.ts
+++ b/sequencing-server/test/command-expansion.spec.ts
@@ -37,7 +37,7 @@ beforeEach(async () => {
     simulation_start_time: '2020-001T00:00:00Z',
     simulation_end_time: '2020-002T00:00:00Z',
   });
-  commandDictionaryId = await insertCommandDictionary(graphqlClient);
+  commandDictionaryId = (await insertCommandDictionary(graphqlClient)).id;
 });
 
 afterEach(async () => {

--- a/sequencing-server/test/command-types.spec.ts
+++ b/sequencing-server/test/command-types.spec.ts
@@ -9,7 +9,7 @@ beforeEach(async () => {
   graphqlClient = new GraphQLClient(process.env['MERLIN_GRAPHQL_URL'] as string, {
     headers: { 'x-hasura-admin-secret': process.env['HASURA_GRAPHQL_ADMIN_SECRET'] as string },
   });
-  commandDictionaryId = await insertCommandDictionary(graphqlClient);
+  commandDictionaryId = (await insertCommandDictionary(graphqlClient)).id;
 });
 
 afterEach(async () => {

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -44,7 +44,7 @@ beforeEach(async () => {
     simulation_start_time: '2020-001T00:00:00Z',
     simulation_end_time: '2020-002T00:00:00Z',
   });
-  commandDictionaryId = await insertCommandDictionary(graphqlClient);
+  commandDictionaryId = (await insertCommandDictionary(graphqlClient)).id;
 });
 
 afterEach(async () => {

--- a/sequencing-server/test/testUtils/CommandDictionary.ts
+++ b/sequencing-server/test/testUtils/CommandDictionary.ts
@@ -3,7 +3,7 @@ import { gql, GraphQLClient } from 'graphql-request';
 import { randomUUID } from 'node:crypto';
 import type { CommandDictionary } from '@nasa-jpl/aerie-ampcs';
 
-const commandDictionaryString = fs.readFileSync(
+export const commandDictionaryString = fs.readFileSync(
   new URL('../../cdict/command_banananation.xml', import.meta.url).pathname,
   'utf-8',
 );

--- a/sequencing-server/test/testUtils/CommandDictionary.ts
+++ b/sequencing-server/test/testUtils/CommandDictionary.ts
@@ -1,20 +1,37 @@
 import fs from 'node:fs';
 import { gql, GraphQLClient } from 'graphql-request';
 import { randomUUID } from 'node:crypto';
+import type { CommandDictionary } from '@nasa-jpl/aerie-ampcs';
 
 const commandDictionaryString = fs.readFileSync(
   new URL('../../cdict/command_banananation.xml', import.meta.url).pathname,
   'utf-8',
 );
 
-export async function insertCommandDictionary(graphqlClient: GraphQLClient): Promise<number> {
+export async function insertCommandDictionary(graphqlClient: GraphQLClient): Promise<{
+  id: number;
+  command_types_typescript_path: string;
+  mission: string;
+  version: string;
+  parsed_json: CommandDictionary;
+}> {
   const res = await graphqlClient.request<{
-    uploadDictionary: { id: number };
+    uploadDictionary: {
+      id: number;
+      command_types_typescript_path: string;
+      mission: string;
+      version: string;
+      parsed_json: CommandDictionary;
+    };
   }>(
     gql`
       mutation PutCommandDictionary($dictionary: String!) {
         uploadDictionary(dictionary: $dictionary) {
           id
+          command_types_typescript_path
+          mission
+          version
+          parsed_json
         }
       }
     `,
@@ -24,7 +41,7 @@ export async function insertCommandDictionary(graphqlClient: GraphQLClient): Pro
     },
   );
 
-  return res.uploadDictionary.id;
+  return res.uploadDictionary;
 }
 
 export async function removeCommandDictionary(


### PR DESCRIPTION
* **Tickets addressed:** Closes #927
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Adds a new column in the `command_dictionary` table that stores the entire parsed command dictionary. This is in support of hooking into `min` and `max` values that @Cobular is working on. 

## Verification
Added a basic unit test to make sure the command dictionary gets inserted.

## Documentation
NA

## Future work
NA
