### PR TITLE
Merlin server action permissions

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
@@ -9,11 +9,13 @@ import gov.nasa.jpl.aerie.merlin.server.http.LocalAppExceptionBindings;
 import gov.nasa.jpl.aerie.merlin.server.http.MerlinBindings;
 import gov.nasa.jpl.aerie.merlin.server.http.MissionModelRepositoryExceptionBindings;
 import gov.nasa.jpl.aerie.merlin.server.remotes.ConstraintRepository;
+import gov.nasa.jpl.aerie.merlin.server.http.PermissionsService;
 import gov.nasa.jpl.aerie.merlin.server.remotes.MissionModelRepository;
 import gov.nasa.jpl.aerie.merlin.server.remotes.PlanRepository;
 import gov.nasa.jpl.aerie.merlin.server.remotes.ResultsCellRepository;
 import gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresConstraintRepository;
 import gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresMissionModelRepository;
+import gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PermissionsRepository;
 import gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresPlanRepository;
 import gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresResultsCellRepository;
 import gov.nasa.jpl.aerie.merlin.server.services.CachedSimulationService;
@@ -85,7 +87,8 @@ public final class AerieAppDriver {
         planController,
         simulationAction,
         generateConstraintsLibAction,
-        constraintAction
+        constraintAction,
+        new PermissionsService(stores.permissions())
     );
     // Configure an HTTP server.
     //default javalin jetty server has a QueuedThreadPool with maxThreads to 250
@@ -111,7 +114,13 @@ public final class AerieAppDriver {
     javalin.start(configuration.httpPort());
   }
 
