### PR TITLE
Support Pass By Position for Sequencing

### DIFF
--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
@@ -42,131 +42,50 @@ describe('Command', () => {
     it('should handle absolute time tagged commands', () => {
       const command = CommandStem.new({
         stem: 'TEST',
-        arguments: [{type: 'string', value: 'string' }, {type: 'number', value: 0 }, { type: 'boolean', value: true }],
+        arguments: [],
         absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
       });
 
-      expect(command.toEDSLString()).toEqual(`A\`2020-001T00:00:00.000\`.TEST([
-  {
-    type: 'string',
-    value: 'string',
-  },
-  {
-    type: 'number',
-    value: 0,
-  },
-  {
-    type: 'boolean',
-    value: true,
-  },
-])`);
+      expect(command.toEDSLString()).toEqual(`A\`2020-001T00:00:00.000\`.TEST`);
     });
 
     it('should handle relative time tagged commands', () => {
       const command = CommandStem.new({
         stem: 'TEST',
-        arguments: [{type: 'string', value: 'string' }, {type: 'number', value: 0 }, { type: 'boolean', value: true }],
+        arguments: [],
         relativeTime: hmsToDuration('00:00:00.000' as HMS_STRING),
       });
 
-      expect(command.toEDSLString()).toEqual(`R\`00:00:00.000\`.TEST([
-  {
-    type: 'string',
-    value: 'string',
-  },
-  {
-    type: 'number',
-    value: 0,
-  },
-  {
-    type: 'boolean',
-    value: true,
-  },
-])`);
+      expect(command.toEDSLString()).toEqual(`R\`00:00:00.000\`.TEST`);
     });
 
     it('should handle epoch relative time tagged commands', () => {
       const command = CommandStem.new({
         stem: 'TEST',
-        arguments: [{type: 'string', value: 'string' }, {type: 'number', value: 0 }, { type: 'boolean', value: true }],
+        arguments: [],
         epochTime: hmsToDuration('00:00:00.000' as HMS_STRING),
       });
 
-      expect(command.toEDSLString()).toEqual(`E\`00:00:00.000\`.TEST([
-  {
-    type: 'string',
-    value: 'string',
-  },
-  {
-    type: 'number',
-    value: 0,
-  },
-  {
-    type: 'boolean',
-    value: true,
-  },
-])`);
+      expect(command.toEDSLString()).toEqual(`E\`00:00:00.000\`.TEST`);
     });
 
     it('should handle command complete commands', () => {
       const command = CommandStem.new({
         stem: 'TEST',
-        arguments: [{type: 'string', value: 'string' }, {type: 'number', value: 0 }, { type: 'boolean', value: true }],
-      });
-
-      expect(command.toEDSLString()).toEqual(`C.TEST([
-  {
-    type: 'string',
-    value: 'string',
-  },
-  {
-    type: 'number',
-    value: 0,
-  },
-  {
-    type: 'boolean',
-    value: true,
-  },
-])`);
-    });
-
-    it('should handle commands without arguments', () => {
-      const command = CommandStem.new({
-        stem: 'TEST',
         arguments: [],
       });
 
-      expect(command.toEDSLString()).toEqual('C.TEST');
-
-      const command2 = CommandStem.new({
-        stem: 'TEST',
-        arguments: {},
-      });
-
-      expect(command2.toEDSLString()).toEqual('C.TEST');
+      expect(command.toEDSLString()).toEqual(`C.TEST`);
     });
 
     it('should convert to EDSL string with array arguments', () => {
       const command = CommandStem.new({
         stem: 'TEST',
-        arguments: [{type: 'string', value: 'string' }, {type: 'number', value: 0 }, { type: 'boolean', value: true }],
+        arguments: [{value: 'string' }, { value: 0 }, { value: true }],
         absoluteTime: doyToInstant('2020-001T00:00:00.000' as DOY_STRING),
       });
 
-      expect(command.toEDSLString()).toEqual(`A\`2020-001T00:00:00.000\`.TEST([
-  {
-    type: 'string',
-    value: 'string',
-  },
-  {
-    type: 'number',
-    value: 0,
-  },
-  {
-    type: 'boolean',
-    value: true,
-  },
-])`);
+      expect(command.toEDSLString()).toEqual(`A\`2020-001T00:00:00.000\`.TEST(['string'],[0],[true])`);
     });
 
     it('should convert to EDSL string with named arguments', () => {
@@ -181,7 +100,7 @@ describe('Command', () => {
       });
 
       expect(command.toEDSLString()).toEqual(
-        "A`2020-001T00:00:00.000`.TEST({\n  string: 'string',\n  number: 0,\n  boolean: true,\n})",
+        "A`2020-001T00:00:00.000`.TEST('string',0,true)",
       );
     });
 
@@ -195,13 +114,7 @@ describe('Command', () => {
       });
 
       expect(groundEvent.toEDSLString()).toEqual(`A\`2020-001T00:00:00.000\`.GROUND_EVENT('Ground Event Name')
-  .ARGUMENTS([
-    {
-      name: 'name',
-      type: 'string',
-      value: 'hello',
-    },
-  ])
+  .ARGUMENTS('hello')
   .DESCRIPTION('ground event description')
   .METADATA({
     author: 'Emery',
@@ -217,13 +130,7 @@ describe('Command', () => {
       });
 
       expect(groundBlock.toEDSLString()).toEqual(`C.GROUND_BLOCK('Ground Block Name')
-  .ARGUMENTS([
-    {
-      name: 'turnOff',
-      type: 'boolean',
-      value: false,
-    },
-  ])
+  .ARGUMENTS(false)
   .DESCRIPTION('ground block description')
   .METADATA({
     author: 'Jasmine',
@@ -246,13 +153,7 @@ describe('Command', () => {
       });
 
       expect(activateStep.toEDSLString()).toEqual(`C.ACTIVATE('test0001')
-  .ARGUMENTS([
-    {
-      name: 'turnOff',
-      type: 'boolean',
-      value: false,
-    },
-  ])
+  .ARGUMENTS(false)
   .DESCRIPTION('ground block description')
   .ENGINE(45)
   .EPOCH('epoch1')
@@ -284,13 +185,7 @@ describe('Command', () => {
       });
 
       expect(loadStep.toEDSLString()).toEqual(`C.LOAD('test0001')
-  .ARGUMENTS([
-    {
-      name: 'turnOff',
-      type: 'boolean',
-      value: false,
-    },
-  ])
+  .ARGUMENTS(false)
   .DESCRIPTION('ground block description')
   .ENGINE(45)
   .EPOCH('epoch1')\t  .METADATA({
@@ -497,23 +392,12 @@ describe('Sequence', () => {
       ENUM('duration', 'POSSIBLE_DURATION')
     ],
     steps: ({ locals, parameters }) => ([
-      A\`2020-001T00:00:00.000\`.TEST([
-          'string',
-          0,
-          true,
-      ]),
-      A\`2020-001T00:00:00.000\`.TEST({
-        string: 'string',
-        number: 0,
-        boolean: true,
-      })
+      A\`2020-001T00:00:00.000\`.TEST(['string'],[0],[true]),
+      A\`2020-001T00:00:00.000\`.TEST('string',0,true)
         .METADATA({
           author: 'XXXXXXXXXXXXXXXXXXXXXXXXXX',
         }),
-      A\`2021-001T00:00:00.000\`.TEST({
-        temperature: locals.temp,
-        duration: parameters.duration,
-      })
+      A\`2021-001T00:00:00.000\`.TEST(locals.temp,parameters.duration)
         .METADATA({
           author: 'ZZZZ',
         }),
@@ -562,9 +446,7 @@ describe('Sequence', () => {
     seqId: 'Immediate',
     metadata: {},
     immediate_commands: [
-      SMASH_BANANA({
-        behavior: 'AGRESSIVE',
-      })
+      SMASH_BANANA('AGRESSIVE')
         .DESCRIPTION('Hulk smash banannas')
         .METADATA({
           author: 'An Avenger',

--- a/sequencing-server/src/lib/codegen/CommandTypeCodegen.ts
+++ b/sequencing-server/src/lib/codegen/CommandTypeCodegen.ts
@@ -133,36 +133,122 @@ ${doc}
 
   const value = `
 ${doc}
-function ${fswCommandName}(...args: [{ ${argsWithType.map(arg => arg.name + ': ' + arg.type).join(',')} }]) {
+function ${fswCommandName}(...args:
+\t\t| [ ${argsWithType.map(arg => convertObjectArgsToPassByPosition(arg.name,arg.type)).join(',')} ]
+\t\t| [{ ${argsWithType.map(arg => arg.name + ': ' + arg.type).join(',')} }]) {
   return ImmediateStem.new({
     stem: '${fswCommandName}',
-    arguments: args
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['${fswCommandName}']) : commandArraysToObj(args, argumentOrders['${fswCommandName}']),
   }) as ${fswCommandName}_IMMEDIATE;
 }
-function ${fswCommandName}_STEP(...args: [{ ${argsWithType
-    .map(arg => arg.name + ': ' + arg.type + `${argumentTypeToVariable(arg.type)}`)
-    .join(',')} }]) {
+function ${fswCommandName}_STEP(...args:
+\t\t|[ ${argsWithType.map(arg => `${convertObjectArgsToPassByPosition(arg.name,arg.type)} ${argumentTypeToVariable(arg.type)}`).join(',')} ]
+\t\t|[{ ${argsWithType.map(arg => arg.name + ': ' + arg.type + `${argumentTypeToVariable(arg.type)}`).join(',')} }]) {
   return CommandStem.new({
     stem: '${fswCommandName}',
-    arguments: sortCommandArguments(args, argumentOrders['${fswCommandName}'])
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['${fswCommandName}']) : commandArraysToObj(args, argumentOrders['${fswCommandName}']),
   }) as ${fswCommandName}_STEP;
 }`;
 
   const interfaces = `
-\tinterface ${fswCommandName}_IMMEDIATE extends ImmediateStem<[ [{ ${argsWithType
-    .map(arg => arg.name + ': ' + arg.type)
-    .join(',')} }] ]> {}
-\tinterface ${fswCommandName}_STEP extends CommandStem<[ [{ ${argsWithType
-    .map(arg => arg.name + ': ' + arg.type + `${argumentTypeToVariable(arg.type)}`)
-    .join(',')} }] ]> {}
-\tfunction ${fswCommandName}(...args: [{ ${argsWithType
-    .map(arg => arg.name + ': ' + arg.type)
-    .join(',')} }]) : ${fswCommandName}_IMMEDIATE`;
+\tinterface ${fswCommandName}_IMMEDIATE extends ImmediateStem<[
+\t\t | [ ${argsWithType
+      .map(arg => convertObjectArgsToPassByPosition(arg.name,arg.type))
+    .join(',')}]
+\t\t | [{ ${argsWithType
+      .map(arg => arg.name + ': ' + arg.type)
+      .join(',')} }]]> {}
+\tinterface ${fswCommandName}_STEP extends CommandStem<[
+\t\t | [ ${argsWithType
+      .map(arg => `${convertObjectArgsToPassByPosition(arg.name,arg.type)} ${argumentTypeToVariable(arg.type)}`)
+    .join(',')}]
+\t\t | [{ ${argsWithType
+      .map(arg => arg.name + ': ' + arg.type + `${argumentTypeToVariable(arg.type)}`)
+      .join(',')} }]]> {}
+\tfunction ${fswCommandName}(...args:
+\t\t| [ ${argsWithType
+      .map(arg => convertObjectArgsToPassByPosition(arg.name,arg.type))
+    .join(',')}]
+\t\t| [{ ${argsWithType
+      .map(arg => arg.name + ': ' + arg.type)
+      .join(',')} }]) : ${fswCommandName}_IMMEDIATE`;
 
   return {
     value,
     interfaces,
   };
+}
+
+/**
+ * Converts object-based function arguments to pass-by-position format.
+ *
+ * This function takes a name and a type as input, where the type is represented
+ * using TypeScript type notation. It converts the type to pass-by-position format
+ * by replacing curly braces ('{}') with square brackets ('[]'), semicolons (';') with
+ * commas (','), and removing single quotes from property names in the type.
+ * The output will be a string representation of the name and the converted type in
+ * pass-by-position format.
+ *
+ * @param {string} name - The name of the function argument.
+ * @param {string} type - The TypeScript type representation of the function argument.
+ * @returns {string} A string representation of the name and the converted type in
+ * pass-by-position format.
+ *
+ * @example
+ * const name = "'person'";
+ * const type = "'TALL' | 'SHORT'";
+ * const result = convertObjectArgsToPassByPosition(name, type);
+ * // Output: "person : ['TALL' | 'SHORT']"
+ *
+ * @example
+ * const name = "'Television'";
+ * const type = "Array<{
+ *   ops_cat: 'FULLSCREEN' | 'WINDOWED';
+ *   channel_num: U16;
+ * }>";
+ * const result = convertObjectArgsToPassByPosition(name, type);
+ * // Output: "Television : Array<[
+ * //   ops_cat: 'FULLSCREEN' | 'WINDOWED',
+ * //   channel_num: U16
+ * // ]>"
+ */
+function convertObjectArgsToPassByPosition(name : string, type: string){
+  // remove ' around name
+  name = name.replace(/'/g, '');
+  // change [] to {} and ; to ,
+  type = type.replace(/[{;}]/g, (match) => {
+    switch (match) {
+      case '{':
+        return '[';
+      case '}':
+        return ']';
+      case ';':
+        return ',';
+      default:
+        return match;
+    }
+  });
+
+  /*
+   * The regex will remove single quotes only around property names (e.g., ops_cat) while
+   * ignoring single quotes around specific literals (e.g., FULLSCREEN, WINDOWED).
+   * For example:
+   * Input:
+   *     Array<[
+   *       'ops_cat': 'FULLSCREEN' | 'WINDOWED',
+   *       'channel_num': U16
+   *     ]>
+   *
+   * Output:
+   *     Array<[
+   *       ops_cat: 'FULLSCREEN' | 'WINDOWED',
+   *       channel_num: U16
+   *     ]>
+   */
+  type = type.replace(/'([^']+)':/g, '$1:')
+
+  return `${name} : ${type}`
+
 }
 
 /**

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -1415,7 +1415,10 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
                 ? \`R\\\`\${durationToHms(this.relativeTime)}\\\`\`
                 : 'C';
 
-    const argsString = Object.keys(this.arguments).length === 0 ? '' : \`(\${argumentsToString(this.arguments)})\`;
+    const argsString =
+        Object.keys(this.arguments).length === 0
+            ? ''
+            : \`(\${argumentsToPositionString(this.arguments)})\`;
 
     const metadata =
         this._metadata && Object.keys(this._metadata).length !== 0
@@ -1505,7 +1508,11 @@ export class ImmediateStem<A extends Args[] | { [argName: string]: any } = [] | 
   }
 
   public toEDSLString(): string {
-    const argsString = Object.keys(this.arguments).length === 0 ? '' : \`(\${argumentsToString(this.arguments)})\`;
+    const argsString =
+        Object.keys(this.arguments).length === 0
+            ? ''
+            : \`(\${argumentsToPositionString(this.arguments)})\`;
+
 
     const metadata =
         this._metadata && Object.keys(this._metadata).length !== 0
@@ -1651,11 +1658,11 @@ export class Ground_Block implements GroundBlock {
   }
 
   // @ts-ignore : 'Description' found in JSON Spec
-  public ARGUMENTS(args: Args): Ground_Block {
+  public ARGUMENTS(...args: [Args] | [A, ...A[]]): Ground_Block {
     return Ground_Block.new({
       name: this.name,
       ...(this._models && { models: this._models }),
-      args: args,
+      args: typeof args[0] === 'object' ? args[0] : convertArgsToInterfaces(commandArraysToObj(args, [])),
       ...(this._description && { description: this._description }),
       ...(this._metadata && { metadata: this._metadata }),
       ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
@@ -1723,7 +1730,7 @@ export class Ground_Block implements GroundBlock {
 
     const args =
         this._args && Object.keys(this._args).length !== 0
-            ? '\\n' + indent(\`.ARGUMENTS(\${argumentsToString(this._args)})\`, 1)
+            ? '\\n' + indent(\`.ARGUMENTS(\${argumentsToPositionString(convertInterfacesToArgs(this._args))})\`, 1)
             : '';
 
     const metadata =
@@ -1884,11 +1891,11 @@ export class Ground_Event implements GroundEvent {
   }
 
   // @ts-ignore : 'Description' found in JSON Spec
-  public ARGUMENTS(args: Args): Ground_Event {
+  public ARGUMENTS(...args: [Args] | [A, ...A[]]): Ground_Event {
     return Ground_Event.new({
       name: this.name,
       ...(this._models && { models: this._models }),
-      args: args,
+      args: typeof args[0] === 'object' ? args[0] : convertArgsToInterfaces(commandArraysToObj(args, [])),
       ...(this._description && { description: this._description }),
       ...(this._metadata && { metadata: this._metadata }),
       ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
@@ -1955,7 +1962,7 @@ export class Ground_Event implements GroundEvent {
 
     const args =
         this._args && Object.keys(this._args).length !== 0
-            ? \`\\n\` + indent(\`.ARGUMENTS(\${argumentsToString(this._args)})\`, 1)
+            ? \`\\n\` + indent(\`.ARGUMENTS(\${argumentsToPositionString(convertInterfacesToArgs(this._args))})\`, 1)
             : '';
 
     const metadata =
@@ -2069,10 +2076,10 @@ export class ActivateStep implements Activate {
   }
 
   // @ts-ignore : 'Args' found in JSON Spec
-  public ARGUMENTS(args: Args): ActivateStep {
+  public ARGUMENTS(...args: [Args] | [A, ...A[]]): ActivateStep {
     return ActivateStep.new({
       sequence: this.sequence,
-      args: args,
+      args: typeof args[0] === 'object' ? args[0] : convertArgsToInterfaces(commandArraysToObj(args, [])),
       ...(this._description && { description: this._description }),
       ...(this._engine && { engine: this._engine }),
       ...(this._epoch && { epoch: this._epoch }),
@@ -2245,7 +2252,7 @@ export class ActivateStep implements Activate {
 
     const args =
         this._args && Object.keys(this._args).length !== 0
-            ? '\\n' + indent(\`.ARGUMENTS(\${argumentsToString(this._args)})\`, 1)
+            ? '\\n' + indent(\`.ARGUMENTS(\${argumentsToPositionString(convertInterfacesToArgs(this._args))})\`, 1)
             : '';
 
     const description =
@@ -2363,10 +2370,10 @@ export class LoadStep implements Load {
   }
 
   // @ts-ignore : 'Args' found in JSON Spec
-  public ARGUMENTS(args: Args): LoadStep {
+  public ARGUMENTS(...args: [Args] | [A, ...A[]]): LoadStep {
     return LoadStep.new({
       sequence: this.sequence,
-      args: args,
+      args: typeof args[0] === 'object' ? args[0] : convertArgsToInterfaces(commandArraysToObj(args, [])),
       ...(this._description && { description: this._description }),
       ...(this._engine && { engine: this._engine }),
       ...(this._epoch && { epoch: this._epoch }),
@@ -2539,7 +2546,7 @@ export class LoadStep implements Load {
 
     const args =
         this._args && Object.keys(this._args).length !== 0
-            ? '\\n' + indent(\`.ARGUMENTS(\${argumentsToString(this._args)})\`, 1)
+            ? '\\n' + indent(\`.ARGUMENTS(\${argumentsToPositionString(convertInterfacesToArgs(this._args))})\`, 1)
             : '';
 
     const description =
@@ -3296,6 +3303,46 @@ function commandsWithTimeValue<T extends TimingTypes>(
  * ---------------------------------
  */
 
+
+/**
+ * Converts an array of arguments and keys into an object.
+ *
+ * @param {any[]} args - The array of arguments.
+ * @param {string[]} keys - The array of keys.
+ * @returns {Record<string, any>} The object.
+ */
+// @ts-ignore : Used in generated code
+function commandArraysToObj(args: any[], keys: string[]): Record<string, any> {
+  const obj: Record<string, any> = {};
+
+  function handleNestedArrays(values: any[], subKeys: string[]): any[] {
+    const nestedObjs = [];
+    for (const subArray of values) {
+      nestedObjs.push(commandArraysToObj(subArray, subKeys));
+    }
+    return nestedObjs;
+  }
+
+  for (let i = 0; i < args.length; i++) {
+    const key = keys[i] || \`arg_\${i}\`; // Use \`arg_\${i}\` if key is undefined
+    const value = args[i];
+
+    if (Array.isArray(value)) {
+      const subKeys = keys.slice(i + 1);
+      obj[key] = handleNestedArrays(value, subKeys);
+      if (value.length > 0) {
+        keys = keys.slice(0, i + 1).concat(subKeys.slice(value[0].length));
+      }
+    } else {
+      // Assign values to properties
+      obj[key] = value;
+    }
+  }
+
+  return obj;
+}
+
+
 // @ts-ignore : Used in generated code
 function sortCommandArguments(args: { [argName: string]: any }, order: string[]): { [argName: string]: any } {
   if (typeof args[0] === 'object') {
@@ -3425,7 +3472,7 @@ function convertInterfacesToArgs(interfaces: Args, localNames?: String[], parame
             } else if (parameterNames && parameterNames.includes(arg.value)) {
               variable.setKind('parameters');
             } else {
-              const errorMsg = \`Variable '\${arg.value}' is not defined as a local or parameter\`;
+              const errorMsg = \`Variable '\${arg.value}' is not defined as a local or parameter\\n\`;
               variable = Variable.new({ name: \`\${arg.value} //ERROR: \${errorMsg}\`, type: VariableType.INT });
               variable.setKind('unknown');
             }
@@ -3593,6 +3640,73 @@ function argumentsToString<A extends Args[] | { [argName: string]: any } = [] | 
     output += ']';
   } else {
     output += '}';
+  }
+
+  return output;
+}
+
+/**
+ * Converts an object of arguments to an array string representation,
+ * preserving the position-based structure of the arguments.
+ *
+ * @template A - Type parameter representing the type of the arguments.
+ * @param {A} args - The arguments to convert.
+ * @returns {string} - The string representation of the arguments.
+ */
+function argumentsToPositionString<A extends any[] | { [argName: string]: any } = [] | {}>(args: A): string {
+  let output = '';
+
+  function printObject(obj: { [argName: string]: any }) {
+    Object.keys(obj).forEach((key, index) => {
+      const value = obj[key];
+
+      if (Array.isArray(value)) {
+        if (index > 0) output += ',';
+        output += \`[\`;
+        printArray(value);
+        output += \`]\`;
+      } else if (typeof value === 'object') {
+        if (value instanceof Variable) {
+          if (index > 0) output += ',';
+          output += \`\${value.toReferenceString()}\`;
+        } else {
+          if (index > 0) output += ',';
+          output += \`[\`;
+          printValue(value);
+          output += \`]\`;
+        }
+      } else {
+        if (index > 0) output += ',';
+        output += \`\${typeof value === 'string' ? \`'\${value}'\` : value}\`;
+      }
+    });
+  }
+
+  function printArray(array: any[]) {
+    array.forEach((item, index) => {
+      if (index > 0) output += ',';
+      output += \`[\`;
+      printValue(item);
+      output += \`]\`;
+    });
+  }
+
+  function printValue(value: any) {
+    if (Array.isArray(value)) {
+      printArray(value);
+    } else if (typeof value === 'object') {
+      printObject(value);
+    } else {
+      output += \`\${typeof value === 'string' ? \`'\${value}'\` : value}\`;
+    }
+  }
+
+  if (Array.isArray(args)) {
+    printArray(args);
+  } else if (typeof args === 'object') {
+    printObject(args);
+  } else {
+    output += \`\${typeof args === 'string' ? \`'\${args}'\` : args}\`;
   }
 
   return output;
@@ -3999,33 +4113,75 @@ export interface HardwareCommand {
 /** END Sequence JSON Spec */
 declare global {
 
-	interface ECHO_IMMEDIATE extends ImmediateStem<[ [{ 'echo_string': VarString<8, 1024> }] ]> {}
-	interface ECHO_STEP extends CommandStem<[ [{ 'echo_string': VarString<8, 1024>| 'STRING' }] ]> {}
-	function ECHO(...args: [{ 'echo_string': VarString<8, 1024> }]) : ECHO_IMMEDIATE
+	interface ECHO_IMMEDIATE extends ImmediateStem<[
+		 | [ echo_string : VarString<8, 1024>]
+		 | [{ 'echo_string': VarString<8, 1024> }]]> {}
+	interface ECHO_STEP extends CommandStem<[
+		 | [ echo_string : VarString<8, 1024> | 'STRING']
+		 | [{ 'echo_string': VarString<8, 1024>| 'STRING' }]]> {}
+	function ECHO(...args:
+		| [ echo_string : VarString<8, 1024>]
+		| [{ 'echo_string': VarString<8, 1024> }]) : ECHO_IMMEDIATE
 
-	interface PREHEAT_OVEN_IMMEDIATE extends ImmediateStem<[ [{ 'temperature': U8 }] ]> {}
-	interface PREHEAT_OVEN_STEP extends CommandStem<[ [{ 'temperature': U8| 'UINT' }] ]> {}
-	function PREHEAT_OVEN(...args: [{ 'temperature': U8 }]) : PREHEAT_OVEN_IMMEDIATE
+	interface PREHEAT_OVEN_IMMEDIATE extends ImmediateStem<[
+		 | [ temperature : U8]
+		 | [{ 'temperature': U8 }]]> {}
+	interface PREHEAT_OVEN_STEP extends CommandStem<[
+		 | [ temperature : U8 | 'UINT']
+		 | [{ 'temperature': U8| 'UINT' }]]> {}
+	function PREHEAT_OVEN(...args:
+		| [ temperature : U8]
+		| [{ 'temperature': U8 }]) : PREHEAT_OVEN_IMMEDIATE
 
-	interface THROW_BANANA_IMMEDIATE extends ImmediateStem<[ [{ 'distance': U8 }] ]> {}
-	interface THROW_BANANA_STEP extends CommandStem<[ [{ 'distance': U8| 'UINT' }] ]> {}
-	function THROW_BANANA(...args: [{ 'distance': U8 }]) : THROW_BANANA_IMMEDIATE
+	interface THROW_BANANA_IMMEDIATE extends ImmediateStem<[
+		 | [ distance : U8]
+		 | [{ 'distance': U8 }]]> {}
+	interface THROW_BANANA_STEP extends CommandStem<[
+		 | [ distance : U8 | 'UINT']
+		 | [{ 'distance': U8| 'UINT' }]]> {}
+	function THROW_BANANA(...args:
+		| [ distance : U8]
+		| [{ 'distance': U8 }]) : THROW_BANANA_IMMEDIATE
 
-	interface GROW_BANANA_IMMEDIATE extends ImmediateStem<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
-	interface GROW_BANANA_STEP extends CommandStem<[ [{ 'quantity': U8| 'UINT','durationSecs': U8| 'UINT' }] ]> {}
-	function GROW_BANANA(...args: [{ 'quantity': U8,'durationSecs': U8 }]) : GROW_BANANA_IMMEDIATE
+	interface GROW_BANANA_IMMEDIATE extends ImmediateStem<[
+		 | [ quantity : U8,durationSecs : U8]
+		 | [{ 'quantity': U8,'durationSecs': U8 }]]> {}
+	interface GROW_BANANA_STEP extends CommandStem<[
+		 | [ quantity : U8 | 'UINT',durationSecs : U8 | 'UINT']
+		 | [{ 'quantity': U8| 'UINT','durationSecs': U8| 'UINT' }]]> {}
+	function GROW_BANANA(...args:
+		| [ quantity : U8,durationSecs : U8]
+		| [{ 'quantity': U8,'durationSecs': U8 }]) : GROW_BANANA_IMMEDIATE
 
-	interface GrowBanana_IMMEDIATE extends ImmediateStem<[ [{ 'quantity': U8,'durationSecs': U8 }] ]> {}
-	interface GrowBanana_STEP extends CommandStem<[ [{ 'quantity': U8| 'UINT','durationSecs': U8| 'UINT' }] ]> {}
-	function GrowBanana(...args: [{ 'quantity': U8,'durationSecs': U8 }]) : GrowBanana_IMMEDIATE
+	interface GrowBanana_IMMEDIATE extends ImmediateStem<[
+		 | [ quantity : U8,durationSecs : U8]
+		 | [{ 'quantity': U8,'durationSecs': U8 }]]> {}
+	interface GrowBanana_STEP extends CommandStem<[
+		 | [ quantity : U8 | 'UINT',durationSecs : U8 | 'UINT']
+		 | [{ 'quantity': U8| 'UINT','durationSecs': U8| 'UINT' }]]> {}
+	function GrowBanana(...args:
+		| [ quantity : U8,durationSecs : U8]
+		| [{ 'quantity': U8,'durationSecs': U8 }]) : GrowBanana_IMMEDIATE
 
-	interface PREPARE_LOAF_IMMEDIATE extends ImmediateStem<[ [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }] ]> {}
-	interface PREPARE_LOAF_STEP extends CommandStem<[ [{ 'tb_sugar': U8| 'UINT','gluten_free': ('FALSE' | 'TRUE')| 'ENUM' }] ]> {}
-	function PREPARE_LOAF(...args: [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }]) : PREPARE_LOAF_IMMEDIATE
+	interface PREPARE_LOAF_IMMEDIATE extends ImmediateStem<[
+		 | [ tb_sugar : U8,gluten_free : ('FALSE' | 'TRUE')]
+		 | [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }]]> {}
+	interface PREPARE_LOAF_STEP extends CommandStem<[
+		 | [ tb_sugar : U8 | 'UINT',gluten_free : ('FALSE' | 'TRUE') | 'ENUM']
+		 | [{ 'tb_sugar': U8| 'UINT','gluten_free': ('FALSE' | 'TRUE')| 'ENUM' }]]> {}
+	function PREPARE_LOAF(...args:
+		| [ tb_sugar : U8,gluten_free : ('FALSE' | 'TRUE')]
+		| [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }]) : PREPARE_LOAF_IMMEDIATE
 
-	interface PEEL_BANANA_IMMEDIATE extends ImmediateStem<[ [{ 'peelDirection': ('fromStem' | 'fromTip') }] ]> {}
-	interface PEEL_BANANA_STEP extends CommandStem<[ [{ 'peelDirection': ('fromStem' | 'fromTip')| 'ENUM' }] ]> {}
-	function PEEL_BANANA(...args: [{ 'peelDirection': ('fromStem' | 'fromTip') }]) : PEEL_BANANA_IMMEDIATE
+	interface PEEL_BANANA_IMMEDIATE extends ImmediateStem<[
+		 | [ peelDirection : ('fromStem' | 'fromTip')]
+		 | [{ 'peelDirection': ('fromStem' | 'fromTip') }]]> {}
+	interface PEEL_BANANA_STEP extends CommandStem<[
+		 | [ peelDirection : ('fromStem' | 'fromTip') | 'ENUM']
+		 | [{ 'peelDirection': ('fromStem' | 'fromTip')| 'ENUM' }]]> {}
+	function PEEL_BANANA(...args:
+		| [ peelDirection : ('fromStem' | 'fromTip')]
+		| [{ 'peelDirection': ('fromStem' | 'fromTip') }]) : PEEL_BANANA_IMMEDIATE
 
 
 /**
@@ -4047,9 +4203,15 @@ declare global {
 	const ADD_WATER: ADD_WATER_IMMEDIATE;
 
 
-	interface PACKAGE_BANANA_IMMEDIATE extends ImmediateStem<[ [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }] ]> {}
-	interface PACKAGE_BANANA_STEP extends CommandStem<[ [{ 'lot_number': U16| 'UINT','bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }] ]> {}
-	function PACKAGE_BANANA(...args: [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]) : PACKAGE_BANANA_IMMEDIATE
+	interface PACKAGE_BANANA_IMMEDIATE extends ImmediateStem<[
+		 | [ lot_number : U16,bundle : Array<[ bundle_name: VarString<8, 1024>, number_of_bananas: U8 ]>]
+		 | [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]]> {}
+	interface PACKAGE_BANANA_STEP extends CommandStem<[
+		 | [ lot_number : U16 | 'UINT',bundle : Array<[ bundle_name: VarString<8, 1024>, number_of_bananas: U8 ]> ]
+		 | [{ 'lot_number': U16| 'UINT','bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]]> {}
+	function PACKAGE_BANANA(...args:
+		| [ lot_number : U16,bundle : Array<[ bundle_name: VarString<8, 1024>, number_of_bananas: U8 ]>]
+		| [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]) : PACKAGE_BANANA_IMMEDIATE
 
 
 /**
@@ -4118,16 +4280,20 @@ const argumentOrders = {
 * This command will echo back a string
 * @param echo_string String to echo back
 */
-function ECHO(...args: [{ 'echo_string': VarString<8, 1024> }]) {
+function ECHO(...args:
+		| [ echo_string : VarString<8, 1024> ]
+		| [{ 'echo_string': VarString<8, 1024> }]) {
   return ImmediateStem.new({
     stem: 'ECHO',
-    arguments: args
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['ECHO']) : commandArraysToObj(args, argumentOrders['ECHO']),
   }) as ECHO_IMMEDIATE;
 }
-function ECHO_STEP(...args: [{ 'echo_string': VarString<8, 1024>| 'STRING' }]) {
+function ECHO_STEP(...args:
+		|[ echo_string : VarString<8, 1024> | 'STRING' ]
+		|[{ 'echo_string': VarString<8, 1024>| 'STRING' }]) {
   return CommandStem.new({
     stem: 'ECHO',
-    arguments: sortCommandArguments(args, argumentOrders['ECHO'])
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['ECHO']) : commandArraysToObj(args, argumentOrders['ECHO']),
   }) as ECHO_STEP;
 }
 
@@ -4136,16 +4302,20 @@ function ECHO_STEP(...args: [{ 'echo_string': VarString<8, 1024>| 'STRING' }]) {
 * This command will turn on the oven
 * @param temperature Set the oven temperature
 */
-function PREHEAT_OVEN(...args: [{ 'temperature': U8 }]) {
+function PREHEAT_OVEN(...args:
+		| [ temperature : U8 ]
+		| [{ 'temperature': U8 }]) {
   return ImmediateStem.new({
     stem: 'PREHEAT_OVEN',
-    arguments: args
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['PREHEAT_OVEN']) : commandArraysToObj(args, argumentOrders['PREHEAT_OVEN']),
   }) as PREHEAT_OVEN_IMMEDIATE;
 }
-function PREHEAT_OVEN_STEP(...args: [{ 'temperature': U8| 'UINT' }]) {
+function PREHEAT_OVEN_STEP(...args:
+		|[ temperature : U8 | 'UINT' ]
+		|[{ 'temperature': U8| 'UINT' }]) {
   return CommandStem.new({
     stem: 'PREHEAT_OVEN',
-    arguments: sortCommandArguments(args, argumentOrders['PREHEAT_OVEN'])
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['PREHEAT_OVEN']) : commandArraysToObj(args, argumentOrders['PREHEAT_OVEN']),
   }) as PREHEAT_OVEN_STEP;
 }
 
@@ -4154,16 +4324,20 @@ function PREHEAT_OVEN_STEP(...args: [{ 'temperature': U8| 'UINT' }]) {
 * This command will throw a banana
 * @param distance The distance you throw the bananan
 */
-function THROW_BANANA(...args: [{ 'distance': U8 }]) {
+function THROW_BANANA(...args:
+		| [ distance : U8 ]
+		| [{ 'distance': U8 }]) {
   return ImmediateStem.new({
     stem: 'THROW_BANANA',
-    arguments: args
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['THROW_BANANA']) : commandArraysToObj(args, argumentOrders['THROW_BANANA']),
   }) as THROW_BANANA_IMMEDIATE;
 }
-function THROW_BANANA_STEP(...args: [{ 'distance': U8| 'UINT' }]) {
+function THROW_BANANA_STEP(...args:
+		|[ distance : U8 | 'UINT' ]
+		|[{ 'distance': U8| 'UINT' }]) {
   return CommandStem.new({
     stem: 'THROW_BANANA',
-    arguments: sortCommandArguments(args, argumentOrders['THROW_BANANA'])
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['THROW_BANANA']) : commandArraysToObj(args, argumentOrders['THROW_BANANA']),
   }) as THROW_BANANA_STEP;
 }
 
@@ -4173,16 +4347,20 @@ function THROW_BANANA_STEP(...args: [{ 'distance': U8| 'UINT' }]) {
 * @param quantity Number of bananas to grow
 * @param durationSecs How many seconds will it take to grow
 */
-function GROW_BANANA(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
+function GROW_BANANA(...args:
+		| [ quantity : U8,durationSecs : U8 ]
+		| [{ 'quantity': U8,'durationSecs': U8 }]) {
   return ImmediateStem.new({
     stem: 'GROW_BANANA',
-    arguments: args
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['GROW_BANANA']) : commandArraysToObj(args, argumentOrders['GROW_BANANA']),
   }) as GROW_BANANA_IMMEDIATE;
 }
-function GROW_BANANA_STEP(...args: [{ 'quantity': U8| 'UINT','durationSecs': U8| 'UINT' }]) {
+function GROW_BANANA_STEP(...args:
+		|[ quantity : U8 | 'UINT',durationSecs : U8 | 'UINT' ]
+		|[{ 'quantity': U8| 'UINT','durationSecs': U8| 'UINT' }]) {
   return CommandStem.new({
     stem: 'GROW_BANANA',
-    arguments: sortCommandArguments(args, argumentOrders['GROW_BANANA'])
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['GROW_BANANA']) : commandArraysToObj(args, argumentOrders['GROW_BANANA']),
   }) as GROW_BANANA_STEP;
 }
 
@@ -4192,16 +4370,20 @@ function GROW_BANANA_STEP(...args: [{ 'quantity': U8| 'UINT','durationSecs': U8|
 * @param quantity Number of bananas to grow
 * @param durationSecs How many seconds will it take to grow
 */
-function GrowBanana(...args: [{ 'quantity': U8,'durationSecs': U8 }]) {
+function GrowBanana(...args:
+		| [ quantity : U8,durationSecs : U8 ]
+		| [{ 'quantity': U8,'durationSecs': U8 }]) {
   return ImmediateStem.new({
     stem: 'GrowBanana',
-    arguments: args
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['GrowBanana']) : commandArraysToObj(args, argumentOrders['GrowBanana']),
   }) as GrowBanana_IMMEDIATE;
 }
-function GrowBanana_STEP(...args: [{ 'quantity': U8| 'UINT','durationSecs': U8| 'UINT' }]) {
+function GrowBanana_STEP(...args:
+		|[ quantity : U8 | 'UINT',durationSecs : U8 | 'UINT' ]
+		|[{ 'quantity': U8| 'UINT','durationSecs': U8| 'UINT' }]) {
   return CommandStem.new({
     stem: 'GrowBanana',
-    arguments: sortCommandArguments(args, argumentOrders['GrowBanana'])
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['GrowBanana']) : commandArraysToObj(args, argumentOrders['GrowBanana']),
   }) as GrowBanana_STEP;
 }
 
@@ -4211,16 +4393,20 @@ function GrowBanana_STEP(...args: [{ 'quantity': U8| 'UINT','durationSecs': U8| 
 * @param tb_sugar How much sugar is needed
 * @param gluten_free Do you hate flavor
 */
-function PREPARE_LOAF(...args: [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }]) {
+function PREPARE_LOAF(...args:
+		| [ tb_sugar : U8,gluten_free : ('FALSE' | 'TRUE') ]
+		| [{ 'tb_sugar': U8,'gluten_free': ('FALSE' | 'TRUE') }]) {
   return ImmediateStem.new({
     stem: 'PREPARE_LOAF',
-    arguments: args
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['PREPARE_LOAF']) : commandArraysToObj(args, argumentOrders['PREPARE_LOAF']),
   }) as PREPARE_LOAF_IMMEDIATE;
 }
-function PREPARE_LOAF_STEP(...args: [{ 'tb_sugar': U8| 'UINT','gluten_free': ('FALSE' | 'TRUE')| 'ENUM' }]) {
+function PREPARE_LOAF_STEP(...args:
+		|[ tb_sugar : U8 | 'UINT',gluten_free : ('FALSE' | 'TRUE') | 'ENUM' ]
+		|[{ 'tb_sugar': U8| 'UINT','gluten_free': ('FALSE' | 'TRUE')| 'ENUM' }]) {
   return CommandStem.new({
     stem: 'PREPARE_LOAF',
-    arguments: sortCommandArguments(args, argumentOrders['PREPARE_LOAF'])
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['PREPARE_LOAF']) : commandArraysToObj(args, argumentOrders['PREPARE_LOAF']),
   }) as PREPARE_LOAF_STEP;
 }
 
@@ -4229,16 +4415,20 @@ function PREPARE_LOAF_STEP(...args: [{ 'tb_sugar': U8| 'UINT','gluten_free': ('F
 * This command peels a single banana
 * @param peelDirection Which way do you peel the banana
 */
-function PEEL_BANANA(...args: [{ 'peelDirection': ('fromStem' | 'fromTip') }]) {
+function PEEL_BANANA(...args:
+		| [ peelDirection : ('fromStem' | 'fromTip') ]
+		| [{ 'peelDirection': ('fromStem' | 'fromTip') }]) {
   return ImmediateStem.new({
     stem: 'PEEL_BANANA',
-    arguments: args
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['PEEL_BANANA']) : commandArraysToObj(args, argumentOrders['PEEL_BANANA']),
   }) as PEEL_BANANA_IMMEDIATE;
 }
-function PEEL_BANANA_STEP(...args: [{ 'peelDirection': ('fromStem' | 'fromTip')| 'ENUM' }]) {
+function PEEL_BANANA_STEP(...args:
+		|[ peelDirection : ('fromStem' | 'fromTip') | 'ENUM' ]
+		|[{ 'peelDirection': ('fromStem' | 'fromTip')| 'ENUM' }]) {
   return CommandStem.new({
     stem: 'PEEL_BANANA',
-    arguments: sortCommandArguments(args, argumentOrders['PEEL_BANANA'])
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['PEEL_BANANA']) : commandArraysToObj(args, argumentOrders['PEEL_BANANA']),
   }) as PEEL_BANANA_STEP;
 }
 
@@ -4276,16 +4466,20 @@ const ADD_WATER_STEP: ADD_WATER_STEP = CommandStem.new({
 * @param lot_number Identification number assigned to a particular quantity
 * @param bundle A repeated set of strings and integer containing the arguments to the lot
 */
-function PACKAGE_BANANA(...args: [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]) {
+function PACKAGE_BANANA(...args:
+		| [ lot_number : U16,bundle : Array<[ bundle_name: VarString<8, 1024>, number_of_bananas: U8 ]> ]
+		| [{ 'lot_number': U16,'bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]) {
   return ImmediateStem.new({
     stem: 'PACKAGE_BANANA',
-    arguments: args
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['PACKAGE_BANANA']) : commandArraysToObj(args, argumentOrders['PACKAGE_BANANA']),
   }) as PACKAGE_BANANA_IMMEDIATE;
 }
-function PACKAGE_BANANA_STEP(...args: [{ 'lot_number': U16| 'UINT','bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]) {
+function PACKAGE_BANANA_STEP(...args:
+		|[ lot_number : U16 | 'UINT',bundle : Array<[ bundle_name: VarString<8, 1024>, number_of_bananas: U8 ]>  ]
+		|[{ 'lot_number': U16| 'UINT','bundle': Array<{ 'bundle_name': VarString<8, 1024>, 'number_of_bananas': U8 }> }]) {
   return CommandStem.new({
     stem: 'PACKAGE_BANANA',
-    arguments: sortCommandArguments(args, argumentOrders['PACKAGE_BANANA'])
+    arguments: typeof args[0] === 'object' && !Array.isArray(args[0]) && !(args[0] instanceof Variable) ? sortCommandArguments(args, argumentOrders['PACKAGE_BANANA']) : commandArraysToObj(args, argumentOrders['PACKAGE_BANANA']),
   }) as PACKAGE_BANANA_STEP;
 }
 

--- a/sequencing-server/test/command-expansion.spec.ts
+++ b/sequencing-server/test/command-expansion.spec.ts
@@ -357,10 +357,7 @@ describe('expansion', () => {
         .METADATA({
           simulatedActivityId: ${simulatedActivityId},
         }),
-      R\`04:00:00.000\`.GROW_BANANA({
-        quantity: 10,
-        durationSecs: 7200,
-      })
+      R\`04:00:00.000\`.GROW_BANANA(10,7200)
         .METADATA({
           simulatedActivityId: ${simulatedActivityId},
         }),

--- a/sequencing-server/test/seqjson-to-edsl.spec.ts
+++ b/sequencing-server/test/seqjson-to-edsl.spec.ts
@@ -49,9 +49,7 @@ describe('getEdslForSeqJson', () => {
     metadata: {},
     steps: ({ locals, parameters }) => ([
       C.BAKE_BREAD,
-      A\`2020-060T03:45:19.000\`.PREHEAT_OVEN({
-        temperature: 100,
-      }),
+      A\`2020-060T03:45:19.000\`.PREHEAT_OVEN(100),
     ]),
   });`);
   });
@@ -413,72 +411,11 @@ describe('getEdslForSeqJson', () => {
     ],
     steps: ({ locals, parameters }) => ([
       E\`00:00:01.000\`.ACTIVATE('d:/eng/test.mod')
-        .ARGUMENTS([
-          {
-            type: 'number',
-            value: 30,
-          },
-          {
-            type: 'number',
-            value: 4.3,
-          },
-          {
-            type: 'boolean',
-            value: true,
-          },
-          {
-            type: 'string',
-            value: 'test_string',
-          },
-          {
-            type: 'repeat',
-            value: [
-              [
-                {
-                  type: 'number',
-                  value: 10,
-                },
-                {
-                  type: 'string',
-                  value: 'another_test',
-                },
-                {
-                  type: 'boolean',
-                  value: false,
-                },
-              ],
-              [
-                {
-                  type: 'number',
-                  value: 5,
-                },
-                {
-                  type: 'string',
-                  value: 'repeat_test',
-                },
-                {
-                  type: 'boolean',
-                  value: true,
-                },
-              ],
-            ],
-          },
-        ])
+        .ARGUMENTS(30,4.3,true,'test_string',[[10,'another_test',false],[5,'repeat_test',true]])
         .DESCRIPTION('Epoch-relative activate step for test.mod into engine 2 with all possible fields.')
         .ENGINE(2)
         .EPOCH('TEST_EPOCH'),
-      A\`2020-173T20:00:00.000\`.FAKE_COMMAND1({
-        arg0: 30,
-        arg1: 4.3,
-        arg2: true,
-        arg3: 'test_string',
-        arg4: [
-          {
-            repeat0: 10,
-            repeat1: 'another_test',
-          },
-        ],
-      })
+      A\`2020-173T20:00:00.000\`.FAKE_COMMAND1(30,4.3,true,'test_string',[[10,'another_test']])
         .DESCRIPTION('Absolute-timed standard command step with all possible fields.')
         .MODELS([
           {
@@ -503,36 +440,7 @@ describe('getEdslForSeqJson', () => {
           }
         ]),
       R\`00:00:01.000\`.GROUND_BLOCK('SEQTRAN_directive')
-        .ARGUMENTS([
-          {
-            type: 'string',
-            value: 'SEQSTR',
-          },
-          {
-            type: 'string',
-            value: '2019-365T00:00:00',
-          },
-          {
-            type: 'string',
-            value: '2020-025T00:00:00',
-          },
-          {
-            type: 'string',
-            value: 'BOTH',
-          },
-          {
-            type: 'string',
-            value: '',
-          },
-          {
-            type: 'string',
-            value: '',
-          },
-          {
-            type: 'string',
-            value: 'real_time_cmds',
-          },
-        ])
+        .ARGUMENTS('SEQSTR','2019-365T00:00:00','2020-025T00:00:00','BOTH','','','real_time_cmds')
         .DESCRIPTION('Ground activity step with required fields.')
         .METADATA({
           stringfield: 'stringval',
@@ -560,16 +468,7 @@ describe('getEdslForSeqJson', () => {
           }
         ]),
       C.GROUND_EVENT('UPLINK_SEQUENCE_FILE')
-        .ARGUMENTS([
-          {
-            type: 'string',
-            value: '/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf',
-          },
-          {
-            type: 'string',
-            value: 'd:/tmp/eng_nom_htr_off.mod',
-          },
-        ])
+        .ARGUMENTS('/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf','d:/tmp/eng_nom_htr_off.mod')
         .DESCRIPTION('Ground event step with all possible fields.')
         .METADATA({
           listfield: [
@@ -600,16 +499,9 @@ describe('getEdslForSeqJson', () => {
           }
         ]),
       E\`00:00:01.000\`.LOAD('d:/eng/test.mod')
-        .ARGUMENTS([
-          {
-            type: 'symbol',
-            value: 'Local_Var_A',
-          },
-          {
-            type: 'symbol',
-            value: 'Global_Var_B',
-          },
-        ])
+        .ARGUMENTS(unknown.Local_Var_A //ERROR: Variable 'Local_Var_A' is not defined as a local or parameter
+        ,unknown.Global_Var_B //ERROR: Variable 'Global_Var_B' is not defined as a local or parameter
+        )
         .DESCRIPTION('Epoch-relative activate step for test.mod into engine 2 with all possible fields.')
         .ENGINE(2)
         .EPOCH('TEST_EPOCH'),
@@ -708,13 +600,9 @@ describe('getEdslForSeqJson', () => {
       INT('sugar')
     ],
     steps: ({ locals, parameters }) => ([
-      C.PREHEAT_OVEN({
-        temperature: locals.temp,
-      }),
-      C.PREPARE_LOAF({
-        tb_sugar: unknown.sugarrrrr //ERROR: Variable 'sugarrrrr' is not defined as a local or parameter,
-        gluten_free: 'FALSE',
-      }),
+      C.PREHEAT_OVEN(locals.temp),
+      C.PREPARE_LOAF(unknown.sugarrrrr //ERROR: Variable 'sugarrrrr' is not defined as a local or parameter
+      ,'FALSE'),
     ]),
   });`);
   });
@@ -779,8 +667,8 @@ describe('getEdslForSeqJsonBulk', () => {
     );
 
     expect(res.getEdslForSeqJsonBulk).toEqual([
-      "export default () =>\n  Sequence.new({\n    seqId: 'test_00001',\n    metadata: {},\n    steps: ({ locals, parameters }) => ([\n      C.BAKE_BREAD,\n      A`2020-060T03:45:19.000`.PREHEAT_OVEN({\n        temperature: 100,\n      }),\n    ]),\n  });",
-      "export default () =>\n  Sequence.new({\n    seqId: 'test_00002',\n    metadata: {},\n    steps: ({ locals, parameters }) => ([\n      C.BAKE_BREAD,\n      A`2020-060T03:45:19.000`.PREHEAT_OVEN({\n        temperature: 100,\n      }),\n    ]),\n  });",
+      "export default () =>\n  Sequence.new({\n    seqId: 'test_00001',\n    metadata: {},\n    steps: ({ locals, parameters }) => ([\n      C.BAKE_BREAD,\n      A`2020-060T03:45:19.000`.PREHEAT_OVEN(100),\n    ]),\n  });",
+      "export default () =>\n  Sequence.new({\n    seqId: 'test_00002',\n    metadata: {},\n    steps: ({ locals, parameters }) => ([\n      C.BAKE_BREAD,\n      A`2020-060T03:45:19.000`.PREHEAT_OVEN(100),\n    ]),\n  });"
     ]);
   });
 });

--- a/sequencing-server/test/sequence-generation.spec.ts
+++ b/sequencing-server/test/sequence-generation.spec.ts
@@ -83,7 +83,7 @@ describe('sequence generation', () => {
       `
     export default function SingleCommandExpansion(props: { activityInstance: ActivityType }): ExpansionReturn {
       return [
-        C.PREHEAT_OVEN({ temperature: 70 }),
+        C.PREHEAT_OVEN(70),
         C.BAKE_BREAD,
         C.PREPARE_LOAF({ tb_sugar: 50, gluten_free: "FALSE" }),
       ];
@@ -100,7 +100,7 @@ describe('sequence generation', () => {
         A(Temporal.Instant.from("2025-12-24T12:01:59Z")).PREHEAT_OVEN({ temperature: 360 }),
         R\`00:15:30\`.PREHEAT_OVEN({ temperature: 425 }),
         R(Temporal.Duration.from({ hours: 1, minutes: 15, seconds: 30 })).EAT_BANANA,
-        E(Temporal.Duration.from({ days: -1, hours: -12, minutes: -16, seconds: -54 })).PREPARE_LOAF({ tb_sugar: 50, gluten_free: "FALSE" }),
+        E(Temporal.Duration.from({ days: -1, hours: -12, minutes: -16, seconds: -54 })).PREPARE_LOAF( 50,  "FALSE"),
         E\`04:56:54\`.EAT_BANANA,
         C.PACKAGE_BANANA({
           bundle: [
@@ -127,7 +127,8 @@ describe('sequence generation', () => {
               number_of_bananas: 12
             }
           ]
-        })
+        }),
+        C.PACKAGE_BANANA(1034,[['companyA',100_000],['companyB',10_100]]),
       ];
     }
     `,
@@ -395,6 +396,44 @@ describe('sequence generation', () => {
                   name: 'number_of_bananas',
                   type: 'number',
                   value: 12,
+                },
+              ],
+            ],
+          },
+        ],
+        metadata: { simulatedActivityId: simulatedActivityId3 },
+      },{
+        type: 'command',
+        stem: 'PACKAGE_BANANA',
+        time: { type: TimingTypes.COMMAND_COMPLETE },
+        args: [
+          { name: 'lot_number', type: 'number', value: 1034 },
+          {
+            name: 'bundle',
+            type: 'repeat',
+            value: [
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyA',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 100000,
+                },
+              ],
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyB',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 10100,
                 },
               ],
             ],
@@ -721,6 +760,45 @@ describe('sequence generation', () => {
         ],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
+      {
+        type: 'command',
+        stem: 'PACKAGE_BANANA',
+        time: { type: TimingTypes.COMMAND_COMPLETE },
+        args: [
+          { name: 'lot_number', type: 'number', value: 1034 },
+          {
+            name: 'bundle',
+            type: 'repeat',
+            value: [
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyA',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 100000,
+                },
+              ],
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyB',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 10100,
+                },
+              ],
+            ],
+          },
+        ],
+        metadata: { simulatedActivityId: simulatedActivityId3 },
+      },
     ]);
 
     const secondSequence = getSequenceSeqJsonBulkResponse[1]!;
