### PR TITLE
EPOCH HMS String Parsing should support Negative Duration

### DIFF
--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
@@ -575,3 +575,94 @@ describe('Sequence', () => {
     });
   });
 });
+
+describe('Time Validation', () => {
+  it('should have valid Epoch and Relative Times', () => {
+    let epoch = CommandStem.new({
+      stem: 'TEST',
+      arguments: {
+      },
+      epochTime : hmsToDuration('001T00:01:34.284' as HMS_STRING,true),
+    })
+    expect(epoch.toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "001T00:01:34.284",
+        "type": "EPOCH_RELATIVE"
+      },
+      type: 'command',
+    });
+
+    epoch = CommandStem.new({
+      stem: 'TEST',
+      arguments: {
+      },
+      epochTime : hmsToDuration('-001T00:01:34.284' as HMS_STRING,true),
+    })
+    expect(epoch.toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "-001T00:01:34.284",
+        "type": "EPOCH_RELATIVE"
+      },
+      type: 'command',
+    });
+
+    epoch = CommandStem.new({
+      stem: 'TEST',
+      arguments: {
+      },
+      epochTime : hmsToDuration('-000T03:01:34.284' as HMS_STRING,true),
+    })
+    expect(epoch.toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "-03:01:34.284",
+        "type": "EPOCH_RELATIVE"
+      },
+      type: 'command',
+    });
+
+    let relative = CommandStem.new({
+      stem: 'TEST',
+      arguments: {
+      },
+      relativeTime : hmsToDuration('03:01:34.284' as HMS_STRING),
+    })
+    expect(relative.toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "03:01:34.284",
+        "type": "COMMAND_RELATIVE"
+      },
+      type: 'command',
+    });
+  });
+
+  it('should have invalid Relative Times', () => {
+
+    try {
+      CommandStem.new({
+        stem: 'TEST',
+        arguments: {},
+        relativeTime: hmsToDuration('-03:01:34.284' as HMS_STRING),
+      })
+    }catch (e: any) {
+      expect(e.message).toEqual('Signed time (+/-) is not allowed for Relative Times: -03:01:34.284')
+    }
+    try {
+      CommandStem.new({
+        stem: 'TEST',
+        arguments: {},
+        relativeTime: hmsToDuration('009T03:01:34.284' as HMS_STRING),
+      })
+    }catch (e: any) {
+      expect(e.message).toEqual('Day (DDD) is not allowed for Relative Times: 009T03:01:34.284')
+    }
+  });
+
+});

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -1366,7 +1366,7 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
         : json.time.type === TimingTypes.COMMAND_RELATIVE
             ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : json.time.type === TimingTypes.EPOCH_RELATIVE
