### PR TITLE
Help gradle find node for testing

### DIFF
--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -49,19 +49,14 @@ assemble {
 }
 
 test {
-  dependsOn(assembleConstraintsDSLCompiler)
+  dependsOn nodeSetup
+  dependsOn assembleConstraintsDSLCompiler
   useJUnitPlatform {
     includeEngines 'jqwik', 'junit-jupiter'
   }
 
   // Add node bin directory to PATH, helps CI/CD services without node installed
-  projectDir.toPath().resolve('.gradle/nodejs').toFile().listFiles().each {
-    environment 'NODE_PATH', "$it/bin/node"
-  }
-
-  if (System.getenv("NODE_PATH") == null) {
-    environment 'NODE_PATH', "node"
-  }
+  environment 'NODE_PATH', nodeSetup.nodeDir.get().toString().concat("/bin/node")
 
   environment "CONSTRAINTS_DSL_COMPILER_ROOT", projectDir.toPath().resolve('constraints-dsl-compiler')
   environment "CONSTRAINTS_DSL_COMPILER_COMMAND", './build/main.js'

--- a/scheduler-worker/build.gradle
+++ b/scheduler-worker/build.gradle
@@ -70,7 +70,8 @@ assemble {
 }
 
 test {
-  dependsOn(assembleSchedulingDSLCompiler)
+  dependsOn nodeSetup
+  dependsOn assembleSchedulingDSLCompiler
   useJUnitPlatform()
 
   testLogging {
@@ -78,13 +79,7 @@ test {
   }
 
   // Add node bin directory to PATH, helps CI/CD services without node installed
-  projectDir.toPath().resolve('.gradle/nodejs').toFile().listFiles().each {
-    environment 'NODE_PATH', "$it/bin/node"
-  }
-
-  if (System.getenv("NODE_PATH") == null) {
-    environment 'NODE_PATH', "node"
-  }
+  environment 'NODE_PATH', nodeSetup.nodeDir.get().toString().concat("/bin/node")
 
   environment "SCHEDULING_DSL_COMPILER_ROOT", projectDir.toPath().resolve('scheduling-dsl-compiler')
   environment "SCHEDULING_DSL_COMPILER_COMMAND", './build/main.js'


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
@jmdelfa ran `./gradlew test`, and ran into the following error:

```
Cannot run program "node" (in directory "/home/jmdelfa/dev/aerie/merlin-server/constraints-dsl-compiler"): error=2, No such file or directory
```

What this error message means is that the `node` executable was not found on the `PATH`.

We can tell from this message that the `NODE_PATH` environment variable had assumed its "fallback" value of `"node"`, in the final if statement below:

https://github.com/NASA-AMMOS/aerie/blob/06182bf6945d6e15352012edd567b3fb9a4feb5d/merlin-server/build.gradle#L57C1-L64

What I _think_ this means is that the `NODE_PATH` environment variable does not immediately get set by `environment "NODE_PATH", ...` - which means the check `System.getenv("NODE_PATH")` returns `null` regardless of whether the loop above is able to successfully find the nodejs directory.

This PR uses a local variable, `node_path`, to handle this logic, and delays calling `environment` until the end of the block. This removes the assumption that the environment variable is updated in flight.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

I removed the `node` executable from my path, and ran `./gradlew test`, and reproduced the error mentioned above. I then made the changes included in this PR, and ran `./gradlew test` again, and the tests passed.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Open to ideas for whether this needs to be documented.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None, at the moment.