### PR TITLE
Track simulation extent during simulation

### DIFF
--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -39,6 +39,7 @@ See the [environment variables document](https://github.com/NASA-AMMOS/aerie-gat
 | `MERLIN_WORKER_DB_USER`     | Username of the DB instance                                                                                                 | `string` | (this must the same as the Merlin container) |
 | `MERLIN_WORKER_DB_PASSWORD` | Password of the DB instance                                                                                                 | `string` | (this must the same as the Merlin container) |
 | `MERLIN_WORKER_DB`          | The DB for Merlin.                                                                                                          | `string` | (this must the same as the Merlin container) |
+| `SIMULATION_PROGRESS_POLL_PERIOD_MILLIS`          | Cadence at which the worker will report simulation progress to the database.                                                | `number` | 5000                                         |
 | `UNTRUE_PLAN_START`         | Temporary solution to provide plan start time to models, should be set to a time that models will not fail to initialize on | `string` |                                              |
 
 ## Aerie Scheduler

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       MERLIN_WORKER_DB_SERVER: postgres
       MERLIN_WORKER_DB_USER: "${AERIE_USERNAME}"
       MERLIN_WORKER_LOCAL_STORE: /usr/src/app/merlin_file_store
+      SIMULATION_PROGRESS_POLL_PERIOD_MILLIS: 2000
       JAVA_OPTS: >
         -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=WARN

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation_dataset.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation_dataset.yaml
@@ -8,6 +8,15 @@ object_relationships:
 - name: simulation
   using:
     foreign_key_constraint_on: simulation_id
+- name: extent
+  using:
+    manual_configuration:
+      remote_table:
+        schema: public
+        name: simulation_extent
+      insertion_order: null
+      column_mapping:
+        id: simulation_dataset_id
 array_relationships:
 - name: simulated_activities
   using:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation_extent.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation_extent.yaml
@@ -1,0 +1,23 @@
+table:
+  name: simulation_extent
+  schema: public
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [simulation_dataset_id, extent]
+      filter: {}
+      allow_aggregations: true
+  - role: user
+    permission:
+      columns: [simulation_dataset_id, extent]
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: [simulation_dataset_id, extent]
+      filter: {}
+      allow_aggregations: true
+delete_permissions:
+  - role: aerie_admin
+    permission:
+      filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
@@ -27,6 +27,7 @@
 - "!include public_simulation.yaml"
 - "!include public_simulated_activity_view.yaml"
 - "!include public_simulation_dataset.yaml"
+- "!include public_simulation_extent.yaml"
 - "!include public_simulation_template.yaml"
 - "!include public_span.yaml"
 - "!include public_topic.yaml"

--- a/deployment/hasura/migrations/AerieMerlin/22_simulation_extent/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/22_simulation_extent/down.sql
@@ -1,0 +1,3 @@
+drop table simulation_extent;
+
+call migrations.mark_migration_rolled_back('22');

--- a/deployment/hasura/migrations/AerieMerlin/22_simulation_extent/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/22_simulation_extent/up.sql
@@ -1,0 +1,22 @@
+create table simulation_extent (
+  simulation_dataset_id integer not null primary key,
+  extent interval not null,
+  constraint simulation_dataset_exists
+    foreign key (simulation_dataset_id)
+    references simulation_dataset
+    on update cascade
+    on delete cascade
+);
+
+comment on table simulation_extent is e''
+  'Tracks the progress of a simulation as the latest achieved offset from the simulation start time. \n'
+  'This is expected to be an update-heavy table, so it is to be kept compact to maximize the likelihood of HOT updates and minimize bloat \n'
+  'The data in this table is not particularly valuable once a simulation has completed, and can be cleared out periodically';
+
+comment on column simulation_extent.simulation_dataset_id is e''
+  'The simulation dataset to which this extent pertains';
+
+comment on column simulation_extent.extent is e''
+  'The latest achieved offset from the simulation start time';
+
+call migrations.mark_migration_applied('22');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,7 @@ services:
       MERLIN_WORKER_DB_SERVER: postgres
       MERLIN_WORKER_DB_USER: "${AERIE_USERNAME}"
       MERLIN_WORKER_LOCAL_STORE: /usr/src/app/merlin_file_store
+      SIMULATION_PROGRESS_POLL_PERIOD_MILLIS: 2000
       JAVA_OPTS: >
         -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
@@ -150,6 +151,7 @@ services:
       MERLIN_WORKER_DB_SERVER: postgres
       MERLIN_WORKER_DB_USER: "${AERIE_USERNAME}"
       MERLIN_WORKER_LOCAL_STORE: /usr/src/app/merlin_file_store
+      SIMULATION_PROGRESS_POLL_PERIOD_MILLIS: 2000
       JAVA_OPTS: >
         -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -24,3 +24,4 @@ call migrations.mark_migration_applied('18');
 call migrations.mark_migration_applied('19');
 call migrations.mark_migration_applied('20');
 call migrations.mark_migration_applied('21');
+call migrations.mark_migration_applied('22');

--- a/merlin-server/sql/merlin/init.sql
+++ b/merlin-server/sql/merlin/init.sql
@@ -53,6 +53,7 @@ begin;
 
   \ir tables/mission_model_parameters.sql
   \ir tables/simulation_dataset.sql
+  \ir tables/simulation_extent.sql
   \ir tables/plan_dataset.sql
   \ir tables/constraint_run.sql
 

--- a/merlin-server/sql/merlin/tables/simulation_extent.sql
+++ b/merlin-server/sql/merlin/tables/simulation_extent.sql
@@ -1,0 +1,20 @@
+create table simulation_extent (
+  simulation_dataset_id integer not null primary key,
+  extent interval not null,
+  constraint simulation_dataset_exists
+    foreign key (simulation_dataset_id)
+    references simulation_dataset
+    on update cascade
+    on delete cascade
+);
+
+comment on table simulation_extent is e''
+  'Tracks the progress of a simulation as the latest achieved offset from the simulation start time. \n'
+  'This is expected to be an update-heavy table, so it is to be kept compact to maximize the likelihood of HOT updates and minimize bloat \n'
+  'The data in this table is not particularly valuable once a simulation has completed, and can be cleared out periodically';
+
+comment on column simulation_extent.simulation_dataset_id is e''
+  'The simulation dataset to which this extent pertains';
+
+comment on column simulation_extent.extent is e''
+  'The latest achieved offset from the simulation start time';

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/ResultsProtocol.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/ResultsProtocol.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.server;
 
 import gov.nasa.jpl.aerie.merlin.driver.SimulationFailure;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.server.models.SimulationResultsHandle;
 
 import java.util.function.Consumer;
@@ -46,6 +47,8 @@ public final class ResultsProtocol {
       builderConsumer.accept(builder);
       failWith(builder.build());
     }
+
+    void reportSimulationExtent(Duration extent);
   }
 
   public interface OwnerRole extends ReaderRole, WriterRole {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
@@ -129,6 +129,11 @@ public final class InMemoryResultsCellRepository implements ResultsCellRepositor
       this.state = new ResultsProtocol.State.Failed(0, reason);
     }
 
