### PR TITLE
Update postgres base image to 14.8

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -167,7 +167,7 @@ services:
       POSTGRES_USER: "${POSTGRES_USER}"
       AERIE_USERNAME: "${AERIE_USERNAME}"
       AERIE_PASSWORD: "${AERIE_PASSWORD}"
-    image: postgres:14.1
+    image: postgres:14.8
     ports: ["5432:5432"]
     restart: always
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -244,7 +244,7 @@ services:
       POSTGRES_USER: "${POSTGRES_USER}"
       AERIE_USERNAME: "${AERIE_USERNAME}"
       AERIE_PASSWORD: "${AERIE_PASSWORD}"
-    image: postgres:14.1
+    image: postgres:14.8
     ports: ["5432:5432"]
     restart: always
     volumes:

--- a/docker/Dockerfile.postgres
+++ b/docker/Dockerfile.postgres
@@ -1,2 +1,2 @@
-FROM postgres:14.1
+FROM postgres:14.8
 COPY deployment/postgres-init-db /docker-entrypoint-initdb.d

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -241,7 +241,7 @@ services:
       POSTGRES_USER: '${POSTGRES_USER}'
       AERIE_USERNAME: '${AERIE_USERNAME}'
       AERIE_PASSWORD: '${AERIE_PASSWORD}'
-    image: postgres:14.1
+    image: postgres:14.8
     ports: ['5432:5432']
     restart: always
     volumes:


### PR DESCRIPTION
* **Tickets addressed:** n/a
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The base image that `aerie-postgres` is based on is susceptible to several critical security vulnerabilities, which can be seen in the [results of our security scan](https://github.com/NASA-AMMOS/aerie/actions/runs/5146978225) in `publish`. Updating our base image to 14.8 fixes all of the detected vulnerabilities.

## Verification
Mainly relying on e2e tests passing, although according to the [postgres versioning policy](https://www.postgresql.org/support/versioning/), no breaking changes are introduced between minor versions, and all the release notes for versions 14.1 to 14.8 say a dump/restore is not needed when upgrading.

## Documentation
None

## Future work
Change `deployment/docker-compose.yml` to use `aerie-postgres` instead of bind mounting metadata, which would remove the need to clone aerie or download `deployment.zip` when doing a non-custom Aerie deployment.
