### PR TITLE
Add `getEffectiveArgumentsBulk` Hasura Action

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -65,6 +65,13 @@ type Query {
 }
 
 type Query {
+  getActivityEffectiveArgumentsBulk(
+    missionModelId: ID!
+    activities: [EffectiveArgumentsInput!]!
+  ): [EffectiveArgumentsBulkResponse!]!
+}
+
+type Query {
   getActivityTypeScript(missionModelId: Int!, activityTypeName: String!): DslTypescriptResponse
 }
 
@@ -198,6 +205,13 @@ type EffectiveArgumentsResponse {
   errors: [String!]
 }
 
+type EffectiveArgumentsBulkResponse {
+  typeName: String!
+  success: Boolean!
+  arguments: ActivityArguments
+  errors: [String!]
+}
+
 type AddExternalDatasetResponse {
   datasetId: Int!
 }
@@ -271,6 +285,11 @@ type ResourceSamplesResponse {
 
 type ConstraintViolationsResponse {
   violations: ConstraintViolations!
+}
+
+input EffectiveArgumentsInput {
+  activityTypeName: String!
+  activityArguments: ActivityArguments!
 }
 
 scalar ResourceSchema

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -62,13 +62,14 @@ type Query {
     activityTypeName: String!
     activityArguments: ActivityArguments!
   ): EffectiveArgumentsResponse
+  @deprecated(reason: "Use bulk query getActivityEffectiveArgumentsBulk instead")
 }
 
 type Query {
   getActivityEffectiveArgumentsBulk(
     missionModelId: ID!
     activities: [EffectiveArgumentsInput!]!
-  ): [EffectiveArgumentsBulkResponse!]!
+  ): [EffectiveArgumentsResponse!]!
 }
 
 type Query {
@@ -203,13 +204,7 @@ type EffectiveArgumentsResponse {
   success: Boolean!
   arguments: ActivityArguments
   errors: [String!]
-}
-
-type EffectiveArgumentsBulkResponse {
-  typeName: String!
-  success: Boolean!
-  arguments: ActivityArguments
-  errors: [String!]
+  typeName: String
 }
 
 type AddExternalDatasetResponse {

--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -79,6 +79,14 @@ actions:
     permissions:
       - role: aerie_admin
       - role: user
+  - name: getActivityEffectiveArgumentsBulk
+    definition:
+      kind: ""
+      handler: "{{AERIE_MERLIN_URL}}/getActivityEffectiveArgumentsBulk"
+      timeout: 300
+    permissions:
+      - role: aerie_admin
+      - role: user
   - name: getActivityTypeScript
     definition:
       kind: ""

--- a/e2e-tests/src/tests/effective-arguments.test.ts
+++ b/e2e-tests/src/tests/effective-arguments.test.ts
@@ -1,0 +1,186 @@
+import { expect, test } from "@playwright/test";
+import req from "../utilities/requests.js";
+import time from "../utilities/time.js";
+
+let jar_id: number;
+let mission_model_id: number;
+const rd = Math.random() * 100;
+
+test.describe("Initialize", async () => {
+  test("Upload jar and create mission model", async ({ request }) => {
+    jar_id = await req.uploadJarFile(request);
+
+    const model: MissionModelInsertInput = {
+      jar_id,
+      mission: "aerie_e2e_tests" + rd,
+      name: "Banananation (e2e tests)"+rd,
+      version: "0.0.0"+ rd,
+    };
+    mission_model_id = await req.createMissionModel(request, model);
+
+    expect(mission_model_id).not.toBeNull();
+    expect(mission_model_id).toBeDefined();
+    expect(typeof mission_model_id).toEqual("number");
+
+    // delay 2000ms for model generation
+    await time.delay(2000);
+  });
+});
+
+test.describe.serial("Query Effect Argument", async () => {
+  test("Query single activity for default arguments", async ({ request }) => {
+    const resp = await req.getEffectiveArguments(request, mission_model_id, "BiteBanana", {});
+
+    expect(resp).not.toBeNull();
+    expect(resp).toBeDefined();
+    expect(resp.success).toEqual(true);
+    expect(resp.arguments).not.toBeNull();
+    expect(resp.arguments).toBeDefined();
+    expect(resp.arguments.biteSize).toEqual(1);
+  });
+
+  test("Query single activity for passed arguments", async ({ request }) => {
+    const resp = await req.getEffectiveArguments(request, mission_model_id, "BiteBanana", { biteSize: 2 });
+
+    expect(resp).not.toBeNull();
+    expect(resp).toBeDefined();
+    expect(resp.success).toEqual(true);
+    expect(resp.arguments).not.toBeNull();
+    expect(resp.arguments).toBeDefined();
+    expect(resp.arguments.biteSize).toEqual(2);
+  });
+
+  test("Query bulk activities with proper passed arguments", async ({ request }) => {
+    const bite_banana_bulk_item: EffectiveArgumentItem = {
+      activityTypeName: "BiteBanana",
+      activityArguments: { biteSize: 1 },
+    };
+    const bake_banana_bulk_item_1: EffectiveArgumentItem = {
+      activityTypeName: "BakeBananaBread",
+      activityArguments: {
+        tbSugar: 1,
+        glutenFree: true,
+      },
+    };
+    const bake_banana_bulk_item_2: EffectiveArgumentItem = {
+      activityTypeName: "BakeBananaBread",
+      activityArguments: {
+        tbSugar: 2,
+        glutenFree: true,
+        temperature: 400,
+      },
+    };
+
+    const bulk_input = [ bite_banana_bulk_item, bake_banana_bulk_item_1, bake_banana_bulk_item_2 ];
+    const resp = await req.getEffectiveArgumentsBulk(request, mission_model_id, bulk_input);
+
+    expect(resp).not.toBeNull();
+    expect(resp).toBeDefined();
+    expect(resp).toHaveLength(bulk_input.length);
+
+    for (let i = 0; i < resp.length; i++) {
+      expect(resp[i].success).toEqual(true);
+      expect(resp[i].typeName).toEqual(bulk_input[i].activityTypeName);
+    }
+
+    expect(resp[1].arguments.temperature).toEqual(350); // default arg value
+    expect(resp[2].arguments.temperature).toEqual(400); // passed arg value
+  });
+
+  test("Bulk query one activity with proper passed arguments", async ({ request }) => {
+    const bite_banana_bulk_item: EffectiveArgumentItem = {
+      activityTypeName: "BiteBanana",
+      activityArguments: { biteSize: 1 },
+    };
+    const bulk_input = [ bite_banana_bulk_item ];
+    const resp = await req.getEffectiveArgumentsBulk(request, mission_model_id, bulk_input);
+
+    expect(resp).not.toBeNull();
+    expect(resp).toBeDefined();
+    expect(resp).toHaveLength(bulk_input.length);
+
+    expect(resp[0].success).toEqual(true);
+    expect(resp[0].typeName).toEqual(bulk_input[0].activityTypeName);
+  });
+
+  test("Query bulk activities with one activity missing arguments", async ({ request }) => {
+    const bite_banana_bulk_item: EffectiveArgumentItem = {
+      activityTypeName: "BiteBanana",
+      activityArguments: { biteSize: 1 },
+    };
+    const bake_banana_bulk_item: EffectiveArgumentItem = {
+      activityTypeName: "BakeBananaBread",
+      activityArguments: {},
+    };
+    const bulk_input = [ bite_banana_bulk_item, bake_banana_bulk_item ];
+    const resp = await req.getEffectiveArgumentsBulk(request, mission_model_id, bulk_input);
+
+    expect(resp).not.toBeNull();
+    expect(resp).toBeDefined();
+    expect(resp).toHaveLength(bulk_input.length);
+
+    expect(resp[1].success).toEqual(false);
+  });
+
+  test("Query bulk activities with multiple input errors", async ({ request }) => {
+    const bite_banana_dne_bulk_item: EffectiveArgumentItem = {
+      activityTypeName: "BiteBananaDOESNOTEXIST",
+      activityArguments: { biteSize: 1 },
+    };
+    const bake_banana_bulk_item: EffectiveArgumentItem = {
+      activityTypeName: "BakeBananaBread",
+      activityArguments: {},
+    };
+    const bite_banana_bulk_item: EffectiveArgumentItem = {
+      activityTypeName: "BiteBanana",
+      activityArguments: {},
+    };
+
+    const bite_banana_dne_bulk_item_expected = {
+      typeName: "BiteBananaDOESNOTEXIST",
+      success: false,
+      errors: "No such activity type",
+    };
+    const bake_banana_bulk_item_expected = {
+      typeName: "BakeBananaBread",
+      success: false,
+      arguments: {
+        temperature: 350,
+      },
+      errors: {
+        extraneousArguments: [],
+        missingArguments: [ "tbSugar", "glutenFree" ],
+        unconstructableArguments: [],
+      },
+    };
+    const bite_banana_bulk_item_expected = {
+      typeName: "BiteBanana",
+      success: true,
+      arguments: {
+        biteSize: 1,
+      },
+    };
+
+    const bulk_input = [ bite_banana_dne_bulk_item, bake_banana_bulk_item, bite_banana_bulk_item ];
+    const resp = await req.getEffectiveArgumentsBulk(request, mission_model_id, bulk_input);
+
+    expect(resp).not.toBeNull();
+    expect(resp).toBeDefined();
+    expect(resp).toHaveLength(bulk_input.length);
+
+    expect(resp[0]).toEqual(bite_banana_dne_bulk_item_expected);
+    expect(resp[1]).toEqual(bake_banana_bulk_item_expected);
+    expect(resp[2]).toEqual(bite_banana_bulk_item_expected);
+  });
+
+});
+
+test.describe("Clean Up", async () => {
+  test("Check model is deleted", async ({ request }) => {
+    const id = await req.deleteMissionModel(request, mission_model_id);
+
+    expect(id).not.toBeNull();
+    expect(id).toBeDefined();
+    expect(id).toEqual(mission_model_id);
+  });
+});

--- a/e2e-tests/src/types/parameter.d.ts
+++ b/e2e-tests/src/types/parameter.d.ts
@@ -1,9 +1,14 @@
 type EffectiveArguments = {
-  arguments: ArgumentsMap;
-  errors: ParametersErrorMap;
+  arguments?: ArgumentsMap;
+  errors?: ParametersErrorMap;
   success: boolean;
+  typeName?: string;
 };
 
+type EffectiveArgumentItem = {
+  activityTypeName: string;
+  activityArguments: ArgumentsMap;
+};
 
 type Argument = any;
 

--- a/e2e-tests/src/utilities/gql.ts
+++ b/e2e-tests/src/utilities/gql.ts
@@ -402,6 +402,35 @@ const gql = {
       }
     }
   `,
+
+  GET_EFFECTIVE_ACTIVITY_ARGUMENTS: `#graphql
+    query GetEffectiveActivityArguments($modelId: ID!, $activityTypeName: String!, $activityArguments: ActivityArguments!) {
+      getActivityEffectiveArguments(
+        missionModelId: $modelId,
+        activityTypeName: $activityTypeName,
+        activityArguments: $activityArguments
+      ) {
+        arguments
+        errors
+        success
+      }
+    }
+  `,
+
+  GET_EFFECTIVE_ACTIVITY_ARGUMENTS_BULK: `#graphql
+    query GetEffectiveActivityArgumentsBulk($modelId: ID!, $activities: [EffectiveArgumentsInput!]!) {
+      getActivityEffectiveArgumentsBulk(
+        missionModelId: $modelId,
+        activities: $activities
+      ) {
+        typeName
+        arguments
+        errors
+        success
+      }
+    }
+  `,
+
 };
 
 export default gql;

--- a/e2e-tests/src/utilities/requests.ts
+++ b/e2e-tests/src/utilities/requests.ts
@@ -354,6 +354,27 @@ const req = {
     return id;
   },
 
+  async getEffectiveArguments(
+    request: APIRequestContext,
+    modelId: number,
+    activityTypeName: string,
+    activityArguments: any
+  ): Promise<EffectiveArguments> {
+    const data = await req.hasura(request, gql.GET_EFFECTIVE_ACTIVITY_ARGUMENTS, { modelId, activityTypeName, activityArguments });
+    const { getActivityEffectiveArguments } = data;
+    return getActivityEffectiveArguments;
+  },
+
+  async getEffectiveArgumentsBulk(
+    request: APIRequestContext,
+    modelId: number,
+    activities: EffectiveArgumentItem[]
+  ): Promise<EffectiveArguments[]> {
+    const data = await req.hasura(request, gql.GET_EFFECTIVE_ACTIVITY_ARGUMENTS_BULK, { modelId, activities });
+    const { getActivityEffectiveArgumentsBulk } = data;
+    return <EffectiveArguments[]> getActivityEffectiveArgumentsBulk;
+  },
+
   async getConstraintRuns(request: APIRequestContext, simulationDatasetId: number): Promise<ConstraintRun[]> {
     const data = await req.hasura(request, gql.GET_CONSTRAINT_RUNS, { simulationDatasetId });
     const { constraint_run } = data;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.http;
 
 import gov.nasa.jpl.aerie.json.JsonParser;
+import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.merlin.server.models.HasuraAction;
 import gov.nasa.jpl.aerie.merlin.server.models.HasuraActivityDirectiveEvent;
@@ -9,6 +10,7 @@ import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 
 import java.util.Optional;
 
+import static gov.nasa.jpl.aerie.json.BasicParsers.listP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.longP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.mapP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.nullableP;
@@ -132,6 +134,23 @@ public abstract class HasuraParsers {
       .map(
           untuple(HasuraAction.ActivityInput::new),
           $ -> tuple($.missionModelId(), $.activityTypeName(), $.arguments()));
+
+  private static final JsonParser<SerializedActivity> hasuraActivityBulkItemP
+      = productP
+      .field("activityTypeName", stringP)
+      .field("activityArguments", mapP(serializedValueP))
+      .map(
+          untuple(SerializedActivity::new),
+          $ -> tuple($.getTypeName(), $.getArguments()));
+
+  public static final JsonParser<HasuraAction<HasuraAction.ActivityBulkInput>> hasuraActivityBulkActionP
+      = hasuraActionF(
+          productP
+              .field("missionModelId", stringP)
+              .field("activities", listP(hasuraActivityBulkItemP))
+              .map(
+                  untuple(HasuraAction.ActivityBulkInput::new),
+                  $ -> tuple($.missionModelId(), $.activities())));
 
   public static final JsonParser<HasuraAction<HasuraAction.ActivityInput>> hasuraActivityActionP
       = hasuraActionF(hasuraActivityInputP);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -328,6 +328,7 @@ public final class MerlinBindings implements Plugin {
     }
   }
 
+  @Deprecated
   private void getActivityEffectiveArguments(final Context ctx) {
     try {
       final var input = parseJson(ctx.body(), hasuraActivityActionP).input();
@@ -338,14 +339,11 @@ public final class MerlinBindings implements Plugin {
 
       final var serializedActivity = new SerializedActivity(activityTypeName, activityArguments);
 
-      final var arguments = this.missionModelService.getActivityEffectiveArguments(missionModelId, serializedActivity);
+      final var arguments = this.missionModelService.getActivityEffectiveArgumentsBulk(
+          missionModelId,
+          List.of(serializedActivity));
 
-      ctx.result(ResponseSerializers.serializeEffectiveArgumentMap(arguments).toString());
-    } catch (final InstantiationException ex) {
-      ctx.status(200).result(ResponseSerializers.serializeInstantiationException(ex).toString());
-    } catch (final MissionModelService.NoSuchActivityTypeException ex) {
-      ctx.status(400)
-         .result(ResponseSerializers.serializeFailures(List.of(ex.getMessage())).toString());
+      ctx.result(ResponseSerializers.serializeBulkEffectiveArgumentResponse(arguments.get(0)).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
     } catch (final InvalidJsonException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
@@ -1,7 +1,9 @@
 package gov.nasa.jpl.aerie.merlin.server.models;
 
+import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -17,6 +19,7 @@ public record HasuraAction<I extends HasuraAction.Input>(String name, I input, S
   public record ActivityInput(String missionModelId,
                               String activityTypeName,
                               Map<String, SerializedValue> arguments) implements Input {}
+  public record ActivityBulkInput(String missionModelId, List<SerializedActivity> activities) implements Input {}
   public record MissionModelArgumentsInput(String missionModelId,
                               Map<String, SerializedValue> arguments) implements Input {}
   public record UploadExternalDatasetInput(PlanId planId,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -167,21 +167,6 @@ public final class LocalMissionModelService implements MissionModelService {
   }
 
   @Override
-  public Map<String, SerializedValue> getActivityEffectiveArguments(final String missionModelId, final SerializedActivity activity)
-  throws NoSuchMissionModelException,
-         NoSuchActivityTypeException,
-         MissionModelLoadException,
-         InstantiationException
-  {
-    final var modelType = this.loadMissionModelType(missionModelId);
-    final var registry = DirectiveTypeRegistry.extract(modelType);
-    final var directiveType = Optional
-        .ofNullable(registry.directiveTypes().get(activity.getTypeName()))
-        .orElseThrow(() -> new MissionModelService.NoSuchActivityTypeException(activity.getTypeName()));
-    return directiveType.getInputType().getEffectiveArguments(activity.getArguments());
-  }
-
-  @Override
   public List<BulkEffectiveArgumentResponse> getActivityEffectiveArgumentsBulk(
       final String missionModelId,
       final List<SerializedActivity> serializedActivities)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -178,6 +179,38 @@ public final class LocalMissionModelService implements MissionModelService {
         .ofNullable(registry.directiveTypes().get(activity.getTypeName()))
         .orElseThrow(() -> new MissionModelService.NoSuchActivityTypeException(activity.getTypeName()));
     return directiveType.getInputType().getEffectiveArguments(activity.getArguments());
+  }
+
+  @Override
+  public List<BulkEffectiveArgumentResponse> getActivityEffectiveArgumentsBulk(
+      final String missionModelId,
+      final List<SerializedActivity> serializedActivities)
+  throws NoSuchMissionModelException, MissionModelLoadException {
+      final var modelType = this.loadMissionModelType(missionModelId);
+      final var registry = DirectiveTypeRegistry.extract(modelType);
+      final var response = new ArrayList<BulkEffectiveArgumentResponse>();
+
+      for (final var activity : serializedActivities) {
+        final var typeName = activity.getTypeName();
+
+        try {
+          final var directiveType = Optional
+              .ofNullable(registry.directiveTypes().get(typeName))
+              .orElseThrow(() -> new NoSuchActivityTypeException(activity.getTypeName()));
+
+          response.add(new BulkEffectiveArgumentResponse.Success(
+              new SerializedActivity(
+              typeName,
+              directiveType.getInputType().getEffectiveArguments(activity.getArguments())
+          )));
+        } catch (NoSuchActivityTypeException e) {
+          response.add(new BulkEffectiveArgumentResponse.TypeFailure(e));
+        } catch (InstantiationException e) {
+          response.add(new BulkEffectiveArgumentResponse.InstantiationFailure(e));
+        }
+      }
+
+      return response;
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -45,11 +45,6 @@ public interface MissionModelService {
       SerializedActivity> activities
   ) throws NoSuchMissionModelException, LocalMissionModelService.MissionModelLoadException;
 
-  Map<String, SerializedValue> getActivityEffectiveArguments(String missionModelId, SerializedActivity activity)
-  throws NoSuchMissionModelException,
-         NoSuchActivityTypeException,
-         InstantiationException;
-
   List<BulkEffectiveArgumentResponse> getActivityEffectiveArgumentsBulk(
       String missionModelId,
       List<SerializedActivity> serializedActivities)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -50,6 +50,11 @@ public interface MissionModelService {
          NoSuchActivityTypeException,
          InstantiationException;
 
+  List<BulkEffectiveArgumentResponse> getActivityEffectiveArgumentsBulk(
+      String missionModelId,
+      List<SerializedActivity> serializedActivities)
+  throws NoSuchMissionModelException;
+
   List<ValidationNotice> validateModelArguments(String missionModelId, Map<String, SerializedValue> arguments)
   throws NoSuchMissionModelException,
          LocalMissionModelService.MissionModelLoadException,
@@ -97,5 +102,11 @@ public interface MissionModelService {
     }
 
     public NoSuchActivityTypeException(final String activityTypeId) { this(activityTypeId, null); }
+  }
+
+  sealed interface BulkEffectiveArgumentResponse {
+    record Success(SerializedActivity activity) implements  BulkEffectiveArgumentResponse { }
+    record TypeFailure(NoSuchActivityTypeException ex) implements  BulkEffectiveArgumentResponse { }
+    record InstantiationFailure(InstantiationException ex) implements  BulkEffectiveArgumentResponse { }
   }
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -177,6 +177,13 @@ public final class StubMissionModelService implements MissionModelService {
   }
 
   @Override
+  public List<BulkEffectiveArgumentResponse> getActivityEffectiveArgumentsBulk(
+      String missionModelId,
+      List<SerializedActivity> serializedActivities) {
+    return List.of();
+  }
+
+  @Override
   public List<ValidationNotice> validateModelArguments(final String missionModelId, final Map<String, SerializedValue> arguments)
   throws LocalMissionModelService.MissionModelLoadException
   {

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -169,14 +169,6 @@ public final class StubMissionModelService implements MissionModelService {
   }
 
   @Override
-  public Map<String, SerializedValue> getActivityEffectiveArguments(
-      final String missionModelId,
-      final SerializedActivity activity)
-  {
-    return Map.of();
-  }
-
-  @Override
   public List<BulkEffectiveArgumentResponse> getActivityEffectiveArgumentsBulk(
       String missionModelId,
       List<SerializedActivity> serializedActivities) {


### PR DESCRIPTION
* **Tickets addressed:** closes #666 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Adds a new `getEffectiveArgumentsBulk` Hasura action that takes a list of `EffectiveArgumentsInput` (i.e. a list of activity types and arguments), loads the mission model only once, and retrieves the effective arguments for every element in the input list.

Additionally, this PR deprecates the existing `getActivityEffectiveArguments` action in favor of the new bulk query action.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
e2e tests were added for checking effective arguments in several different cases (single, bulk, malformed, etc) 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Existing hasura action docs need to be updated to reference this new API endpoint.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A