### PR TITLE
Make `Description` optional across the DB

### DIFF
--- a/deployment/hasura/migrations/AerieMerlin/15_defintion_consistency/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/15_defintion_consistency/down.sql
@@ -1,0 +1,7 @@
+alter table public.simulation_template
+  alter column description drop default;
+
+alter table public."constraint"
+  alter column description drop default;
+
+call migrations.mark_migration_rolled_back('15');

--- a/deployment/hasura/migrations/AerieMerlin/15_defintion_consistency/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/15_defintion_consistency/up.sql
@@ -1,0 +1,7 @@
+alter table public."constraint"
+  alter column description set default '';
+
+alter table public.simulation_template
+  alter column description set default '';
+
+call migrations.mark_migration_applied('15');

--- a/deployment/hasura/migrations/AerieScheduler/7_definition_consistency/down.sql
+++ b/deployment/hasura/migrations/AerieScheduler/7_definition_consistency/down.sql
@@ -1,0 +1,9 @@
+alter table scheduling_condition
+  alter column description drop default,
+  alter column description drop not null;
+
+alter table scheduling_goal
+  alter column description drop default,
+  alter column description drop not null;
+
+call migrations.mark_migration_rolled_back('7');

--- a/deployment/hasura/migrations/AerieScheduler/7_definition_consistency/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/7_definition_consistency/up.sql
@@ -1,0 +1,9 @@
+alter table scheduling_goal
+  alter column description set default '',
+  alter column description set not null;
+
+alter table scheduling_condition
+  alter column description set default '',
+  alter column description set not null;
+
+call migrations.mark_migration_applied('7');

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -17,3 +17,4 @@ call migrations.mark_migration_applied('11');
 call migrations.mark_migration_applied('12');
 call migrations.mark_migration_applied('13');
 call migrations.mark_migration_applied('14');
+call migrations.mark_migration_applied('15');

--- a/merlin-server/sql/merlin/tables/constraint.sql
+++ b/merlin-server/sql/merlin/tables/constraint.sql
@@ -2,7 +2,7 @@ create table "constraint" (
   id integer generated always as identity,
 
   name text not null,
-  description text not null,
+  description text not null default '',
   definition text not null,
   tags text[] default '{}',
 

--- a/merlin-server/sql/merlin/tables/simulation_template.sql
+++ b/merlin-server/sql/merlin/tables/simulation_template.sql
@@ -3,7 +3,7 @@ create table simulation_template (
   revision integer not null default 0,
 
   model_id integer not null,
-  description text not null,
+  description text not null default '',
   arguments merlin_argument_set not null,
   owner text not null default '',
 

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -9,3 +9,4 @@ call migrations.mark_migration_applied('3');
 call migrations.mark_migration_applied('4');
 call migrations.mark_migration_applied('5');
 call migrations.mark_migration_applied('6');
+call migrations.mark_migration_applied('7');

--- a/scheduler-server/sql/scheduler/tables/scheduling_condition.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_condition.sql
@@ -5,7 +5,7 @@ create table scheduling_condition (
   definition text not null,
 
   model_id integer not null,
-  description text null,
+  description text not null default '',
   author text null,
   last_modified_by text null,
   created_date timestamptz not null default now(),

--- a/scheduler-server/sql/scheduler/tables/scheduling_goal.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_goal.sql
@@ -6,7 +6,7 @@ create table scheduling_goal (
   tags text[] not null default '{}',
 
   model_id integer not null,
-  description text null,
+  description text not null default '',
   author text null,
   last_modified_by text null,
   created_date timestamptz not null default now(),


### PR DESCRIPTION
* **Tickets addressed:** Closes #950
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
As pointed out in #950, there were places where there was an optional `description` column that was specified as not optional (as in, not null, no default). These columns have been updated to have a default value of `''`. Additionally, the scheduler was representing this optionality as `NULL` in two places. Those locations have been updated to match with the rest of the DB.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
No existing tests would be affected by this change.