@@ -921,6 +999,45 @@ describe('sequence generation', () => {
                   name: 'number_of_bananas',
                   type: 'number',
                   value: 12,
+                },
+              ],
+            ],
+          },
+        ],
+        metadata: { simulatedActivityId: simulatedActivityId6 },
+      },
+      {
+        type: 'command',
+        stem: 'PACKAGE_BANANA',
+        time: { type: TimingTypes.COMMAND_COMPLETE },
+        args: [
+          { name: 'lot_number', type: 'number', value: 1034 },
+          {
+            name: 'bundle',
+            type: 'repeat',
+            value: [
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyA',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 100000,
+                },
+              ],
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyB',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 10100,
                 },
               ],
             ],
@@ -1221,6 +1338,45 @@ describe('sequence generation', () => {
                   name: 'number_of_bananas',
                   type: 'number',
                   value: 12,
+                },
+              ],
+            ],
+          },
+        ],
+        metadata: { simulatedActivityId: simulatedActivityId3 },
+      },
+      {
+        type: 'command',
+        stem: 'PACKAGE_BANANA',
+        time: { type: TimingTypes.COMMAND_COMPLETE },
+        args: [
+          { name: 'lot_number', type: 'number', value: 1034 },
+          {
+            name: 'bundle',
+            type: 'repeat',
+            value: [
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyA',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 100000,
+                },
+              ],
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyB',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 10100,
                 },
               ],
             ],
