### PR TITLE
Optionally associate external datasets with simulation datasets

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -13,7 +13,12 @@ interface Fallible {
 }
 
 type Mutation {
-  addExternalDataset(planId: Int!, datasetStart: String!, profileSet: ProfileSet!): AddExternalDatasetResponse
+  addExternalDataset(
+    planId: Int!,
+    simulationDatasetId: Int,
+    datasetStart: String!,
+    profileSet: ProfileSet!
+  ): AddExternalDatasetResponse
 }
 
 type Mutation {
@@ -86,7 +91,7 @@ type Query {
 }
 
 type Query {
-  constraintViolations(planId: Int!): ConstraintViolationsResponse
+  constraintViolations(planId: Int!, simulationDatasetId: Int): ConstraintViolationsResponse
 }
 
 type Query {

--- a/deployment/hasura/migrations/AerieMerlin/17_associate_external_datasets_with_simulation/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/17_associate_external_datasets_with_simulation/down.sql
@@ -1,0 +1,5 @@
+alter table plan_dataset
+  drop constraint associated_sim_dataset_exists,
+  drop column simulation_dataset_id;
+
+call migrations.mark_migration_rolled_back('17');

--- a/deployment/hasura/migrations/AerieMerlin/17_associate_external_datasets_with_simulation/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/17_associate_external_datasets_with_simulation/up.sql
@@ -1,0 +1,13 @@
+alter table plan_dataset
+  add column simulation_dataset_id integer,
+  add constraint associated_sim_dataset_exists
+    foreign key (simulation_dataset_id)
+    references simulation_dataset
+    on update cascade
+    on delete cascade;
+
+comment on column plan_dataset.simulation_dataset_id is e''
+  'The ID of the simulation dataset optionally associated with the dataset.'
+  'If null, the dataset is associated with all simulation runs for the plan.';
+
+call migrations.mark_migration_applied('17');

--- a/e2e-tests/src/tests/external-datasets.test.ts
+++ b/e2e-tests/src/tests/external-datasets.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import req from '../utilities/requests.js';
+import req, { awaitSimulation } from '../utilities/requests.js';
 import time from '../utilities/time.js';
 
 test.describe.serial('External Datasets', () => {
@@ -65,6 +65,7 @@ test.describe.serial('External Datasets', () => {
 
   const profile_set_result_1 = {
     plan_dataset_by_pk: {
+      simulation_dataset_id: null,
       offset_from_plan_start: "06:00:00",
       dataset: {
         profiles: [
@@ -99,6 +100,7 @@ test.describe.serial('External Datasets', () => {
 
   const profile_set_result_2 = {
     plan_dataset_by_pk: {
+      simulation_dataset_id: null,
       offset_from_plan_start: "06:00:00",
       dataset: {
         profiles: [
@@ -161,6 +163,7 @@ test.describe.serial('External Datasets', () => {
 
   const profile_set_result_3 = {
     plan_dataset_by_pk: {
+      simulation_dataset_id: null,
       offset_from_plan_start: "06:00:00",
       dataset: {
         profiles: [
@@ -340,4 +343,244 @@ test.describe.serial('External Datasets', () => {
     const deleted_id = await req.deleteExternalDataset(request, input);
     expect(deleted_id).toEqual(dataset_id);
   });
+});
+
+test.describe.serial('Simulation Associated External Datasets', () => {
+  const rd = Math.random() * 100;
+  const plan_start_timestamp = "2021-001T00:00:00.000";
+  const plan_end_timestamp = "2021-001T12:00:00.000";
+  const dataset_start_timestamp = "2021-001T06:00:00.000";
+  const constraint_name = "my_boolean is true"
+  const profile_duration = 3600000000;
+  const profile_set = {
+    "/my_boolean": {
+      type: "discrete",
+      schema: {
+        type: "boolean"
+      },
+      segments: [
+        {duration: profile_duration, "dynamics": true},
+        {duration: profile_duration, "dynamics": false}
+      ]
+    }
+  };
+
+  let profile_set_result = {
+    plan_dataset_by_pk: {
+      simulation_dataset_id: -1,
+      offset_from_plan_start: "06:00:00",
+      dataset: {
+        profiles: [
+          {
+            profile_segments: [
+              {
+                start_offset: "00:00:00",
+                dynamics: true
+              },
+              {
+                start_offset: "01:00:00",
+                dynamics: false
+              },
+            ]
+          }
+        ]
+      }
+    }
+  };
+
+
+  let jar_id: number;
+  let mission_model_id: number;
+  let plan_id: number;
+  let dataset_id: number;
+  let first_simulation_dataset_id: number;
+  let second_simulation_dataset_id: number;
+  let constraint_id: number;
+  let violation: ConstraintViolation;
+  let activity_id: number;
+
+  test('Create mission model and plan', async ({ request }) => {
+    jar_id = await req.uploadJarFile(request);
+
+    const model: MissionModelInsertInput = {
+      jar_id,
+      mission: 'aerie_e2e_tests' + rd,
+      name: 'Banananation (e2e tests)'+rd,
+      version: '0.0.0'+ rd,
+    };
+    mission_model_id = await req.createMissionModel(request, model);
+    expect(mission_model_id).not.toBeNull();
+    expect(mission_model_id).toBeDefined();
+    expect(typeof mission_model_id).toEqual("number");
+
+    const plan_input : CreatePlanInput = {
+      model_id : mission_model_id,
+      name : 'test_plan' + rd,
+      start_time : plan_start_timestamp,
+      duration : time.getIntervalFromDoyRange(plan_start_timestamp, plan_end_timestamp)
+    };
+    plan_id = await req.createPlan(request, plan_input);
+    expect(plan_id).not.toBeNull();
+    expect(plan_id).toBeDefined();
+    expect(typeof plan_id).toEqual("number");
+  });
+
+  test("Add Constraint to Plan", async ({ request }) => {
+    const constraint: ConstraintInsertInput = {
+      name: constraint_name,
+      definition: "export default (): Constraint => Discrete.Resource(\"/my_boolean\").equal(true)",
+      description: "",
+      model_id: null,
+      plan_id,
+    };
+    constraint_id = await req.insertConstraint(request, constraint);
+
+    expect(constraint_id).not.toBeNull();
+    expect(constraint_id).toBeDefined();
+  });
+
+  test("Run simulation", async ({ request }) => {
+    const resp: SimulationResponse = await awaitSimulation(request, plan_id);
+    first_simulation_dataset_id = resp.simulationDatasetId;
+
+    expect(resp.status).toEqual("complete");
+  });
+
+  test('Upload Simulation Associated External Dataset', async ({ request }) => {
+    const externalDatasetInput: ExternalDatasetInsertInput = {
+      plan_id,
+      simulation_dataset_id: first_simulation_dataset_id,
+      dataset_start: dataset_start_timestamp,
+      profile_set
+    };
+
+    dataset_id = await req.insertExternalDataset(request, externalDatasetInput);
+    expect(dataset_id).not.toBeNull();
+    expect(dataset_id).toBeDefined();
+    expect(dataset_id).not.toEqual(first_simulation_dataset_id);
+    expect(typeof dataset_id).toEqual("number");
+  });
+
+  test('Query External Dataset', async ({ request }) => {
+    profile_set_result.plan_dataset_by_pk.simulation_dataset_id = first_simulation_dataset_id;
+    const getExternalDatasetInput: ExternalDatasetQueryInput = { plan_id, dataset_id };
+
+    const result = await req.getExternalDataset(request, getExternalDatasetInput);
+
+    expect(result).toEqual(profile_set_result);
+  });
+
+  test("Check there is one violation when simulationDatasetId isn't provided", async ({ request }) => {
+    const violations: ConstraintViolation[] = await req.checkConstraints(request, plan_id);
+    violation = violations[0];
+
+    expect(violations).not.toBeNull();
+    expect(violations).toBeDefined();
+    expect(violations).toHaveLength(1);
+  });
+
+  test("Check there is one violation when simulationDatasetId is provided", async ({ request }) => {
+    const violations: ConstraintViolation[] = await req.checkConstraints(request, plan_id, first_simulation_dataset_id);
+
+    expect(violation).toEqual(violations[0]); // should be the same as the violation from the prev test
+    violation = violations[0];
+
+    expect(violations).not.toBeNull();
+    expect(violations).toBeDefined();
+    expect(violations).toHaveLength(1);
+  });
+
+  test("Check the violation is the expected one", async () => {
+    expect(violation.constraintName).toEqual(constraint_name)
+    expect(violation.constraintId).toEqual(constraint_id)
+    expect(violation.associations.resourceIds).toHaveLength(1);
+    expect(violation.associations.resourceIds).toContain("/my_boolean");
+  });
+
+  test("Check violation starts and ends as expected", async () => {
+    const plan_start_unix = 1000 * time.getUnixEpochTime(plan_start_timestamp);
+    const dataset_start_unix = 1000 * time.getUnixEpochTime(dataset_start_timestamp);
+
+    expect(violation.windows[0].start).toEqual(dataset_start_unix - plan_start_unix + profile_duration);
+    expect(violation.windows[0].end).toEqual(dataset_start_unix - plan_start_unix + (2 * profile_duration));
+  });
+
+  test("Add activity to plan to make simulation out of date", async ({ request }) => {
+    const activityToInsert : ActivityInsertInput = {
+      arguments : {
+        "biteSize": 1
+      },
+      plan_id: plan_id,
+      type : "BiteBanana",
+      start_offset : "1h",
+    };
+    activity_id = await req.insertActivity(request, activityToInsert);
+
+    expect(activity_id).not.toBeNull();
+    expect(activity_id).toBeDefined();
+  });
+
+  test("Run new simulation", async ({ request }) => {
+    const resp: SimulationResponse = await awaitSimulation(request, plan_id);
+    second_simulation_dataset_id = resp.simulationDatasetId;
+
+    expect(resp.status).toEqual("complete");
+  });
+
+  test("Check there is still one violation when simulationDatasetId isn't provided", async ({ request }) => {
+    const violations: ConstraintViolation[] = await req.checkConstraints(request, plan_id);
+
+    expect(violations).not.toBeNull();
+    expect(violations).toBeDefined();
+    expect(violations).toHaveLength(1);
+  });
+
+  test("Check there is still one violation when the first simulationDatasetId is provided", async ({ request }) => {
+    const violations: ConstraintViolation[] = await req.checkConstraints(request, plan_id, first_simulation_dataset_id);
+
+    expect(violations).not.toBeNull();
+    expect(violations).toBeDefined();
+    expect(violations).toHaveLength(1);
+  });
+
+
+  test("Check there are no violations when second simulationDatasetId is provided", async ({ request }) => {
+    const violations: ConstraintViolation[] = await req.checkConstraints(request, plan_id, second_simulation_dataset_id);
+
+    expect(violations).not.toBeNull();
+    expect(violations).toBeDefined();
+    expect(violations).toHaveLength(0);
+  });
+
+  test("Check constraint is deleted", async ({ request }) => {
+    const id = await req.deleteConstraint(request, constraint_id);
+
+    expect(id).not.toBeNull();
+    expect(id).toBeDefined();
+    expect(id).toEqual(constraint_id);
+  });
+
+  test('Delete External Dataset', async ({ request }) => {
+    const input: ExternalDatasetQueryInput = { dataset_id, plan_id };
+
+    const deleted_id = await req.deleteExternalDataset(request, input);
+    expect(deleted_id).toEqual(dataset_id);
+  });
+
+  test("Check plan is deleted", async ({ request }) => {
+    const id = await req.deletePlan(request, plan_id);
+
+    expect(id).not.toBeNull();
+    expect(id).toBeDefined();
+    expect(id).toEqual(plan_id);
+  });
+
+  test("Check model is deleted", async ({ request }) => {
+    const id = await req.deleteMissionModel(request, mission_model_id);
+
+    expect(id).not.toBeNull();
+    expect(id).toBeDefined();
+    expect(id).toEqual(mission_model_id);
+  });
+
 });

--- a/e2e-tests/src/types/constraint.d.ts
+++ b/e2e-tests/src/types/constraint.d.ts
@@ -7,7 +7,9 @@ type Constraint = {
   plan_id: number | null;
 };
 
-type ConstraintInsertInput = Omit<Constraint, 'id'>;
+type ConstraintInsertInput = Omit<Constraint, 'id'> & {
+  simulationDatasetId?: number;
+};
 
 type ConstraintType = 'model' | 'plan';
 

--- a/e2e-tests/src/types/external-dataset.d.ts
+++ b/e2e-tests/src/types/external-dataset.d.ts
@@ -1,5 +1,6 @@
 type ExternalDatasetInsertInput = {
   plan_id: number,
+  simulation_dataset_id?: number,
   dataset_start: String,
   profile_set: {
     [key: string]: {

--- a/e2e-tests/src/utilities/gql.ts
+++ b/e2e-tests/src/utilities/gql.ts
@@ -309,9 +309,10 @@ const gql = {
   `,
 
   ADD_EXTERNAL_DATASET: `#graphql
-    mutation addExternalDataset($plan_id: Int!, $dataset_start: String!, $profile_set: ProfileSet!) {
+    mutation addExternalDataset($plan_id: Int!, $simulation_dataset_id: Int, $dataset_start: String!, $profile_set: ProfileSet!) {
       addExternalDataset(
         planId: $plan_id
+        simulationDatasetId: $simulation_dataset_id
         datasetStart: $dataset_start
         profileSet: $profile_set
       ) {
@@ -334,6 +335,7 @@ const gql = {
   GET_EXTERNAL_DATASET: `#graphql
     query getExtProfile($plan_id: Int!, $dataset_id: Int!) {
       plan_dataset_by_pk(plan_id:$plan_id, dataset_id:$dataset_id) {
+        simulation_dataset_id
         offset_from_plan_start
         dataset {
           profiles(distinct_on:[], order_by: { name: asc }) {
@@ -364,8 +366,8 @@ const gql = {
   `,
 
   CHECK_CONSTRAINTS: `#graphql
-    query checkConstraints($planId: Int!) {
-      constraintViolations(planId: $planId) {
+    query checkConstraints($planId: Int!, $simulationDatasetId: Int) {
+      constraintViolations(planId: $planId, simulationDatasetId: $simulationDatasetId) {
         violations
       }
     }

--- a/e2e-tests/src/utilities/requests.ts
+++ b/e2e-tests/src/utilities/requests.ts
@@ -306,8 +306,8 @@ const req = {
     return id;
   },
 
-  async checkConstraints(request: APIRequestContext, planId: number): Promise<ConstraintViolation[]> {
-    const data = await req.hasura(request, gql.CHECK_CONSTRAINTS, {planId});
+  async checkConstraints(request: APIRequestContext, planId: number, simulationDatasetId?: number): Promise<ConstraintViolation[]> {
+    const data = await req.hasura(request, gql.CHECK_CONSTRAINTS, {planId, simulationDatasetId});
     const { constraintViolations } = data;
     const { violations } = constraintViolations;
     return <ConstraintViolation[]> violations;

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -19,3 +19,4 @@ call migrations.mark_migration_applied('13');
 call migrations.mark_migration_applied('14');
 call migrations.mark_migration_applied('15');
 call migrations.mark_migration_applied('16');
+call migrations.mark_migration_applied('17');

--- a/merlin-server/sql/merlin/tables/plan_dataset.sql
+++ b/merlin-server/sql/merlin/tables/plan_dataset.sql
@@ -1,6 +1,7 @@
 create table plan_dataset (
   plan_id integer not null,
   dataset_id integer not null,
+  simulation_dataset_id integer,
 
   offset_from_plan_start interval not null,
 
@@ -9,6 +10,11 @@ create table plan_dataset (
   constraint plan_dataset_references_plan
     foreign key (plan_id)
     references plan
+    on update cascade
+    on delete cascade,
+  constraint associated_sim_dataset_exists
+    foreign key (simulation_dataset_id)
+    references simulation_dataset
     on update cascade
     on delete cascade,
   constraint plan_dataset_references_dataset
@@ -22,6 +28,9 @@ comment on column plan_dataset.plan_id is e''
   'The ID of the plan to which the dataset is associated.';
 comment on column plan_dataset.dataset_id is e''
   'The ID of the dataset associated with the plan.';
+comment on column plan_dataset.simulation_dataset_id is e''
+  'The ID of the simulation dataset optionally associated with the dataset.'
+  'If null, the dataset is associated with all simulation runs for the plan.';
 comment on column plan_dataset.offset_from_plan_start is e''
   'The time to judge dataset items against relative to the plan start.'
 '\n'

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraActivityActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraActivityDirectiveEventTriggerP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraConstraintsCodeAction;
+import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraConstraintsViolationsActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraUploadExternalDatasetActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelArgumentsActionP;
@@ -216,9 +217,11 @@ public final class MerlinBindings implements Plugin {
 }
   private void getConstraintViolations(final Context ctx) {
     try {
-      final var planId = parseJson(ctx.body(), hasuraPlanActionP).input().planId();
+      final var input = parseJson(ctx.body(), hasuraConstraintsViolationsActionP).input();
+      final var planId = input.planId();
+      final var simulationDatasetId = input.simulationDatasetId();
 
-      final var constraintViolations = this.simulationAction.getViolations(planId);
+      final var constraintViolations = this.simulationAction.getViolations(planId, simulationDatasetId);
 
       ctx.result(ResponseSerializers.serializeConstraintViolations(constraintViolations).toString());
     } catch (final InvalidJsonException ex) {
@@ -351,10 +354,11 @@ public final class MerlinBindings implements Plugin {
       final var input = parseJson(ctx.body(), hasuraUploadExternalDatasetActionP).input();
 
       final var planId = input.planId();
+      final var simulationDatasetId = input.simulationDatasetId();
       final var datasetStart = input.datasetStart();
       final var profileSet = input.profileSet();
 
-      final var datasetId = this.planService.addExternalDataset(planId, datasetStart, profileSet);
+      final var datasetId = this.planService.addExternalDataset(planId, simulationDatasetId, datasetStart, profileSet);
 
       ctx.status(201).result(ResponseSerializers.serializeCreatedDatasetId(datasetId).toString());
     } catch (final NoSuchPlanException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
@@ -8,6 +8,7 @@ import gov.nasa.jpl.aerie.merlin.driver.SimulationFailure;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.services.UnexpectedSubtypeError;
 
@@ -72,6 +73,12 @@ public abstract class MerlinParsers {
       . map(
           PlanId::new,
           PlanId::id);
+
+  public static final JsonParser<SimulationDatasetId> simulationDatasetIdP
+      = longP
+      . map(
+          SimulationDatasetId::new,
+          SimulationDatasetId::id);
 
   public static final JsonParser<DatasetId> datasetIdP
       = longP

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
@@ -10,6 +10,7 @@ import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.remotes.PlanRepository;
 import org.apache.commons.lang3.tuple.Pair;
@@ -123,7 +124,11 @@ public final class InMemoryPlanRepository implements PlanRepository {
   }
 
   @Override
-  public long addExternalDataset(final PlanId planId, final Timestamp datasetStart, final ProfileSet profileSet)
+  public long addExternalDataset(
+      final PlanId planId,
+      final Optional<SimulationDatasetId> simulationDatasetId,
+      final Timestamp datasetStart,
+      final ProfileSet profileSet)
   {
     return 0;
   }
@@ -134,7 +139,10 @@ public final class InMemoryPlanRepository implements PlanRepository {
   }
 
   @Override
-  public List<Pair<Duration, ProfileSet>> getExternalDatasets(final PlanId planId) {
+  public List<Pair<Duration, ProfileSet>> getExternalDatasets(
+      final PlanId planId,
+      final Optional<SimulationDatasetId> simulationDatasetId)
+  {
     return List.of();
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
@@ -13,12 +13,14 @@ public record HasuraAction<I extends HasuraAction.Input>(String name, I input, S
 
   public record MissionModelInput(String missionModelId) implements Input { }
   public record PlanInput(PlanId planId) implements Input { }
+  public record ConstraintViolationsInput(PlanId planId, Optional<SimulationDatasetId> simulationDatasetId) implements Input { }
   public record ActivityInput(String missionModelId,
                               String activityTypeName,
                               Map<String, SerializedValue> arguments) implements Input {}
   public record MissionModelArgumentsInput(String missionModelId,
                               Map<String, SerializedValue> arguments) implements Input {}
   public record UploadExternalDatasetInput(PlanId planId,
+                                           Optional<SimulationDatasetId> simulationDatasetId,
                                            Timestamp datasetStart,
                                            ProfileSet profileSet) implements Input {}
   public record ExtendExternalDatasetInput(DatasetId datasetId,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/SimulationDatasetId.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/SimulationDatasetId.java
@@ -1,0 +1,3 @@
+package gov.nasa.jpl.aerie.merlin.server.models;
+
+public record SimulationDatasetId(long id) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
@@ -10,12 +10,14 @@ import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.services.RevisionData;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * An owned interface to a concurrency-safe store of plans.
@@ -35,9 +37,15 @@ public interface PlanRepository {
 
   Map<Long, Constraint> getAllConstraintsInPlan(PlanId planId) throws NoSuchPlanException;
 
-  long addExternalDataset(PlanId planId, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
+  long addExternalDataset(
+      PlanId planId,
+      Optional<SimulationDatasetId> simulationDatasetId,
+      Timestamp datasetStart,
+      ProfileSet profileSet) throws NoSuchPlanException;
   void extendExternalDataset(DatasetId datasetId, ProfileSet profileSet) throws NoSuchPlanDatasetException;
-  List<Pair<Duration, ProfileSet>> getExternalDatasets(PlanId planId) throws NoSuchPlanException;
+  List<Pair<Duration, ProfileSet>> getExternalDatasets(
+      PlanId planId,
+      Optional<SimulationDatasetId> simulationDatasetId) throws NoSuchPlanException;
   Map<String, ValueSchema> getExternalResourceSchemas(PlanId planId) throws NoSuchPlanException;
 
   record CreatedPlan(PlanId planId, List<ActivityDirectiveId> activityIds) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreatePlanDatasetAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreatePlanDatasetAction.java
@@ -1,19 +1,22 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.intellij.lang.annotations.Language;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Optional;
 
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
 
 /*package-local*/ final class CreatePlanDatasetAction implements AutoCloseable {
   private final @Language("SQL") String sql = """
-      insert into plan_dataset (plan_id, offset_from_plan_start)
-      values (?, ?::timestamptz - ?::timestamptz)
+      insert into plan_dataset (plan_id, offset_from_plan_start, simulation_dataset_id)
+      values (?, ?::timestamptz - ?::timestamptz, ?)
       returning dataset_id
       """;
 
@@ -25,6 +28,7 @@ import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
 
   public PlanDatasetRecord apply(
       final long planId,
+      final Optional<SimulationDatasetId> simulationDatasetId,
       final Timestamp planStart,
       final Timestamp datasetStart
   ) throws SQLException {
@@ -33,12 +37,17 @@ import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
     this.statement.setLong(1, planId);
     PreparedStatements.setTimestamp(this.statement, 2, datasetStart);
     PreparedStatements.setTimestamp(this.statement, 3, planStart);
+    this.statement.setObject(
+        4,
+        simulationDatasetId.map(SimulationDatasetId::id).orElse(null),
+        Types.INTEGER
+    );
 
     final var results = this.statement.executeQuery();
     if (!results.next()) throw new FailedInsertException("plan_dataset");
     final var datasetId = results.getLong(1);
 
-    return new PlanDatasetRecord(planId, datasetId, offsetFromPlanStart);
+    return new PlanDatasetRecord(planId, datasetId, simulationDatasetId, offsetFromPlanStart);
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimAssociatedPlanDatasetsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimAssociatedPlanDatasetsAction.java
@@ -13,34 +13,31 @@ import java.util.Optional;
 
 import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.parseOffset;
 
-/*package-local*/ final class GetPlanDatasetsAction implements AutoCloseable {
+/*package-local*/ final class GetSimAssociatedPlanDatasetsAction implements AutoCloseable {
   private final @Language("SQL") String sql = """
       select
         p.dataset_id,
-        p.offset_from_plan_start,
-        p.simulation_dataset_id
+        p.offset_from_plan_start
       from plan_dataset as p
       where
-        p.plan_id = ?
+        p.plan_id = ? and p.simulation_dataset_id = ?
     """;
 
   private final PreparedStatement statement;
 
-  public GetPlanDatasetsAction(final Connection connection) throws SQLException {
+  public GetSimAssociatedPlanDatasetsAction(final Connection connection) throws SQLException {
     this.statement = connection.prepareStatement(sql);
   }
 
-  public List<PlanDatasetRecord> get(final PlanId planId) throws SQLException {
+  public List<PlanDatasetRecord> get(final PlanId planId, final SimulationDatasetId simulationDatasetId) throws SQLException {
     final var records = new ArrayList<PlanDatasetRecord>();
     this.statement.setLong(1, planId.id());
+    this.statement.setLong(2, simulationDatasetId.id());
     final var resultSet = statement.executeQuery();
     while (resultSet.next()) {
       final var datasetId = resultSet.getLong(1);
       final var offsetFromPlanStart = parseOffset(resultSet, 2);
-      final Optional<SimulationDatasetId> simulationDatasetId = resultSet.getObject(3) == null
-          ? Optional.empty()
-          : Optional.of(new SimulationDatasetId(resultSet.getLong(3)));
-      records.add(new PlanDatasetRecord(planId.id(), datasetId, simulationDatasetId, offsetFromPlanStart));
+      records.add(new PlanDatasetRecord(planId.id(), datasetId, Optional.of(simulationDatasetId), offsetFromPlanStart));
     }
 
     return records;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PlanDatasetRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PlanDatasetRecord.java
@@ -1,8 +1,12 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
+
+import java.util.Optional;
 
 public record PlanDatasetRecord(
     long planId,
     long datasetId,
+    Optional<SimulationDatasetId> simulationDatasetId,
     Duration offsetFromPlanStart) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ProfileRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ProfileRepository.java
@@ -7,6 +7,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -103,6 +104,15 @@ import static gov.nasa.jpl.aerie.merlin.server.http.ProfileParsers.realDynamicsP
     try (final var getPlanDatasetsAction = new GetPlanDatasetsAction(connection)) {
       return getPlanDatasetsAction.get(planId);
     }
+  }
+
+  static List<PlanDatasetRecord> getAllPlanDatasetsForSimDataset(
+      final Connection connection,
+      final PlanId planId,
+      final SimulationDatasetId simulationDatasetId) throws SQLException {
+      try (final var getSimAssociatedPlanDatasetsAction = new GetSimAssociatedPlanDatasetsAction(connection)) {
+        return getSimAssociatedPlanDatasetsAction.get(planId, simulationDatasetId);
+      }
   }
 
   static List<ProfileRecord> getProfileRecords(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -16,6 +16,7 @@ import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.SimulationResultsHandle;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -120,7 +121,7 @@ public final class GetSimulationResultsAction {
     return samples;
   }
 
-  public List<Violation> getViolations(final PlanId planId)
+  public List<Violation> getViolations(final PlanId planId, final Optional<SimulationDatasetId> simulationDatasetId)
   throws NoSuchPlanException, MissionModelService.NoSuchMissionModelException
   {
     final var plan = this.planService.getPlanForValidation(planId);
@@ -165,7 +166,7 @@ public final class GetSimulationResultsAction {
           Interval.between(activityOffset, activityOffset.plus(activity.duration()))));
     }
 
-    final var externalDatasets = this.planService.getExternalDatasets(planId);
+    final var externalDatasets = this.planService.getExternalDatasets(planId, simulationDatasetId);
     final var realExternalProfiles = new HashMap<String, LinearProfile>();
     final var discreteExternalProfiles = new HashMap<String, DiscreteProfile>();
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
@@ -9,12 +9,14 @@ import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.remotes.PlanRepository;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public final class LocalPlanService implements PlanService {
   private final PlanRepository planRepository;
@@ -46,10 +48,14 @@ public final class LocalPlanService implements PlanService {
   }
 
   @Override
-  public long addExternalDataset(final PlanId planId, final Timestamp datasetStart, final ProfileSet profileSet)
+  public long addExternalDataset(
+      final PlanId planId,
+      final Optional<SimulationDatasetId> simulationDatasetId,
+      final Timestamp datasetStart,
+      final ProfileSet profileSet)
   throws NoSuchPlanException
   {
-    return this.planRepository.addExternalDataset(planId, datasetStart, profileSet);
+    return this.planRepository.addExternalDataset(planId, simulationDatasetId, datasetStart, profileSet);
   }
 
   @Override
@@ -60,8 +66,11 @@ public final class LocalPlanService implements PlanService {
   }
 
   @Override
-  public List<Pair<Duration, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
-    return this.planRepository.getExternalDatasets(planId);
+  public List<Pair<Duration, ProfileSet>> getExternalDatasets(
+      final PlanId planId,
+      final Optional<SimulationDatasetId> simulationDatasetId) throws NoSuchPlanException
+  {
+    return this.planRepository.getExternalDatasets(planId, simulationDatasetId);
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
@@ -9,11 +9,13 @@ import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface PlanService {
   Plan getPlanForSimulation(PlanId planId) throws NoSuchPlanException;
@@ -22,8 +24,14 @@ public interface PlanService {
 
   Map<Long, Constraint> getConstraintsForPlan(PlanId planId) throws NoSuchPlanException;
 
-  long addExternalDataset(PlanId planId, Timestamp datasetStart, ProfileSet profileSet) throws NoSuchPlanException;
+  long addExternalDataset(
+      PlanId planId,
+      Optional<SimulationDatasetId> simulationDatasetId,
+      Timestamp datasetStart,
+      ProfileSet profileSet) throws NoSuchPlanException;
   void extendExternalDataset(DatasetId datasetId, ProfileSet profileSet) throws NoSuchPlanDatasetException;
-  List<Pair<Duration, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException;
+  List<Pair<Duration, ProfileSet>> getExternalDatasets(
+      final PlanId planId,
+      final Optional<SimulationDatasetId> simulationDatasetId) throws NoSuchPlanException;
   Map<String, ValueSchema> getExternalResourceSchemas(final PlanId planId) throws NoSuchPlanException;
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
@@ -11,6 +11,7 @@ import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Plan;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 import gov.nasa.jpl.aerie.merlin.server.services.PlanService;
 import gov.nasa.jpl.aerie.merlin.server.services.RevisionData;
@@ -19,6 +20,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public final class StubPlanService implements PlanService {
   public static final PlanId EXISTENT_PLAN_ID = new PlanId(1L);
@@ -83,7 +85,11 @@ public final class StubPlanService implements PlanService {
   }
 
   @Override
-  public long addExternalDataset(final PlanId planId, final Timestamp datasetStart, final ProfileSet profileSet)
+  public long addExternalDataset(
+      final PlanId planId,
+      final Optional<SimulationDatasetId> simulationDatasetId,
+      final Timestamp datasetStart,
+      final ProfileSet profileSet)
   throws NoSuchPlanException
   {
     return 0;
@@ -95,7 +101,11 @@ public final class StubPlanService implements PlanService {
   }
 
   @Override
-  public List<Pair<Duration, ProfileSet>> getExternalDatasets(final PlanId planId) throws NoSuchPlanException {
+  public List<Pair<Duration, ProfileSet>> getExternalDatasets(
+      final PlanId planId,
+      final Optional<SimulationDatasetId> simulationDatasetId
+      ) throws NoSuchPlanException
+  {
     return List.of();
   }
 


### PR DESCRIPTION
* **Tickets addressed:** Closes #594 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
A new nullable column, `associated_simulation_dataset_id`, was added to the `plan_dataset` table. This allows for `plan_datasets`, which are commonly used to store external datasets, to be associated to a single simulation dataset, instead of being implicitly associated with all simulation dataset runs for a given plan.

Simulation associated plan datasets can now be selectively queried using the new eloquently named `GetSimAssociatedPlanDatasetsAction` database action, which is called by `ProfileRepository.getAllPlanDatasetsForPlan` if it is passed a non-empty optional `SimulationDatasetId`.

This allows for existing modules to grab all external datasets pertaining to a plan (such as `TypescriptCodeGenerationService`) while `GetSimulationResultsAction.getViolations` can filter external datasets based on a specific simulation run.

The `addExternalDataset` hasura action has also updated to take in an optional `associatedSimulationDatasetId`. 

Additionally, the `constraintViolations` hasura action has also been updated to take this same (optional) `associatedSimulationDatasetId`.

Since the UI can submit a simulation dataset ID for either `constraintViolations` or in its `GET_PROFILES_EXTERNAL` GQL query, external datasets for a particular simulation can now be selectively queried, and shown as out of date if a new simulation has occurred.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Added rudimentary integration tests to check `constraintViolations` Hasura action can optionally take a new `simulation_dataset_id` and only returned violations for the respective simulation dataset.

Additional tests (WIP) will validate `GET_PROFILES_EXTERNAL` being able to query external profiles associated with a single simulation.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Add optional association to external dataset documentation, as well as the general hasura action docs.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Frontend will need to be updated to call `/constraintViolations` with a simulation dataset id when this filtering is desired. Additionally, the [GQL query for getting external profiles](https://github.com/NASA-AMMOS/aerie-ui/blob/develop/src/utilities/effects.ts#L1759) in the UI can be updated to include the latest fresh simulation dataset id.