### PR TITLE
Allow user role to update scheduling_specification.plan_revision

### DIFF
--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_specification.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_specification.yaml
@@ -34,7 +34,7 @@ update_permissions:
       filter: {}
   - role: user
     permission:
-      columns: [horizon_start, horizon_end, simulation_arguments, analysis_only]
+      columns: [plan_revision, horizon_start, horizon_end, simulation_arguments, analysis_only]
       filter: {}
 delete_permissions:
   - role: aerie_admin


### PR DESCRIPTION
* **Tickets addressed:** Fixes https://github.com/NASA-AMMOS/aerie-ui/issues/802
* **Review:** By commit 
* **Merge strategy:** squash and merge

## Description
In order to perform scheduling, or a scheduling analysis, the User role needs to be able to update the `plan_revision` column in the scheduling_specifications table.

## Verification
- In the Aerie UI, change role to a user and attempt to perform any scheduling or scheduling analysis.
- The analysis should immediately fail due to lack of permissions to update the plan_revision field.
- After the permission changes in this PR have been applied, retry scheduling.
- Scheduling should now succeed.