### PR TITLE
Add optional name parameter to `createExpansionSet`

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -39,7 +39,13 @@ type Mutation {
 }
 
 type Mutation {
-  createExpansionSet(commandDictionaryId: Int!, missionModelId: Int!, expansionIds: [Int!]!, description: String): ExpansionSetResponse
+  createExpansionSet(
+    commandDictionaryId: Int!,
+    missionModelId: Int!,
+    expansionIds: [Int!]!,
+    description: String,
+    name: String
+  ): ExpansionSetResponse
 }
 
 type Mutation {

--- a/sequencing-server/test/testUtils/Expansion.ts
+++ b/sequencing-server/test/testUtils/Expansion.ts
@@ -43,16 +43,26 @@ export async function insertExpansionSet(
   commandDictionaryId: number,
   missionModelId: number,
   expansionIds: number[],
+  description?: string,
+  name?: string
 ): Promise<number> {
   const res = await graphqlClient.request<{
     createExpansionSet: { id: number };
   }>(
     gql`
-      mutation AddExpansionSet($commandDictionaryId: Int!, $missionModelId: Int!, $expansionIds: [Int!]!) {
+      mutation AddExpansionSet(
+        $commandDictionaryId: Int!,
+        $missionModelId: Int!,
+        $expansionIds: [Int!]!,
+        $description: String,
+        $name: String
+      ) {
         createExpansionSet(
           commandDictionaryId: $commandDictionaryId
           missionModelId: $missionModelId
           expansionIds: $expansionIds
+          description: $description
+          name: $name
         ) {
           id
         }
@@ -62,9 +72,27 @@ export async function insertExpansionSet(
       commandDictionaryId,
       missionModelId,
       expansionIds,
+      description,
+      name
     },
   );
   return res.createExpansionSet.id;
+}
+
+export async function getExpansionSet(graphqlClient: GraphQLClient, expansionSetId: number): Promise<any> {
+  return graphqlClient.request(
+    gql`
+      query GetExpansionRule($expansionSetId: Int!) {
+        expansion_set_by_pk(id: $expansionSetId) {
+          name
+          description
+        }
+      }
+    `,
+    {
+      expansionSetId,
+    },
+  );
 }
 
 export async function removeExpansionSet(graphqlClient: GraphQLClient, expansionSetId: number): Promise<void> {


### PR DESCRIPTION
* **Tickets addressed:** closes #977 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds a new optional parameter to the `createExpansionSet` hasura action. Defaults to an empty string in the database if not provided.

## Verification
Added a rudimentary test that checks the optional arguments are accepted.

## Documentation
Doesn't look like `createExpansionSet` is directly referenced in the docs, so no change is necessary.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
`aerie-ui` can now add a name form to the expansion set creation page and pass this to `createExpansionSet`.