### PR TITLE
Activate and load: remove addition properties

### DIFF
--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -2204,9 +2204,6 @@ export class ActivateStep implements Activate {
       ...(this._epoch ? { epoch: this._epoch } : {}),
       ...(this._metadata ? { metadata: this._metadata } : {}),
       ...(this._models ? { model: this._models } : {}),
-      ...(this._absoluteTime ? { absoluteTime: this._absoluteTime } : {}),
-      ...(this._epochTime ? { epochTime: this._epochTime } : {}),
-      ...(this._relativeTime ? { relativeTime: this._relativeTime } : {}),
     };
   }
 
@@ -2501,9 +2498,6 @@ export class LoadStep implements Load {
       ...(this._epoch ? { epoch: this._epoch } : {}),
       ...(this._metadata ? { metadata: this._metadata } : {}),
       ...(this._models ? { model: this._models } : {}),
-      ...(this._absoluteTime ? { absoluteTime: this._absoluteTime } : {}),
-      ...(this._epochTime ? { epochTime: this._epochTime } : {}),
-      ...(this._relativeTime ? { relativeTime: this._relativeTime } : {}),
     };
   }
 

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -2207,9 +2207,6 @@ export class ActivateStep implements Activate {
       ...(this._epoch ? { epoch: this._epoch } : {}),
       ...(this._metadata ? { metadata: this._metadata } : {}),
       ...(this._models ? { model: this._models } : {}),
-      ...(this._absoluteTime ? { absoluteTime: this._absoluteTime } : {}),
-      ...(this._epochTime ? { epochTime: this._epochTime } : {}),
-      ...(this._relativeTime ? { relativeTime: this._relativeTime } : {}),
     };
   }
 
@@ -2504,9 +2501,6 @@ export class LoadStep implements Load {
       ...(this._epoch ? { epoch: this._epoch } : {}),
       ...(this._metadata ? { metadata: this._metadata } : {}),
       ...(this._models ? { model: this._models } : {}),
-      ...(this._absoluteTime ? { absoluteTime: this._absoluteTime } : {}),
-      ...(this._epochTime ? { epochTime: this._epochTime } : {}),
-      ...(this._relativeTime ? { relativeTime: this._relativeTime } : {}),
     };
   }
 


### PR DESCRIPTION

## Description
A hotfix to remove these extra properties added to the SeqJSON. This isn't allowed in the SPEC

## Verification
Ran e2e test without any issues. 