-            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING,true) }
         : {};
 
     return CommandStem.new({
@@ -1699,7 +1699,7 @@ export class Ground_Block implements GroundBlock {
         : json.time.type === TimingTypes.COMMAND_RELATIVE
             ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : json.time.type === TimingTypes.EPOCH_RELATIVE
-            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING,true) }
         : {};
 
     return Ground_Block.new({
@@ -1931,7 +1931,7 @@ export class Ground_Event implements GroundEvent {
         : json.time.type === TimingTypes.COMMAND_RELATIVE
             ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : json.time.type === TimingTypes.EPOCH_RELATIVE
-            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING,true) }
         : {};
 
     return Ground_Event.new({
@@ -2219,7 +2219,7 @@ export class ActivateStep implements Activate {
         : json.time.type === TimingTypes.COMMAND_RELATIVE
             ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : json.time.type === TimingTypes.EPOCH_RELATIVE
-            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING,true) }
         : {};
 
     return ActivateStep.new({
@@ -2513,7 +2513,7 @@ export class LoadStep implements Load {
         : json.time.type === TimingTypes.COMMAND_RELATIVE
             ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
         : json.time.type === TimingTypes.EPOCH_RELATIVE
-            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+            ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING,true) }
         : {};
 
     return LoadStep.new({
@@ -2862,7 +2862,7 @@ class RequestTime extends RequestCommon implements RequestWithTime {
           : json.time.type === TimingTypes.COMMAND_RELATIVE
               ? { relativeTime: hmsToDuration(json.time.tag as HMS_STRING) }
           : json.time.type === TimingTypes.EPOCH_RELATIVE
-              ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING) }
+              ? { epochTime: hmsToDuration(json.time.tag as HMS_STRING,true) }
           : {}
         : {};
 
@@ -3064,7 +3064,7 @@ export type DOY_STRING = string & { __brand: 'DOY_STRING' };
 export type HMS_STRING = string & { __brand: 'HMS_STRING' };
 
 const DOY_REGEX = /(\\d{4})-(\\d{3})T(\\d{2}):(\\d{2}):(\\d{2})(?:\\.(\\d{3}))?/;
-const HMS_REGEX = /(\\d{2}):(\\d{2}):(\\d{2})(?:\\.(\\d{3}))?/;
+const HMS_REGEX = /^([-+])?(\\d{3}T)?(\\d{2}):(\\d{2}):(\\d{2})(?:\\.(\\d{3}))?$/;
 
 /** YYYY-DOYTHH:MM:SS.sss */
 export function instantToDoy(time: Temporal.Instant): DOY_STRING {
@@ -3120,32 +3120,49 @@ export function doyToInstant(doy: DOY_STRING): Temporal.Instant {
   }).toInstant();
 }
 
-/** HH:MM:SS.sss */
+/** [+/-][DDDT]HH:MM:SS.sss */
 export function durationToHms(time: Temporal.Duration): HMS_STRING {
-  const HH = formatNumber(time.hours, 2);
-  const MM = formatNumber(time.minutes, 2);
-  const SS = formatNumber(time.seconds, 2);
-  const sss = formatNumber(time.milliseconds, 3);
+  let { days, hours, minutes, seconds, milliseconds } = time;
 
-  return \`\${HH}:\${MM}:\${SS}.\${sss}\` as HMS_STRING;
+  const DD = days !== 0 ? \`\${formatNumber(days, 3)}T\` : '';
+  const HH = days !== 0 ? formatNumber(hours, 2).replace('-', '') : formatNumber(hours, 2);
+  const MM = formatNumber(minutes, 2).replace('-', '');
+  const SS = formatNumber(seconds, 2).replace('-', '');
+  const sss = formatNumber(milliseconds, 3).replace('-', '');
+
+  return \`\${DD}\${HH}:\${MM}:\${SS}.\${sss}\` as HMS_STRING;
 }
 
-export function hmsToDuration(hms: HMS_STRING): Temporal.Duration {
+export function hmsToDuration(hms: HMS_STRING, epoch: boolean = false): Temporal.Duration {
   const match = hms.match(HMS_REGEX);
   if (match === null) {
     throw new Error(\`Invalid HMS string: \${hms}\`);
   }
-  const [, hours, minutes, seconds, milliseconds] = match as [unknown, string, string, string, string | undefined];
+
+  const [, sign, days = '0', hours = "0", minutes = "0", seconds = "0", milliseconds = '0'] = match;
+  const isPositive = sign !== '-';
+  const parseNumber = (value: string) => (isPositive ? 1 : -1) * parseInt(value, 10);
+
+  if (!epoch) {
+    if(!isPositive)
+      throw new Error(\`Signed time (+/-) is not allowed for Relative Times: \${hms}\`);
+    if(days !== '0')
+      throw new Error(\`Day (DDD) is not allowed for Relative Times: \${hms}\`);
+  }
   return Temporal.Duration.from({
-    hours: parseInt(hours, 10),
-    minutes: parseInt(minutes, 10),
-    seconds: parseInt(seconds, 10),
-    milliseconds: parseInt(milliseconds ?? '0', 10),
+    days: parseNumber(days.replace('T', '')),
+    hours: parseNumber(hours),
+    minutes: parseNumber(minutes),
+    seconds: parseNumber(seconds),
+    milliseconds: parseNumber(milliseconds),
   });
 }
 
 function formatNumber(number: number, size: number): string {
-  return number.toString().padStart(size, '0');
+  const isNegative = number < 0;
+  const absoluteNumber = Math.abs(number).toString();
+  const formattedNumber = absoluteNumber.padStart(size, '0');
+  return isNegative ? \`-\${formattedNumber}\` : formattedNumber;
 }
 
 // @ts-ignore : Used in generated code
@@ -3189,9 +3206,9 @@ function E(
     typeof Commands & typeof STEPS & typeof REQUESTS {
   let duration: Temporal.Duration;
   if (Array.isArray(args[0])) {
-    duration = hmsToDuration(String.raw(...(args as [TemplateStringsArray, ...string[]])) as HMS_STRING);
+    duration = hmsToDuration(String.raw(...(args as [TemplateStringsArray, ...string[]])) as HMS_STRING,true);
   } else if (typeof args[0] === 'string') {
-    duration = hmsToDuration(args[0] as HMS_STRING);
+    duration = hmsToDuration(args[0] as HMS_STRING,true);
   } else {
     duration = args[0] as Temporal.Duration;
   }

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -100,7 +100,7 @@ describe('sequence generation', () => {
         A(Temporal.Instant.from("2025-12-24T12:01:59Z")).PREHEAT_OVEN({ temperature: 360 }),
         R\`00:15:30\`.PREHEAT_OVEN({ temperature: 425 }),
         R(Temporal.Duration.from({ hours: 1, minutes: 15, seconds: 30 })).EAT_BANANA,
-        E(Temporal.Duration.from({ hours: 12, minutes: 6, seconds: 54 })).PREPARE_LOAF({ tb_sugar: 50, gluten_free: "FALSE" }),
+        E(Temporal.Duration.from({ days: -1, hours: -12, minutes: -16, seconds: -54 })).PREPARE_LOAF({ tb_sugar: 50, gluten_free: "FALSE" }),
         E\`04:56:54\`.EAT_BANANA,
         C.PACKAGE_BANANA({
           bundle: [
@@ -305,7 +305,7 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PREPARE_LOAF',
         time: {
-          tag: '12:06:54.000',
+          tag: '-001T12:16:54.000',
           type: 'EPOCH_RELATIVE',
         },
         args: [
@@ -624,7 +624,7 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PREPARE_LOAF',
         time: {
-          tag: '12:06:54.000',
+          tag: '-001T12:16:54.000',
           type: 'EPOCH_RELATIVE',
         },
         args: [
@@ -831,7 +831,7 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PREPARE_LOAF',
         time: {
-          tag: '12:06:54.000',
+          tag: '-001T12:16:54.000',
           type: 'EPOCH_RELATIVE',
         },
         args: [
@@ -1131,7 +1131,7 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PREPARE_LOAF',
         time: {
-          tag: '12:06:54.000',
+          tag: '-001T12:16:54.000',
           type: 'EPOCH_RELATIVE',
         },
         args: [
@@ -1481,7 +1481,7 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PREPARE_LOAF',
         time: {
-          tag: '12:06:54.000',
+          tag: '-001T12:16:54.000',
           type: 'EPOCH_RELATIVE',
         },
         args: [
@@ -1691,7 +1691,7 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PREPARE_LOAF',
         time: {
-          tag: '12:06:54.000',
+          tag: '-001T12:16:54.000',
           type: 'EPOCH_RELATIVE',
         },
         args: [
@@ -1994,7 +1994,7 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PREPARE_LOAF',
         time: {
-          tag: '12:06:54.000',
+          tag: '-001T12:16:54.000',
           type: 'EPOCH_RELATIVE',
         },
         args: [
@@ -2324,7 +2324,7 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PREPARE_LOAF',
         time: {
-          tag: '12:06:54.000',
+          tag: '-001T12:16:54.000',
           type: 'EPOCH_RELATIVE',
         },
         args: [
@@ -2531,7 +2531,7 @@ describe('sequence generation', () => {
         type: 'command',
         stem: 'PREPARE_LOAF',
         time: {
-          tag: '12:06:54.000',
+          tag: '-001T12:16:54.000',
           type: 'EPOCH_RELATIVE',
         },
         args: [
@@ -3140,7 +3140,7 @@ describe('sequence generation', () => {
     export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
       return [
         A\`2023-091T08:19:00.000\`.ADD_WATER,
-        E\`04:00:00.000\`.PICK_BANANA,
+        E\`000T04:00:00.000\`.PICK_BANANA,
         A\`2023-091T04:20:00.000\`.GROW_BANANA({ quantity: 10, durationSecs: 7200 })
       ];
     }
@@ -3341,7 +3341,7 @@ describe('user sequence to seqjson', () => {
         steps: [
             C.BAKE_BREAD,
             A\`2020-060T03:45:19\`.PREHEAT_OVEN({ temperature: 100 }),
-            E(Temporal.Duration.from({ hours: 12, minutes: 6, seconds: 54 })).PACKAGE_BANANA({
+            E(Temporal.Duration.from({ hours: -12, minutes: -1, seconds: -54 })).PACKAGE_BANANA({
               lot_number: 1093,
               bundle: [
                 {
@@ -3381,7 +3381,7 @@ describe('user sequence to seqjson', () => {
         type: 'command',
         stem: 'PACKAGE_BANANA',
         time: {
-          tag: '12:06:54.000',
+          tag: '-12:01:54.000',
           type: 'EPOCH_RELATIVE',
         },
         args: [


### PR DESCRIPTION
* **Tickets addressed:** Closes [#647](https://github.com/NASA-AMMOS/aerie-ui/issues/647)
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The epoch duration should allow both positive and negative durations, while the relative duration should only accept positive durations. We have made updates to the custom worker on the user interface (UI) to inform users about invalid time formats. Additionally, the eDSL will now alert users if a negative time value is not supported, preventing the creation of an invalid SeqJson.

```ts
E`-12:30:00`.SEQ_VAR_CMD
E`+12:30:00`.SEQ_VAR_CMD
E`-003T12:30:00`.SEQ_VAR_CMD

R`12:30:00`.SEQ_VAR_CMD
R`-12:30:00`.SEQ_VAR_CMD <-- invalid
R`003T12:30:00`.SEQ_VAR_CMD <-- invalid
```
## Verification
Updated e2e test and did some manual testing


## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
Address time values that are 90s as they should be converted to 1:30
