### PR TITLE
Added ability to specify a rate for a SampledResource

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/SampledResource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/SampledResource.java
@@ -1,34 +1,67 @@
 package gov.nasa.jpl.aerie.contrib.models;
 
 import gov.nasa.jpl.aerie.merlin.framework.resources.discrete.DiscreteResource;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
 import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.*;
-import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECOND;
 
+/**
+ * Simple resource that samples arbitrarily many existing resources/values at a specified rate (default rate is once per
+ * second).
+ */
 public class SampledResource<T> implements DiscreteResource<T> {
   private final Register<T> result;
   private final Supplier<T> sampler;
+  private double rate;
 
+  /**
+   * Constructor that does not require caller to specify a rate and therefore assumes a sample
+   * rate of 1 sample per second.
+   */
   public SampledResource(final Supplier<T> sampler, final UnaryOperator<T> duplicator) {
     this.result = Register.create(sampler.get(), duplicator);
     this.sampler = Objects.requireNonNull(sampler);
-
+    this.rate = 1.0;
     spawn(this::takeSamples);
   }
 
+  /**
+   * Constructor that requires caller to specify an initial sample rate
+   */
+  public SampledResource(final Supplier<T> sampler, final UnaryOperator<T> duplicator, final double rate) {
+    this.result = Register.create(sampler.get(), duplicator);
+    this.sampler = Objects.requireNonNull(sampler);
+    this.rate = rate;
+    spawn(this::takeSamples);
+  }
+
+  /**
+   * Method that samples the supplied resource at the current specified rate
+   */
   private void takeSamples() {
     while (true) {
       var sample = sampler.get();
       if (!result.get().equals(sample)) {
         result.set(sample);
       }
-      delay(1, SECOND);
+      delay( Duration.roundNearest(rate, Duration.SECONDS) );
     }
   }
+
+  /**
+   * Get current sample rate
+   */
+  public double getRate() { return rate; }
+
+  /**
+   * Method to adjust the specified rate of sampling. Note if takeSamples() is currently waiting, the
+   * new rate will not take effect until after the current wait cycle.
+   */
+  public void setRate(final double newRate ) { rate = newRate; }
 
   @Override
   public T getDynamics() {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/SampledResource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/SampledResource.java
@@ -10,8 +10,8 @@ import java.util.function.UnaryOperator;
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.*;
 
 /**
- * Simple resource that samples arbitrarily many existing resources/values at a specified period (default period is once per
- * second).
+ * Simple resource that samples arbitrarily many existing resources/values at a specified period (default period is once
+ * per second).
  */
 public class SampledResource<T> implements DiscreteResource<T> {
   private final Register<T> result;
@@ -52,7 +52,7 @@ public class SampledResource<T> implements DiscreteResource<T> {
   }
 
   /**
-   * Get current sample period
+   * Get current sample period (seconds per sample)
    */
   public double getPeriod() { return period.get(); }
 

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/SampledResource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/SampledResource.java
@@ -16,7 +16,7 @@ import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.*;
 public class SampledResource<T> implements DiscreteResource<T> {
   private final Register<T> result;
   private final Supplier<T> sampler;
-  private Register<Double> period = Register.forImmutable(1.0);
+  private final Register<Double> period = Register.forImmutable(1.0);
 
   /**
    * Constructor that does not require caller to specify a period and therefore assumes a sample


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  
* **Merge strategy:** Merge (no squash) 

## Description
The example SampledResource in the contrib package was a little too simple in that it did not provide the capability to sample at a user specified rate. This PR updates the SampledResource so that users can both initialize a resource to a custom sample rate and change the rate later if they wish.  

## Verification
No tests were added and the original resource constructor still exists, which defaults the rate to one second. 

## Documentation
The [Resource and Models](https://nasa-ammos.github.io/aerie-docs/mission-modeling/resources-and-models/) section of the docs should be updated, but my plan was to address this update as part of https://github.com/NASA-AMMOS/aerie-docs/issues/46