@@ -1580,6 +1736,45 @@ describe('sequence generation', () => {
       },
       {
         type: 'command',
+        stem: 'PACKAGE_BANANA',
+        time: { type: TimingTypes.COMMAND_COMPLETE },
+        args: [
+          { name: 'lot_number', type: 'number', value: 1034 },
+          {
+            name: 'bundle',
+            type: 'repeat',
+            value: [
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyA',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 100000,
+                },
+              ],
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyB',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 10100,
+                },
+              ],
+            ],
+          },
+        ],
+        metadata: { simulatedActivityId: simulatedActivityId3 },
+      },
+      {
+        type: 'command',
         stem: '$$ERROR$$',
         time: { type: TimingTypes.COMMAND_COMPLETE },
         args: [{ name: 'message', type: 'string', value: 'Error: Unimplemented' }],
@@ -1781,6 +1976,45 @@ describe('sequence generation', () => {
                   name: 'number_of_bananas',
                   type: 'number',
                   value: 12,
+                },
+              ],
+            ],
+          },
+        ],
+        metadata: { simulatedActivityId: simulatedActivityId7 },
+      },
+      {
+        type: 'command',
+        stem: 'PACKAGE_BANANA',
+        time: { type: TimingTypes.COMMAND_COMPLETE },
+        args: [
+          { name: 'lot_number', type: 'number', value: 1034 },
+          {
+            name: 'bundle',
+            type: 'repeat',
+            value: [
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyA',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 100000,
+                },
+              ],
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyB',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 10100,
                 },
               ],
             ],
