### PR TITLE
Fix recurrence goal bug that doesn't schedule goal if recurrence interval is greater than plan

### DIFF
--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/ActivityExpression.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/ActivityExpression.java
@@ -414,9 +414,6 @@ public class ActivityExpression implements Expression<Spans> {
    */
   protected @Nullable Expression<? extends Profile<?>> duration;
 
-  public @Nullable
-  Expression<? extends Profile<?>>  getDuration() { return duration; }
-
   /**
    * the bounding super-type for matching activities
    *

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/ActivityExpression.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/activities/ActivityExpression.java
@@ -414,6 +414,9 @@ public class ActivityExpression implements Expression<Spans> {
    */
   protected @Nullable Expression<? extends Profile<?>> duration;
 
+  public @Nullable
+  Expression<? extends Profile<?>>  getDuration() { return duration; }
+
   /**
    * the bounding super-type for matching activities
    *

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Goal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Goal.java
@@ -9,6 +9,7 @@ import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.scheduler.conflicts.Conflict;
 import gov.nasa.jpl.aerie.scheduler.model.Plan;
+import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -44,6 +45,9 @@ public class Goal {
 
   /** Set to true if partial satisfaction is ok, the scheduler will try to do its best */
   private boolean shouldRollbackIfUnsatisfied = false;
+
+  protected PlanningHorizon planHorizon;
+
 
   public boolean shouldRollbackIfUnsatisfied() {
     return shouldRollbackIfUnsatisfied;
@@ -137,6 +141,12 @@ public class Goal {
 
     protected Expression<Windows> range;
 
+    public T withinPlanHorizon(PlanningHorizon planHorizon) {
+      this.planHorizon = planHorizon;
+      return getThis();
+    }
+
+    protected PlanningHorizon planHorizon;
 
     /**
      * allows to attach state constraints to the goal
@@ -222,6 +232,13 @@ public class Goal {
         final var windows = new Windows(false).set(Interval.between(starting, ending), true);
         goal.temporalContext = new WindowsWrapperExpression(windows);
       }
+
+      if (planHorizon == null) {
+        throw new IllegalArgumentException(
+            "Plan Horizon cannot be null");
+      }
+
+      goal.planHorizon = planHorizon;
 
       goal.simulateAfter = this.simulateAfter;
 

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/Problem.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/Problem.java
@@ -132,6 +132,7 @@ public class Problem {
     goalsOrderedByPriority.addAll(goals);
   }
 
+
   /**
    * retrieves the set of all requested plan goals
    *

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/FixedDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/FixedDurationTest.java
@@ -47,6 +47,7 @@ public class FixedDurationTest {
         .startsAt(start)
         .named("FixedCoexistenceGoal")
         .aliasForAnchors("its a me")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -75,6 +76,7 @@ public class FixedDurationTest {
         .startsAt(start)
         .named("FixedCoexistenceGoal")
         .aliasForAnchors("its a me")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/LongDurationPlanTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/LongDurationPlanTest.java
@@ -88,6 +88,7 @@ public class LongDurationPlanTest {
         .named("g0")
         .generateWith((plan) -> expectedPlan.getActivitiesByTime())
         .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(h.getHor(), true)))
+        .withinPlanHorizon(h)
         .build();
     problem.setGoals(List.of(goal));
     final var solver = makeProblemSolver(problem);

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/ParametricDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/ParametricDurationTest.java
@@ -51,6 +51,7 @@ public class ParametricDurationTest {
         .startsAt(start)
         .named("ParamDurationCoexistenceGoal")
         .aliasForAnchors("its a me")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -79,6 +80,7 @@ public class ParametricDurationTest {
         .startsAt(TimeExpression.offsetByBeforeStart(Duration.of(8, Duration.MINUTE)))
         .named("ParamDurationCoexistenceGoal")
         .aliasForAnchors("its a me")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
@@ -137,6 +137,7 @@ public class PrioritySolverTest {
         .named("g0")
         .generateWith((plan) -> expectedPlan.getActivitiesByTime())
         .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(h.getHor(), true)))
+        .withinPlanHorizon(h)
         .build();
     problem.setGoals(List.of(goal));
     final var solver = makeProblemSolver(problem);
@@ -156,6 +157,7 @@ public class PrioritySolverTest {
         .named("g0")
         .generateWith((plan) -> expectedPlan.getActivitiesByTime())
         .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(h.getHor(), true)))
+        .withinPlanHorizon(h)
         .build();
     problem.setGoals(List.of(goal));
     final var solver = makeProblemSolver(problem);
@@ -182,6 +184,7 @@ public class PrioritySolverTest {
                             .ofType(problem.getActivityType("ControllableDurationActivity"))
                             .duration(d1min)
                             .build())
+        .withinPlanHorizon(h)
         .build();
     problem.setGoals(List.of(goal));
     final var solver = makeProblemSolver(problem);
@@ -217,6 +220,7 @@ public class PrioritySolverTest {
                             .build())
         .startsAt(TimeAnchor.START)
         .aliasForAnchors("Bond. James Bond")
+        .withinPlanHorizon(h)
         .build();
     problem.setGoals(List.of(goal));
     final var solver = makeProblemSolver(problem);
@@ -260,6 +264,7 @@ public class PrioritySolverTest {
         .named("TestCardGoal")
         .forAllTimeIn(new WindowsWrapperExpression(goalWindow))
         .owned(ChildCustody.Jointly)
+        .withinPlanHorizon(h)
         .build();
 
     TestUtility.createAutoMutexGlobalSchedulingCondition(activityType).forEach(problem::add);

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
@@ -156,6 +156,7 @@ public class SimulationFacadeTest {
                            .build())
         .startsAt(TimeAnchor.END)
         .aliasForAnchors("its a me")
+        .withinPlanHorizon(horizon)
         .build();
 
     problem.setGoals(List.of(goal));
@@ -285,6 +286,7 @@ public class SimulationFacadeTest {
         .owned(ChildCustody.Jointly)
         .startsAt(TimeAnchor.START)
         .aliasForAnchors("its a me")
+        .withinPlanHorizon(horizon)
         .build();
 
     problem.setGoals(List.of(cg));
@@ -324,6 +326,7 @@ public class SimulationFacadeTest {
         .attachStateConstraint(constraint)
         .generateWith(fixedGenerator)
         .owned(ChildCustody.Jointly)
+        .withinPlanHorizon(horizon)
         .build();
 
     problem.setGoals(List.of(proceduralGoalWithConstraints));
@@ -365,6 +368,7 @@ public class SimulationFacadeTest {
         .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(horizon.getHor(), true)))
         .generateWith(fixedGenerator)
         .owned(ChildCustody.Jointly)
+        .withinPlanHorizon(horizon)
         .build();
 
     problem.setGoals(List.of(proceduralgoalwithoutconstraints));

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
@@ -56,6 +56,7 @@ public class TestApplyWhen {
                             .ofType(activityType)
                             .build())
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -90,6 +91,7 @@ public class TestApplyWhen {
                             .ofType(activityType)
                             .build())
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -124,6 +126,7 @@ public class TestApplyWhen {
                             .ofType(activityType)
                             .build())
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -158,6 +161,7 @@ public class TestApplyWhen {
                             .ofType(activityType)
                             .build())
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -192,6 +196,7 @@ public class TestApplyWhen {
                             .ofType(activityType)
                             .build())
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -204,7 +209,7 @@ public class TestApplyWhen {
       logger.debug(a.startOffset().toString());
     }
 
-    assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType));
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
@@ -236,6 +241,7 @@ public class TestApplyWhen {
                             .ofType(activityType)
                             .build())
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -281,6 +287,7 @@ public class TestApplyWhen {
                             .ofType(activityType)
                             .build())
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -293,9 +300,9 @@ public class TestApplyWhen {
       logger.debug(a.startOffset().toString());
     }
 
-    assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType)); //cutting off mid interval should fail, i.e. no scheduling
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType)); //cutting off mid interval should fail, i.e. no scheduling
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
-    assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
   }
 
@@ -327,6 +334,7 @@ public class TestApplyWhen {
                             .ofType(activityType)
                             .build())
         .repeatingEvery(Duration.of(3, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -342,7 +350,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(8, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
-    assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(17, Duration.SECONDS), activityType)); //interval (len 4) needs to be 2 longer than the recurrence repeatingEvery (len 3)
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(17, Duration.SECONDS), activityType)); //interval (len 4) needs to be 2 longer than the recurrence repeatingEvery (len 3)
   }
 
   @Test
@@ -373,6 +381,7 @@ public class TestApplyWhen {
                             .ofType(activityType)
                             .build())
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -406,6 +415,7 @@ public class TestApplyWhen {
                             .ofType(activityType)
                             .build())
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -450,6 +460,7 @@ public class TestApplyWhen {
         .named("TestCardGoal")
         .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(period, true)))
         .owned(ChildCustody.Jointly)
+        .withinPlanHorizon(planningHorizon)
         .build();
 
     problem.setGoals(List.of(goal));
@@ -495,6 +506,7 @@ public class TestApplyWhen {
         .named("TestCardGoal")
         .forAllTimeIn(new WindowsWrapperExpression(goalWindow))
         .owned(ChildCustody.Jointly)
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -545,6 +557,7 @@ public class TestApplyWhen {
         .named("TestCardGoal")
         .forAllTimeIn(new WindowsWrapperExpression(goalWindow))
         .owned(ChildCustody.Jointly)
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -590,6 +603,7 @@ public class TestApplyWhen {
         .named("TestCardGoal")
         .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(period, true)))
         .owned(ChildCustody.Jointly)
+        .withinPlanHorizon(planningHorizon)
         .build();
 
     problem.setGoals(List.of(goal));
@@ -648,6 +662,7 @@ public class TestApplyWhen {
                             .build())
         .startsAt(TimeAnchor.START)
         .aliasForAnchors("Bond. James Bond")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
     problem.setGoals(List.of(goal));
@@ -702,6 +717,7 @@ public class TestApplyWhen {
                             .build())
         .startsAt(TimeAnchor.START)
         .aliasForAnchors("Bond. James Bond")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
     problem.setGoals(List.of(goal));
@@ -763,6 +779,7 @@ public class TestApplyWhen {
                             .build())
         .startsAt(TimeAnchor.START)
         .aliasForAnchors("Bond. James Bond")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
     problem.setGoals(List.of(goal));
@@ -827,6 +844,7 @@ public class TestApplyWhen {
                             .build())
         .startsAt(TimeAnchor.START)
         .aliasForAnchors("Bond. James Bond")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
     problem.setGoals(List.of(goal));
@@ -897,6 +915,7 @@ public class TestApplyWhen {
                             .build())
         .startsAt(TimeAnchor.START)
         .aliasForAnchors("Bond. James Bond")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
     problem.setGoals(List.of(goal));
@@ -967,6 +986,7 @@ public class TestApplyWhen {
                             .build())
         .startsAt(TimeAnchor.START)
         .aliasForAnchors("Bond. James Bond")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
     problem.setGoals(List.of(goal));
@@ -1032,6 +1052,7 @@ public class TestApplyWhen {
                             .build())
         .startsAt(TimeAnchor.START)
         .aliasForAnchors("Bond. James Bond")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
     problem.setGoals(List.of(goal));
@@ -1089,6 +1110,7 @@ public class TestApplyWhen {
                             .build())
         .startsAt(TimeAnchor.START)
         .aliasForAnchors("Bond. James Bond")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
     problem.setGoals(List.of(goal));
@@ -1137,6 +1159,7 @@ public class TestApplyWhen {
         .named("TestCardGoal")
         .forAllTimeIn(gte)
         .owned(ChildCustody.Jointly)
+        .withinPlanHorizon(hor)
         .build();
 
 
@@ -1150,6 +1173,7 @@ public class TestApplyWhen {
                             .duration(Duration.of(2, Duration.SECONDS))
                             .build())
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(hor)
         .build();
 
     //problem.setGoals(List.of(whenActivitiesGreaterThan2, addRecurringActivityModifyingResource)); ORDER SENSITIVE
@@ -1212,6 +1236,7 @@ public class TestApplyWhen {
         .named("TestCardGoal")
         .forAllTimeIn(gte)
         .owned(ChildCustody.Jointly)
+        .withinPlanHorizon(hor)
         .build();
 
 
@@ -1225,6 +1250,7 @@ public class TestApplyWhen {
                             .duration(Duration.of(2, Duration.SECONDS))
                             .build())
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(hor)
         .build();
 
     //problem.setGoals(List.of(whenActivitiesGreaterThan2, addRecurringActivityModifyingResource)); ORDER SENSITIVE
@@ -1295,6 +1321,7 @@ public class TestApplyWhen {
         .named("TestCardGoal")
         .forAllTimeIn(gte)
         .owned(ChildCustody.Jointly)
+        .withinPlanHorizon(hor)
         .build();
 
 
@@ -1308,6 +1335,7 @@ public class TestApplyWhen {
                             .duration(Duration.of(2, Duration.SECONDS))
                             .build())
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(hor)
         .build();
 
     //problem.setGoals(List.of(whenActivitiesGreaterThan2, addRecurringActivityModifyingResource)); ORDER SENSITIVE

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
@@ -182,6 +182,19 @@ public class TestApplyWhen {
 
   @Test
   public void testRecurrenceBabyWindow() {
+    /*
+    The plan horizon ranges from [0,20).
+    The recurrent activities can be placed inside the following window: [1,2). That is, there is exactly 1 unit of time where an activity can be placed
+    If the interval was [1,2], the time available to place activities would be 1.000....1
+    The activities instantiating the goal have a duration of 1
+    The activities should repeat every 5 time units
+
+    It is therefore possible to place an activity in time slot 1, with a duration of 1
+    Graphically
+    RECURRENCE WINDOW: [+----+----+----+----]
+    GOAL WINDOW: [+-------------------]
+    RESULT: [+-------------------]
+    */
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
@@ -300,7 +313,7 @@ public class TestApplyWhen {
       logger.debug(a.startOffset().toString());
     }
 
-    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType)); //cutting off mid interval should fail, i.e. no scheduling
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
@@ -42,6 +42,7 @@ public class TestCardinalityGoal {
         .named("TestCardGoal")
         .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(period, true)))
         .owned(ChildCustody.Jointly)
