### PR TITLE
Declare default permissions for Hasura actions/functions

### DIFF
--- a/deployment/hasura/metadata/actions.yaml
+++ b/deployment/hasura/metadata/actions.yaml
@@ -4,131 +4,183 @@ actions:
       kind: synchronous
       handler: "{{AERIE_MERLIN_URL}}/addExternalDataset"
       timeout: 300
+    permissions:
+      - role: user
   - name: extendExternalDataset
     definition:
       kind: synchronous
       handler: "{{AERIE_MERLIN_URL}}/extendExternalDataset"
       timeout: 300
+    permissions:
+      - role: user
   - name: uploadDictionary
     definition:
       kind: synchronous
       handler: "{{AERIE_SEQUENCING_URL}}/put-dictionary"
       timeout: 300
+    permissions:
+      - role: user
   - name: addCommandExpansionTypeScript
     definition:
       kind: synchronous
       handler: "{{AERIE_SEQUENCING_URL}}/command-expansion/put-expansion"
       timeout: 300
+    permissions:
+      - role: user
   - name: createExpansionSet
     definition:
       kind: synchronous
       handler: "{{AERIE_SEQUENCING_URL}}/command-expansion/put-expansion-set"
       timeout: 300
+    permissions:
+      - role: user
   - name: expandAllActivities
     definition:
       kind: synchronous
       handler: "{{AERIE_SEQUENCING_URL}}/command-expansion/expand-all-activity-instances"
       timeout: 300
+    permissions:
+      - role: user
   - name: getEdslForSeqJson
     definition:
       kind: synchronous
       handler: "{{AERIE_SEQUENCING_URL}}/seqjson/get-edsl-for-seqjson"
       timeout: 300
+    permissions:
+      - role: user
   - name: getEdslForSeqJsonBulk
     definition:
       kind: synchronous
       handler: "{{AERIE_SEQUENCING_URL}}/seqjson/bulk-get-edsl-for-seqjson"
       timeout: 300
+    permissions:
+      - role: user
   - name: getModelEffectiveArguments
     definition:
       kind: ""
       handler: "{{AERIE_MERLIN_URL}}/getModelEffectiveArguments"
       timeout: 300
+    permissions:
+      - role: user
   - name: getActivityEffectiveArguments
     definition:
       kind: ""
       handler: "{{AERIE_MERLIN_URL}}/getActivityEffectiveArguments"
       timeout: 300
+    permissions:
+      - role: user
   - name: getActivityTypeScript
     definition:
       kind: ""
       handler: "{{AERIE_SEQUENCING_URL}}/get-activity-typescript"
       timeout: 300
+    permissions:
+      - role: user
   - name: getCommandTypeScript
     definition:
       kind: ""
       handler: "{{AERIE_SEQUENCING_URL}}/get-command-typescript"
       timeout: 300
+    permissions:
+      - role: user
   - name: getSequenceSeqJson
     definition:
       kind: ""
       handler: "{{AERIE_SEQUENCING_URL}}/seqjson/get-seqjson-for-seqid-and-simulation-dataset"
       timeout: 300
+    permissions:
+      - role: user
   - name: getSequenceSeqJsonBulk
     definition:
       kind: ""
       handler: "{{AERIE_SEQUENCING_URL}}/seqjson/bulk-get-seqjson-for-seqid-and-simulation-dataset"
       timeout: 300
+    permissions:
+      - role: user
   - name: getUserSequenceSeqJson
     definition:
       kind: ""
       handler: "{{AERIE_SEQUENCING_URL}}/seqjson/get-seqjson-for-sequence-standalone"
       timeout: 300
+    permissions:
+      - role: user
   - name: getUserSequenceSeqJsonBulk
     definition:
       kind: ""
       handler: "{{AERIE_SEQUENCING_URL}}/seqjson/bulk-get-seqjson-for-sequence-standalone"
       timeout: 300
+    permissions:
+      - role: user
   - name: resourceTypes
     definition:
       kind: ""
       handler: "{{AERIE_MERLIN_URL}}/resourceTypes"
       timeout: 300
+    permissions:
+      - role: user
   - name: schedule
     definition:
       kind: ""
       handler: "{{AERIE_SCHEDULER_URL}}/schedule"
       timeout: 300
+    permissions:
+      - role: user
   - name: schedulingDslTypescript
     definition:
       kind: ""
       handler: "{{AERIE_SCHEDULER_URL}}/schedulingDslTypescript"
       timeout: 300
+    permissions:
+      - role: user
   - name: constraintsDslTypescript
     definition:
       kind: ""
       handler: "{{AERIE_MERLIN_URL}}/constraintsDslTypescript"
       timeout: 300
+    permissions:
+      - role: user
   - name: simulate
     definition:
       kind: ""
       handler: "{{AERIE_MERLIN_URL}}/getSimulationResults"
       timeout: 300
+    permissions:
+      - role: user
   - name: resourceSamples
     definition:
       kind: ""
       handler: "{{AERIE_MERLIN_URL}}/resourceSamples"
       timeout: 300
