### PR TITLE
Fix dynamics serialization in GraphQLMerlinService

### DIFF
--- a/e2e-tests/src/tests/scheduler.test.ts
+++ b/e2e-tests/src/tests/scheduler.test.ts
@@ -236,6 +236,8 @@ test.describe.serial('Scheduling', () => {
         expect(eqSet(startOffsetOfResource, startOffsetsActivityDirectives)).toEqual(true)
       }
     }
+    const fruit = dataset.filter($ => $.name === "/fruit")[0];
+    expect(fruit.profile_segments[0].dynamics).toEqual({"initial": 3, "rate": 0});
     let topics = await req.getTopicsEvents(request, dataset_id)
     let prefixInput = "ActivityType.Input."
     let prefixOutput = "ActivityType.Output."

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -988,13 +988,13 @@ public SimulationId getSimulationId(PlanId planId) throws PlanServiceException, 
       final var duration = pair.extent();
       final var dynamics = pair.dynamics();
 
-      final String stringDynamics;
+      final JsonValue serializedDynamics;
       final boolean stringIsGap;
-      if(dynamics.isPresent()){
-        stringDynamics = serializeDynamics(dynamics.get(), dynamicsP);
+      if (dynamics.isPresent()) {
+        serializedDynamics = dynamicsP.unparse(dynamics.get());
         stringIsGap = false;
-      } else{
-        stringDynamics = null;
+      } else {
+        serializedDynamics = null;
         stringIsGap = true;
       }
       profiles.add(Json.createObjectBuilder()
@@ -1002,7 +1002,7 @@ public SimulationId getSimulationId(PlanId planId) throws PlanServiceException, 
           .add("profile_id", profileRecord.id())
           .add("start_offset", graphQLIntervalFromDuration(accumulatedOffset).toString())
           .add("is_gap", stringIsGap)
-          .add("dynamics", stringDynamics)
+          .add("dynamics", serializedDynamics)
           .build());
       accumulatedOffset = Duration.add(accumulatedOffset, duration);
     }
@@ -1021,10 +1021,8 @@ public SimulationId getSimulationId(PlanId planId) throws PlanServiceException, 
     if(affected_rows!=segments.size()) {
       throw new PlanServiceException("not the same size");
     }
-}
-  private <Dynamics> String serializeDynamics(final Dynamics dynamics, final JsonParser<Dynamics> dynamicsP) {
-    return dynamicsP.unparse(dynamics).toString();
   }
+
   private void postRealProfileSegments(final DatasetId datasetId,
                                               final ProfileRecord profileRecord,
                                               final List<ProfileSegment<Optional<RealDynamics>>> segments)

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -533,7 +533,6 @@ public record GraphQLMerlinService(URI merlinGraphqlURI, String hasuraGraphQlAdm
       }
 
       for (final var arg : act.arguments().entrySet()) {
-        //serializedValueP is safe to use here because only unparsing. otherwise subject to int/double typing confusion
         insertionObjectArguments.add(arg.getKey(), serializedValueP.unparse(arg.getValue()));
       }
       insertionObject.add("arguments", insertionObjectArguments.build());


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
@ewferg observed that in simulation results produced by the scheduler, profile segment dynamics are represented as stringified JSON objects (note the quotes):

<img width="952" alt="Screenshot 2023-06-06 at 7 06 12 AM" src="https://github.com/NASA-AMMOS/aerie/assets/1189602/8657830e-01a3-4516-8028-045542c9c3a7">

Running simulation again (without scheduling) produces profiles with the correct dynamics:

<img width="952" alt="Screenshot 2023-06-06 at 7 08 00 AM" src="https://github.com/NASA-AMMOS/aerie/assets/1189602/00dc7bb5-9646-45ce-8655-38cbc9d94f3d">

The root cause is the `.add("dynamics", stringDynamics)` towards the bottom of the following snippet. All dynamics are being stringified, then represented as a string:

https://github.com/NASA-AMMOS/aerie/blob/692968ec7fb0585da2a9b2c6236b070b686cbdb0/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java#L979-L994

This PR removes the `toString` call from `serializeDynamics`, and inlines that method into the call site. The `dynamicsP.unparse` method produces a `JsonValue`, which can directly be added to the JsonObjectBuilder.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I added an assertion to the existing scheduler e2e test. If you check out the first commit of this PR, redeploy Aerie, and run that test, you will see this assertion error:
```
Expected: {"initial": 3, "rate": 0}
Received: "{\"initial\":3.0,\"rate\":0.0}"
```

After the changes in this PR, this test should now pass.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
This is a bug fix - no documentation was invalidated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
We should talk about whether the UI should auto-switch to the simulation dataset produced by scheduling. Currently it takes some manual steps to pull it up. 