+        .withinPlanHorizon(planningHorizon)
         .build();
 
     problem.setGoals(List.of(goal));

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
@@ -35,6 +35,7 @@ public class TestRecurrenceGoal {
                             .ofType(activityType)
                             .build())
         .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -70,6 +71,7 @@ public class TestRecurrenceGoal {
                               .ofType(activityType)
                               .build())
           .repeatingEvery(Duration.of(-1, Duration.SECONDS))
+          .withinPlanHorizon(planningHorizon)
           .build();
     }
     catch (IllegalArgumentException e) {

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoalExtended.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoalExtended.java
@@ -1,0 +1,269 @@
+package gov.nasa.jpl.aerie.scheduler;
+
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate;
+import gov.nasa.jpl.aerie.scheduler.goals.RecurrenceGoal;
+import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
+import gov.nasa.jpl.aerie.scheduler.model.Problem;
+import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
+import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestRecurrenceGoalExtended {
+
+  /**
+   * This test checks that a number activities are placed in the plan. VV
+   */
+  @Test
+  public void testRecurrence() {
+    var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
+        planningHorizon,
+        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var activityType = problem.getActivityType("ControllableDurationActivity");
+    RecurrenceGoal goal = new RecurrenceGoal.Builder()
+        .named("Test recurrence goal")
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(Interval.betweenClosedOpen(Duration.of(1, Duration.SECONDS), Duration.of(20, Duration.SECONDS)), true)))
+        .thereExistsOne(new ActivityCreationTemplate.Builder()
+                            .duration(Duration.of(2, Duration.SECONDS))
+                            .ofType(activityType)
+                            .build())
+        .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
+        .build();
+
+
+    problem.setGoals(List.of(goal));
+
+    final var solver = new PrioritySolver(problem);
+
+    var plan = solver.getNextSolution().orElseThrow();
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType));
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
+  }
+
+  /**
+   * This test checks that only one activity is placed as the second one would exceed the goal window and the plan horizon. VV
+   */
+  @Test
+  public void testRecurrenceSecondGoalOutOfWindowAndPlanHorizon() {
+    var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
+        planningHorizon,
+        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var activityType = problem.getActivityType("ControllableDurationActivity");
+    RecurrenceGoal goal = new RecurrenceGoal.Builder()
+        .named("Test recurrence goal")
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(Interval.betweenClosedOpen(Duration.of(1, Duration.SECONDS), Duration.of(20, Duration.SECONDS)), true)))
+        .thereExistsOne(new ActivityCreationTemplate.Builder()
+                            .duration(Duration.of(2, Duration.SECONDS))
+                            .ofType(activityType)
+                            .build())
+        .repeatingEvery(Duration.of(18, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
+        .build();
+
+
+    problem.setGoals(List.of(goal));
+
+    final var solver = new PrioritySolver(problem);
+
+    var plan = solver.getNextSolution().orElseThrow();
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType) && (plan.getActivities().size() == 1));
+  }
+
+  /**
+   * This test checks that in case the repeat interval is larger than the window where the goal can be placed, the scheduler still manages to place one activity. VV
+   */
+  @Test
+  public void testRecurrenceRepeatIntervalLargerThanGoalWindow() {
+    var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
+        planningHorizon,
+        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var activityType = problem.getActivityType("ControllableDurationActivity");
+    RecurrenceGoal goal = new RecurrenceGoal.Builder()
+        .named("Test recurrence goal")
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(Interval.betweenClosedOpen(Duration.of(1, Duration.SECONDS), Duration.of(20, Duration.SECONDS)), true)))
+        .thereExistsOne(new ActivityCreationTemplate.Builder()
+                            .duration(Duration.of(2, Duration.SECONDS))
+                            .ofType(activityType)
+                            .build())
+        .repeatingEvery(Duration.of(20, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
+        .build();
+
+
+    problem.setGoals(List.of(goal));
+
+    final var solver = new PrioritySolver(problem);
+
+    var plan = solver.getNextSolution().orElseThrow();
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType));
+  }
+
+  /**
+   * This test checks that in case the window where the goal can be placed is larger than the plan horizon, then the window is updated to the plan horizon size. xx
+   */
+  @Test
+  public void testGoalWindowLargerThanPlanHorizon() {
+    var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(5),TestUtility.timeFromEpochSeconds(15));
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
+        planningHorizon,
+        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var activityType = problem.getActivityType("ControllableDurationActivity");
+    final var goalWindow = new Windows(false).set(List.of(
+        Interval.between(Duration.of(1, Duration.SECONDS), Duration.of(5, Duration.SECONDS)),
+        Interval.between(Duration.of(8, Duration.SECONDS), Duration.of(15, Duration.SECONDS)),
+        Interval.between(Duration.of(17, Duration.SECONDS), Duration.of(20, Duration.SECONDS))
+    ), true);
+    RecurrenceGoal goal = new RecurrenceGoal.Builder()
+        .named("Test recurrence goal")
+        .forAllTimeIn(new WindowsWrapperExpression(goalWindow))
+        .thereExistsOne(new ActivityCreationTemplate.Builder()
+                            .duration(Duration.of(2, Duration.SECONDS))
+                            .ofType(activityType)
+                            .build())
+        .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
+        .build();
+
+
+    problem.setGoals(List.of(goal));
+
+    final var solver = new PrioritySolver(problem);
+
+    var plan = solver.getNextSolution().orElseThrow();
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType));
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(8, Duration.SECONDS), activityType));
+  }
+
+
+  /**
+   * This test checks that in case the goal duration is larger than goal window, no activity is added to the plan. VV
+   */
+  @Test
+  public void testGoalDurationLargerGoalWindow() {
+    var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
+        planningHorizon,
+        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var activityType = problem.getActivityType("ControllableDurationActivity");
+    RecurrenceGoal goal = new RecurrenceGoal.Builder()
+        .named("Test recurrence goal")
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(Interval.betweenClosedOpen(Duration.of(0, Duration.SECONDS), Duration.of(20, Duration.SECONDS)), true)))
+        .thereExistsOne(new ActivityCreationTemplate.Builder()
+                            .duration(Duration.of(25, Duration.SECONDS))
+                            .ofType(activityType)
+                            .build())
+        .repeatingEvery(Duration.of(30, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
+        .build();
+
+
+    problem.setGoals(List.of(goal));
+
+    final var solver = new PrioritySolver(problem);
+
+    var plan = solver.getNextSolution().orElseThrow();
+    assertTrue(TestUtility.emptyPlan(plan));
+  }
+
+
+  /**
+   * This test checks that in case the goal repeat cycle is shorter than the goal duration, then no activity is added to the plan. VV
+   */
+  @Test
+  public void testGoalDurationLargerRepeatInterval() {
+    var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
+        planningHorizon,
+        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var activityType = problem.getActivityType("ControllableDurationActivity");
+    RecurrenceGoal goal = new RecurrenceGoal.Builder()
+        .named("Test recurrence goal")
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(Interval.betweenClosedOpen(Duration.of(0, Duration.SECONDS), Duration.of(20, Duration.SECONDS)), true)))
+        .thereExistsOne(new ActivityCreationTemplate.Builder()
+                            .duration(Duration.of(10, Duration.SECONDS))
+                            .ofType(activityType)
+                            .build())
+        .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
+        .build();
+
+
+    problem.setGoals(List.of(goal));
+
+    final var solver = new PrioritySolver(problem);
+
+    var plan = solver.getNextSolution().orElseThrow();
+    assertTrue(TestUtility.emptyPlan(plan));
+  }
+
+
+  /**
+   * This test checks the behaviour when activity is added to a non-empty plan. How is distance preserved? What happens if activity already existing is deleted?
+   */
+  @Test
+  public void testAddActivityNonEmptyPlan() {
+    var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
+        planningHorizon,
+        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var activityType = problem.getActivityType("ControllableDurationActivity");
+    RecurrenceGoal goal = new RecurrenceGoal.Builder()
+        .named("Test recurrence goal")
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(Interval.betweenClosedOpen(Duration.of(0, Duration.SECONDS), Duration.of(20, Duration.SECONDS)), true)))
+        .thereExistsOne(new ActivityCreationTemplate.Builder()
+                            .duration(Duration.of(2, Duration.SECONDS))
+                            .ofType(activityType)
+                            .build())
+        .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
+        .build();
+    problem.setGoals(List.of(goal));
+
+    final var solver = new PrioritySolver(problem);
+    var plan = solver.getNextSolution().orElseThrow();
+
+    // Create a new problem with previous plan and add new goal interleaved two time units wrt original goal
+    Problem problem2 = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
+        planningHorizon, fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    problem2.setInitialPlan(plan);
+    RecurrenceGoal goal2 = new RecurrenceGoal.Builder()
+        .named("Test recurrence goal 2")
+        .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(Interval.betweenClosedOpen(Duration.of(2, Duration.SECONDS), Duration.of(20, Duration.SECONDS)), true)))
+        .thereExistsOne(new ActivityCreationTemplate.Builder()
+                            .duration(Duration.of(2, Duration.SECONDS))
+                            .ofType(activityType)
+                            .build())
+        .repeatingEvery(Duration.of(5, Duration.SECONDS))
+        .withinPlanHorizon(planningHorizon)
+        .build();
+    problem2.setGoals(List.of(goal2));
+    final var solver2 = new PrioritySolver(problem2);
+    var newplan = solver2.getNextSolution().orElseThrow();
+
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(0, Duration.SECONDS), activityType));
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(5, Duration.SECONDS), activityType));
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(10, Duration.SECONDS), activityType));
+    assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(15, Duration.SECONDS), activityType));
+  }
+}

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUnsatisfiableCompositeGoals.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUnsatisfiableCompositeGoals.java
@@ -68,6 +68,7 @@ public class TestUnsatisfiableCompositeGoals {
                             .build())
         .startsAt(TimeAnchor.START)
         .aliasForAnchors("hi I'm an alias")
