### PR TITLE
Make Migration Script Return Non-Zero Exit Code 

### DIFF
--- a/deployment/aerie_db_migration.py
+++ b/deployment/aerie_db_migration.py
@@ -9,7 +9,7 @@ import subprocess
 import psycopg
 
 def clear_screen():
-  os.system('cls' if os.name=='nt' else 'clear')
+  os.system('cls' if os.name == 'nt' else 'clear')
 
 # internal class
 class DB_Migration:
@@ -18,7 +18,7 @@ class DB_Migration:
   def __init__(self, db_name):
     self.db_name = db_name
 
-  def add_migration_step(self,_migration_step):
+  def add_migration_step(self, _migration_step):
     self.steps = sorted(_migration_step, key=lambda x:int(x.split('_')[0]))
 
 def step_by_step_migration(database, apply):
@@ -49,7 +49,7 @@ def step_by_step_migration(database, apply):
       else:
         display_string += _output[i] + "\n"
     else:
-      if (len(split) == 5 and "Not Present" == (split[3]+" "+split[4])) \
+      if (len(split) == 5 and "Not Present" == (split[3] + " " + split[4])) \
           or (not os.path.isfile(f'migrations/{database.db_name}/{split[0]}_{split[1]}/down.sql')):
         available_steps.remove(f'{split[0]}_{split[1]}')
       else:
@@ -207,7 +207,7 @@ def main():
     print("\033[91mError\033[0m:"+ str(fne).split("]")[1])
     sys.exit(1)
   for db in os.listdir(MIGRATION_PATH):
-    #ignore hidden folders
+    # ignore hidden folders
     if db.startswith('.'):
       continue
     # Only process if the folder is on the list of databases or if we don't have a list of databases
@@ -257,10 +257,10 @@ def main():
         passwordFound = True
         continue
   if not usernameFound:
-    print("\033[91mError\033[0m: AERIE_USERNAME environment variable is not defined in "+args.env-path+".")
+    print("\033[91mError\033[0m: AERIE_USERNAME environment variable is not defined in "+args.env_path+".")
     sys.exit(1)
   if not passwordFound:
-    print("\033[91mError\033[0m: AERIE_PASSWORD environment variable is not defined in "+args.env-path+".")
+    print("\033[91mError\033[0m: AERIE_PASSWORD environment variable is not defined in "+args.env_path+".")
     sys.exit(1)
 
   # Navigate to the hasura directory


### PR DESCRIPTION
* **Tickets addressed:** Closes #917
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Rather than use the exit code of the dryrun, which always returns 0, the script now uses the exit code of running the migration to determine if migrating failed, and if so, to update the exit code of the program. The exit code now communicates how many and which DBs failed to migrate.

The dry-run command has been kept, as it prints which migrations will be run, which is not printed when the migration is actually run.

Additionally a bug that would allow failed migrations to be "skipped" in step-by-step mode has been patched.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Locally tested by running modified migrations that failed and checking the exit codes.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No documentation updates are needed.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
