### PR TITLE
Users Table

### DIFF
--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MerlinDatabaseTestHelper.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MerlinDatabaseTestHelper.java
@@ -7,8 +7,24 @@ import java.util.UUID;
 final class MerlinDatabaseTestHelper {
   private final Connection connection;
 
-  MerlinDatabaseTestHelper(Connection connection) {
+  MerlinDatabaseTestHelper(Connection connection) throws SQLException {
     this.connection = connection;
+    insertUser("Merlin DB Tests");
+  }
+
+  void insertUser(final String username) throws SQLException {
+    insertUser(username, "admin");
+  }
+
+  void insertUser(final String username, final String defaultRole) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      statement.execute(
+              """
+              INSERT INTO metadata.users (username, default_role)
+              VALUES ('%s', '%s');
+              """.formatted(username, defaultRole)
+          );
+    }
   }
 
   int insertFileUpload() throws SQLException {
@@ -32,7 +48,7 @@ final class MerlinDatabaseTestHelper {
           .executeQuery(
               """
                   INSERT INTO mission_model (name, mission, owner, version, jar_id)
-                  VALUES ('test-mission-model-%s', 'test-mission', 'tester', '0', %s)
+                  VALUES ('test-mission-model-%s', 'test-mission', 'Merlin DB Tests', '0', %s)
                   RETURNING id;"""
                   .formatted(UUID.randomUUID().toString(), fileId)
           );

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PlanCollaborationTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PlanCollaborationTests.java
@@ -80,6 +80,10 @@ public class PlanCollaborationTests {
     helper.startDatabase();
     connection = helper.connection();
     merlinHelper = new MerlinDatabaseTestHelper(connection);
+    merlinHelper.insertUser("PlanCollaborationTests");
+    merlinHelper.insertUser("PlanCollaborationTests Reviewer");
+    merlinHelper.insertUser("PlanCollaborationTests Requester");
+    merlinHelper.insertUser("TagsTest");
   }
 
   @AfterAll
@@ -104,7 +108,7 @@ public class PlanCollaborationTests {
   int duplicatePlan(final int planId, final String newPlanName) throws SQLException {
     try (final var statement = connection.createStatement()) {
       final var res = statement.executeQuery("""
-        select duplicate_plan(%s, '%s', 'DBTests') as id;
+        select duplicate_plan(%s, '%s', 'PlanCollaborationTests') as id;
       """.formatted(planId, newPlanName));
       res.next();
       return res.getInt("id");

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/TagsTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/TagsTests.java
@@ -75,6 +75,7 @@ public class TagsTests {
     helper.startDatabase();
     setConnection(helper);
     merlinHelper = new MerlinDatabaseTestHelper(connection);
+    merlinHelper.insertUser("TagsTest");
   }
 
   @AfterAll

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/user_roles.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/user_roles.yaml
@@ -1,0 +1,17 @@
+table:
+  name: user_roles
+  schema: metadata
+configuration:
+  custom_name: "user_roles"
+is_enum: true
+select_permissions:
+  - role: user
+    permission:
+      columns: [role, description]
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: [role, description]
+      filter: {}
+      allow_aggregations: true

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/users.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/users.yaml
@@ -1,0 +1,16 @@
+table:
+  name: users
+  schema: metadata
+configuration:
+  custom_name: "users"
+select_permissions:
+  - role: user
+    permission:
+      columns: [username]
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: [username]
+      filter: {}
+      allow_aggregations: true

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/users_allowed_roles.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/users_allowed_roles.yaml
@@ -1,0 +1,16 @@
+table:
+  name: users_allowed_roles
+  schema: metadata
+configuration:
+  custom_name: "users_allowed_roles"
+select_permissions:
+  - role: user
+    permission:
+      columns: [username, allowed_role]
+      filter: {"username":{"_eq":"X-Hasura-User-Id"}}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: [username, allowed_role]
+      filter: {"username":{"_eq":"X-Hasura-User-Id"}}
+      allow_aggregations: true

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/users_and_roles_view.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/users_and_roles_view.yaml
@@ -1,0 +1,16 @@
+table:
+  name: users_and_roles
+  schema: metadata
+configuration:
+  custom_name: "users_and_roles"
+select_permissions:
+  - role: user
+    permission:
+      columns: [username, hasura_default_role, hasura_allowed_roles]
+      filter: {"username":{"_eq":"X-Hasura-User-Id"}}
+      allow_aggregations: false
+  - role: viewer
+    permission:
+      columns: [ username, hasura_default_role, hasura_allowed_roles ]
+      filter: { "username": { "_eq": "X-Hasura-User-Id" } }
+      allow_aggregations: false

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
@@ -48,3 +48,7 @@
 - "!include metadata/activity_directive_tags.yaml"
 - "!include metadata/constraint_tags.yaml"
 - "!include metadata/plan_tags.yaml"
+- "!include metadata/users_allowed_roles.yaml"
+- "!include metadata/user_roles.yaml"
+- "!include metadata/users.yaml"
+- "!include metadata/users_and_roles_view.yaml"

--- a/deployment/hasura/metadata/databases/AerieUI/tables/public_view.yaml
+++ b/deployment/hasura/metadata/databases/AerieUI/tables/public_view.yaml
@@ -22,7 +22,7 @@ insert_permissions:
 update_permissions:
   - role: user
     permission:
-      columns: [definition, name]
+      columns: [definition, name, owner]
       filter: {"owner":{"_eq":"x-hasura-user-id"}}
 delete_permissions:
   - role: user

--- a/deployment/hasura/migrations/AerieMerlin/19_users/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/19_users/down.sql
@@ -1,0 +1,19 @@
+-- USERS AND ROLES VIEW
+comment on view metadata.users_and_roles is null;
+drop view metadata.users_and_roles;
+
+-- USERS ALLOWED ROLES
+comment on table metadata.users_allowed_roles is null;
+drop table metadata.users_allowed_roles;
+
+-- USERS
+comment on column metadata.users.default_role is null;
+comment on column metadata.users.username is null;
+comment on table metadata.users is null;
+drop table metadata.users;
+
+-- USER ROLES
+comment on table metadata.user_roles is null;
+drop table metadata.user_roles;
+
+call migrations.mark_migration_rolled_back('19');

--- a/deployment/hasura/migrations/AerieMerlin/19_users/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/19_users/down.sql
@@ -1,3 +1,123 @@
+--------------- TABLES ---------------
+-- MERGE REQUEST
+comment on column merge_request.requester_username is null;
+comment on column merge_request.reviewer_username is null;
+
+alter table public.merge_request
+  drop constraint merge_request_reviewer_exists,
+  drop constraint merge_request_requester_exists;
+update public.merge_request
+  set requester_username = ''
+  where requester_username is null;
+alter table public.merge_request
+  alter column requester_username set not null;
+
+comment on column merge_request.requester_username is e''
+  'The username of the user who created this merge request.';
+comment on column merge_request.reviewer_username is e''
+  'The username of the user who reviews this merge request. Is empty until the request enters review.';
+
+-- MERGE REQUEST COMMENT
+comment on column merge_request_comment.commenter_username is null;
+
+alter table public.merge_request_comment
+  drop constraint merge_request_commenter_exists,
+  alter column commenter_username set default '';
+update public.merge_request_comment
+  set commenter_username = default
+  where commenter_username is null;
+alter table public.merge_request_comment
+  alter column commenter_username set not null;
+
+comment on column merge_request_comment.commenter_username is e''
+  'The username of the user who left this comment.';
+
+-- SIMULATION TEMPLATE
+alter table public.simulation_template
+  drop constraint simulation_template_owner_exists,
+  alter column owner set default '';
+
+update simulation_template
+  set owner = default
+  where owner is null;
+
+alter table public.simulation_template
+  alter column owner set not null;
+
+-- SIMULATION DATASET
+alter table simulation_dataset
+  drop constraint simulation_dataset_requested_by_exists,
+  alter column requested_by set default '';
+
+update simulation_dataset
+  set requested_by = default
+  where requested_by is null;
+
+alter table simulation_dataset
+  alter column requested_by set not null;
+
+-- PLAN COLLABORATORS
+alter table public.plan_collaborators
+  drop constraint plan_collaborator_collaborator_fkey;
+
+-- PLAN
+alter table public.plan
+  drop constraint plan_updated_by_exists,
+  drop constraint plan_owner_exists,
+  alter column updated_by set default '',
+  alter column owner set default '';
+
+update public.plan
+  set owner = default
+  where owner is null;
+update public.plan
+  set updated_by = default
+  where updated_by is null;
+
+alter table public.plan
+  alter column updated_by set not null,
+  alter column owner set not null;
+
+-- MISSION MODEL
+alter table public.mission_model
+  drop constraint mission_model_owner_exists;
+
+-- CONSTRAINTS
+alter table public."constraint"
+  drop constraint constraint_updated_by_exists,
+  drop constraint constraint_owner_exists,
+  alter column updated_by set default '',
+  alter column owner set default '';
+update public."constraint"
+  set owner = default
+  where owner is null;
+update public."constraint"
+  set updated_by = default
+  where updated_by is null;
+alter table public."constraint"
+  alter column updated_by drop not null,
+  alter column owner set not null;
+
+-- ACTIVITY PRESETS
+alter table public.activity_presets
+  drop constraint activity_presets_owner_exists,
+  alter column owner set default '';
+update public.activity_presets
+  set owner = default
+  where owner is null;
+alter table public.activity_presets
+  alter column owner set not null;
+
+-- TAGS
+alter table metadata.tags
+  drop constraint tags_owner_exists,
+  alter column owner set default '';
+update metadata.tags
+  set owner = default
+  where owner is null;
+alter table metadata.tags
+  alter column owner set not null;
+
 -- USERS AND ROLES VIEW
 comment on view metadata.users_and_roles is null;
 drop view metadata.users_and_roles;

--- a/deployment/hasura/migrations/AerieMerlin/19_users/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/19_users/up.sql
@@ -1,0 +1,66 @@
+-- USER ROLES
+-- This table is an enum-compatible table (https://hasura.io/docs/latest/schema/postgres/enums/#pg-create-enum-table)
+create table metadata.user_roles(
+  role text primary key,
+  description text null
+);
+insert into metadata.user_roles(role) values ('admin'), ('user'), ('viewer');
+
+comment on table metadata.user_roles is e''
+  'A list of all the allowed Hasura roles, with an optional description per role';
+
+-- USERS
+create table metadata.users(
+  username text not null primary key,
+  default_role text not null references metadata.user_roles
+    on update cascade
+    on delete restrict
+);
+
+comment on table metadata.users is e''
+'All users recognized by this deployment.';
+comment on column metadata.users.username is e''
+'The user''s username. A unique identifier for this user.';
+comment on column metadata.users.default_role is e''
+'The user''s default role for making Hasura requests.';
+
+-- USERS ALLOWED ROLES
+create table metadata.users_allowed_roles(
+  username text references metadata.users
+    on update cascade
+    on delete cascade,
+  allowed_role text not null references metadata.user_roles
+    on update cascade
+    on delete cascade,
+
+  primary key (username, allowed_role),
+
+  constraint system_roles_have_no_allowed_roles
+    check (username != 'Mission Model' and username != 'Aerie Legacy' )
+);
+
+comment on table metadata.users_allowed_roles is e''
+'An association between a user and all of the roles they are allowed to use for Hasura requests';
+
+-- USERS AND ROLES VIEW
+create view metadata.users_and_roles as
+(
+  select
+    u.username as username,
+    -- Roles
+    u.default_role as hasura_default_role,
+    array_agg(r.allowed_role) filter (where r.allowed_role is not null) as hasura_allowed_roles
+  from metadata.users u
+  left join metadata.users_allowed_roles r using (username)
+  group by u.username
+);
+
+comment on view metadata.users_and_roles is e''
+'View a user''s information with their role information';
+
+-- ADD SYSTEM USERS
+insert into metadata.users(username, default_role)
+  values ('Mission Model', 'viewer'),
+         ('Aerie Legacy', 'viewer');
+
+call migrations.mark_migration_applied('19');

--- a/deployment/hasura/migrations/AerieMerlin/19_users/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/19_users/up.sql
@@ -58,6 +58,248 @@ create view metadata.users_and_roles as
 comment on view metadata.users_and_roles is e''
 'View a user''s information with their role information';
 
+-- TAGS
+alter table metadata.tags
+  alter column owner drop not null,
+  alter column owner drop default;
+update metadata.tags t
+  set owner = null
+  where owner = '';
+
+insert into metadata.users(username, default_role)
+  select owner, 'user' from metadata.tags
+  where owner is not null
+  on conflict (username) do nothing;
+
+alter table metadata.tags
+  add constraint tags_owner_exists
+    foreign key (owner) references metadata.users
+    on update cascade
+    on delete set null;
+
+-- ACTIVITY PRESETS
+alter table public.activity_presets
+  alter column owner drop not null,
+  alter column owner drop default;
+update public.activity_presets
+  set owner = null
+  where owner = '';
+
+insert into metadata.users(username, default_role)
+  select owner, 'user' from public.activity_presets
+  where owner is not null
+  on conflict (username) do nothing;
+
+alter table public.activity_presets
+  add constraint activity_presets_owner_exists
+    foreign key (owner) references metadata.users
+    on update cascade
+    on delete set null;
+
+-- CONSTRAINTS
+alter table public."constraint"
+  alter column owner drop not null,
+  alter column owner drop default,
+  alter column updated_by drop not null,
+  alter column updated_by drop default;
+update public."constraint"
+  set owner = null
+  where owner = '';
+update public."constraint"
+  set updated_by = null
+  where updated_by = '';
+
+insert into metadata.users(username, default_role)
+    select owner, 'user' from public."constraint"
+    where owner is not null
+  union distinct
+    select updated_by, 'user' from public."constraint"
+    where updated_by is not null
+  on conflict (username) do nothing;
+
+alter table public."constraint"
+  add constraint constraint_owner_exists
+    foreign key (owner)
+    references metadata.users
+    on update cascade
+    on delete set null,
+  add constraint constraint_updated_by_exists
+    foreign key (updated_by)
+    references metadata.users
+    on update cascade
+    on delete set null;
+
+-- MISSION MODEL
+update public.mission_model
+  set owner = null
+  where owner = '';
+
+insert into metadata.users(username, default_role)
+    select owner, 'user' from public.mission_model
+    where owner is not null
+  on conflict (username) do nothing;
+
+alter table public.mission_model
+  add constraint mission_model_owner_exists
+    foreign key (owner) references metadata.users
+    on update cascade
+    on delete set null;
+
+-- PLAN
+alter table public.plan
+  alter column owner drop not null,
+  alter column owner drop default,
+  alter column updated_by drop not null,
+  alter column updated_by drop default;
+
+update public.plan
+  set owner = null
+  where owner = '';
+update public.plan
+  set updated_by = null
+  where updated_by = '';
+
+insert into metadata.users(username, default_role)
+    select owner, 'user' from public.plan
+    where owner is not null
+  union distinct
+    select updated_by, 'user' from public.plan
+    where updated_by is not null
+  on conflict (username) do nothing;
+
+alter table public.plan
+  add constraint plan_owner_exists
+    foreign key (owner)
+    references metadata.users
+    on update cascade
+    on delete set null,
+  add constraint plan_updated_by_exists
+    foreign key (updated_by)
+    references metadata.users
+    on update cascade
+    on delete set null;
+
+-- PLAN COLLABORATORS
+delete from public.plan_collaborators
+  where collaborator = '';
+
+insert into metadata.users(username, default_role)
+    select collaborator, 'user' from public.plan_collaborators
+  on conflict (username) do nothing;
+
+alter table public.plan_collaborators
+  add constraint plan_collaborator_collaborator_fkey
+    foreign key (collaborator) references metadata.users
+    on update cascade
+    on delete cascade;
+
+-- SIMULATION DATASET
+alter table simulation_dataset
+  alter column requested_by drop not null,
+  alter column requested_by drop default;
+
+update simulation_dataset
+  set requested_by = null
+  where requested_by = '';
+
+insert into metadata.users(username, default_role)
+    select requested_by, 'user' from public.simulation_dataset
+    where requested_by is not null
+  on conflict (username) do nothing;
+
+alter table simulation_dataset
+  add constraint simulation_dataset_requested_by_exists
+    foreign key (requested_by) references metadata.users
+    on update cascade
+    on delete set null;
+
+-- SIMULATION TEMPLATE
+alter table public.simulation_template
+  alter column owner drop not null,
+  alter column owner drop default;
+
+update simulation_template
+  set owner = null
+  where owner = '';
+
+insert into metadata.users(username, default_role)
+    select owner, 'user' from public.simulation_template
+    where owner is not null
+  on conflict (username) do nothing;
+
+alter table public.simulation_template
+  add constraint simulation_template_owner_exists
+    foreign key (owner)
+    references metadata.users
+    on update cascade
+    on delete set null;
+
+-- MERGE REQUEST COMMENT
+comment on column merge_request_comment.commenter_username is null;
+
+alter table public.merge_request_comment
+  alter column commenter_username drop not null,
+  alter column commenter_username drop default;
+
+update public.merge_request_comment
+  set commenter_username = null
+  where commenter_username = '';
+
+insert into metadata.users(username, default_role)
+    select commenter_username, 'user' from public.merge_request_comment
+    where not commenter_username is not null
+  on conflict (username) do nothing;
+
+alter table public.merge_request_comment
+  add constraint merge_request_commenter_exists
+    foreign key (commenter_username)
+    references metadata.users
+    on update cascade
+    on delete set null;
+
+comment on column merge_request_comment.commenter_username is e''
+  'The user who left this comment.';
+
+-- MERGE REQUEST
+comment on column merge_request.requester_username is null;
+comment on column merge_request.reviewer_username is null;
+
+alter table public.merge_request
+  alter column requester_username drop not null,
+  alter column requester_username drop default;
+update public.merge_request mr
+  set requester_username = null
+  where requester_username = '';
+
+insert into metadata.users(username, default_role)
+    select requester_username, 'user' from public.merge_request
+    where not requester_username = ''
+  union distinct
+    select reviewer_username, 'user' from public.merge_request
+    where not reviewer_username = ''
+  on conflict (username) do nothing;
+
+alter table public.merge_request
+  add constraint merge_request_requester_exists
+    foreign key (requester_username)
+    references metadata.users
+    on update cascade
+    on delete set null,
+  add constraint merge_request_reviewer_exists
+    foreign key (reviewer_username)
+    references metadata.users
+    on update cascade
+    on delete set null;
+
+comment on column merge_request.requester_username is e''
+  'The user who created this merge request.';
+comment on column merge_request.reviewer_username is e''
+  'The user who reviews this merge request. Is empty until the request enters review.';
+
+-- UPDATE USERS ALLOWED ROLES
+insert into metadata.users_allowed_roles(username, allowed_role)
+  select u.username, roles.role
+  from metadata.users u cross join (values ('user'), ('viewer')) roles(role);
 -- ADD SYSTEM USERS
 insert into metadata.users(username, default_role)
   values ('Mission Model', 'viewer'),

--- a/deployment/hasura/migrations/AerieScheduler/9_users/down.sql
+++ b/deployment/hasura/migrations/AerieScheduler/9_users/down.sql
@@ -1,0 +1,10 @@
+-- Scheduling Request
+alter table scheduling_request
+  alter column requested_by set default '';
+update scheduling_request
+  set requested_by = default
+  where requested_by is null;
+alter table scheduling_request
+  alter column requested_by set not null;
+
+call migrations.mark_migration_rolled_back('9');

--- a/deployment/hasura/migrations/AerieScheduler/9_users/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/9_users/up.sql
@@ -1,0 +1,9 @@
+-- Scheduling Request
+alter table scheduling_request
+  alter column requested_by drop not null,
+  alter column requested_by drop default;
+update scheduling_request
+  set requested_by = null
+  where requested_by = '';
+
+call migrations.mark_migration_applied('9');

--- a/deployment/hasura/migrations/AerieSequencing/6_users/down.sql
+++ b/deployment/hasura/migrations/AerieSequencing/6_users/down.sql
@@ -1,0 +1,43 @@
+-- Expansion Rule
+alter table expansion_rule
+  alter column updated_by set default '',
+  alter column owner set default '';
+update expansion_rule
+  set updated_by = default
+  where updated_by is null;
+update expansion_rule
+  set owner = default
+  where owner is null;
+alter table expansion_rule
+  alter column updated_by set not null,
+  alter column owner set not null;
+
+-- Expansion Set
+alter table expansion_set
+  alter column updated_by set default '',
+  alter column owner set default '';
+update expansion_set
+  set updated_by = default
+  where updated_by is null;
+update expansion_set
+  set owner = default
+  where owner is null;
+alter table expansion_set
+  alter column updated_by set not null,
+  alter column owner set not null;
+
+-- User Sequence
+comment on column user_sequence.owner is null;
+
+alter table user_sequence
+  alter column owner set default 'unknown';
+update user_sequence
+  set owner = default
+  where owner is null;
+alter table user_sequence
+  alter column owner set not null;
+
+comment on column user_sequence.owner is e''
+  'Username of the user sequence owner.';
+
+call migrations.mark_migration_rolled_back('6');

--- a/deployment/hasura/migrations/AerieSequencing/6_users/up.sql
+++ b/deployment/hasura/migrations/AerieSequencing/6_users/up.sql
@@ -1,0 +1,40 @@
+-- User Sequence
+comment on column user_sequence.owner is null;
+
+alter table user_sequence
+  alter column owner drop not null,
+  alter column owner drop default;
+update user_sequence
+  set owner = null
+  where owner = 'unknown';
+
+comment on column user_sequence.owner is e''
+  'The user responsible for this sequence.';
+
+-- Expansion Set
+alter table expansion_set
+  alter column owner drop not null,
+  alter column owner drop default,
+  alter column updated_by drop not null,
+  alter column updated_by drop default;
+update expansion_set
+  set owner = null
+  where owner = '';
+update expansion_set
+  set updated_by = null
+  where updated_by = '';
+
+-- Expansion Rule
+alter table expansion_rule
+  alter column owner drop not null,
+  alter column owner drop default,
+  alter column updated_by drop not null,
+  alter column updated_by drop default;
+update expansion_rule
+  set owner = null
+  where owner = '';
+update expansion_rule
+  set updated_by = null
+  where updated_by = '';
+
+call migrations.mark_migration_applied('6');

--- a/deployment/hasura/migrations/AerieUI/1_users/down.sql
+++ b/deployment/hasura/migrations/AerieUI/1_users/down.sql
@@ -1,0 +1,12 @@
+comment on column view.owner is null;
+alter table view
+  alter column owner set default 'system';
+update view
+  set owner = default
+  where owner is null;
+alter table view
+  alter column owner set not null;
+comment on column view.owner is e''
+  'Username of the view owner.';
+
+call migrations.mark_migration_rolled_back('1');

--- a/deployment/hasura/migrations/AerieUI/1_users/up.sql
+++ b/deployment/hasura/migrations/AerieUI/1_users/up.sql
@@ -1,0 +1,11 @@
+comment on column view.owner is null;
+alter table view
+  alter column owner drop not null,
+  alter column owner drop default;
+update view
+  set owner = null
+  where owner = 'system';
+comment on column view.owner is e''
+  'The user who owns the view.';
+
+call migrations.mark_migration_applied('1');

--- a/deployment/postgres-init-db/sql/ui/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/ui/applied_migrations.sql
@@ -3,3 +3,4 @@ This file denotes which migrations occur "before" this version of the schema.
 */
 
 call migrations.mark_migration_applied('0');
+call migrations.mark_migration_applied('1');

--- a/deployment/postgres-init-db/sql/ui/tables/view.sql
+++ b/deployment/postgres-init-db/sql/ui/tables/view.sql
@@ -3,7 +3,7 @@ create table view (
   definition jsonb not null,
   id integer generated always as identity,
   name text not null,
-  owner text not null default 'system',
+  owner text,
   updated_at timestamptz not null default now(),
 
   constraint view_primary_key primary key (id)
@@ -20,7 +20,7 @@ comment on column view.id is e''
 comment on column view.name is e''
   'Human-readable name of the view.';
 comment on column view.owner is e''
-  'Username of the view owner.';
+  'The user who owns the view.';
 comment on column view.updated_at is e''
   'Time the view was last updated.';
 

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -21,3 +21,4 @@ call migrations.mark_migration_applied('15');
 call migrations.mark_migration_applied('16');
 call migrations.mark_migration_applied('17');
 call migrations.mark_migration_applied('18');
+call migrations.mark_migration_applied('19');

--- a/merlin-server/sql/merlin/init.sql
+++ b/merlin-server/sql/merlin/init.sql
@@ -14,6 +14,9 @@ begin;
   \ir domain-types/plan-merge-types.sql
 
   -- Deployment-level Metadata
+  \ir tables/metadata/user_roles.sql
+  \ir tables/metadata/users.sql
+  \ir tables/metadata/users_allowed_roles.sql
   \ir tables/metadata/tags.sql
 
   -- Activity Directive Metadata schema
@@ -78,6 +81,7 @@ begin;
   \ir tables/metadata/snapshot_activity_tags.sql
 
   -- Views
+  \ir views/users_and_roles.sql
   \ir views/simulated_activity.sql
   \ir views/resource_profile.sql
   \ir views/activity_directive_extended.sql

--- a/merlin-server/sql/merlin/tables/activity_presets.sql
+++ b/merlin-server/sql/merlin/tables/activity_presets.sql
@@ -4,12 +4,16 @@ create table activity_presets(
   name text not null,
   associated_activity_type text not null,
   arguments merlin_argument_set not null,
-  owner text not null default '',
+  owner text,
 
   foreign key (model_id, associated_activity_type)
     references activity_type
     on delete cascade,
-  unique (model_id, associated_activity_type, name)
+  unique (model_id, associated_activity_type, name),
+  constraint activity_presets_owner_exists
+    foreign key (owner) references metadata.users
+    on update cascade
+    on delete set null
 );
 
 comment on table activity_presets is e''

--- a/merlin-server/sql/merlin/tables/constraint.sql
+++ b/merlin-server/sql/merlin/tables/constraint.sql
@@ -11,11 +11,21 @@ create table "constraint" (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
 
-  owner text not null default '',
-  updated_by text not null default '',
+  owner text,
+  updated_by text,
 
   constraint constraint_synthetic_key
     primary key (id),
+  constraint constraint_owner_exists
+    foreign key (owner)
+    references metadata.users
+    on update cascade
+    on delete set null,
+  constraint constraint_updated_by_exists
+    foreign key (updated_by)
+    references metadata.users
+    on update cascade
+    on delete set null,
   constraint constraint_scoped_to_plan
     foreign key (plan_id)
     references plan

--- a/merlin-server/sql/merlin/tables/merge_comments.sql
+++ b/merlin-server/sql/merlin/tables/merge_comments.sql
@@ -1,13 +1,18 @@
 create table merge_request_comment(
   comment_id integer generated always as identity primary key,
   merge_request_id integer,
-  commenter_username text not null default '',
+  commenter_username text,
   comment_text text not null,
 
   constraint comment_owned_by_merge_request
     foreign key (merge_request_id)
     references merge_request
-    on delete cascade
+    on delete cascade,
+  constraint merge_request_commenter_exists
+    foreign key (commenter_username)
+    references metadata.users
+    on update cascade
+    on delete set null
 );
 
 comment on table merge_request_comment is e''
@@ -17,7 +22,7 @@ comment on column merge_request_comment.comment_id is e''
 comment on column merge_request_comment.merge_request_id is e''
   'The id of the merge request associated with this comment.';
 comment on column merge_request_comment.commenter_username is e''
-  'The username of the user who left this comment.';
+  'The user who left this comment.';
 comment on column merge_request_comment.comment_text is e''
   'The contents of this comment.';
 

--- a/merlin-server/sql/merlin/tables/merge_request.sql
+++ b/merlin-server/sql/merlin/tables/merge_request.sql
@@ -5,8 +5,18 @@ create table merge_request(
       snapshot_id_supplying_changes integer,
       merge_base_snapshot_id integer not null,
       status merge_request_status default 'pending',
-      requester_username text not null,
-      reviewer_username text
+      requester_username text,
+      reviewer_username text,
+      constraint merge_request_requester_exists
+        foreign key (requester_username)
+        references metadata.users
+        on update cascade
+        on delete set null,
+      constraint merge_request_reviewer_exists
+        foreign key (reviewer_username)
+        references metadata.users
+        on update cascade
+        on delete set null
 );
 
 comment on table merge_request is e''
@@ -26,6 +36,6 @@ comment on column merge_request.merge_base_snapshot_id is e''
 comment on column merge_request.status is e''
   'The current status of this merge request.';
 comment on column merge_request.requester_username is e''
-  'The username of the user who created this merge request.';
+  'The user who created this merge request.';
 comment on column merge_request.reviewer_username is e''
-  'The username of the user who reviews this merge request. Is empty until the request enters review.';
+  'The user who reviews this merge request. Is empty until the request enters review.';

--- a/merlin-server/sql/merlin/tables/metadata/tags.sql
+++ b/merlin-server/sql/merlin/tables/metadata/tags.sql
@@ -3,11 +3,15 @@ create table metadata.tags(
     primary key,
   name text not null unique,
   color text null,
-  owner text not null default '',
+  owner text,
   created_at timestamptz not null default now(),
 
   constraint color_is_hex_format
-    check (color is null or color ~* '^#[a-f0-9]{6}$' )
+    check (color is null or color ~* '^#[a-f0-9]{6}$' ),
+  constraint tags_owner_exists
+    foreign key (owner) references metadata.users
+    on update cascade
+    on delete set null
 );
 
 comment on table metadata.tags is e''

--- a/merlin-server/sql/merlin/tables/metadata/user_roles.sql
+++ b/merlin-server/sql/merlin/tables/metadata/user_roles.sql
@@ -1,0 +1,9 @@
+-- This table is an enum-compatible table (https://hasura.io/docs/latest/schema/postgres/enums/#pg-create-enum-table)
+create table metadata.user_roles(
+  role text primary key,
+  description text null
+);
+insert into metadata.user_roles(role) values ('admin'), ('user'), ('viewer');
+
+comment on table metadata.user_roles is e''
+  'A list of all the allowed Hasura roles, with an optional description per role';

--- a/merlin-server/sql/merlin/tables/metadata/users.sql
+++ b/merlin-server/sql/merlin/tables/metadata/users.sql
@@ -1,0 +1,18 @@
+create table metadata.users(
+  username text not null primary key,
+  default_role text not null references metadata.user_roles
+    on update cascade
+    on delete restrict
+);
+-- Insert the default roles into the table, then change the generated status to "Always"
+-- This can be changed back if we need to add more default users in the future
+insert into metadata.users(username, default_role)
+  values ('Mission Model', 'viewer'),
+         ('Aerie Legacy', 'viewer');
+
+comment on table metadata.users is e''
+'All users recognized by this deployment.';
+comment on column metadata.users.username is e''
+'The user''s username. A unique identifier for this user.';
+comment on column metadata.users.default_role is e''
+'The user''s default role for making Hasura requests.';

--- a/merlin-server/sql/merlin/tables/metadata/users_allowed_roles.sql
+++ b/merlin-server/sql/merlin/tables/metadata/users_allowed_roles.sql
@@ -1,0 +1,16 @@
+create table metadata.users_allowed_roles(
+  username text references metadata.users
+    on update cascade
+    on delete cascade,
+  allowed_role text not null references metadata.user_roles
+    on update cascade
+    on delete cascade,
+
+  primary key (username, allowed_role),
+
+  constraint system_roles_have_no_allowed_roles
+    check (username != 'Mission Model' and username != 'Aerie Legacy' )
+);
+
+comment on table metadata.users_allowed_roles is e''
+'An association between a user and all of the roles they are allowed to use for Hasura requests';

--- a/merlin-server/sql/merlin/tables/mission_model.sql
+++ b/merlin-server/sql/merlin/tables/mission_model.sql
@@ -20,7 +20,11 @@ create table mission_model (
     foreign key (jar_id)
     references uploaded_file
     on update cascade
-    on delete restrict
+    on delete restrict,
+  constraint mission_model_owner_exists
+    foreign key (owner) references metadata.users
+    on update cascade
+    on delete set null
 );
 
 comment on table mission_model is e''

--- a/merlin-server/sql/merlin/tables/plan.sql
+++ b/merlin-server/sql/merlin/tables/plan.sql
@@ -16,8 +16,8 @@ create table plan (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
 
-  owner text not null default '',
-  updated_by text not null default '',
+  owner text,
+  updated_by text,
 
   constraint plan_synthetic_key
     primary key (id),
@@ -26,6 +26,16 @@ create table plan (
   constraint plan_uses_model
     foreign key (model_id)
     references mission_model
+    on update cascade
+    on delete set null,
+  constraint plan_owner_exists
+    foreign key (owner)
+    references metadata.users
+    on update cascade
+    on delete set null,
+  constraint plan_updated_by_exists
+    foreign key (updated_by)
+    references metadata.users
     on update cascade
     on delete set null
 );

--- a/merlin-server/sql/merlin/tables/plan_collaborators.sql
+++ b/merlin-server/sql/merlin/tables/plan_collaborators.sql
@@ -7,7 +7,11 @@ create table plan_collaborators(
   constraint plan_collaborators_plan_id_fkey
     foreign key (plan_id) references plan
     on update cascade
-    on delete cascade
+    on delete cascade,
+  constraint plan_collaborator_collaborator_fkey
+    foreign key (collaborator) references metadata.users
+        on update cascade
+        on delete cascade
 );
 
 comment on table plan_collaborators is e''

--- a/merlin-server/sql/merlin/tables/simulation_dataset.sql
+++ b/merlin-server/sql/merlin/tables/simulation_dataset.sql
@@ -28,7 +28,7 @@ create table simulation_dataset (
   canceled boolean not null default false,
 
   -- Additional Metadata
-  requested_by text not null default '',
+  requested_by text,
   requested_at timestamptz not null default now(),
 
   constraint simulation_dataset_synthetic_key
@@ -45,6 +45,10 @@ create table simulation_dataset (
     references dataset
     on update cascade
     on delete cascade,
+  constraint simulation_dataset_requested_by_exists
+    foreign key (requested_by) references metadata.users
+    on update cascade
+    on delete set null,
   constraint start_before_end
     check (simulation_start_time <= simulation_end_time)
 );

--- a/merlin-server/sql/merlin/tables/simulation_template.sql
+++ b/merlin-server/sql/merlin/tables/simulation_template.sql
@@ -5,7 +5,7 @@ create table simulation_template (
   model_id integer not null,
   description text not null default '',
   arguments merlin_argument_set not null,
-  owner text not null default '',
+  owner text,
 
   constraint simulation_template_synthetic_key
     primary key (id),
@@ -13,7 +13,12 @@ create table simulation_template (
     foreign key (model_id)
     references mission_model
     on update cascade
-    on delete cascade
+    on delete cascade,
+  constraint simulation_template_owner_exists
+    foreign key (owner)
+    references metadata.users
+    on update cascade
+    on delete set null
 );
 
 comment on table simulation_template is e''

--- a/merlin-server/sql/merlin/views/users_and_roles.sql
+++ b/merlin-server/sql/merlin/views/users_and_roles.sql
@@ -1,0 +1,14 @@
+create view metadata.users_and_roles as
+(
+  select
+    u.username as username,
+    -- Roles
+    u.default_role as hasura_default_role,
+    array_agg(r.allowed_role) filter (where r.allowed_role is not null) as hasura_allowed_roles
+  from metadata.users u
+  left join metadata.users_allowed_roles r using (username)
+  group by u.username
+);
+
+comment on view metadata.users_and_roles is e''
+'View a user''s information with their role information';

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -11,3 +11,4 @@ call migrations.mark_migration_applied('5');
 call migrations.mark_migration_applied('6');
 call migrations.mark_migration_applied('7');
 call migrations.mark_migration_applied('8');
+call migrations.mark_migration_applied('9');

--- a/scheduler-server/sql/scheduler/tables/scheduling_request.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_request.sql
@@ -3,7 +3,7 @@ create type status_t as enum('pending', 'incomplete', 'failed', 'success');
 create table scheduling_request (
   specification_id integer not null,
   analysis_id integer generated always as identity,
-  requested_by text not null default  '',
+  requested_by text,
   requested_at timestamptz not null default now(),
 
   status status_t not null default 'pending',

--- a/sequencing-server/sql/sequencing/applied_migrations.sql
+++ b/sequencing-server/sql/sequencing/applied_migrations.sql
@@ -8,3 +8,4 @@ call migrations.mark_migration_applied('2');
 call migrations.mark_migration_applied('3');
 call migrations.mark_migration_applied('4');
 call migrations.mark_migration_applied('5');
+call migrations.mark_migration_applied('6');

--- a/sequencing-server/sql/sequencing/tables/expansion_rule.sql
+++ b/sequencing-server/sql/sequencing/tables/expansion_rule.sql
@@ -11,8 +11,8 @@ create table expansion_rule (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
 
-  owner text not null default '',
-  updated_by text not null default '',
+  owner text,
+  updated_by text,
 
   description text not null default '',
 

--- a/sequencing-server/sql/sequencing/tables/expansion_set.sql
+++ b/sequencing-server/sql/sequencing/tables/expansion_set.sql
@@ -9,8 +9,8 @@ create table expansion_set (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
 
-  owner text not null default '',
-  updated_by text not null default '',
+  owner text,
+  updated_by text,
 
   constraint expansion_set_unique_name_per_dict_and_model
     unique (mission_model_id, command_dict_id, name),

--- a/sequencing-server/sql/sequencing/tables/user_sequence.sql
+++ b/sequencing-server/sql/sequencing/tables/user_sequence.sql
@@ -4,7 +4,7 @@ create table user_sequence (
   definition text not null,
   id integer generated always as identity,
   name text not null,
-  owner text not null default 'unknown',
+  owner text,
   updated_at timestamptz not null default now(),
 
   constraint user_sequence_primary_key primary key (id)
@@ -21,7 +21,7 @@ comment on column user_sequence.id is e''
 comment on column user_sequence.name is e''
   'Human-readable name of the user sequence.';
 comment on column user_sequence.owner is e''
-  'Username of the user sequence owner.';
+  'The user responsible for this sequence.';
 comment on column user_sequence.updated_at is e''
   'Time the user sequence was last updated.';
 


### PR DESCRIPTION
* **Tickets addressed:** Closes #938
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

Three tables and a view have been added to Merlin: 
- `user_roles`, which contains all the valid roles and optionally a description. By default, it contains `user`, `admin`, and `viewer`
- `users`, which by default has the "users" `Mission Model` and `Aerie Legacy`. This table also specifies the default role for each user, however no one with the `user` role may select this column, as the current user may only see _their_ default_role, [but the `user` role more pressingly needed to be able to select the `id` and `username` of all users](https://github.com/hasura/graphql-engine/issues/3442).
- `user_allowed_roles`, which contains all the roles a user may use for querying Hasura
- `user_and_roles`, which is a view that collects the role information for each user. This is what I recommend get queried for getting Hasura role information

Foreign key relationships have been established between Merlin tables and the the `users` table where applicable. Additionally, all instances along the lines of `owner text not null default ''` have been replaced with `owner text` columns, with existing `default` values getting replaced with `null`.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
The DBTests now insert the users that they will need as part of their `beforeAll` tasks. The users that are used in `MerlinDatabaseTestHelper` methods are now inserted as part of the class's constructor.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
