### PR TITLE
Tweak sampled resource initialization

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/SampledResource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/SampledResource.java
@@ -16,16 +16,14 @@ import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.*;
 public class SampledResource<T> implements DiscreteResource<T> {
   private final Register<T> result;
   private final Supplier<T> sampler;
-  private final Register<Double> period = Register.forImmutable(1.0);
+  private final Register<Double> period;
 
   /**
    * Constructor that does not require caller to specify a period and therefore assumes a sample
    * period of 1 sample per second.
    */
   public SampledResource(final Supplier<T> sampler, final UnaryOperator<T> duplicator) {
-    this.result = Register.create(sampler.get(), duplicator);
-    this.sampler = Objects.requireNonNull(sampler);
-    spawn(this::takeSamples);
+    this(sampler, duplicator, 1.0);
   }
 
   /**
@@ -34,7 +32,7 @@ public class SampledResource<T> implements DiscreteResource<T> {
   public SampledResource(final Supplier<T> sampler, final UnaryOperator<T> duplicator, final double period) {
     this.result = Register.create(sampler.get(), duplicator);
     this.sampler = Objects.requireNonNull(sampler);
-    this.period.set(period);
+    this.period =  Register.forImmutable(period);
     spawn(this::takeSamples);
   }
 

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/models/SampledResourceTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/models/SampledResourceTest.java
@@ -1,0 +1,31 @@
+package gov.nasa.jpl.aerie.contrib.models;
+
+import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECOND;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MerlinExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SampledResourceTest {
+  final Accumulator accumulator = new Accumulator(0.0, 1.0);
+  final SampledResource<Double> sampledResource = new SampledResource<>(() -> accumulator.get(), $ -> $, 10.0);
+
+  @Test
+  void testSampledResource() {
+    assertEquals(0.0, sampledResource.get());
+    delay(1, SECOND);
+    assertEquals(0.0, sampledResource.get());
+    delay(10, SECONDS);
+    assertEquals(10.0, sampledResource.get());
+    delay(5, SECONDS);
+    assertEquals(10.0, sampledResource.get());
+    delay(5, SECONDS);
+    assertEquals(20.0, sampledResource.get());
+  }
+}


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR is a minor adjustment to #956 that slipped my mind when reviewing yesterday. Cell allocation and updates are not allowed to occur during the same phase of simulation (Allocation must occur during initialization, updates must occur during task execution).  This PR moves the allocation into the SampledResource constructor - using the user-provided period as the initial value for the register, removing the need for an update during initialization.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I added a simple `SampledResourceTest` to exercise this code a little bit.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
See documentation section of the original PR #956 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Sampled resources, while a good example of a daemon tasks, are pretty inefficient. @Twisol has some ideas for some better tools we can provide out of the box to address some use cases that currently require daemon tasks.