### PR TITLE
Add hasura relationship metadata for linking scheduling goals/conditions to scheduling specs

### DIFF
--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_condition.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_condition.yaml
@@ -12,20 +12,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns:
-        [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns:
-        [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns:
-        [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
       filter: {}
       allow_aggregations: true
 # TODO: Modify these once we have a solution for cross-db auth (These permissions should be based on plan ownership/collaboratorship)

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_condition.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_condition.yaml
@@ -1,20 +1,31 @@
 table:
   name: scheduling_condition
   schema: public
+array_relationships:
+  - name: scheduling_specification_conditions
+    using:
+      foreign_key_constraint_on:
+        column: condition_id
+        table:
+          name: scheduling_specification_conditions
+          schema: public
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns:
+        [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns:
+        [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns:
+        [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
       filter: {}
       allow_aggregations: true
 # TODO: Modify these once we have a solution for cross-db auth (These permissions should be based on plan ownership/collaboratorship)

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal.yaml
@@ -1,37 +1,48 @@
 table:
   name: scheduling_goal
   schema: public
+object_relationships:
+  - name: scheduling_specification_goal
+    using:
+      foreign_key_constraint_on:
+        column: goal_id
+        table:
+          name: scheduling_specification_goals
+          schema: public
 array_relationships:
-- name: analyses
-  using:
-    foreign_key_constraint_on:
-      column: goal_id
-      table:
-        name: scheduling_goal_analysis
-        schema: public
-- name: tags
-  using:
-    manual_configuration:
-      remote_table:
-        name: scheduling_goal_tags
-        schema: metadata
-      insertion_order: null
-      column_mapping:
-        id: goal_id
+  - name: analyses
+    using:
+      foreign_key_constraint_on:
+        column: goal_id
+        table:
+          name: scheduling_goal_analysis
+          schema: public
+  - name: tags
+    using:
+      manual_configuration:
+        remote_table:
+          name: scheduling_goal_tags
+          schema: metadata
+        insertion_order: null
+        column_mapping:
+          id: goal_id
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns:
+        [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns:
+        [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns:
+        [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
       filter: {}
       allow_aggregations: true
 # TODO: Modify these once we have a solution for cross-db auth (These permissions should be based on plan ownership/collaboratorship)

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal.yaml
@@ -10,39 +10,36 @@ object_relationships:
           name: scheduling_specification_goals
           schema: public
 array_relationships:
-  - name: analyses
-    using:
-      foreign_key_constraint_on:
-        column: goal_id
-        table:
-          name: scheduling_goal_analysis
-          schema: public
-  - name: tags
-    using:
-      manual_configuration:
-        remote_table:
-          name: scheduling_goal_tags
-          schema: metadata
-        insertion_order: null
-        column_mapping:
-          id: goal_id
+- name: analyses
+  using:
+    foreign_key_constraint_on:
+      column: goal_id
+      table:
+        name: scheduling_goal_analysis
+        schema: public
+- name: tags
+  using:
+    manual_configuration:
+      remote_table:
+        name: scheduling_goal_tags
+        schema: metadata
+      insertion_order: null
+      column_mapping:
+        id: goal_id
 select_permissions:
   - role: aerie_admin
     permission:
-      columns:
-        [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns:
-        [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns:
-        [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
       filter: {}
       allow_aggregations: true
 # TODO: Modify these once we have a solution for cross-db auth (These permissions should be based on plan ownership/collaboratorship)


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Adds the following object/array relationships:

- scheduling_goal . id  → scheduling_specification_goals . goal_id
- scheduling_condition . id  → scheduling_specification_conditions . condition_id

This creates a more direct link between goals/conditions and their associated plans, allowing for easier determination of permissions in the UI.

## Verification
Upon rebuilding, confirmed the following queries ran successfully in the Hasura API Explorer

```graphql
{
  conditions: scheduling_condition(order_by: { id: desc }) {
    id
    name
    scheduling_specification_conditions {
      specification_id
    }
  }
}

{
  goals: scheduling_goal(order_by: { id: desc }) {
    id
    name
    scheduling_specification_goal {
      specification_id
    }
  }
}
```

## Documentation
N/A

## Future work
N/A