-  private record Stores (PlanRepository plans, MissionModelRepository missionModels, ResultsCellRepository results, ConstraintRepository constraints) {}
+  private record Stores (
+      PlanRepository plans,
+      MissionModelRepository missionModels,
+      ResultsCellRepository results,
+      ConstraintRepository constraints,
+      PermissionsRepository permissions
+  ) {}
 
   private static Stores loadStores(final AppConfiguration config) {
     final var store = config.store();
@@ -134,7 +143,8 @@ public final class AerieAppDriver {
           new PostgresPlanRepository(hikariDataSource),
           new PostgresMissionModelRepository(hikariDataSource),
           new PostgresResultsCellRepository(hikariDataSource),
-          new PostgresConstraintRepository(hikariDataSource));
+          new PostgresConstraintRepository(hikariDataSource),
+          new PermissionsRepository(hikariDataSource));
     } else {
       throw new UnexpectedSubtypeError(Store.class, store);
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/LocalAppExceptionBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/LocalAppExceptionBindings.java
@@ -4,12 +4,20 @@ import gov.nasa.jpl.aerie.merlin.server.services.LocalMissionModelService;
 import io.javalin.Javalin;
 import io.javalin.plugin.Plugin;
 
+import javax.json.Json;
+
 public final class LocalAppExceptionBindings implements Plugin {
     @Override
     public void apply(final Javalin javalin) {
         javalin.exception(LocalMissionModelService.MissionModelLoadException.class, (ex, ctx) -> ctx
             .status(500)
             .result(ResponseSerializers.serializeMissionModelLoadException(ex).toString())
+            .contentType("application/json"));
+        javalin.exception(Unauthorized.class, (ex, ctx) -> ctx
+            .status(401)
+            .result(Json.createObjectBuilder()
+                        .add("message", "Unauthorized: " + ex.getMessage())
+                        .build().toString())
             .contentType("application/json"));
     }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -7,6 +7,9 @@ import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveForValidation;
 import gov.nasa.jpl.aerie.merlin.server.services.ConstraintAction;
+import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
+import gov.nasa.jpl.aerie.merlin.server.models.HasuraAction;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.services.GenerateConstraintsLibAction;
 import gov.nasa.jpl.aerie.merlin.server.services.GetSimulationResultsAction;
 import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService;
@@ -56,19 +59,22 @@ public final class MerlinBindings implements Plugin {
   private final GetSimulationResultsAction simulationAction;
   private final GenerateConstraintsLibAction generateConstraintsLibAction;
   private final ConstraintAction constraintAction;
+  private final PermissionsService permissionsService;
 
   public MerlinBindings(
       final MissionModelService missionModelService,
       final PlanService planService,
       final GetSimulationResultsAction simulationAction,
       final GenerateConstraintsLibAction generateConstraintsLibAction,
-      final ConstraintAction constraintAction
+      final ConstraintAction constraintAction,
+      final PermissionsService permissionsService
   ) {
     this.missionModelService = missionModelService;
     this.planService = planService;
     this.simulationAction = simulationAction;
     this.generateConstraintsLibAction = generateConstraintsLibAction;
     this.constraintAction = constraintAction;
+    this.permissionsService = permissionsService;
   }
 
   @Override
@@ -185,14 +191,15 @@ public final class MerlinBindings implements Plugin {
     }
   }
 
-  private void getSimulationResults(final Context ctx) {
+  private void getSimulationResults(final Context ctx) throws Unauthorized {
     try {
       final var body = parseJson(ctx.body(), hasuraPlanActionP);
       final var planId = body.input().planId();
 
+      this.checkPlanPermissions("simulate", body.session(), planId);
+
       final var response = this.simulationAction.run(planId);
       ctx.result(ResponseSerializers.serializeSimulationResultsResponse(response).toString());
-
     } catch (final InvalidEntityException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
     } catch(final InvalidJsonException ex) {
@@ -204,12 +211,14 @@ public final class MerlinBindings implements Plugin {
     }
   }
 
-  private void getResourceSamples(final Context ctx) {
+  private void getResourceSamples(final Context ctx) throws Unauthorized {
     try {
-      final var planId = parseJson(ctx.body(), hasuraPlanActionP).input().planId();
+      final var body = parseJson(ctx.body(), hasuraPlanActionP);
+      final var planId = body.input().planId();
+
+      this.checkPlanPermissions("resource_samples", body.session(), planId);
 
       final var resourceSamples = this.simulationAction.getResourceSamples(planId);
-
       ctx.result(ResponseSerializers.serializeResourceSamples(resourceSamples).toString());
     } catch (final InvalidJsonException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
@@ -219,10 +228,14 @@ public final class MerlinBindings implements Plugin {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchPlanException(ex).toString());
     }
 }
-  private void getConstraintViolations(final Context ctx) {
+  private void getConstraintViolations(final Context ctx) throws Unauthorized {
     try {
-      final var input = parseJson(ctx.body(), hasuraConstraintsViolationsActionP).input();
+      final var body = parseJson(ctx.body(), hasuraConstraintsViolationsActionP);
+      final var input = body.input();
       final var planId = input.planId();
+
+      this.checkPlanPermissions("check_constraints", body.session(), planId);
+
       final var simulationDatasetId = input.simulationDatasetId();
 
       final var constraintViolations = this.constraintAction.getViolations(planId, simulationDatasetId);
@@ -353,11 +366,14 @@ public final class MerlinBindings implements Plugin {
     }
   }
 
-  private void addExternalDataset(final Context ctx) {
+  private void addExternalDataset(final Context ctx) throws Unauthorized {
     try {
-      final var input = parseJson(ctx.body(), hasuraUploadExternalDatasetActionP).input();
+      final var body = parseJson(ctx.body(), hasuraUploadExternalDatasetActionP);
+      final var input = body.input();
 
       final var planId = input.planId();
+      this.checkPlanPermissions("insert_ext_dataset", body.session(), planId);
+
       final var simulationDatasetId = input.simulationDatasetId();
       final var datasetStart = input.datasetStart();
       final var profileSet = input.profileSet();
@@ -374,13 +390,14 @@ public final class MerlinBindings implements Plugin {
     }
   }
 
-  private void extendExternalDataset(final Context ctx) {
+  private void extendExternalDataset(final Context ctx) throws NoSuchPlanException, Unauthorized {
     try {
-      final var input = parseJson(ctx.body(), hasuraExtendExternalDatasetActionP).input();
+      final var body = parseJson(ctx.body(), hasuraExtendExternalDatasetActionP);
+      final var datasetId = body.input().datasetId();
 
-      final var datasetId = input.datasetId();
-      final var profileSet = input.profileSet();
+      this.checkDatasetPermissions("extend_ext_dataset", body.session(), datasetId);
 
+      final var profileSet = body.input().profileSet();
       this.planService.extendExternalDataset(datasetId, profileSet);
 
       ctx.status(200).result(
@@ -451,5 +468,21 @@ public final class MerlinBindings implements Plugin {
     } catch (JsonParsingException e) {
       throw new InvalidJsonException(e);
     }
+  }
+
+  private void checkPlanPermissions(
+      final String action,
+      final HasuraAction.Session session,
+      final PlanId planId
+  ) throws NoSuchPlanException, Unauthorized {
+    permissionsService.check(action, session, planId);
+  }
+
+  private void checkDatasetPermissions(
+      final String action,
+      final HasuraAction.Session session,
+      final DatasetId datasetId
+  ) throws Unauthorized {
+    permissionsService.check(action, session, datasetId);
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/PermissionsService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/PermissionsService.java
@@ -1,0 +1,39 @@
+package gov.nasa.jpl.aerie.merlin.server.http;
+
+import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
+import gov.nasa.jpl.aerie.merlin.server.models.HasuraAction;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import gov.nasa.jpl.aerie.merlin.server.remotes.PermissionType;
+import gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PermissionsRepository;
+
+public class PermissionsService {
+
+  private final PermissionsRepository permissionsRepository;
+
+  public PermissionsService(final PermissionsRepository permissionsRepository) {
+    this.permissionsRepository = permissionsRepository;
+  }
+
+  public void check(final String action, final HasuraAction.Session session, final PlanId planId) throws Unauthorized, NoSuchPlanException {
+    final var role = session.hasuraRole();
+    final var username = session.hasuraUserId();
+
+    final var permissionType = permissionsRepository.lookupPermissionType(action, role);
+    if (permissionType == PermissionType.ALWAYS_UNAUTHORIZED) throw new Unauthorized(role, action);
+
+    final var authorized = permissionsRepository.canPerformAction(permissionType, username, action, planId);
+    if (!authorized) throw new Unauthorized(action, role, username, permissionType, planId);
+  }
+
+  public void check(final String action, final HasuraAction.Session session, final DatasetId datasetId) throws Unauthorized {
+    final var role = session.hasuraRole();
+    final var username = session.hasuraUserId();
+
+    final var permissionType = permissionsRepository.lookupPermissionType(action, role);
+    if (permissionType == PermissionType.ALWAYS_UNAUTHORIZED) throw new Unauthorized(role, action);
+
+    final var authorized = permissionsRepository.canPerformAction(permissionType, username, action, datasetId);
+    if (!authorized) throw new Unauthorized(action, role, username, permissionType, datasetId);
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/Unauthorized.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/Unauthorized.java
@@ -1,0 +1,39 @@
+package gov.nasa.jpl.aerie.merlin.server.http;
+
+import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import gov.nasa.jpl.aerie.merlin.server.remotes.PermissionType;
+
+public class Unauthorized extends Exception {
+  public Unauthorized(final String role, final String action) {
+    super("Role \"" + role + "\" is not allowed to perform action \"" + action + "\"");
+  }
+
+  public Unauthorized(
+      final String action,
+      final String role,
+      final String username,
+      final PermissionType permissionType,
+      final PlanId planId) {
+    super("User \"%s\" with role \"%s\" cannot perform \"%s\" because they are not a \"%s\" for plan with id \"%d\"".formatted(
+        username,
+        role,
+        action,
+        permissionType,
+        planId.id()));
+  }
+
+  public Unauthorized(
+      final String action,
+      final String role,
+      final String username,
+      final PermissionType permissionType,
+      final DatasetId datasetId) {
+    super("User \"%s\" with role \"%s\" cannot perform \"%s\" because they are not a \"%s\" for dataset with id \"%d\"".formatted(
+        username,
+        role,
+        action,
+        permissionType,
+        datasetId.id()));
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PermissionType.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PermissionType.java
@@ -1,0 +1,32 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes;
+
+public enum PermissionType {
+  /**
+   * The given role is always allowed to perform this action
+   */
+  NO_CHECK,
+  /**
+   * The given user must be the owner of the relevant object. The interpretation can vary by action
+   */
+  OWNER,
+  /**
+   * The given user must be the owner of the given mission model
+   */
+  MISSION_MODEL_OWNER,
+  /**
+   * The given user must be the plan owner of the given plan
+   */
+  PLAN_OWNER,
+  /**
+   * The given user must be a plan collaborator on the given plan
+   */
+  PLAN_COLLABORATOR,
+  /**
+   * The given user must be either the plan owner or a plan collaborator on the given plan
+   */
+  PLAN_OWNER_COLLABORATOR,
+  /**
+   * The given role is never allowed to perform this action
+   */
+  ALWAYS_UNAUTHORIZED
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CheckPlanOwnerOrCollaboratorAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CheckPlanOwnerOrCollaboratorAction.java
@@ -1,0 +1,45 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/*package local*/ final class CheckPlanOwnerOrCollaboratorAction implements AutoCloseable {
+  private static final @Language("SQL") String sql = """
+    select
+        ? in (select owner from plan where id=?) as is_owner,
+        ? in (select collaborator from plan_collaborators where plan_id=?) as is_collaborator;
+    """;
+
+  private final PreparedStatement statement;
+
+  public CheckPlanOwnerOrCollaboratorAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public PlanOwnerOrCollaborator get(final long planId, final String username)
+  throws SQLException {
+    this.statement.setString(1, username);
+    this.statement.setLong(2, planId);
+    this.statement.setString(3, username);
+    this.statement.setLong(4, planId);
+    final var results = this.statement.executeQuery();
+
+    if (!results.next()) throw new SQLException("Unexpected empty result");
+
+    final var isOwner = results.getBoolean("is_owner");
+    final var isCollaborator = results.getBoolean("is_collaborator");
+
+    if (isOwner && isCollaborator) return PlanOwnerOrCollaborator.OWNER_AND_COLLABORATOR;
+    if (isOwner) return PlanOwnerOrCollaborator.ONLY_OWNER;
+    if (isCollaborator) return PlanOwnerOrCollaborator.ONLY_COLLABORATOR;
+    return PlanOwnerOrCollaborator.NEITHER;
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CheckPlanOwnerOrCollaboratorForPlanDatasetAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CheckPlanOwnerOrCollaboratorForPlanDatasetAction.java
@@ -1,0 +1,45 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/*package local*/ final class CheckPlanOwnerOrCollaboratorForPlanDatasetAction implements AutoCloseable {
+  private static final @Language("SQL") String sql = """
+    select
+        ? in (select owner from plan join plan_dataset on plan_dataset.dataset_id=? and plan.id = plan_dataset.plan_id) as is_owner,
+        ? in (select collaborator from plan_collaborators join plan_dataset on plan_dataset.dataset_id=? and plan_collaborators.plan_id = plan_dataset.plan_id) as is_collaborator;
+    """;
+
+  private final PreparedStatement statement;
+
+  public CheckPlanOwnerOrCollaboratorForPlanDatasetAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public PlanOwnerOrCollaborator get(final long datasetId, final String username)
+  throws SQLException {
+    this.statement.setString(1, username);
+    this.statement.setLong(2, datasetId);
+    this.statement.setString(3, username);
+    this.statement.setLong(4, datasetId);
+    final var results = this.statement.executeQuery();
+
+    if (!results.next()) throw new SQLException("Unexpected empty result");
+
+    final var isOwner = results.getBoolean("is_owner");
+    final var isCollaborator = results.getBoolean("is_collaborator");
+
+    if (isOwner && isCollaborator) return PlanOwnerOrCollaborator.OWNER_AND_COLLABORATOR;
+    if (isOwner) return PlanOwnerOrCollaborator.ONLY_OWNER;
+    if (isCollaborator) return PlanOwnerOrCollaborator.ONLY_COLLABORATOR;
+    return PlanOwnerOrCollaborator.NEITHER;
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/LookupPermissionTypeAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/LookupPermissionTypeAction.java
@@ -1,0 +1,59 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.jpl.aerie.merlin.server.remotes.PermissionType;
+import org.intellij.lang.annotations.Language;
+
+import javax.json.Json;
+import java.io.Reader;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Map;
+
+import static gov.nasa.jpl.aerie.json.BasicParsers.mapP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
+
+/*package local*/ final class LookupPermissionTypeAction implements AutoCloseable {
+  private static final @Language("SQL") String sql = """
+    select
+      action_permissions
+    from metadata.user_role_permissions
+    where role = ?
+    """;
+
+  private final PreparedStatement statement;
+
+  public LookupPermissionTypeAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public PermissionType get(final String role, final String action)
+  throws SQLException {
+    this.statement.setString(1, role);
+    final var results = this.statement.executeQuery();
+
+    if (!results.next()) return PermissionType.ALWAYS_UNAUTHORIZED;
+
+    final var permissionTypesByAction = parse(results.getCharacterStream("action_permissions"));
+    if (!permissionTypesByAction.containsKey(action)) return PermissionType.ALWAYS_UNAUTHORIZED;
+
+    final var permissionTypeString = permissionTypesByAction.get(action);
+    try {
+      return PermissionType.valueOf(permissionTypeString);
+    } catch (IllegalArgumentException e) {
+      throw new SQLException("Invalid permission type " + permissionTypeString);
+    }
+  }
+
+  private Map<String, String> parse(final Reader stream) {
+    try (final var reader = Json.createReader(stream)) {
+      final var json = reader.readValue();
+      return mapP(stringP).parse(json).getSuccessOrThrow($ -> new RuntimeException($.toString()));
+    }
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PermissionsRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PermissionsRepository.java
@@ -1,0 +1,84 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import gov.nasa.jpl.aerie.merlin.server.remotes.PermissionType;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+
+public final class PermissionsRepository {
+  private final DataSource dataSource;
+
+  public PermissionsRepository(final DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public PermissionType lookupPermissionType(final String action, final String role) {
+    try (
+        final var connection = dataSource.getConnection();
+        final var lookupPermissionTypeAction = new LookupPermissionTypeAction(connection)
+    ) {
+      if (role.equals("admin")) {
+        return PermissionType.NO_CHECK;
+      }
+      return lookupPermissionTypeAction.get(role, action);
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public boolean canPerformAction(
+      final PermissionType permissionType,
+      final String username,
+      final String action,
+      final PlanId planId) {
+    return switch (permissionType) {
+      case NO_CHECK -> true;
+      case OWNER -> throw new RuntimeException("OWNER permission cannot be applied to action \"" + action + "\"");
+      case MISSION_MODEL_OWNER -> throw new RuntimeException("MISSION_MODEL_OWNER permission cannot be applied to action \"" + action + "\"");
+      case PLAN_OWNER -> getPlanPermissions(username, planId).isPlanOwner();
+      case PLAN_COLLABORATOR -> getPlanPermissions(username, planId).isPlanCollaborator();
+      case PLAN_OWNER_COLLABORATOR -> getPlanPermissions(username, planId).isPlanOwnerOrCollaborator();
+      case ALWAYS_UNAUTHORIZED -> false;
+    };
+  }
+
+  public boolean canPerformAction(
+      final PermissionType permissionType,
+      final String username,
+      final String action,
+      final DatasetId datasetId) {
+    return switch (permissionType) {
+      case NO_CHECK -> true;
+      case OWNER -> throw new RuntimeException("OWNER permission cannot be applied to action \"" + action + "\"");
+      case MISSION_MODEL_OWNER -> throw new RuntimeException("MISSION_MODEL_OWNER permission cannot be applied to action \"" + action + "\"");
+      case PLAN_OWNER -> getPlanDatasetPermissions(username, datasetId).isPlanOwner();
+      case PLAN_COLLABORATOR -> getPlanDatasetPermissions(username, datasetId).isPlanCollaborator();
+      case PLAN_OWNER_COLLABORATOR -> getPlanDatasetPermissions(username, datasetId).isPlanOwnerOrCollaborator();
+      case ALWAYS_UNAUTHORIZED -> false;
+    };
+  }
+
+  private PlanOwnerOrCollaborator getPlanPermissions(final String username, final PlanId planId) {
+    try (
+        final var connection = dataSource.getConnection();
+        final var action = new CheckPlanOwnerOrCollaboratorAction(connection)
+    ) {
+      return action.get(planId.id(), username);
+    } catch (SQLException ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  private PlanOwnerOrCollaborator getPlanDatasetPermissions(final String username, final DatasetId datasetId) {
+    try (
+        final var connection = dataSource.getConnection();
+        final var action = new CheckPlanOwnerOrCollaboratorForPlanDatasetAction(connection)
+    ) {
+      return action.get(datasetId.id(), username);
+    } catch (SQLException ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PlanOwnerOrCollaborator.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PlanOwnerOrCollaborator.java
@@ -1,0 +1,29 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+public enum PlanOwnerOrCollaborator {
+  NEITHER,
+  ONLY_OWNER,
+  ONLY_COLLABORATOR,
+  OWNER_AND_COLLABORATOR;
+
+  boolean isPlanOwner() {
+    return switch(this) {
+      case NEITHER, ONLY_COLLABORATOR -> false;
+      case ONLY_OWNER, OWNER_AND_COLLABORATOR -> true;
+    };
+  }
+
+  boolean isPlanCollaborator() {
+    return switch(this) {
+      case NEITHER, ONLY_OWNER -> false;
+      case ONLY_COLLABORATOR, OWNER_AND_COLLABORATOR -> true;
+    };
+  }
+
+  boolean isPlanOwnerOrCollaborator() {
+    return switch(this) {
+      case NEITHER -> false;
+      case ONLY_OWNER, ONLY_COLLABORATOR, OWNER_AND_COLLABORATOR -> true;
+    };
+  }
+}


### PR DESCRIPTION
* **Tickets addressed:** Closes #952 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

This PR implements permissions for `getSimulationResults`, `getResourceSamples`, `getConstraintViolations`, `addExternalDataset` and `extendExternalDataset` based on the schema defined [here](https://github.com/NASA-AMMOS/aerie/discussions/983#discussioncomment-6257146).

Open question: which of the above actions does `MISSION_MODEL_OWNER` make sense for? What exactly would its semantics be?

For the time being, this PR rejects `MISSION_MODEL_OWNER` for all of the above actions.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
@Mythicaeda and I did some manual testing yesterday. To do this, create the `metadata.user_role_permissions` table:

```sql
create table metadata.user_role_permissions(
  role user_roles not null primary key,
  action_permissions jsonb not null default '{}',
  function_permissions jsonb not null default '{}'
);
```

Add some permissions for the user role:

```sql
insert into metadata.user_role_permissions (role, action_permissions, function_permissions) values ('user', '{"simulate": "PLAN_OWNER"}'::jsonb, '{}'::jsonb);
```

Then create a plan, and attempt simulation. Verify that you can only simulate if you are a plan owner.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

The only documentation is currently here: https://github.com/NASA-AMMOS/aerie/discussions/983#discussioncomment-6257146

We need to write analogous user-facing docs for this schema.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Do the same for the scheduler and sequencing servers
- Consider whether this logic would be worth "librarifying"
