### PR TITLE
Add description field to createExpansionSet

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -34,7 +34,7 @@ type Mutation {
 }
 
 type Mutation {
-  createExpansionSet(commandDictionaryId: Int!, missionModelId: Int!, expansionIds: [Int!]!): ExpansionSetResponse
+  createExpansionSet(commandDictionaryId: Int!, missionModelId: Int!, expansionIds: [Int!]!, description: String): ExpansionSetResponse
 }
 
 type Mutation {


### PR DESCRIPTION
* **Tickets addressed:** Closes #949 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR adds an optional `description` field to the `createExpansionSet` action.

It does it with the following steps:
- Add a nullable `description: String` field in actions.graphql
- Pull the description field out of the payload in `command-expansion.ts`

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Manual testing in progress...

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
I couldn't find any API docs for creating an expansion set. Do we have any yet?

## Future work
<!-- What next steps can we anticipate from here, if any? -->
This PR duplicates the default "" value between the database and the sequencer server code. We can consider a refactor to make sure that the database default is always used. I didn't want to hold this PR up on that, however.