### PR TITLE
Allow filtering forEach ActivityExpressions on activity arguments

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
@@ -462,7 +462,7 @@ public final class ConstraintParsers {
         .field("expression", spansExpressionP)
         .map(
             untuple((kind, actType, alias, expression) -> new ForEachActivitySpans(actType, alias, expression)),
-            $ -> tuple(Unit.UNIT, $.activityType, $.alias, $.expression));
+            $ -> tuple(Unit.UNIT, ((ForEachActivitySpans.MatchType) $.activityPredicate()).type(), $.alias(), $.expression()));
   }
 
   static JsonParser<ForEachActivityViolations> forEachActivityViolationsF(final JsonParser<Expression<List<Violation>>> violationListExpressionP) {


### PR DESCRIPTION
* **Tickets addressed:** #925 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This does two main things:
- modify `ForEachActivitySpans` to use an arbitrary activity predicate for its filtering.
- Use this and the argument data provided to `forEach` activity expressions to allow CoexistenceGoal's to filter activities in the `forEach` field based on their arguments.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Added an integration test.

Also, the transition to predicates in `ForEachActivitySpans` caused a bunch of tests that relied on equality checks between `ForEachActivitySpans` instances to fail. So I added a little helper record `ForEachActivitySpans.MatchType` which implements `TriFunction` and more importantly provides an equality check.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
