### PR TITLE
Add Hasura relationships to support Expansion Runs UI

### DIFF
--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expanded_sequences.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expanded_sequences.yaml
@@ -5,6 +5,16 @@ object_relationships:
   - name: expansion_run
     using:
       foreign_key_constraint_on: expansion_run_id
+  - name: sequence
+    using:
+      manual_configuration:
+        remote_table:
+          name: sequence
+          schema: public
+        insertion_order: null
+        column_mapping:
+          seq_id: seq_id
+          simulation_dataset_id: simulation_dataset_id
 select_permissions:
   - role: user
     permission:

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expansion_run.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expansion_run.yaml
@@ -2,17 +2,24 @@ table:
   name: expansion_run
   schema: public
 object_relationships:
-- name: expansion_set
-  using:
-    foreign_key_constraint_on: expansion_set_id
+  - name: expansion_set
+    using:
+      foreign_key_constraint_on: expansion_set_id
 array_relationships:
-- name: activity_instance_commands
-  using:
-    foreign_key_constraint_on:
-      column: expansion_run_id
-      table:
-        name: activity_instance_commands
-        schema: public
+  - name: activity_instance_commands
+    using:
+      foreign_key_constraint_on:
+        column: expansion_run_id
+        table:
+          name: activity_instance_commands
+          schema: public
+  - name: expanded_sequences
+    using:
+      foreign_key_constraint_on:
+        column: expansion_run_id
+        table:
+          name: expanded_sequences
+          schema: public
 remote_relationships:
   - name: simulation_dataset
     definition:


### PR DESCRIPTION
Required for https://github.com/NASA-AMMOS/aerie-ui/issues/577

* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Adds the following object/array relationships:

- expanded_sequences . ( seq_id, simulation_dataset_id )  → sequence . ( seq_id, simulation_dataset_id )
- expanded_sequences . expansion_run_id  → expansion_run . id

Allowing the UI to gather the necessary details to display information about the expanded sequences and the applicable activity types within each expansion/sequence.

## Verification
Upon rebuilding, confirmed the following query ran successfully in the Hasura API Explorer

```graphql
{
  expansionRuns: expansion_run(order_by: {id: desc}) {
    created_at
    expansion_set {
      command_dict_id
      created_at
      id
      name
    }
    expanded_sequences {
      edsl_string
      expanded_sequence
      id
      seq_id
      sequence {
        activity_instance_joins {
          simulated_activity {
            id
            activity_type_name
          }
        }
      }
    }
    simulation_dataset {
      dataset_id
      simulation {
        plan {
          id
          name
        }
      }
    }
    id
  }
}
```

## Documentation
N/A

## Future work
N/A
