### PR TITLE
Fix Merge Function Volatility and Add Missing Select Permissions

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/functions/functions.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/functions/functions.yaml
@@ -85,6 +85,7 @@
     custom_root_fields:
       function: get_non_conflicting_activities
     session_argument: hasura_session
+    exposed_as: query
   permissions:
     - role: aerie_admin
     - role: user
@@ -96,6 +97,7 @@
     custom_root_fields:
       function: get_conflicting_activities
     session_argument: hasura_session
+    exposed_as: query
   permissions:
     - role: aerie_admin
     - role: user

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan_snapshot.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan_snapshot.yaml
@@ -11,3 +11,23 @@ object_relationships:
       remote_table:
         name: plan
         schema: public
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [snapshot_id, plan_id, revision, name, duration, start_time]
+      filter: {}
+      allow_aggregations: true
+  - role: user
+    permission:
+      columns: [snapshot_id, plan_id, revision, name, duration, start_time]
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: [snapshot_id, plan_id, revision, name, duration, start_time]
+      filter: {}
+      allow_aggregations: true
+delete_permissions:
+  - role: aerie_admin
+    permission:
+      filter: {}

--- a/deployment/hasura/migrations/AerieMerlin/21_user_role_permissions/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/21_user_role_permissions/up.sql
@@ -721,7 +721,7 @@ drop function hasura_functions.get_non_conflicting_activities(merge_request_id i
 create function hasura_functions.get_non_conflicting_activities(_merge_request_id integer, hasura_session json)
   returns setof hasura_functions.get_non_conflicting_activities_return_value
   strict
-  stable
+  volatile
   language plpgsql as $$
 declare
   _snapshot_id_supplying_changes integer;
@@ -789,7 +789,7 @@ drop function hasura_functions.get_conflicting_activities(merge_request_id integ
 create function hasura_functions.get_conflicting_activities(_merge_request_id integer, hasura_session json)
   returns setof hasura_functions.get_conflicting_activities_return_value
   strict
-  stable
+  volatile
   language plpgsql as $$
 declare
   _snapshot_id_supplying_changes integer;

--- a/merlin-server/sql/merlin/functions/hasura/plan_merge_functions.sql
+++ b/merlin-server/sql/merlin/functions/hasura/plan_merge_functions.sql
@@ -29,7 +29,7 @@ create table hasura_functions.get_non_conflicting_activities_return_value(
 create function hasura_functions.get_non_conflicting_activities(_merge_request_id integer, hasura_session json)
   returns setof hasura_functions.get_non_conflicting_activities_return_value
   strict
-  stable
+  volatile
   language plpgsql as $$
 declare
   _snapshot_id_supplying_changes integer;
@@ -109,7 +109,7 @@ create table hasura_functions.get_conflicting_activities_return_value(
 create function hasura_functions.get_conflicting_activities(_merge_request_id integer, hasura_session json)
   returns setof hasura_functions.get_conflicting_activities_return_value
   strict
-  stable
+  volatile
   language plpgsql as $$
 declare
   _snapshot_id_supplying_changes integer;


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
- Adds missing SELECT permissions to `plan_snapshot`. Additionally, `aerie_admin` can DELETE snapshots
- Adjusts the volatility of `get_conflicting_activities` and `get_non_conflicting_activities` from `STABLE` to `VOLATILE`. This was needed, as `check_merge_permissions` is a procedure, which cannot be called in `STABLE` functions

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
@camargo will validate against the UI

