### PR TITLE
Add field to condition trigger of scheduler worker after insertion on scheduling request

### DIFF
--- a/deployment/hasura/migrations/AerieScheduler/8_add_condition_trigger_scheduler/down.sql
+++ b/deployment/hasura/migrations/AerieScheduler/8_add_condition_trigger_scheduler/down.sql
@@ -1,0 +1,14 @@
+-- Drop Triggers
+drop trigger notify_scheduler_workers on scheduling_request;
+
+alter table scheduling_request
+  drop column for_aerie_scheduler;
+
+comment on column scheduling_goal.for_aerie_scheduler is null;
+
+create trigger notify_scheduler_workers
+  after insert on scheduling_request
+  for each row
+  execute function notify_scheduler_workers();
+
+call migrations.mark_migration_rolled_back('8');

--- a/deployment/hasura/migrations/AerieScheduler/8_add_condition_trigger_scheduler/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/8_add_condition_trigger_scheduler/up.sql
@@ -1,0 +1,16 @@
+-- Drop Triggers
+drop trigger notify_scheduler_workers on scheduling_request;
+
+alter table scheduling_request
+  add column for_aerie_scheduler boolean not null default true;
+
+comment on column scheduling_request.for_aerie_scheduler is e''
+  'Whether the request is destined to the aerie scheduler or to an external scheduler;';
+
+create trigger notify_scheduler_workers
+  after insert on scheduling_request
+  for each row
+  when (NEW.for_aerie_scheduler)
+  execute function notify_scheduler_workers();
+
+call migrations.mark_migration_applied('8');

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -10,3 +10,4 @@ call migrations.mark_migration_applied('4');
 call migrations.mark_migration_applied('5');
 call migrations.mark_migration_applied('6');
 call migrations.mark_migration_applied('7');
+call migrations.mark_migration_applied('8');

--- a/scheduler-server/sql/scheduler/tables/scheduling_request.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_request.sql
@@ -10,6 +10,7 @@ create table scheduling_request (
   reason jsonb null,
   canceled boolean not null default false,
   dataset_id integer default null,
+  for_aerie_scheduler boolean not null default true,
 
   specification_revision integer not null,
 
@@ -34,6 +35,8 @@ comment on column scheduling_request.status is e''
   'The state of the the scheduling request.';
 comment on column scheduling_request.reason is e''
   'The reason for failure when a scheduling request fails.';
+comment on column scheduling_request.for_aerie_scheduler is e''
+  'Whether the request is destined to the aerie scheduler or to an external scheduler;';
 comment on column scheduling_request.specification_revision is e''
   'The revision of the scheduling_specification associated with this request.';
 comment on column scheduling_request.requested_by is e''
@@ -68,5 +71,6 @@ do $$ begin
 create trigger notify_scheduler_workers
   after insert on scheduling_request
   for each row
+  when (NEW.for_aerie_scheduler)
   execute function notify_scheduler_workers();
 end $$;


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
PR #880 merged `analysis_id` into the `scheduling_request` table so now we are forced to create a request to have an analysis. This broke how the Clipper external scheduler works and I predict that's going to be the same for any external scheduler that uses the UI.

Specifically, when we update the plan, we push a scheduling analysis to the UI so the user can visualize it. Creating a `scheduling_request` as is does not work as it triggers automatically the scheduler workers. In this PR, I am adding a field to condition this triggering to the value of a new field in the request.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
No functionality has changed, the field has a default value equal to true.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None. 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None.