+    permissions:
+      - role: user
   - name: constraintViolations
     definition:
       kind: ""
       handler: "{{AERIE_MERLIN_URL}}/constraintViolations"
       timeout: 300
+    permissions:
+      - role: user
   - name: validateActivityArguments
     definition:
       kind: ""
       handler: "{{AERIE_MERLIN_URL}}/validateActivityArguments"
       timeout: 300
+    permissions:
+      - role: user
   - name: validateModelArguments
     definition:
       kind: ""
       handler: "{{AERIE_MERLIN_URL}}/validateModelArguments"
       timeout: 300
+    permissions:
+      - role: user
   - name: validatePlan
     definition:
       kind: ""
       handler: "{{AERIE_MERLIN_URL}}/validatePlan"
       timeout: 300
+    permissions:
+      - role: user
 custom_types:
   enums:
     - name: MerlinSimulationStatus

--- a/deployment/hasura/metadata/databases/AerieMerlin/functions/functions.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/functions/functions.yaml
@@ -5,12 +5,16 @@
     custom_root_fields:
       function: duplicate_plan
     session_argument: hasura_session
+  permissions:
+    - role: user
 - function:
     name: get_plan_history
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: get_plan_history
+  permissions:
+    - role: user
 - function:
     name: create_merge_request
     schema: hasura_functions
@@ -18,6 +22,8 @@
     custom_root_fields:
       function: create_merge_request
     session_argument: hasura_session
+  permissions:
+    - role: user
 - function:
     name: begin_merge
     schema: hasura_functions
@@ -25,98 +31,132 @@
     custom_root_fields:
       function: begin_merge
     session_argument: hasura_session
+  permissions:
+    - role: user
 - function:
     name: commit_merge
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: commit_merge
+  permissions:
+    - role: user
 - function:
     name: deny_merge
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: deny_merge
+  permissions:
+    - role: user
 - function:
     name: withdraw_merge_request
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: withdraw_merge_request
+  permissions:
+    - role: user
 - function:
     name: cancel_merge
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: cancel_merge
+  permissions:
+    - role: user
 - function:
     name: get_non_conflicting_activities
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: get_non_conflicting_activities
+  permissions:
+    - role: user
 - function:
     name: get_conflicting_activities
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: get_conflicting_activities
+  permissions:
+    - role: user
 - function:
     name: set_resolution
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: set_resolution
+  permissions:
+    - role: user
 - function:
     name: set_resolution_bulk
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: set_resolution_bulk
+  permissions:
+    - role: user
 - function:
     name: delete_activity_by_pk_reanchor_plan_start
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: delete_activity_by_pk_reanchor_plan_start
+  permissions:
+    - role: user
 - function:
     name: delete_activity_by_pk_reanchor_to_anchor
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: delete_activity_by_pk_reanchor_to_anchor
+  permissions:
+    - role: user
 - function:
     name: delete_activity_by_pk_delete_subtree
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: delete_activity_by_pk_delete_subtree
+  permissions:
+    - role: user
 - function:
     name: delete_activity_by_pk_reanchor_plan_start_bulk
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: delete_activity_by_pk_reanchor_plan_start_bulk
+  permissions:
+    - role: user
 - function:
     name: delete_activity_by_pk_reanchor_to_anchor_bulk
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: delete_activity_by_pk_reanchor_to_anchor_bulk
+  permissions:
+    - role: user
 - function:
     name: delete_activity_by_pk_delete_subtree_bulk
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: delete_activity_by_pk_delete_subtree_bulk
+  permissions:
+    - role: user
 - function:
     name: apply_preset_to_activity
     schema: hasura_functions
   configuration:
     custom_root_fields:
       function: apply_preset_to_activity
+  permissions:
+    - role: user
 - function:
     name: get_resources_at_start_offset
     schema: hasura_functions
   configuration:
     custom_name: getResourcesAtStartOffset
+  permissions:
+    - role: user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,6 +228,7 @@ services:
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
+      HASURA_GRAPHQL_INFER_FUNCTION_PERMISSIONS: false
       HASURA_GRAPHQL_JWT_SECRET: "${HASURA_GRAPHQL_JWT_SECRET}"
       HASURA_GRAPHQL_LOG_LEVEL: info
       HASURA_GRAPHQL_METADATA_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_hasura"


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
[This Slack](https://jpl.slack.com/archives/CJ07FGRPH/p1687814932955879?thread_ts=1687812777.519679&cid=CJ07FGRPH) conversation made me realize that, despite having `SELECT` permissions on the correct tables and appearing to have access in the console, none of our `volatile` functions were being exposed to those with the `user` role. It turns out that for volatile functions, permissions need to be explicitly granted. At the same time, I've also granted the `user` role permission to run all actions. Fine-tuning of these permissions will be implemented in a later PR.

Additionally, I have set `HASURA_GRAPHQL_INFER_FUNCTION_PERMISSIONS` to `false` in our Docker Compose. This allows us to see what the permission _actually_ is for a given function.

## Verification
Attempted to call various actions/functions in the Hasura Metadata

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work

