### PR TITLE
Add missing columns to hasura permissions

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan_dataset.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan_dataset.yaml
@@ -11,12 +11,12 @@ object_relationships:
 select_permissions:
   - role: user
     permission:
-      columns: [plan_id, dataset_id, offset_from_plan_start]
+      columns: [plan_id, dataset_id, offset_from_plan_start, simulation_dataset_id]
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [plan_id, dataset_id, offset_from_plan_start]
+      columns: [plan_id, dataset_id, offset_from_plan_start, simulation_dataset_id]
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_span.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_span.yaml
@@ -26,11 +26,11 @@ array_relationships:
 select_permissions:
   - role: user
     permission:
-      columns: [id, dataset_id, parent_id, start_offset, type, attributes]
+      columns: [id, duration, dataset_id, parent_id, start_offset, type, attributes]
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, dataset_id, parent_id, start_offset, type, attributes]
+      columns: [id, duration, dataset_id, parent_id, start_offset, type, attributes]
       filter: {}
       allow_aggregations: true

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_command_dictionary.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_command_dictionary.yaml
@@ -12,11 +12,11 @@ array_relationships:
 select_permissions:
   - role: user
     permission:
-      columns: [id, command_types_typescript_path, mission, version, created_at]
+      columns: [id, command_types_typescript_path, mission, version, created_at, parsed_json]
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, command_types_typescript_path, mission, version, created_at]
+      columns: [id, command_types_typescript_path, mission, version, created_at, parsed_json]
       filter: {}
       allow_aggregations: true

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_sequence.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_sequence.yaml
@@ -25,18 +25,18 @@ remote_relationships:
 select_permissions:
   - role: user
     permission:
-      columns: [seq_id, simulation_dataset_id, created_at]
+      columns: [seq_id, simulation_dataset_id, created_at, metadata]
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [seq_id, simulation_dataset_id, created_at]
+      columns: [seq_id, simulation_dataset_id, created_at, metadata]
       filter: {}
       allow_aggregations: true
 insert_permissions:
   - role: user
     permission:
-      columns: [seq_id, simulation_dataset_id, created_at]
+      columns: [seq_id, simulation_dataset_id, created_at, metadata]
       check: {}
 delete_permissions:
   - role: user


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
When manually testing simulation permissions with @Mythicaeda and @skovati , we noticed that the "user" role was missing select permissions on the span "duration" column.

We did a survey of the other permissions and added any missing columns we found.

We included `metadata` in sequence insert permissions because otherwise it would always be null.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Restarting hasura showed no inconsistent metadata.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No documentation was updated - these permissions are consistent with the default permissions laid out in #983 (pending more up-to-date permissions from https://docs.google.com/document/d/1sCIH2AhNDf6LXsSr6il44l_E4QFk3-ykH5SRPqGbdlw/edit)

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None