@@ -2084,6 +2318,45 @@ describe('sequence generation', () => {
                   name: 'number_of_bananas',
                   type: 'number',
                   value: 12,
+                },
+              ],
+            ],
+          },
+        ],
+        metadata: { simulatedActivityId: simulatedActivityId3 },
+      },
+      {
+        type: 'command',
+        stem: 'PACKAGE_BANANA',
+        time: { type: TimingTypes.COMMAND_COMPLETE },
+        args: [
+          { name: 'lot_number', type: 'number', value: 1034 },
+          {
+            name: 'bundle',
+            type: 'repeat',
+            value: [
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyA',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 100000,
+                },
+              ],
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyB',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 10100,
                 },
               ],
             ],
@@ -2421,6 +2694,45 @@ describe('sequence generation', () => {
         ],
         metadata: { simulatedActivityId: simulatedActivityId3 },
       },
+      {
+        type: 'command',
+        stem: 'PACKAGE_BANANA',
+        time: { type: TimingTypes.COMMAND_COMPLETE },
+        args: [
+          { name: 'lot_number', type: 'number', value: 1034 },
+          {
+            name: 'bundle',
+            type: 'repeat',
+            value: [
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyA',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 100000,
+                },
+              ],
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyB',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 10100,
+                },
+              ],
+            ],
+          },
+        ],
+        metadata: { simulatedActivityId: simulatedActivityId3 },
+      },
     ]);
 
     const secondSequence = getSequenceSeqJsonResponse[1]!;