+        .withinPlanHorizon(h)
         .build();
   }
 
@@ -84,6 +85,7 @@ public class TestUnsatisfiableCompositeGoals {
         .and(goal2)
         .and(goal)
         .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(h.getHor(), true)))
+        .withinPlanHorizon(TestUnsatisfiableCompositeGoals.h)
         .build();
     final var exclusionBasic = TestUtility.createExclusionSchedulingZone(actTypeBasic,
                                                                          new Windows(
@@ -118,6 +120,7 @@ public class TestUnsatisfiableCompositeGoals {
         .and(goal)
         .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(h.getHor(), true)))
         .shouldRollbackIfUnsatisfied(true)
+        .withinPlanHorizon(TestUnsatisfiableCompositeGoals.h)
         .build();
     final var exclusionBasic = TestUtility.createExclusionSchedulingZone(actTypeBasic,
                                                                          new Windows(
@@ -148,6 +151,7 @@ public class TestUnsatisfiableCompositeGoals {
         .or(goal2)
         .or(goal)
         .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(h.getHor(), true)))
+        .withinPlanHorizon(TestUnsatisfiableCompositeGoals.h)
         .build();
     final var exclusionBasic = TestUtility.createExclusionSchedulingZone(actTypeBasic,
                                                                          new Windows(
@@ -187,6 +191,7 @@ public class TestUnsatisfiableCompositeGoals {
         .or(goal)
         .shouldRollbackIfUnsatisfied(true)
         .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(h.getHor(), true)))
+        .withinPlanHorizon(TestUnsatisfiableCompositeGoals.h)
         .build();
     final var exclusionBasic = TestUtility.createExclusionSchedulingZone(actTypeBasic,
                                                                          new Windows(Interval.between(t1hr.minus(d1min), t1hr.plus(d1min)),
@@ -234,6 +239,7 @@ public class TestUnsatisfiableCompositeGoals {
         .forAllTimeIn(new WindowsWrapperExpression(goalWindow))
         .owned(ChildCustody.Jointly)
         .shouldRollbackIfUnsatisfied(true)
+        .withinPlanHorizon(TestUnsatisfiableCompositeGoals.h)
         .build();
 
 

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUtility.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUtility.java
@@ -19,6 +19,9 @@ import java.util.List;
 
 public class TestUtility {
 
+  public static boolean emptyPlan(Plan plan) {
+    return plan.getActivities().isEmpty();
+  }
   public static boolean activityStartingAtTime(Plan plan, Duration time, ActivityType activityType) {
     List<SchedulingActivityDirective> acts = plan.getActivitiesByTime();
     for (SchedulingActivityDirective act : acts) {

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/UncontrollableDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/UncontrollableDurationTest.java
@@ -205,6 +205,7 @@ public class UncontrollableDurationTest {
         .forEach(horizonExpression)
         .startsAt(intervalStartTimeExpression)
         .aliasForAnchors("its a me")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
     problem.setGoals(List.of(coexistenceControllable));

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/UncontrollableDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/UncontrollableDurationTest.java
@@ -71,6 +71,7 @@ public class UncontrollableDurationTest {
         .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(planningHorizon.getHor(), true)))
         .repeatingEvery(Duration.of(1000, Duration.SECONDS))
         .named("UncontrollableRecurrenceGoal")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -81,6 +82,7 @@ public class UncontrollableDurationTest {
         .endsAt(TimeAnchor.START)
         .named("UncontrollableCoexistenceGoal")
         .aliasForAnchors("Bond. James Bond")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -119,6 +121,7 @@ public class UncontrollableDurationTest {
         .forAllTimeIn(new WindowsWrapperExpression(new Windows(false).set(planningHorizon.getHor(), true)))
         .repeatingEvery(Duration.of(1000, Duration.SECONDS))
         .named("UncontrollableRecurrenceGoal")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -130,6 +133,7 @@ public class UncontrollableDurationTest {
         .endsAt(start)
         .named("UncontrollableCoexistenceGoal")
         .aliasForAnchors("its a me")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
 
@@ -166,6 +170,7 @@ public class UncontrollableDurationTest {
         .forEach(ActivityExpression.ofType(problem.getActivityType("ControllableDurationActivity")))
         .startsAt(intervalStartTimeExpression)
         .aliasForAnchors("its a me")
+        .withinPlanHorizon(planningHorizon)
         .build();
 
     problem.setGoals(List.of(coexistenceControllable));


### PR DESCRIPTION
* **Tickets addressed:** Closes https://github.com/NASA-AMMOS/aerie/issues/703
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Add modifications to Goal and RecurrenceGoal to make consistency checks between goal duration (if fixed), goal time windows and Planning Horizon

## Verification
Execution of all scheduler and e2e tests

## Documentation
Extension of RecurrenceGoal documentation is being produced

## Future work
N/A