### PR TITLE
Remove Action Keys that Cannot Take Fine-Grained Permissions

### DIFF
--- a/deployment/hasura/migrations/AerieMerlin/21_user_role_permissions/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/21_user_role_permissions/up.sql
@@ -5,10 +5,8 @@ create type metadata.permission
     'PLAN_OWNER_TARGET', 'PLAN_COLLABORATOR_TARGET', 'PLAN_OWNER_COLLABORATOR_TARGET');
 
 create type metadata.action_permission_key
-  as enum ('simulate', 'schedule', 'insert_command_dict', 'insert_ext_dataset', 'extend_ext_dataset',
-    'check_constraints', 'create_expansion_set', 'create_expansion_rule', 'expand_all_activities',
-    'resource_samples', 'sequence_seq_json', 'sequence_seq_json_bulk', 'user_sequence_seq_json',
-    'user_sequence_seq_json_bulk', 'get_command_dict_ts');
+  as enum ('simulate', 'schedule', 'insert_ext_dataset', 'check_constraints', 'create_expansion_set',
+    'create_expansion_rule', 'expand_all_activities', 'sequence_seq_json_bulk', 'resource_samples');
 
 create type metadata.function_permission_key
   as enum ('apply_preset', 'branch_plan', 'create_merge_rq', 'withdraw_merge_rq', 'begin_merge', 'cancel_merge',

--- a/merlin-server/sql/merlin/domain-types/permissions.sql
+++ b/merlin-server/sql/merlin/domain-types/permissions.sql
@@ -4,10 +4,8 @@ create type metadata.permission
     'PLAN_OWNER_TARGET', 'PLAN_COLLABORATOR_TARGET', 'PLAN_OWNER_COLLABORATOR_TARGET');
 
 create type metadata.action_permission_key
-  as enum ('simulate', 'schedule', 'insert_command_dict', 'insert_ext_dataset', 'extend_ext_dataset',
-    'check_constraints', 'create_expansion_set', 'create_expansion_rule', 'expand_all_activities',
-    'resource_samples', 'sequence_seq_json', 'sequence_seq_json_bulk', 'user_sequence_seq_json',
-    'user_sequence_seq_json_bulk', 'get_command_dict_ts');
+  as enum ('simulate', 'schedule', 'insert_ext_dataset', 'check_constraints', 'create_expansion_set',
+    'create_expansion_rule', 'expand_all_activities', 'sequence_seq_json_bulk', 'resource_samples');
 
 create type metadata.function_permission_key
   as enum ('apply_preset', 'branch_plan', 'create_merge_rq', 'withdraw_merge_rq', 'begin_merge', 'cancel_merge',


### PR DESCRIPTION
* **Review:** By file
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

While implementing #1030, @cohansen found that implementing fine-grained permissions for the following action keys was not feasible given the available metadata:
- insert_command_dict
- sequence_seq_json
- ~~sequence_seq_json_bulk~~ this key is being kept
- user_sequence_seq_json
- user_sequence_seq_json_bulk
- get_command_dict_ts

Additionally, while implementing #1032, I found that `extend_ext_dataset` could also not take fine-grained permissions, as Plan Datasets can be associated with multiple plans across multiple mission models and do not have an `owner` field.

## Documentation/Future Work
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

Once this PR is approved, [this comment](https://github.com/NASA-AMMOS/aerie/discussions/983#discussioncomment-6257146) will be updated to remove the keys from the spec
