### PR TITLE
Shift operation for profiles

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
@@ -74,6 +74,18 @@ public final class ConstraintParsers {
         );
   }
 
+  static <P extends Profile<P>> JsonParser<ShiftBy<P>> shiftByF(final JsonParser<Expression<P>> profileParser) {
+    return productP
+        .field("kind", literalP("ProfileExpressionShiftBy"))
+        .field("expression", profileParser)
+        .field("duration", durationExprP)
+        .map(
+            untuple((kind, expression, duration) -> new ShiftBy<>(expression, duration)),
+            $ -> tuple(Unit.UNIT, $.expression(), $.duration())
+        );
+  }
+
+
   static final JsonParser<DiscreteResource> discreteResourceP =
       productP
           .field("kind", literalP("DiscreteProfileResource"))
@@ -106,6 +118,7 @@ public final class ConstraintParsers {
         discreteValueP,
         discreteParameterP,
         assignGapsF(selfP),
+        shiftByF(selfP),
         valueAtExpressionF(profileExpressionP, spansExpressionP),
         listExpressionF(profileExpressionP),
         structExpressionF(profileExpressionP)
@@ -206,6 +219,7 @@ public final class ConstraintParsers {
         timesF(selfP),
         rateF(selfP),
         assignGapsF(selfP),
+        shiftByF(selfP),
         accumulatedDurationF(windowsP),
         accumulatedDurationF(spansP)
     ));
@@ -288,14 +302,14 @@ public final class ConstraintParsers {
               $ -> tuple(Unit.UNIT, $.value(), $.interval())
           );
 
-  static JsonParser<ShiftBy> shiftByF(JsonParser<Expression<Windows>> windowsExpressionP) {
+  static JsonParser<ShiftWindowsEdges> shiftWindowsEdgesF(JsonParser<Expression<Windows>> windowsExpressionP) {
     return productP
         .field("kind", literalP("WindowsExpressionShiftBy"))
         .field("windowExpression", windowsExpressionP)
         .field("fromStart", durationExprP)
         .field("fromEnd", durationExprP)
         .map(
-            untuple((kind, windowsExpression, fromStart, fromEnd) -> new ShiftBy(windowsExpression, fromStart, fromEnd)),
+            untuple((kind, windowsExpression, fromStart, fromEnd) -> new ShiftWindowsEdges(windowsExpression, fromStart, fromEnd)),
             $ -> tuple(Unit.UNIT, $.windows, $.fromStart, $.fromEnd));
   }
   static final JsonParser<EndOf> endOfP =
@@ -515,12 +529,13 @@ public final class ConstraintParsers {
         andF(selfP),
         orF(selfP),
         notF(selfP),
-        shiftByF(selfP),
+        shiftWindowsEdgesF(selfP),
         startsF(selfP),
         endsF(selfP),
         windowsFromSpansF(spansP),
         activityWindowP,
-        assignGapsF(selfP)
+        assignGapsF(selfP),
+        shiftByF(selfP)
     ));
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfile.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/DiscreteProfile.java
@@ -121,6 +121,19 @@ public final class DiscreteProfile implements Profile<DiscreteProfile>, Iterable
   }
 
   @Override
+  public DiscreteProfile shiftBy(final Duration duration) {
+    final var builder = IntervalMap.<SerializedValue>builder();
+
+    for (final var segment : this.profilePieces) {
+      final var interval = segment.interval();
+      final var shiftedInterval = interval.shiftBy(duration);
+
+      builder.set(Segment.of(shiftedInterval, segment.value()));
+    }
+    return new DiscreteProfile(builder.build());
+  }
+
+  @Override
   public Optional<SerializedValue> valueAt(final Duration timepoint) {
     final var matchPiece = profilePieces
         .stream()

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/LinearProfile.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/LinearProfile.java
@@ -156,6 +156,25 @@ public final class LinearProfile implements Profile<LinearProfile>, Iterable<Seg
         .map(linearEquationSegment -> SerializedValue.of(linearEquationSegment.value().valueAt(timepoint)));
   }
 