+    @Override
+    public void reportSimulationExtent(final Duration extent) {
+      System.out.println("Simulation extent: " + extent);
+    }
+
     public boolean isEqualTo(final InMemoryCell other) {
       if (this.canceled != other.canceled) return false;
       return Objects.equals(this.state, other.state);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/DeleteSimulationExtentAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/DeleteSimulationExtentAction.java
@@ -1,0 +1,34 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/*package-local*/ final class DeleteSimulationExtentAction implements AutoCloseable {
+  private final @Language("SQL") String sql = """
+        delete from simulation_extent
+        using simulation_dataset
+        where simulation_dataset.id = simulation_extent.simulation_dataset_id
+          and simulation_dataset.dataset_id = ?;
+        """;
+
+  private final PreparedStatement statement;
+
+  public DeleteSimulationExtentAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public void apply(final long datasetId)
+  throws SQLException, NoSuchSimulationDatasetException
+  {
+    this.statement.setLong(1, datasetId);
+    this.statement.executeUpdate();
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -223,6 +223,25 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
     }
   }
 
+  private static void deleteSimulationExtent(final Connection connection, final long datasetId)
+  throws SQLException, NoSuchSimulationDatasetException
+  {
+    try (final var deleteSimulationExtent = new DeleteSimulationExtentAction(connection)) {
+      deleteSimulationExtent.apply(datasetId);
+    }
+  }
+
+  private static void reportSimulationExtent(
+      final Connection connection,
+      final long datasetId,
+      final Duration extent
+  ) throws SQLException, NoSuchSimulationDatasetException
+  {
+    try (final var updateSimulationExtentAction = new UpdateSimulationExtentAction(connection)) {
+      updateSimulationExtentAction.apply(datasetId, extent);
+    }
+  }
+
   private static List<Triple<Integer, String, ValueSchema>> getSimulationTopics(Connection connection, long datasetId)
   throws SQLException
   {
@@ -465,6 +484,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
       try (final var connection = dataSource.getConnection();
            final var transactionContext = new TransactionContext(connection)) {
         postSimulationResults(connection, datasetId, results);
+        deleteSimulationExtent(connection, datasetId);
         transactionContext.commit();
       } catch (final SQLException ex) {
         throw new DatabaseException("Failed to store simulation results", ex);
@@ -477,11 +497,27 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
 
     @Override
     public void failWith(final SimulationFailure reason) {
-      try (final var connection = dataSource.getConnection()) {
+      try (final var connection = dataSource.getConnection();
+           final var transactionContext = new TransactionContext(connection)) {
         failSimulation(connection, datasetId, reason);
+        deleteSimulationExtent(connection, datasetId);
+        transactionContext.commit();
       } catch (final SQLException ex) {
         throw new DatabaseException("Failed to update simulation state to failure", ex);
       } catch (final NoSuchSimulationDatasetException ex) {
+        // A cell should only be created for a valid, existing dataset
+        // A dataset should only be deleted by its cell
+        throw new Error("Cell references nonexistent simulation dataset");
+      }
+    }
+
+    @Override
+    public void reportSimulationExtent(final Duration extent) {
+      try (final var connection = dataSource.getConnection()) {
+        PostgresResultsCellRepository.reportSimulationExtent(connection, datasetId, extent);
+      } catch (SQLException ex) {
+        throw new DatabaseException("Failed to update simulation extent", ex);
+      } catch (NoSuchSimulationDatasetException e) {
         // A cell should only be created for a valid, existing dataset
         // A dataset should only be deleted by its cell
         throw new Error("Cell references nonexistent simulation dataset");

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateSimulationExtentAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateSimulationExtentAction.java
@@ -1,0 +1,41 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/*package-local*/ final class UpdateSimulationExtentAction implements AutoCloseable {
+  private final @Language("SQL") String sql = """
+        insert into simulation_extent (simulation_dataset_id, extent)
+        values (?, ?::interval)
+        on conflict (simulation_dataset_id)
+        do update
+          set extent = ?::interval;
+        """;
+
+  private final PreparedStatement statement;
+
+  public UpdateSimulationExtentAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public void apply(final long simulationDatasetId, final Duration extent)
+  throws SQLException, NoSuchSimulationDatasetException
+  {
+    this.statement.setLong(1, simulationDatasetId);
+    PreparedStatements.setDuration(this.statement, 2, extent);
+    PreparedStatements.setDuration(this.statement, 3, extent);
+
+    final var count = this.statement.executeUpdate();
+    if (count < 1) throw new NoSuchSimulationDatasetException(simulationDatasetId);
+    if (count > 1) throw new Error("More than one row affected by dataset update by primary key. Is the database corrupted?");
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/FixedRateListener.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/FixedRateListener.java
@@ -1,0 +1,46 @@
+package gov.nasa.jpl.aerie.merlin.server.services;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+public interface FixedRateListener<T> extends AutoCloseable {
+  void updateValue(T t);
+
+  @Override
+  void close();
+
+  /**
+   * Call reporter.accept at fixed intervals using the given period. The value passed to the consumer is the
+   * most recent argument to `updateValue`.
+   *
+   * @param reporter The Consumer to call periodically
+   * @param initialValue The initial value to pass to the given Consumer
+   * @param periodMillis The interval at which to call reporter.accept
+   * @return a FixedRateListener
+   */
+  static <T> FixedRateListener<T> callAtFixedRate(final Consumer<T> reporter, final T initialValue, final long periodMillis) {
+    final var latestValue = new AtomicReference<>(initialValue);
+
+    final var executor = new ScheduledThreadPoolExecutor(1);
+    final var task = executor.scheduleAtFixedRate(
+        () -> reporter.accept(latestValue.get()),
+        0,
+        periodMillis,
+        TimeUnit.MILLISECONDS);
+
+    return new FixedRateListener<>() {
+      @Override
+      public void updateValue(final T t) {
+        latestValue.set(t);
+      }
+
+      @Override
+      public void close() {
+          task.cancel(false);
+          executor.shutdown();
+      }
+    };
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -1,10 +1,16 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
-import gov.nasa.jpl.aerie.merlin.driver.*;
 import gov.nasa.jpl.aerie.merlin.driver.ActivityDirectiveId;
+import gov.nasa.jpl.aerie.merlin.driver.DirectiveTypeRegistry;
+import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
+import gov.nasa.jpl.aerie.merlin.driver.MissionModelLoader;
+import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationDriver;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.model.ModelType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
@@ -23,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 /**
  * Implements the missionModel service {@link MissionModelService} interface on a set of local domain objects.

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -242,7 +242,7 @@ public final class LocalMissionModelService implements MissionModelService {
    * @throws NoSuchMissionModelException If no mission model is known by the given ID.
    */
   @Override
-  public SimulationResults runSimulation(final CreateSimulationMessage message)
+  public SimulationResults runSimulation(final CreateSimulationMessage message, final Consumer<Duration> simulationExtentConsumer)
   throws NoSuchMissionModelException
   {
     final var config = message.configuration();
@@ -253,12 +253,16 @@ public final class LocalMissionModelService implements MissionModelService {
 
     // TODO: [AERIE-1516] Teardown the mission model after use to release any system resources (e.g. threads).
     return SimulationDriver.simulate(
-        loadAndInstantiateMissionModel(message.missionModelId(), message.simulationStartTime(), SerializedValue.of(config)),
+        loadAndInstantiateMissionModel(
+            message.missionModelId(),
+            message.simulationStartTime(),
+            SerializedValue.of(config)),
         message.activityDirectives(),
         message.simulationStartTime(),
         message.simulationDuration(),
         message.planStartTime(),
-        message.planDuration());
+        message.planDuration(),
+        simulationExtentConsumer);
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -6,9 +6,11 @@ import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.ValidationNotice;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveForValidation;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
@@ -16,6 +18,7 @@ import gov.nasa.jpl.aerie.merlin.server.models.MissionModelJar;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 public interface MissionModelService {
   Map<String, MissionModelJar> getMissionModels();
@@ -63,7 +66,7 @@ public interface MissionModelService {
          LocalMissionModelService.MissionModelLoadException,
          InstantiationException;
 
-  SimulationResults runSimulation(CreateSimulationMessage message)
+  SimulationResults runSimulation(CreateSimulationMessage message, Consumer<Duration> writer)
           throws NoSuchMissionModelException, MissionModelService.NoSuchActivityTypeException;
 
   void refreshModelParameters(String missionModelId) throws NoSuchMissionModelException;

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindingsTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindingsTest.java
@@ -46,7 +46,7 @@ public final class MerlinBindingsTest {
 
     Runtime.getRuntime().addShutdownHook(new Thread(constraintsDSLCompilationService::close));
 
-    final var simulationService = new UncachedSimulationService(new SynchronousSimulationAgent(planApp, missionModelApp));
+    final var simulationService = new UncachedSimulationService(new SynchronousSimulationAgent(planApp, missionModelApp, 5000));
     final var simulationAction = new GetSimulationResultsAction(
         planApp,
         simulationService

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -8,6 +8,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveForValidation;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
+import java.util.function.Consumer;
 
 public final class StubMissionModelService implements MissionModelService {
   public static final String EXISTENT_MISSION_MODEL_ID = "abc";
@@ -197,7 +199,7 @@ public final class StubMissionModelService implements MissionModelService {
   }
 
   @Override
-  public SimulationResults runSimulation(final CreateSimulationMessage message) throws NoSuchMissionModelException {
+  public SimulationResults runSimulation(final CreateSimulationMessage message, Consumer<Duration> simulationExtentConsumer) throws NoSuchMissionModelException {
     if (!Objects.equals(message.missionModelId(), EXISTENT_MISSION_MODEL_ID)) {
       throw new NoSuchMissionModelException(message.missionModelId());
     }

--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
@@ -51,9 +51,10 @@ public final class MerlinWorkerAppDriver {
     final var missionModelController = new LocalMissionModelService(
         configuration.merlinFileStore(),
         stores.missionModels(),
-        configuration.untruePlanStart());
+        configuration.untruePlanStart()
+    );
     final var planController = new LocalPlanService(stores.plans());
-    final var simulationAgent = new SynchronousSimulationAgent(planController, missionModelController);
+    final var simulationAgent = new SynchronousSimulationAgent(planController, missionModelController, configuration.simulationProgressPollPeriodMillis());
 
     final var notificationQueue = new LinkedBlockingQueue<PostgresSimulationNotificationPayload>();
     final var listenAction = new ListenSimulationCapability(hikariDataSource, notificationQueue);
@@ -101,6 +102,7 @@ public final class MerlinWorkerAppDriver {
                           Integer.parseInt(getEnv("MERLIN_WORKER_DB_PORT", "5432")),
                           getEnv("MERLIN_WORKER_DB_PASSWORD", ""),
                           getEnv("MERLIN_WORKER_DB", "aerie_merlin")),
+        Integer.parseInt(getEnv("SIMULATION_PROGRESS_POLL_PERIOD_MILLIS", "5000")),
         Instant.parse(getEnv("UNTRUE_PLAN_START", ""))
     );
   }

--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/WorkerAppConfiguration.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/WorkerAppConfiguration.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 public record WorkerAppConfiguration(
     Path merlinFileStore,
     Store store,
+    long simulationProgressPollPeriodMillis,
     Instant untruePlanStart
 ) {
   public WorkerAppConfiguration {


### PR DESCRIPTION
* **Tickets addressed:** Closes #771
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Inspired by some user observation, I felt compelled to implement simulation extent tracking. This PR adds a new `simulation_extent` table to track the elapsed simulation time, and wires up the simulation driver to report its `elapsedTime` variable to a listener.

The `SimulationDriver::simulate` method has a new overload that takes a `SimulationExtentReporter`. During the simulation, the driver will call the listener's `report` method with the current elapsed time.

One design driver was to limit the overhead of this `report` method - it will be called in the simulation's hot loop, and we don't want reporting to slow down the simulation. For this reason, the `report` method on the `ThreadedSimulationExtentReporter` merely sets an `AtomicReference` and returns immediately:

https://github.com/NASA-AMMOS/aerie/blob/64caed7372d32927c3dfa5689a6a56d243bff31a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ThreadedSimulationExtentReporter.java#L30-L32

A separate worker thread polls this value at a configurable cadence and uses the `ResultsCell.WriterRole` to report it to the database.

https://github.com/NASA-AMMOS/aerie/blob/64caed7372d32927c3dfa5689a6a56d243bff31a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ThreadedSimulationExtentReporter.java#L59-L81

(Pasting from slack):
Another consideration is that this is a very update-heavy workload, which isn’t postgres’s strong suit. Originally, I wanted to make the extent a new column on the simulation_dataset table - but that means that the entire row will be copied on every update. Since those rows contain the simulation arguments, I was concerned those could spill over page boundaries and hinder postgres’s ability to use Heap-Only-Tuple updates. This drove the decision to make a new table, with a foreign key to the simulation_dataset table

I made all the changes in one commit - if anyone would like them to be split, I will be happy to oblige.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
All testing has been done manually thus far, using the UI changes in the aerie-ui PR I will open soon.

https://github.com/NASA-AMMOS/aerie/assets/1189602/82291d4a-daa0-42f8-af41-4eb8f767a81f

Additional manual testing encouraged, if reviewers have time.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
- [ ] TODO: Consider what documentation, if any, this PR needs

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- A natural next step is to think about graceful cancellation of simulation runs