### PR TITLE
Fix enum types for scheduling eDSL presets

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
@@ -212,11 +212,11 @@ return (<T>makeAllDiscreteProfile(args))
         .entrySet()
         .stream()
         .sorted(Map.Entry.comparingByKey())
-        .map($ -> new ActivityParameter($.getKey(), valueSchemaToTypescriptTypeOrProfile($.getValue())))
+        .map($ -> new ActivityParameter($.getKey(), valueSchemaToTypescriptType($.getValue())))
         .toList();
   }
 
-  private static TypescriptType valueSchemaToTypescriptTypeOrProfile(final ValueSchema valueSchema) {
+  private static TypescriptType valueSchemaToTypescriptType(final ValueSchema valueSchema) {
     return valueSchema.match(new ValueSchema.Visitor<>() {
       @Override
       public TypescriptType onReal() {
@@ -250,7 +250,7 @@ return (<T>makeAllDiscreteProfile(args))
 
       @Override
       public TypescriptType onSeries(final ValueSchema value) {
-        return new TypescriptType.TSArray(valueSchemaToTypescriptTypeOrProfile(value));
+        return new TypescriptType.TSArray(valueSchemaToTypescriptType(value));
       }
 
       @Override
@@ -263,7 +263,7 @@ return (<T>makeAllDiscreteProfile(args))
                 .map($ ->
                          Pair.of(
                              $.getKey(),
-                             valueSchemaToTypescriptTypeOrProfile($.getValue())))
+                             valueSchemaToTypescriptType($.getValue())))
                 .toList());
       }
 

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
@@ -18,6 +18,7 @@ import type { Windows } from './constraints-edsl-fluent-api.js';
 import type * as ConstraintEDSL from './constraints-edsl-fluent-api.js'
 interface SampleActivity1 extends ActivityTemplate<ActivityType.SampleActivity1> {}
 interface SampleActivity2 extends ActivityTemplate<ActivityType.SampleActivity2> {}
+interface SampleActivity3 extends ActivityTemplate<ActivityType.SampleActivity3> {}
 interface SampleActivityEmpty extends ActivityTemplate<ActivityType.SampleActivityEmpty> {}
 export function makeAllDiscreteProfile (argument: any) : any{
   if (argument === undefined){
@@ -68,6 +69,11 @@ const ActivityTemplateConstructors = {
   // @ts-ignore
     return { activityType: ActivityType.SampleActivity2, args: makeArgumentsDiscreteProfiles(args) };
   },
+  SampleActivity3: function SampleActivity3Constructor(args:  ConstraintEDSL.Gen.ActivityTypeParameterMap[ActivityType.SampleActivity3]
+  ): SampleActivity3 {
+  // @ts-ignore
+    return { activityType: ActivityType.SampleActivity3, args: makeArgumentsDiscreteProfiles(args) };
+  },
   SampleActivityEmpty: function SampleActivityEmptyConstructor(): SampleActivityEmpty {
     return { activityType: ActivityType.SampleActivityEmpty, args: {} };
   },
@@ -79,6 +85,13 @@ const ActivityPresetMap = Object.freeze({
     get "my preset"(): { quantity:(number | Real),} {
       return {
         "quantity": 5,
+      };
+    },
+  }),
+  SampleActivity3: Object.freeze({
+    get "my preset"(): { variant:(("option1" | "option2") | Discrete<("option1" | "option2")>),} {
+      return {
+        "variant": "option1",
       };
     },
   }),

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
@@ -76,9 +76,7 @@ const ActivityPresetMap = Object.freeze({
   SampleActivity1: Object.freeze({
   }),
   SampleActivity2: Object.freeze({
-    get "my preset"(): {
-      "quantity": number,
-    } {
+    get "my preset"(): { quantity:(number | Real),} {
       return {
         "quantity": 5,
       };

--- a/scheduler-server/src/testFixtures/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTestFixtures.java
+++ b/scheduler-server/src/testFixtures/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTestFixtures.java
@@ -47,6 +47,20 @@ public final class TypescriptCodeGenerationServiceTestFixtures {
                   )
               ),
               new MissionModelService.ActivityType(
+                  "SampleActivity3",
+                  Map.of(
+                      "variant",
+                      ValueSchema.ofVariant(List.of(
+                        new ValueSchema.Variant("option1", "option1"),
+                        new ValueSchema.Variant("option2", "option2")
+                      ))
+                  ),
+                  Map.of(
+                      "my preset",
+                      Map.of("variant", SerializedValue.of("option1"))
+                  )
+              ),
+              new MissionModelService.ActivityType(
                   "SampleActivityEmpty",
                   Map.of(),
                   Map.of()

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingDSLCompilationServiceTests.java
@@ -153,6 +153,12 @@ class SchedulingDSLCompilationServiceTests {
     ));
   }
 
+  private static StructExpressionAt getSampleActivity3PresetParameters() {
+    return new StructExpressionAt(Map.ofEntries(
+       Map.entry("variant", new ProfileExpression<>(new DiscreteValue(SerializedValue.of("option1"))))
+    ));
+  }
+
   @Test
   void  testSchedulingDSL_basic()
   {
@@ -1001,6 +1007,33 @@ class SchedulingDSLCompilationServiceTests {
     if (result2 instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success<SchedulingDSL.GoalSpecifier> r) {
       assertEquals(expectedGoalDefinition2, r.value());
     } else if (result2 instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
+      fail(r.toString());
+    }
+  }
+
+  @Test
+  void testPresetWithEnum() {
+    final var result = schedulingDSLCompilationService.compileSchedulingGoalDSL(
+        missionModelService,
+        PLAN_ID, """
+                export default (): Goal => {
+                  return Goal.ActivityRecurrenceGoal({
+                    activityTemplate: ActivityTemplates.SampleActivity3(ActivityPresets.SampleActivity3["my preset"]),
+                    interval: Temporal.Duration.from({ hours: 1 })
+                  })
+                }
+            """);
+    final var expectedGoalDefinition1 = new SchedulingDSL.GoalSpecifier.RecurrenceGoalDefinition(
+        new SchedulingDSL.ActivityTemplate(
+            "SampleActivity3",
+            getSampleActivity3PresetParameters()
+        ),
+        Optional.empty(),
+        HOUR,
+        false);
+    if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Success<SchedulingDSL.GoalSpecifier> r) {
+      assertEquals(expectedGoalDefinition1, r.value());
+    } else if (result instanceof SchedulingDSLCompilationService.SchedulingDSLCompilationResult.Error<SchedulingDSL.GoalSpecifier> r) {
       fail(r.toString());
     }
   }


### PR DESCRIPTION
* **Tickets addressed:** Closes #916 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This fixes a bug where presets that included enum parameters caused the eDSL compiler to give a type error.

This is because the type was not specific enough: the preset's type was inferred to be `string`, which is not specific enough to be applied to a type like `"option1" | "option2"`, even if the actual value of the the preset was `"option1"`. The presets now have the proper type annotation.

Also, in a previous PR I changed the function `valueSchemaToTypescriptType` to `valueSchemaToTypescriptTypeOrProfile` for no apparent reason. I've reverted that change here.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I added a unit test to SchedulingDSLCompilationServiceTests.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