+  @Override
+  public LinearProfile shiftBy(final Duration duration) {
+    final var builder = IntervalMap.<LinearEquation>builder();
+
+    for (final var segment : this.profilePieces) {
+      final var interval = segment.interval();
+      final var shiftedInterval = interval.shiftBy(duration);
+
+      final var shiftedValue = new LinearEquation(
+          segment.value().initialTime.saturatingPlus(duration),
+          segment.value().initialValue,
+          segment.value().rate
+      );
+
+      builder.set(Segment.of(shiftedInterval, shiftedValue));
+    }
+    return new LinearProfile(builder.build());
+  }
+
   public static LinearProfile fromSimulatedProfile(final List<ProfileSegment<RealDynamics>> simulatedProfile) {
     return fromProfileHelper(Duration.ZERO, simulatedProfile, Optional::of);
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/Profile.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/Profile.java
@@ -13,6 +13,7 @@ public interface Profile<P extends Profile<P>> {
   boolean isConstant();
 
   P assignGaps(P def);
+  P shiftBy(Duration duration);
 
   Optional<SerializedValue> valueAt(Duration timepoint);
 }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Interval.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Interval.java
@@ -148,6 +148,15 @@ public final class Interval implements Comparable<Interval>{
         this.start == this.end;
   }
 
+  public Interval shiftBy(final Duration duration) {
+    return Interval.between(
+        this.start.saturatingPlus(duration),
+        this.startInclusivity,
+        this.end.saturatingPlus(duration),
+        this.endInclusivity
+    );
+  }
+
   public Duration duration() {
     if (this.isEmpty()) return Duration.ZERO;
     return this.end.minus(this.start);

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
@@ -342,7 +342,7 @@ public final class Windows implements Iterable<Segment<Boolean>>, IntervalContai
    * @param fromEnd duration to shift true -> false falling edges
    * @return a new Windows
    */
-  public Windows shiftBy(Duration fromStart, Duration fromEnd) {
+  public Windows shiftEdges(Duration fromStart, Duration fromEnd) {
     final var builder = IntervalMap.<Boolean>builder();
 
     for (final var segment : this.segments) {
@@ -361,6 +361,11 @@ public final class Windows implements Iterable<Segment<Boolean>>, IntervalContai
       builder.set(Segment.of(shiftedInterval, segment.value()));
     }
     return new Windows(builder.build());
+  }
+
+  @Override
+  public Windows shiftBy(Duration duration) {
+    return this.shiftEdges(duration, duration);
   }
 
   /**

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ActivityWindow.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ActivityWindow.java
@@ -20,7 +20,7 @@ public final class ActivityWindow implements Expression<Windows> {
   public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var activity = environment.activityInstances().get(this.activityAlias);
     return new Windows(
-        Segment.of(Interval.FOREVER, false),
+        Segment.of(bounds, false),
         Segment.of(activity.interval, true)
     );
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteParameter.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteParameter.java
@@ -22,7 +22,7 @@ public final class DiscreteParameter implements Expression<DiscreteProfile> {
   public DiscreteProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var activity = environment.activityInstances().get(this.activityAlias);
     return new DiscreteProfile(
-        Segment.of(Interval.FOREVER, activity.parameters.get(this.parameterName))
+        Segment.of(bounds, activity.parameters.get(this.parameterName))
     );
   }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteProfileFromDuration.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/DiscreteProfileFromDuration.java
@@ -18,7 +18,7 @@ public record DiscreteProfileFromDuration(
   @Override
   public DiscreteProfile evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final Duration duration = this.duration.evaluate(results, bounds, environment);
-    return new DiscreteProfile(Segment.of(Interval.FOREVER, SerializedValue.of(duration.in(Duration.MICROSECOND))));
+    return new DiscreteProfile(Segment.of(bounds, SerializedValue.of(duration.in(Duration.MICROSECOND))));
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/EndOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/EndOf.java
@@ -20,7 +20,7 @@ public final class EndOf implements Expression<Windows> {
   public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var activity = environment.activityInstances().get(this.activityAlias);
     return new Windows(
-        Segment.of(Interval.FOREVER, false),
+        Segment.of(bounds, false),
         Segment.of(Interval.at(activity.interval.end), true)
     );
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShiftBy.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShiftBy.java
@@ -1,59 +1,38 @@
 package gov.nasa.jpl.aerie.constraints.tree;
 
 import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
+import gov.nasa.jpl.aerie.constraints.model.Profile;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
-import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
-import java.util.Objects;
 import java.util.Set;
 
-public final class ShiftBy implements Expression<Windows> {
-  public final Expression<Windows> windows;
-  public final Expression<Duration> fromStart;
-  public final Expression<Duration> fromEnd;
-
-  public ShiftBy(final Expression<Windows> left, final Expression<Duration> fromStart, final Expression<Duration> fromEnd) {
-    this.windows = left;
-    this.fromStart = fromStart;
-    this.fromEnd = fromEnd;
-  }
+public record ShiftBy<P extends Profile<P>>(
+    Expression<P> expression,
+    Expression<Duration> duration) implements Expression<P> {
 
   @Override
-  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var windows = this.windows.evaluate(results, bounds, environment);
-    return windows.shiftBy(this.fromStart.evaluate(results, bounds, environment), this.fromEnd.evaluate(results, bounds, environment));
+  public P evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+    final var originalProfile = this.expression.evaluate(results, bounds, environment);
+    final var duration = this.duration.evaluate(results, bounds, environment);
+
+    return originalProfile.shiftBy(duration);
   }
 
   @Override
   public void extractResources(final Set<String> names) {
-    this.windows.extractResources(names);
+    this.expression.extractResources(names);
+    this.duration.extractResources(names);
   }
 
   @Override
   public String prettyPrint(final String prefix) {
     return String.format(
-        "\n%s(shift %s by %s %s)",
+        "\n%s(shiftBy %s %s)",
         prefix,
-        this.windows.prettyPrint(prefix + "  "),
-        this.fromStart.toString(),
-        this.fromEnd.toString()
+        this.expression.prettyPrint(prefix + "  "),
+        this.duration.prettyPrint(prefix + "  ")
     );
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (!(obj instanceof ShiftBy)) return false;
-    final var o = (ShiftBy)obj;
-
-    return Objects.equals(this.windows, o.windows) &&
-           Objects.equals(this.fromStart, o.fromStart) &&
-           Objects.equals(this.fromEnd, o.fromEnd);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.windows, this.fromStart, this.fromEnd);
   }
 }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShiftBy.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShiftBy.java
@@ -14,8 +14,11 @@ public record ShiftBy<P extends Profile<P>>(
 
   @Override
   public P evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var originalProfile = this.expression.evaluate(results, bounds, environment);
+    // bounds aren't shifted here because duration expressions don't care about them; durations don't exist on the timeline.
     final var duration = this.duration.evaluate(results, bounds, environment);
+
+    final var shiftedBounds = bounds.shiftBy(Duration.negate(duration));
+    final var originalProfile = this.expression.evaluate(results, shiftedBounds, environment);
 
     return originalProfile.shiftBy(duration);
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShiftWindowsEdges.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShiftWindowsEdges.java
@@ -1,0 +1,59 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.util.Objects;
+import java.util.Set;
+
+public final class ShiftWindowsEdges implements Expression<Windows> {
+  public final Expression<Windows> windows;
+  public final Expression<Duration> fromStart;
+  public final Expression<Duration> fromEnd;
+
+  public ShiftWindowsEdges(final Expression<Windows> left, final Expression<Duration> fromStart, final Expression<Duration> fromEnd) {
+    this.windows = left;
+    this.fromStart = fromStart;
+    this.fromEnd = fromEnd;
+  }
+
+  @Override
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+    final var windows = this.windows.evaluate(results, bounds, environment);
+    return windows.shiftEdges(this.fromStart.evaluate(results, bounds, environment), this.fromEnd.evaluate(results, bounds, environment));
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {
+    this.windows.extractResources(names);
+  }
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return String.format(
+        "\n%s(shiftWindowsEdges %s by %s %s)",
+        prefix,
+        this.windows.prettyPrint(prefix + "  "),
+        this.fromStart.toString(),
+        this.fromEnd.toString()
+    );
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof ShiftWindowsEdges)) return false;
+    final var o = (ShiftWindowsEdges)obj;
+
+    return Objects.equals(this.windows, o.windows) &&
+           Objects.equals(this.fromStart, o.fromStart) &&
+           Objects.equals(this.fromEnd, o.fromEnd);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.windows, this.fromStart, this.fromEnd);
+  }
+}

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShiftWindowsEdges.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ShiftWindowsEdges.java
@@ -22,8 +22,18 @@ public final class ShiftWindowsEdges implements Expression<Windows> {
 
   @Override
   public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
-    final var windows = this.windows.evaluate(results, bounds, environment);
-    return windows.shiftEdges(this.fromStart.evaluate(results, bounds, environment), this.fromEnd.evaluate(results, bounds, environment));
+    final var shiftRising = this.fromStart.evaluate(results, bounds, environment);
+    final var shiftFalling = this.fromEnd.evaluate(results, bounds, environment);
+
+    final var newBounds = Interval.between(
+        Duration.min(bounds.start.minus(shiftRising), bounds.start.minus(shiftFalling)),
+        bounds.startInclusivity,
+        Duration.max(bounds.end.minus(shiftRising), bounds.end.minus(shiftFalling)),
+        bounds.endInclusivity
+    );
+
+    final var windows = this.windows.evaluate(results, newBounds, environment);
+    return windows.shiftEdges(shiftRising, shiftFalling).select(bounds);
   }
 
   @Override

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/StartOf.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/StartOf.java
@@ -20,7 +20,7 @@ public final class StartOf implements Expression<Windows> {
   public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final var activity = environment.activityInstances().get(this.activityAlias);
     return new Windows(
-        Segment.of(Interval.FOREVER, false),
+        Segment.of(bounds, false),
         Segment.of(Interval.at(activity.interval.start), true)
     );
   }

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/time/WindowsTest.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/time/WindowsTest.java
@@ -347,7 +347,7 @@ public class WindowsTest {
                                Segment.of(interval(14, Exclusive, 17, Exclusive, SECONDS), false),
                                Segment.of(at(Duration.MAX_VALUE), true)); //long overflow if at max value
 
-    Windows result = orig.shiftBy(Duration.of(-1, SECONDS), Duration.of(1, SECONDS));
+    Windows result = orig.shiftEdges(Duration.of(-1, SECONDS), Duration.of(1, SECONDS));
 
 
     Windows expected = new Windows(
@@ -392,7 +392,7 @@ public class WindowsTest {
         .set(interval(0, 2, SECONDS), true)
         .set(interval(8, 10, SECONDS), true);
 
-    var fromStartPosFromEndPos = orig.shiftBy(Duration.of(-1, SECONDS), Duration.of(1, SECONDS));
+    var fromStartPosFromEndPos = orig.shiftEdges(Duration.of(-1, SECONDS), Duration.of(1, SECONDS));
     assertIterableEquals(
         new Windows(interval(0, 10, SECONDS), false)
             .set(interval(-1, 3, SECONDS), true)
@@ -400,7 +400,7 @@ public class WindowsTest {
         fromStartPosFromEndPos
     );
 
-    var fromStartPosFromEndNeg = orig.shiftBy(Duration.of(1, SECONDS), Duration.of(-1, SECONDS));
+    var fromStartPosFromEndNeg = orig.shiftEdges(Duration.of(1, SECONDS), Duration.of(-1, SECONDS));
     assertEquals(
         new Windows(interval(1, Exclusive, 9, Exclusive, SECONDS), false)
             .set(at(1, SECONDS), true)
@@ -408,7 +408,7 @@ public class WindowsTest {
         fromStartPosFromEndNeg
     );
 
-    var fromStartNegFromEndPos = orig.shiftBy(Duration.of(1, SECONDS), Duration.of(1, SECONDS));
+    var fromStartNegFromEndPos = orig.shiftEdges(Duration.of(1, SECONDS), Duration.of(1, SECONDS));
     assertEquals(
         new Windows(interval(1, 11, SECONDS), false)
             .set(interval(1, 3, SECONDS), true)
@@ -416,7 +416,7 @@ public class WindowsTest {
         fromStartNegFromEndPos
     );
 
-    var fromStartNegFromEndNeg = orig.shiftBy(Duration.of(-1, SECONDS), Duration.of(-1, SECONDS));
+    var fromStartNegFromEndNeg = orig.shiftEdges(Duration.of(-1, SECONDS), Duration.of(-1, SECONDS));
     assertEquals(
         new Windows(interval(-1, 9, SECONDS), false)
             .set(interval(-1, 1, SECONDS), true)
@@ -424,7 +424,7 @@ public class WindowsTest {
         fromStartNegFromEndNeg
     );
 
-    var removal = orig.shiftBy(Duration.of(0, SECONDS), Duration.of(-3, SECONDS));
+    var removal = orig.shiftEdges(Duration.of(0, SECONDS), Duration.of(-3, SECONDS));
     assertEquals(
         new Windows(interval(-1, Exclusive, 8, Exclusive, SECONDS), false),
         removal
@@ -437,19 +437,19 @@ public class WindowsTest {
         .set(at(0, SECONDS), true)
         .set(at(2, SECONDS), false);
 
-    var fromStartPosFromEndPos = orig.shiftBy(Duration.of(-1, SECONDS), Duration.of(1, SECONDS));
+    var fromStartPosFromEndPos = orig.shiftEdges(Duration.of(-1, SECONDS), Duration.of(1, SECONDS));
     assertIterableEquals(
         new Windows(interval(-1, 1, SECONDS), true),
         fromStartPosFromEndPos
     );
 
-    var fromStartPosFromEndNeg = orig.shiftBy(Duration.of(1, SECONDS), Duration.of(-1, SECONDS));
+    var fromStartPosFromEndNeg = orig.shiftEdges(Duration.of(1, SECONDS), Duration.of(-1, SECONDS));
     assertIterableEquals(
         new Windows(interval(1, 3, SECONDS), false),
         fromStartPosFromEndNeg
     );
 
-    var fromStartNegFromEndPos = orig.shiftBy(Duration.of(1, SECONDS), Duration.of(1, SECONDS));
+    var fromStartNegFromEndPos = orig.shiftEdges(Duration.of(1, SECONDS), Duration.of(1, SECONDS));
     assertIterableEquals(
         new Windows()
             .set(at(1, SECONDS), true)
@@ -457,7 +457,7 @@ public class WindowsTest {
         fromStartNegFromEndPos
     );
 
-    var fromStartNegFromEndNeg = orig.shiftBy(Duration.of(-1, SECONDS), Duration.of(-1, SECONDS));
+    var fromStartNegFromEndNeg = orig.shiftEdges(Duration.of(-1, SECONDS), Duration.of(-1, SECONDS));
     assertIterableEquals(
         new Windows()
             .set(at(-1, SECONDS), true)

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -376,7 +376,7 @@ public class ASTTests {
     final var expandByFromStart = Duration.of(-1, SECONDS);
     final var expandByFromEnd = Duration.of(0, SECONDS);
 
-    final var result = new ShiftBy(Supplier.of(left), Supplier.of(expandByFromStart), Supplier.of(expandByFromEnd)).evaluate(simResults, new EvaluationEnvironment());
+    final var result = new ShiftWindowsEdges(Supplier.of(left), Supplier.of(expandByFromStart), Supplier.of(expandByFromEnd)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between(-1, Inclusive, 7, Inclusive, SECONDS), true)
@@ -408,7 +408,7 @@ public class ASTTests {
     final var clampFromStart = Duration.of(1, SECONDS);
     final var clampFromEnd = Duration.negate(Duration.of(1, SECONDS));
 
-    final var result = new ShiftBy(Supplier.of(left), Supplier.of(clampFromStart), Supplier.of(clampFromEnd)).evaluate(simResults, new EvaluationEnvironment());
+    final var result = new ShiftWindowsEdges(Supplier.of(left), Supplier.of(clampFromStart), Supplier.of(clampFromEnd)).evaluate(simResults, new EvaluationEnvironment());
 
     final var expected = new Windows()
         .set(Interval.between(1, Inclusive, 4, Exclusive, SECONDS), true)

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -844,7 +844,7 @@ public class ASTTests {
     final var result = new StartOf("act").evaluate(simResults, environment);
 
     final var expected = new Windows(
-        Segment.of(FOREVER, false),
+        Segment.of(simResults.bounds, false),
         Segment.of(at(4, SECONDS), true)
     );
 
@@ -878,7 +878,7 @@ public class ASTTests {
     final var result = new EndOf("act").evaluate(simResults, environment);
 
     final var expected = new Windows(
-        Segment.of(FOREVER, false),
+        Segment.of(simResults.bounds, false),
         Segment.of(at(8, SECONDS), true)
     );
 

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -505,6 +505,25 @@ public class ASTTests {
     assertEquivalent(expected, result);
   }
 
+
+  @Test
+  public void testDiscreteShiftBy() {
+    final var simResults = new SimulationResults(
+        Instant.EPOCH, Interval.between(0, 20, SECONDS),
+        List.of(),
+        Map.of(),
+        Map.of(
+            "discrete", new DiscreteProfile(Segment.of(Interval.between(1, 2, SECONDS), SerializedValue.of("much value")))
+        )
+    );
+
+    final var result = new ShiftBy<>(new DiscreteResource("discrete"), new DurationLiteral(Duration.of(1, SECONDS))).evaluate(simResults, new EvaluationEnvironment());
+
+    final var expected = new DiscreteProfile(Segment.of(Interval.between(2, 3, SECONDS), SerializedValue.of("much value")));
+
+    assertEquivalent(expected, result);
+  }
+
   @Test
   public void testValueAt(){
     final var simResults = new SimulationResults(
@@ -619,6 +638,24 @@ public class ASTTests {
       return;
     }
     fail("Expected RealResource node to fail on non-existent resource");
+  }
+
+  @Test
+  public void testRealShiftBy() {
+    final var simResults = new SimulationResults(
+        Instant.EPOCH, Interval.between(0, 20, SECONDS),
+        List.of(),
+        Map.of(
+            "real", new LinearProfile(Segment.of(Interval.between(1, 2, SECONDS), new LinearEquation(Duration.of(1, SECONDS), 1, 1)))
+        ),
+        Map.of()
+    );
+
+    final var result = new ShiftBy<>(new RealResource("real"), new DurationLiteral(Duration.of(1, SECONDS))).evaluate(simResults, new EvaluationEnvironment());
+
+    final var expected = new LinearProfile(Segment.of(Interval.between(2, 3, SECONDS), new LinearEquation(Duration.of(2, SECONDS), 1, 1)));
+
+    assertEquivalent(expected, result);
   }
 
   @Test

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -43,6 +43,7 @@ export enum NodeKind {
   ForEachActivitySpans = 'ForEachActivitySpans',
   ForEachActivityViolations = 'ForEachActivityViolations',
   ProfileChanges = 'ProfileChanges',
+  ProfileExpressionShiftBy = 'ProfileExpressionShiftBy',
   ViolationsOf = 'ViolationsOf',
   AbsoluteInterval = 'AbsoluteInterval',
   IntervalAlias = 'IntervalAlias',
@@ -82,6 +83,7 @@ export type WindowsExpression =
   | WindowsExpressionStartOf
   | WindowsExpressionEndOf
   | ProfileChanges
+  | ProfileExpressionShiftBy<WindowsExpression>
   | RealProfileLessThan
   | RealProfileLessThanOrEqual
   | RealProfileGreaterThan
@@ -118,6 +120,12 @@ export type IntervalsExpression =
 export interface ProfileChanges {
   kind: NodeKind.ProfileChanges;
   expression: ProfileExpression;
+}
+
+export interface ProfileExpressionShiftBy<P extends ProfileExpression> {
+  kind: NodeKind.ProfileExpressionShiftBy,
+  expression: P,
+  duration: Duration
 }
 
 export interface WindowsExpressionValue {
@@ -266,7 +274,8 @@ export type RealProfileExpression =
   | RealProfileValue
   | RealProfileParameter
   | AssignGapsExpression<RealProfileExpression>
-  | RealProfileAccumulatedDuration;
+  | RealProfileAccumulatedDuration
+  | ProfileExpressionShiftBy<RealProfileExpression>;
 
 export interface StructProfileExpression {
   kind: NodeKind.StructProfileExpression,
@@ -333,7 +342,8 @@ export type DiscreteProfileExpression =
     | StructProfileExpression
     | ListProfileExpression
     | ValueAtExpression
-    | IntervalDuration;
+    | IntervalDuration
+    | ProfileExpressionShiftBy<DiscreteProfileExpression>;
 
 export interface DiscreteProfileResource {
   kind: NodeKind.DiscreteProfileResource;

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -226,13 +226,21 @@ export class Windows {
    * @param fromStart duration to add from the start of each true segment
    * @param fromEnd duration to add from the end of each true segment
    */
-  public shiftBy(fromStart: AST.Duration, fromEnd: AST.Duration) : Windows {
-    return new Windows({
-      kind: AST.NodeKind.WindowsExpressionShiftBy,
-      windowExpression: this.__astNode,
-      fromStart,
-      fromEnd
-    })
+  public shiftBy(fromStart: AST.Duration, fromEnd?: AST.Duration | undefined) : Windows {
+    if (fromEnd === undefined) {
+      return new Windows({
+        kind: AST.NodeKind.ProfileExpressionShiftBy,
+        expression: this.__astNode,
+        duration: fromStart
+      });
+    } else {
+      return new Windows({
+        kind: AST.NodeKind.WindowsExpressionShiftBy,
+        windowExpression: this.__astNode,
+        fromStart,
+        fromEnd
+      })
+    }
   }
 
   /**
@@ -707,6 +715,14 @@ export class Real {
       timepoint : timepoint.__astNode
     });
   }
+
+  public shiftBy(duration: Temporal.Duration): Real {
+    return new Real({
+      kind: AST.NodeKind.ProfileExpressionShiftBy,
+      expression: this.__astNode,
+      duration
+    })
+  }
 }
 
 /**
@@ -867,6 +883,14 @@ export class Discrete<Schema> {
       originalProfile: this.__astNode,
       defaultProfile: defaultProfile.__astNode
     });
+  }
+
+  public shiftBy(duration: Temporal.Duration): Discrete<Schema> {
+    return new Discrete<Schema>({
+      kind: AST.NodeKind.ProfileExpressionShiftBy,
+      expression: this.__astNode,
+      duration
+    })
   }
 }
 
@@ -1071,7 +1095,7 @@ declare global {
      * @param fromStart duration to add from the start of each true segment
      * @param fromEnd duration to add from the end of each true segment
      */
-    public shiftBy(fromStart: AST.Duration, fromEnd: AST.Duration): Windows;
+    public shiftBy(fromStart: AST.Duration, fromEnd?: AST.Duration | undefined): Windows;
 
     /**
      * Returns a new windows object, with all true segments shorter than or equal to the given
@@ -1334,6 +1358,8 @@ declare global {
      * @param timepoint the timepoint, represented by a Spans (must be reduced to a single point)
      */
     public valueAt(timepoint: Spans): Discrete<number>;
+
+    public shiftBy(duration: Temporal.Duration): Real;
   }
 
   /**
@@ -1422,6 +1448,8 @@ declare global {
      * @param timepoint the timepoint, represented by a Spans (must be reduced to a single point)
      */
     public valueAt(timepoint: Spans): Discrete<Schema>;
+
+    public shiftBy(duration: Temporal.Duration): Discrete<Schema>;
   }
 
   /** An enum for whether an interval includes its bounds. */

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -716,6 +716,11 @@ export class Real {
     });
   }
 
