### PR TITLE
Fixed the issue where constraint violations were not being calculated properly

### DIFF
--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/Duration.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/Duration.java
@@ -181,9 +181,11 @@ public final class Duration implements Comparable<Duration> {
    * rounding to the nearest representable value above.
    */
   public static Duration roundUpward(final double quantity, final Duration unit) {
+    final var integerPart = Math.floor(quantity);
+    final var decimalPart = quantity - integerPart;
     return add(
-        unit.times((long) Math.floor(quantity)),
-        EPSILON.times((long) Math.ceil(positiveModulo(quantity, 1) * unit.dividedBy(EPSILON))));
+        unit.times((long) integerPart),
+        EPSILON.times((long) Math.ceil(decimalPart * unit.dividedBy(EPSILON))));
   }
 
   /**
@@ -191,9 +193,11 @@ public final class Duration implements Comparable<Duration> {
    * rounding to the nearest representable value below.
    */
   public static Duration roundDownward(final double quantity, final Duration unit) {
+    final var integerPart = Math.floor(quantity);
+    final var decimalPart = quantity - integerPart;
     return add(
-        unit.times((long) Math.floor(quantity)),
-        EPSILON.times((long) Math.floor(positiveModulo(quantity, 1) * unit.dividedBy(EPSILON))));
+        unit.times((long) integerPart),
+        EPSILON.times((long) Math.floor(decimalPart * unit.dividedBy(EPSILON))));
   }
 
   /**
@@ -201,9 +205,11 @@ public final class Duration implements Comparable<Duration> {
    * rounding to the nearest representable value.
    */
   public static Duration roundNearest(final double quantity, final Duration unit) {
+    final var integerPart = Math.floor(quantity);
+    final var decimalPart = quantity - integerPart;
     return add(
-        unit.times((long) Math.floor(quantity)),
-        EPSILON.times((long) Math.rint(positiveModulo(quantity, 1) * unit.dividedBy(EPSILON))));
+        unit.times((long) integerPart),
+        EPSILON.times((long) Math.rint(decimalPart * unit.dividedBy(EPSILON))));
   }
 
   /**
@@ -537,8 +543,4 @@ public final class Duration implements Comparable<Duration> {
     return Long.compare(this.durationInMicroseconds, other.durationInMicroseconds);
   }
 
-  /** Returns the remainder of dividend / divisor as a value between 0 and divisor. */
-  private static double positiveModulo(final double dividend, final double divisor) {
-    return ((dividend % divisor) + divisor) % divisor;
-  }
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/Duration.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/Duration.java
@@ -183,7 +183,7 @@ public final class Duration implements Comparable<Duration> {
   public static Duration roundUpward(final double quantity, final Duration unit) {
     return add(
         unit.times((long) Math.floor(quantity)),
-        EPSILON.times((long) Math.ceil((quantity % 1) * unit.dividedBy(EPSILON))));
+        EPSILON.times((long) Math.ceil(positiveModulo(quantity, 1) * unit.dividedBy(EPSILON))));
   }
 
   /**
@@ -193,7 +193,7 @@ public final class Duration implements Comparable<Duration> {
   public static Duration roundDownward(final double quantity, final Duration unit) {
     return add(
         unit.times((long) Math.floor(quantity)),
-        EPSILON.times((long) Math.floor((quantity % 1) * unit.dividedBy(EPSILON))));
+        EPSILON.times((long) Math.floor(positiveModulo(quantity, 1) * unit.dividedBy(EPSILON))));
   }
 
   /**
@@ -203,7 +203,7 @@ public final class Duration implements Comparable<Duration> {
   public static Duration roundNearest(final double quantity, final Duration unit) {
     return add(
         unit.times((long) Math.floor(quantity)),
-        EPSILON.times((long) Math.rint((quantity % 1) * unit.dividedBy(EPSILON))));
+        EPSILON.times((long) Math.rint(positiveModulo(quantity, 1) * unit.dividedBy(EPSILON))));
   }
 
   /**
@@ -535,5 +535,10 @@ public final class Duration implements Comparable<Duration> {
   @Override
   public int compareTo(final Duration other) {
     return Long.compare(this.durationInMicroseconds, other.durationInMicroseconds);
+  }
+
+  /** Returns the remainder of dividend / divisor as a value between 0 and divisor. */
+  private static double positiveModulo(final double dividend, final double divisor) {
+    return ((dividend % divisor) + divisor) % divisor;
   }
 }

--- a/merlin-sdk/src/test/java/gov/nasa/jpl/aerie/merlin/protocol/types/DurationTest.java
+++ b/merlin-sdk/src/test/java/gov/nasa/jpl/aerie/merlin/protocol/types/DurationTest.java
@@ -17,20 +17,25 @@ public final class DurationTest {
     assertEquals(duration(2756, MILLISECONDS), roundNearest(2.756, SECONDS));
     assertEquals(duration(2756, MILLISECONDS), roundNearest(Math.nextUp(2.756), SECONDS));
     assertEquals(duration(2756, MILLISECONDS), roundNearest(Math.nextDown(2.756), SECONDS));
+    assertEquals(duration(-2756, MILLISECONDS), roundNearest(-2.756, SECONDS));
+    assertEquals(duration(-2756, MILLISECONDS), roundNearest(Math.nextUp(-2.756), SECONDS));
+    assertEquals(duration(-2756, MILLISECONDS), roundNearest(Math.nextDown(-2.756), SECONDS));
   }
 
   @Test
   public void testRoundDown() {
-    assertEquals(duration(2756, MILLISECONDS), roundNearest(2.756, SECONDS));
     assertEquals(duration(2756, MILLISECONDS), roundDownward(Math.nextUp(2.756), SECONDS));
     assertEquals(duration(2756, MILLISECONDS).minus(EPSILON), roundDownward(Math.nextDown(2.756), SECONDS));
+    assertEquals(duration(-2756, MILLISECONDS), roundDownward(Math.nextUp(-2.756), SECONDS));
+    assertEquals(duration(-2756, MILLISECONDS).minus(EPSILON), roundDownward(Math.nextDown(-2.756), SECONDS));
   }
 
   @Test
   public void testRoundUp() {
-    assertEquals(duration(2756, MILLISECONDS), roundNearest(2.756, SECONDS));
     assertEquals(duration(2756, MILLISECONDS), roundUpward(Math.nextDown(2.756), SECONDS));
     assertEquals(duration(2756, MILLISECONDS).plus(EPSILON), roundUpward(Math.nextUp(2.756), SECONDS));
+    assertEquals(duration(-2756, MILLISECONDS), roundUpward(Math.nextDown(-2.756), SECONDS));
+    assertEquals(duration(-2756, MILLISECONDS).plus(EPSILON), roundUpward(Math.nextUp(-2.756), SECONDS));
   }
 
   @Test


### PR DESCRIPTION
* **Tickets addressed:** Closes #919
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
@mattdailis and I walked through the code and tracked down the issue to be not handling negative durations properly. This was causing the segments to be off by 1 second causing the bug. We added a function to the `Duration` class that ensures the modulo is always positive which fixed the issue.

## Verification
Manual testing was done and we updated the unit tests to include negative number checking.

## Documentation
NA

## Future work
NA
