### PR TITLE
Stop resumable simulation driver at end of horizon

### DIFF
--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/ActivityCreationTemplate.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/ActivityCreationTemplate.java
@@ -305,7 +305,7 @@ public class ActivityCreationTemplate extends ActivityExpression implements Expr
         }
 
       };
-      return rootFindingHelper(f, history, solved);
+      return rootFindingHelper(f, history, solved, facade);
       //CASE 2: activity has a controllable duration
     } else if (this.type.getDurationType() instanceof DurationType.Controllable dt) {
       //select earliest start time, STN guarantees satisfiability
@@ -406,7 +406,7 @@ public class ActivityCreationTemplate extends ActivityExpression implements Expr
         }
       };
 
-      return rootFindingHelper(f, history, solved);
+      return rootFindingHelper(f, history, solved, facade);
     } else {
      throw new UnsupportedOperationException("Unsupported duration type found: " + this.type.getDurationType());
     }
@@ -435,7 +435,8 @@ public class ActivityCreationTemplate extends ActivityExpression implements Expr
   private  Optional<SchedulingActivityDirective> rootFindingHelper(
       final EquationSolvingAlgorithms.Function<Duration, HistoryWithActivity> f,
       final HistoryWithActivity history,
-      final TaskNetworkAdapter.TNActData solved
+      final TaskNetworkAdapter.TNActData solved,
+      final SimulationFacade simulationFacade
   ) {
     try {
       var endInterval = solved.end();
@@ -470,6 +471,13 @@ public class ActivityCreationTemplate extends ActivityExpression implements Expr
       logger.debug("Too many iterations");
     } catch (EquationSolvingAlgorithms.NoSolutionException e) {
       logger.debug("No solution");
+    }
+    if(!history.events.isEmpty()) {
+      try {
+        simulationFacade.removeActivitiesFromSimulation(List.of(history.getLastEvent().get().activity()));
+      } catch (SimulationFacade.SimulationException e) {
+        throw new RuntimeException("Exception while simulating original plan after activity insertion failure" ,e);
+      }
     }
     return Optional.empty();
   }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/ActivityCreationTemplate.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/ActivityCreationTemplate.java
@@ -294,7 +294,7 @@ public class ActivityCreationTemplate extends ActivityExpression implements Expr
             if(computedDuration.isPresent()) {
               history.add(new EventWithActivity(start, start.plus(computedDuration.get()), actToSim));
             } else{
-              logger.debug("No simulation error but activity duration could not be found in simulation, unfinished activity?");
+              logger.debug("No simulation error but activity duration could not be found in simulation, likely caused by unfinished activity.");
               history.add(new EventWithActivity(start,  null, actToSim));
             }
           } catch (SimulationFacade.SimulationException e) {

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
@@ -251,6 +251,9 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
       // Update batch and increment real time, if necessary.
       batch = engine.extractNextJobs(Duration.MAX_VALUE);
       delta = batch.offsetFromStart().minus(curTime);
+      if(batch.offsetFromStart().longerThan(planDuration)){
+        break;
+      }
     }
     lastSimResults = null;
   }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -92,9 +92,6 @@ public class SimulationFacade implements AutoCloseable{
     }
     final var duration = driver.getActivityDuration(planActDirectiveIdToSimulationActivityDirectiveId.get(
         schedulingActivityDirective.getId()));
-    if(duration.isEmpty()){
-      logger.error("Simulation is probably outdated, check that no activity is removed between simulation and querying");
-    }
     return duration;
   }
 

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -136,10 +136,10 @@ public class SimulationFacade implements AutoCloseable{
       final Collection<SchedulingActivityDirective> activitiesToRemove,
       final Collection<SchedulingActivityDirective> activitiesToAdd) throws SimulationException
   {
-    var atLeastOne = false;
+    var atLeastOneActualRemoval = false;
     for(final var act: activitiesToRemove){
       if(insertedActivities.containsKey(act)){
-        atLeastOne = true;
+        atLeastOneActualRemoval = true;
         insertedActivities.remove(act);
       }
     }
@@ -147,16 +147,16 @@ public class SimulationFacade implements AutoCloseable{
     for(final var act: activitiesToAdd){
       earliestActStartTime = Duration.min(earliestActStartTime, act.startOffset());
     }
+    final var allActivitiesToSimulate = new ArrayList<>(activitiesToAdd);
     //reset resumable simulation
-    if(atLeastOne || earliestActStartTime.shorterThan(this.driver.getCurrentSimulationEndTime())){
-      final var allActivitiesToSimulate = new ArrayList<>(insertedActivities.keySet());
+    if(atLeastOneActualRemoval || earliestActStartTime.shorterThan(this.driver.getCurrentSimulationEndTime())){
+      allActivitiesToSimulate.addAll(insertedActivities.keySet());
       insertedActivities.clear();
       planActDirectiveIdToSimulationActivityDirectiveId.clear();
       if (driver != null) driver.close();
       driver = new ResumableSimulationDriver<>(missionModel, planningHorizon.getAerieHorizonDuration());
-      allActivitiesToSimulate.addAll(activitiesToAdd);
-      simulateActivities(allActivitiesToSimulate);
     }
+    simulateActivities(allActivitiesToSimulate);
   }
 
   public void removeActivitiesFromSimulation(final Collection<SchedulingActivityDirective> activities)

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
@@ -1774,6 +1774,30 @@ public class SchedulingIntegrationTests {
     assertEquals(96, results.updatedPlan().size());
   }
 
+  @Test
+  void testUnfinishedActivity(){
+    final PlanningHorizon PLANNING_HORIZON = new PlanningHorizon(
+        TimeUtility.fromDOY("2025-090T00:00:00"),
+        TimeUtility.fromDOY("2025-134T00:00:00"));
+    final var results = runScheduler(
+        BANANANATION,
+        List.of(),
+        List.of(new SchedulingGoal(new GoalId(0L), """
+          export default (): Goal => {
+                           return Goal.ActivityRecurrenceGoal({
+                             activityTemplate: ActivityTemplates.parent({
+                               label: "label"
+                           }),
+                             interval: Temporal.Duration.from({ days: 30})
+                           })
+                       }
+            """, true)), PLANNING_HORIZON);
+    //parent takes much more than 134 - 90 = 44 days to finish
+    assertEquals(0, results.updatedPlan.size());
+    final var goalResult = results.scheduleResults.goalResults().get(new GoalId(0L));
+    assertFalse(goalResult.satisfied());
+  }
+
   /**
    * If you passed activities without duration to the scheduler in an initial plan, it would fail
    */


### PR DESCRIPTION
* **Tickets addressed:** Fixes #859 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Stop the resumable simulation driver (when simulating an activity) when the plan horizon is reached. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
A specific test has been added with a task that finishes after the end of the plan horizon.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None, this is a bugfix.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Moaaar bugfixes