### PR TITLE
Add delete permissions for Constraints Table

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_constraint.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_constraint.yaml
@@ -55,3 +55,11 @@ update_permissions:
         { "mission_model": { "plans": { "owner": { "_eq": "X-Hasura-User-Id" } } } } ] }
       set:
         updated_by: "x-hasura-user-id"
+delete_permissions:
+  - role: user
+    permission:
+      filter: {"_or": [
+        {"plan":{"owner":{"_eq":"X-Hasura-User-Id"}}},
+        {"plan":{"collaborators":{"collaborator":{"_eq":"X-Hasura-User-Id"}}}},
+        {"mission_model":{"plans":{"collaborators":{"collaborator":{"_eq":"X-Hasura-User-Id"}}}}},
+        {"mission_model":{"plans":{"owner":{"_eq":"X-Hasura-User-Id"}}}}]}


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Forgot to give `user` delete permissions on the `constraints` table. Users who may update a constraint may now delete it.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Used the GQLConsole to verify that `delete_constraint` and `delete_constraint_by_pk` are now in the user's mutation_root