### PR TITLE
Allow user to update model_id, plan_id of Constraints

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_constraint.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_constraint.yaml
@@ -42,11 +42,16 @@ insert_permissions:
 update_permissions:
   - role: user
     permission:
-      columns: [name, description, definition, owner]
+      columns: [name, description, definition, owner, model_id, plan_id]
       filter: {"_or": [
         {"plan":{"owner":{"_eq":"X-Hasura-User-Id"}}},
         {"plan":{"collaborators":{"collaborator":{"_eq":"X-Hasura-User-Id"}}}},
         {"mission_model":{"plans":{"collaborators":{"collaborator":{"_eq":"X-Hasura-User-Id"}}}}},
         {"mission_model":{"plans":{"owner":{"_eq":"X-Hasura-User-Id"}}}}]}
+      check: { "_or": [
+        { "plan": { "owner": { "_eq": "X-Hasura-User-Id" } } },
+        { "plan": { "collaborators": { "collaborator": { "_eq": "X-Hasura-User-Id" } } } },
+        { "mission_model": { "plans": { "collaborators": { "collaborator": { "_eq": "X-Hasura-User-Id" } } } } },
+        { "mission_model": { "plans": { "owner": { "_eq": "X-Hasura-User-Id" } } } } ] }
       set:
         updated_by: "x-hasura-user-id"


### PR DESCRIPTION
* **Tickets addressed:**  Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

Allow users to update the `plan_id` and `model_id` of constraints they're allowed to update. A post-update check has been added to enforce that they are not assigning either value to one they are not allowed to (ie, they may only update the plan_id to that of another plan they own/collaborate on)

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