@@ -2621,6 +2933,45 @@ describe('sequence generation', () => {
                   name: 'number_of_bananas',
                   type: 'number',
                   value: 12,
+                },
+              ],
+            ],
+          },
+        ],
+        metadata: { simulatedActivityId: simulatedActivityId7 },
+      },
+      {
+        type: 'command',
+        stem: 'PACKAGE_BANANA',
+        time: { type: TimingTypes.COMMAND_COMPLETE },
+        args: [
+          { name: 'lot_number', type: 'number', value: 1034 },
+          {
+            name: 'bundle',
+            type: 'repeat',
+            value: [
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyA',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 100000,
+                },
+              ],
+              [
+                {
+                  name: 'bundle_name',
+                  type: 'string',
+                  value: 'companyB',
+                },
+                {
+                  name: 'number_of_bananas',
+                  type: 'number',
+                  value: 10100,
                 },
               ],
             ],


### PR DESCRIPTION
* **Tickets addressed:** Closes #702
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The Sequence eDSL now offers support for passing arguments by position, while retaining backward compatibility with object notation. This allows users to utilize both options based on their preferences. By default, the sequence editor will suggest passing arguments by position. Additionally, when importing a SeqJson, the generated eDSL will be in position notation.

```ts
export default () =>
  Sequence.new({
    seqId: '',
    metadata: {},
    steps: [
      //Regular Args
      C.PREPARE_LOAF({tb_sugar : 10, gluten_free : "FALSE"}),
      C.PREPARE_LOAF(10,"FALSE"),

      //Repeate Args
      C.PACKAGE_BANANA({lot_number : 10, bundle : [{bundle_name : "Dole", number_of_bananas : 10},{bundle_name : "Blue", number_of_bananas : 100}]}),
      C.PACKAGE_BANANA(1394, [['Dole',100],['Blue',10]])
    ]
  });

```

## Verification
Extensive testing has been conducted using both bananantion and Clipper. Real clipper sequences were executed to ensure that there are no regressions with their command dictionary and sequences. Furthermore, the e2e tests have been updated accordingly.