+  /**
+   * Shifts the profile forward or backward in time.
+   *
+   * @param duration duration shift each segment (can be negative)
+   */
   public shiftBy(duration: Temporal.Duration): Real {
     return new Real({
       kind: AST.NodeKind.ProfileExpressionShiftBy,
@@ -885,6 +890,11 @@ export class Discrete<Schema> {
     });
   }
 
+  /**
+   * Shifts the profile forward or backward in time.
+   *
+   * @param duration duration shift each segment (can be negative)
+   */
   public shiftBy(duration: Temporal.Duration): Discrete<Schema> {
     return new Discrete<Schema>({
       kind: AST.NodeKind.ProfileExpressionShiftBy,
@@ -1359,6 +1369,11 @@ declare global {
      */
     public valueAt(timepoint: Spans): Discrete<number>;
 
+    /**
+     * Shifts the profile forward or backward in time.
+     *
+     * @param duration duration shift each segment (can be negative)
+     */
     public shiftBy(duration: Temporal.Duration): Real;
   }
 
@@ -1449,6 +1464,11 @@ declare global {
      */
     public valueAt(timepoint: Spans): Discrete<Schema>;
 
+    /**
+     * Shifts the profile forward or backward in time.
+     *
+     * @param duration duration shift each segment (can be negative)
+     */
     public shiftBy(duration: Temporal.Duration): Discrete<Schema>;
   }
 

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -220,11 +220,14 @@ export class Windows {
   /**
    * Shifts the start and end of all true segments by a duration.
    *
-   * Shifts the start and end of all false segment by the opposite directions (i.e. the start of each false segment
+   * The second argument is optional: if omitted, `shiftBy(dur)` shifts all segments uniformly by `dur`, which
+   * is equivalent to `shiftBy(dur, dur)`.
+   *
+   * Shifts the start and end of all false segment by the reversed directions (i.e. the start of each false segment
    * is shifted by `fromEnd`).
    *
    * @param fromStart duration to add from the start of each true segment
-   * @param fromEnd duration to add from the end of each true segment
+   * @param fromEnd duration to add from the end of each true segment. Default is equal to `fromStart` if omitted.
    */
   public shiftBy(fromStart: AST.Duration, fromEnd?: AST.Duration | undefined) : Windows {
     if (fromEnd === undefined) {
@@ -1099,11 +1102,14 @@ declare global {
     /**
      * Shifts the start and end of all true segments by a duration.
      *
-     * Shifts the start and end of all false segment by the opposite directions (i.e. the start of each false segment
+     * The second argument is optional: if omitted, `shiftBy(dur)` shifts all segments uniformly by `dur`, which
+     * is equivalent to `shiftBy(dur, dur)`.
+     *
+     * Shifts the start and end of all false segment by the reversed directions (i.e. the start of each false segment
      * is shifted by `fromEnd`).
      *
      * @param fromStart duration to add from the start of each true segment
-     * @param fromEnd duration to add from the end of each true segment
+     * @param fromEnd duration to add from the end of each true segment. Default is equal to `fromStart` if omitted.
      */
     public shiftBy(fromStart: AST.Duration, fromEnd?: AST.Duration | undefined): Windows;
 

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -31,7 +31,7 @@ import gov.nasa.jpl.aerie.constraints.tree.Rate;
 import gov.nasa.jpl.aerie.constraints.tree.RealParameter;
 import gov.nasa.jpl.aerie.constraints.tree.RealResource;
 import gov.nasa.jpl.aerie.constraints.tree.RealValue;
-import gov.nasa.jpl.aerie.constraints.tree.ShiftBy;
+import gov.nasa.jpl.aerie.constraints.tree.ShiftWindowsEdges;
 import gov.nasa.jpl.aerie.constraints.tree.ShorterThan;
 import gov.nasa.jpl.aerie.constraints.tree.SpansFromWindows;
 import gov.nasa.jpl.aerie.constraints.tree.Split;
@@ -486,7 +486,7 @@ class ConstraintsDSLCompilationServiceTests {
   }
 
   @Test
-  void testShiftBy() {
+  void testShiftWindowsEdges() {
     checkSuccessfulCompilation(
         """
             const minute = (m: number) => Temporal.Duration.from({minutes: m});
@@ -494,7 +494,7 @@ class ConstraintsDSLCompilationServiceTests {
               return Real.Resource("state of charge").rate().equal(Real.Value(4.0)).shiftBy(minute(2), minute(-20))
             }
         """,
-        new ViolationsOfWindows(new ShiftBy(
+        new ViolationsOfWindows(new ShiftWindowsEdges(
             new Equal<>(new Rate(new RealResource("state of charge")), new RealValue(4.0)),
             new DurationLiteral(Duration.of(2, Duration.MINUTE)),
             new DurationLiteral(Duration.of(-20, Duration.MINUTE)))
@@ -1227,4 +1227,5 @@ class ConstraintsDSLCompilationServiceTests {
         "TypeError: TS2345 Argument of type 'Discrete<string>' is not assignable to parameter of type '\"Option1\" | \"Option2\" | Discrete<\"Option1\" | \"Option2\">'."
     );
   }
+
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -31,6 +31,7 @@ import gov.nasa.jpl.aerie.constraints.tree.Rate;
 import gov.nasa.jpl.aerie.constraints.tree.RealParameter;
 import gov.nasa.jpl.aerie.constraints.tree.RealResource;
 import gov.nasa.jpl.aerie.constraints.tree.RealValue;
+import gov.nasa.jpl.aerie.constraints.tree.ShiftBy;
 import gov.nasa.jpl.aerie.constraints.tree.ShiftWindowsEdges;
 import gov.nasa.jpl.aerie.constraints.tree.ShorterThan;
 import gov.nasa.jpl.aerie.constraints.tree.SpansFromWindows;
@@ -1225,6 +1226,33 @@ class ConstraintsDSLCompilationServiceTests {
         }
         """,
         "TypeError: TS2345 Argument of type 'Discrete<string>' is not assignable to parameter of type '\"Option1\" | \"Option2\" | Discrete<\"Option1\" | \"Option2\">'."
+    );
+  }
+
+  @Test
+  void testProfileShiftBy() {
+    checkSuccessfulCompilation(
+        """
+        const minute = (m: number) => Temporal.Duration.from({minutes: m});
+        export default() => {
+          return Real.Resource("state of charge").shiftBy(minute(2)).equal(Real.Value(4.0))
+        }
+        """,
+        new ViolationsOfWindows(
+            new Equal<>(new ShiftBy<>(new RealResource("state of charge"), new DurationLiteral(Duration.of(2, Duration.MINUTE))), new RealValue(4.0))
+        )
+    );
+
+    checkSuccessfulCompilation(
+        """
+        const minute = (m: number) => Temporal.Duration.from({minutes: m});
+        export default() => {
+          return Discrete.Resource("mode").shiftBy(minute(2)).equal("Option1")
+        }
+        """,
+        new ViolationsOfWindows(
+            new Equal<>(new ShiftBy<>(new DiscreteResource("mode"), new DurationLiteral(Duration.of(2, Duration.MINUTE))), new DiscreteValue(SerializedValue.of("Option1")))
+        )
     );
   }
 

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/transformers/TransformerAfterEach.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/transformers/TransformerAfterEach.java
@@ -19,7 +19,7 @@ public class TransformerAfterEach implements TimeWindowsTransformer {
     var retWin = windows;
     retWin = retWin.not();
     retWin = retWin.removeTrueSegment(0);
-    retWin = retWin.shiftBy(dur, Duration.ZERO);
+    retWin = retWin.shiftEdges(dur, Duration.ZERO);
     return retWin;
   }
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/transformers/TransformerBeforeEach.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/constraints/transformers/TransformerBeforeEach.java
@@ -19,7 +19,7 @@ public class TransformerBeforeEach implements TimeWindowsTransformer {
     var retWin = windows;
     retWin = retWin.not();
     retWin = retWin.removeTrueSegment(-1);
-    retWin = retWin.shiftBy(Duration.ZERO, Duration.negate(dur));
+    retWin = retWin.shiftEdges(Duration.ZERO, Duration.negate(dur));
     return retWin;
   }
 }


### PR DESCRIPTION
* **Tickets addressed:** closes #830 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
- This operation shifts profiles forward or backward in time. Both this and the original `Windows` shift operation are called `shiftBy` in the eDSL.
  - `real.shiftBy(Duration)`, `discrete.shiftBy(Duration)`, and `windows.shiftBy(Duration)` shifts the whole profile uniformly, and corresponds to the NEW `ShiftBy` AST node.
  - `windows.shiftBy(Duration, Duration)` is the old operation, which shift rising and falling edges separately. This now corresponds to the `ShiftWindowsEdges` AST node, which used to be called `ShiftBy`.
- The fourth commit adds behavior to the two shift nodes which shifts the bounds before giving them to subexpressions. Without this, shifting usually results in an unnecessary gap that could have been avoided and had to be manually removed with `assignGaps`.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
- [x] added tests for new shiftBy
- [x] added tests for new bounds shifting behavior

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
- [x] doc comments for `shiftBy` in eDSL

## Future work
<!-- What next steps can we anticipate from here, if any? -->
