### PR TITLE
Activity Directive Changelog

### DIFF
--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/ActivityDirectiveChangelogTests.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/ActivityDirectiveChangelogTests.java
@@ -1,0 +1,290 @@
+package gov.nasa.jpl.aerie.database;
+
+import gov.nasa.jpl.aerie.database.PlanCollaborationTests.Activity;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ActivityDirectiveChangelogTests {
+  private static final File initSqlScriptFile = new File("../merlin-server/sql/merlin/init.sql");
+  private DatabaseTestHelper helper;
+  private MerlinDatabaseTestHelper merlinHelper;
+  private Connection connection;
+  private int planId;
+
+  @BeforeEach
+  void beforeEach() throws SQLException {
+    int fileId = merlinHelper.insertFileUpload();
+    int missionModelId = merlinHelper.insertMissionModel(fileId);
+    planId = merlinHelper.insertPlan(missionModelId);
+  }
+
+  @AfterEach
+  void afterEach() throws SQLException {
+    helper.clearTable("uploaded_file");
+    helper.clearTable("mission_model");
+    helper.clearTable("plan");
+    helper.clearTable("activity_directive_changelog");
+    helper.clearTable("activity_directive");
+  }
+
+  @BeforeAll
+  void beforeAll() throws SQLException, IOException, InterruptedException {
+    helper = new DatabaseTestHelper(
+        "aerie_merlin_test",
+        "Merlin Database Tests",
+        initSqlScriptFile
+    );
+    helper.startDatabase();
+    connection = helper.connection();
+    merlinHelper = new MerlinDatabaseTestHelper(connection);
+  }
+
+  @AfterAll
+  void afterAll() throws SQLException, IOException, InterruptedException {
+    helper.stopDatabase();
+    connection = null;
+    helper = null;
+  }
+
+  //region Helper Methods
+  private Activity getActivity(final int planId, final int activityId) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement.executeQuery(
+          // language=sql
+          """
+          SELECT *
+          FROM activity_directive
+          WHERE id = %d
+          AND plan_id = %d;
+          """.formatted(activityId, planId));
+
+      res.next();
+
+      return new Activity(
+          res.getInt("id"),
+          res.getInt("plan_id"),
+          res.getString("name"),
+          res.getInt("source_scheduling_goal_id"),
+          res.getString("created_at"),
+          res.getString("last_modified_at"),
+          res.getString("last_modified_by"),
+          res.getString("start_offset"),
+          res.getString("type"),
+          res.getString("arguments"),
+          res.getString("last_modified_arguments_at"),
+          res.getString("metadata"),
+          res.getString("anchor_id"),
+          res.getBoolean("anchored_to_start")
+      );
+    }
+  }
+
+  private void revertActivityDirectiveToChangelog(int planId, int activityDirectiveId, int revision) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      statement.executeQuery(
+          // language=sql
+          """
+          SELECT hasura_functions.restore_activity_changelog(
+            _plan_id => %d,
+            _activity_directive_id => %d,
+            _revision => %d,
+            hasura_session => '%s'::json);
+          """.formatted(planId, activityDirectiveId, revision, merlinHelper.admin.session())
+      );
+    }
+  }
+  private int getChangelogRevisionCount(int planId, int activityDirectiveId) throws SQLException {
+    try (final var statement = connection.createStatement()) {
+      final var res = statement.executeQuery(
+          // language=sql
+          """
+          SELECT count(revision)
+          FROM activity_directive_changelog
+          WHERE plan_id = %d and activity_directive_id = %d;
+          """.formatted(planId, activityDirectiveId)
+      );
+      res.next();
+      return res.getInt(1);
+    }
+  }
+  //endregion
+
+  @Test
+  void shouldHaveNoChangelogsForEmptyPlan() throws SQLException {
+    try (final var statement = connection.createStatement()) {
+       final var res = statement.executeQuery(
+          // language=sql
+          """
+          SELECT count(revision)
+          FROM activity_directive_changelog
+          WHERE plan_id = %d;
+          """.formatted(planId)
+      );
+      res.next();
+      final var count = res.getInt(1);
+      assertEquals(0, count);
+    }
+  }
+
+  @Test
+  void shouldCreateChangelogForInsertedActDir() throws SQLException {
+    final var activityId = merlinHelper.insertActivity(planId);
+    assertEquals(1, getChangelogRevisionCount(planId, activityId));
+  }
+
+  @Test
+  void shouldCreateChangelogForUpdatedActDir() throws SQLException {
+    final var activityId = merlinHelper.insertActivity(planId);
+
+    assertEquals(1, getChangelogRevisionCount(planId, activityId));
+
+    try (final var statement = connection.createStatement()) {
+      final var updatedRows = statement.executeQuery(
+          // language=sql
+          """
+          UPDATE activity_directive
+          SET start_offset = '%s'
+          WHERE plan_id = %d and id = %d
+          RETURNING id;
+          """.formatted("01:01:01", planId, activityId));
+      updatedRows.next();
+      assertEquals(activityId, updatedRows.getInt(1));
+    }
+
+    assertEquals(2, getChangelogRevisionCount(planId, activityId));
+}
+    @Test
+    void changelogRevisionHasCorrectValues() throws SQLException {
+      final var activityId = merlinHelper.insertActivity(planId);
+
+      try (final var statement = connection.createStatement()) {
+        final var res = statement.executeQuery(
+            // language=sql
+            """
+            SELECT *
+            FROM activity_directive_changelog
+            WHERE plan_id = %d and activity_directive_id = %d;
+            """.formatted(planId, activityId));
+
+        res.next();
+        final var current = getActivity(planId, activityId);
+
+        assertEquals(current.activityId(), res.getInt("activity_directive_id"));
+        assertEquals(current.planId(), res.getInt("plan_id"));
+        assertEquals(current.name(), res.getString("name"));
+        assertEquals(current.sourceSchedulingGoalId(), res.getInt("source_scheduling_goal_id"));
+        assertEquals(current.lastModifiedAt(), res.getString("changed_at"));
+        assertEquals(current.lastModifiedBy(), res.getString("changed_by"));
+        assertEquals(current.startOffset(), res.getString("start_offset"));
+        assertEquals(current.type(), res.getString("type"));
+        assertEquals(current.arguments(), res.getString("arguments"));
+        assertEquals(current.lastModifiedArgumentsAt(), res.getString("changed_arguments_at"));
+        assertEquals(current.metadata(), res.getString("metadata"));
+        assertEquals(current.anchorId(), res.getString("anchor_id"));
+        assertEquals(current.anchoredToStart(), res.getBoolean("anchored_to_start"));
+    }
+  }
+
+  @Test
+  void shouldDeleteChangelogsOverRevisionLimit() throws SQLException {
+    final var maxRevisionsLimit = 11;
+    final var activityId = merlinHelper.insertActivity(planId);
+
+    // randomly update activity directive > maxRevisionsLimit times
+    for (int i = 0; i < maxRevisionsLimit * 2; i++) {
+      connection.createStatement()
+                .executeQuery(
+                    // language=sql
+                    """
+                    UPDATE activity_directive
+                    SET start_offset = '%02d'
+                    WHERE plan_id = %d and id = %d
+                    RETURNING id;
+                    """.formatted(i, planId, activityId)
+                )
+                .close();
+    }
+
+    assertEquals(maxRevisionsLimit, getChangelogRevisionCount(planId, activityId));
+  }
+
+  @Test
+  void revertNonExistentPlanThrowsError() throws SQLException {
+    try {
+      revertActivityDirectiveToChangelog(-1, -1, -1);
+    } catch (SQLException ex) {
+      if (!ex.getMessage().contains("Plan %d does not exist".formatted(-1))) {
+        throw ex;
+      }
+    }
+  }
+
+  @Test
+  void revertNonExistentDirectiveThrowsError() throws SQLException {
+    try {
+      revertActivityDirectiveToChangelog(planId, -1, -1);
+    } catch (SQLException ex) {
+      if (!ex.getMessage().contains("Activity Directive %d does not exist in Plan %d".formatted(-1, planId))) {
+        throw ex;
+      }
+    }
+  }
+
+  @Test
+  void revertNonExistentRevisionThrowsError() throws SQLException {
+    final var activityId = merlinHelper.insertActivity(planId);
+    try {
+      revertActivityDirectiveToChangelog(planId, activityId, -1);
+    } catch (SQLException ex) {
+      if (!ex.getMessage().contains("Changelog Revision %d does not exist for Plan %d and Activity Directive %d".formatted(-1, planId, activityId))) {
+        throw ex;
+      }
+    }
+  }
+
+  @Test
+  void shouldRevertActDirToChangelogEntry() throws SQLException {
+    final var activityId = merlinHelper.insertActivity(planId);
+
+    final var actDirBefore = getActivity(planId, activityId);
+
+    try (final var statement = connection.createStatement()) {
+      statement.executeQuery(
+          // language=sql
+          """
+          UPDATE activity_directive
+          SET
+            name = 'changed',
+            start_offset = '01:01:01',
+            arguments = '{"biteSize": 2}'
+          WHERE plan_id = %d and id = %d
+          RETURNING *;
+          """.formatted(planId, activityId));
+    }
+    final var actDirMid = getActivity(planId, activityId);
+
+    revertActivityDirectiveToChangelog(planId, activityId, 0);
+    final var actDirAfter = getActivity(planId, activityId);
+
+    assertNotEquals(actDirBefore.name(), actDirMid.name());
+    assertNotEquals(actDirBefore.startOffset(), actDirMid.startOffset());
+    assertNotEquals(actDirBefore.arguments(), actDirMid.arguments());
+
+    assertEquals(actDirBefore.name(), actDirAfter.name());
+    assertEquals(actDirBefore.startOffset(), actDirAfter.startOffset());
+    assertEquals(actDirBefore.arguments(), actDirAfter.arguments());
+  }
+}

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MerlinDatabaseTestHelper.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MerlinDatabaseTestHelper.java
@@ -120,14 +120,17 @@ final class MerlinDatabaseTestHelper {
   }
 
   int insertActivity(final int planId, final String startOffset, final String arguments) throws SQLException {
+    return insertActivity(planId, startOffset, arguments, admin);
+  }
+  int insertActivity(final int planId, final String startOffset, final String arguments, User user) throws SQLException {
     try (final var statement = connection.createStatement()) {
       final var res = statement
           .executeQuery(
               """
-                  INSERT INTO activity_directive (type, plan_id, start_offset, arguments)
-                  VALUES ('test-activity', '%s', '%s', '%s')
+                  INSERT INTO activity_directive (type, plan_id, start_offset, arguments, last_modified_by)
+                  VALUES ('test-activity', '%s', '%s', '%s', '%s')
                   RETURNING id;"""
-                  .formatted(planId, startOffset, arguments)
+                  .formatted(planId, startOffset, arguments, user.name)
           );
 
       res.next();

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PermissionsTest.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PermissionsTest.java
@@ -26,7 +26,8 @@ public class PermissionsTest {
       apply_preset, branch_plan, create_merge_rq, withdraw_merge_rq, begin_merge, cancel_merge,
       commit_merge, deny_merge, get_conflicting_activities, get_non_conflicting_activities, set_resolution,
       set_resolution_bulk, delete_activity_subtree, delete_activity_subtree_bulk, delete_activity_reanchor_plan,
-      delete_activity_reanchor_plan_bulk, delete_activity_reanchor, delete_activity_reanchor_bulk, get_plan_history
+      delete_activity_reanchor_plan_bulk, delete_activity_reanchor, delete_activity_reanchor_bulk, get_plan_history,
+      restore_activity_changelog
   }
   private enum GeneralPermission {
     OWNER, MISSION_MODEL_OWNER, PLAN_OWNER, PLAN_COLLABORATOR, PLAN_OWNER_COLLABORATOR
@@ -193,6 +194,7 @@ public class PermissionsTest {
       assertEquals("PLAN_OWNER_COLLABORATOR", getFunctionPermission("delete_activity_reanchor", merlinHelper.user.session()));
       assertEquals("PLAN_OWNER_COLLABORATOR", getFunctionPermission("delete_activity_reanchor_bulk", merlinHelper.user.session()));
       assertEquals("NO_CHECK", getFunctionPermission("get_plan_history", merlinHelper.user.session()));
+      assertEquals("PLAN_OWNER_COLLABORATOR", getFunctionPermission("restore_activity_changelog", merlinHelper.user.session()));
     }
 
     @ParameterizedTest

--- a/deployment/hasura/metadata/databases/AerieMerlin/functions/functions.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/functions/functions.yaml
@@ -201,3 +201,12 @@
     - role: aerie_admin
     - role: user
     - role: viewer
+- function:
+    name: restore_activity_changelog
+    schema: hasura_functions
+  configuration:
+    custom_name: restoreActivityFromChangelog
+    session_argument: hasura_session
+  permissions:
+    - role: aerie_admin
+    - role: user

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
@@ -52,6 +52,16 @@ array_relationships:
       column_mapping:
         id: directive_id
         plan_id: plan_id
+- name: activity_directive_changelog
+  using:
+    manual_configuration:
+      insertion_order: null
+      remote_table:
+        name: activity_directive_changelog
+        schema: public
+      column_mapping:
+        id: activity_directive_id
+        plan_id: plan_id
 remote_relationships:
 - name: source_scheduling_goal
   definition:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
@@ -67,20 +67,20 @@ select_permissions:
   - role: aerie_admin
     permission:
       columns: [ id, plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
-                 arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start]
+                 arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start, last_modified_by]
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
       # Need to specify all columns manually
       columns: [ id, plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
-                 arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start]
+                 arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start, last_modified_by]
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
       columns: [ id, plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
-                 arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start ]
+                 arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start, last_modified_by]
       filter: {}
       allow_aggregations: true
 update_permissions:
@@ -88,19 +88,27 @@ update_permissions:
     permission:
       columns: [ name, start_offset, type, arguments, metadata, anchor_id, anchored_to_start ]
       filter: {}
+      set:
+        last_modified_by: "x-hasura-user-id"
   - role: user
     permission:
       columns: [name, start_offset, arguments, metadata, anchor_id, anchored_to_start]
       filter: {"plan":{"_or":[{"owner":{"_eq":"X-Hasura-User-Id"}},{"collaborators":{"collaborator":{"_eq":"X-Hasura-User-Id"}}}]}}
+      set:
+        last_modified_by: "x-hasura-user-id"
 insert_permissions:
   - role: aerie_admin
     permission:
       columns: [name, start_offset, arguments, metadata, anchor_id, anchored_to_start, plan_id, type]
       check: {}
+      set:
+        last_modified_by: "x-hasura-user-id"
   - role: user
     permission:
       columns: [name, start_offset, arguments, metadata, anchor_id, anchored_to_start, plan_id, type]
       check: {"plan":{"_or":[{"owner":{"_eq":"X-Hasura-User-Id"}},{"collaborators":{"collaborator":{"_eq":"X-Hasura-User-Id"}}}]}}
+      set:
+        last_modified_by: "x-hasura-user-id"
 delete_permissions:
   - role: aerie_admin
     permission:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_changelog.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_changelog.yaml
@@ -1,0 +1,81 @@
+table:
+  name: activity_directive_changelog
+  schema: public
+object_relationships:
+- name: activity_directive
+  using:
+    manual_configuration:
+      remote_table:
+        name: activity_directive
+        schema: public
+      column_mapping:
+        plan_id: plan_id
+        activity_directive_id: id
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns:
+       - revision
+       - plan_id
+       - activity_directive_id
+       - name
+       - source_scheduling_goal_id
+       - changed_at
+       - changed_by
+       - start_offset
+       - type
+       - arguments
+       - changed_arguments_at
+       - metadata
+       - anchor_id
+       - anchored_to_start
+      filter: {}
+      allow_aggregations: true
+  - role: user
+    permission:
+      columns:
+       - revision
+       - plan_id
+       - activity_directive_id
+       - name
+       - source_scheduling_goal_id
+       - changed_at
+       - changed_by
+       - start_offset
+       - type
+       - arguments
+       - changed_arguments_at
+       - metadata
+       - anchor_id
+       - anchored_to_start
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns:
+       - revision
+       - plan_id
+       - activity_directive_id
+       - name
+       - source_scheduling_goal_id
+       - changed_at
+       - changed_by
+       - start_offset
+       - type
+       - arguments
+       - changed_arguments_at
+       - metadata
+       - anchor_id
+       - anchored_to_start
+      filter: {}
+      allow_aggregations: true
+update_permissions:
+  - role: aerie_admin
+    permission:
+      columns:
+       - changed_by
+      filter: {}
+delete_permissions:
+  - role: aerie_admin
+    permission:
+      filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_extended.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_extended.yaml
@@ -23,21 +23,21 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
+      columns: [id, plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, last_modified_by, start_offset, type,
                  arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start, approximate_start_time,
                  preset_id, preset_arguments]
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
+      columns: [id, plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, last_modified_by, start_offset, type,
                  arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start, approximate_start_time,
                  preset_id, preset_arguments]
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
+      columns: [id, plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, last_modified_by, start_offset, type,
                  arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start, approximate_start_time,
                  preset_id, preset_arguments]
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/tables.yaml
@@ -1,4 +1,5 @@
 - "!include public_activity_directive.yaml"
+- "!include public_activity_directive_changelog.yaml"
 - "!include public_activity_directive_extended.yaml"
 - "!include public_activity_directive_metadata_schema.yaml"
 - "!include public_activity_directive_validations.yaml"

--- a/deployment/hasura/migrations/AerieMerlin/23_activity_directive_changelog/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/23_activity_directive_changelog/down.sql
@@ -1,0 +1,1013 @@
+-- remove restore_activity_changelog function permissions key enum value
+update metadata.user_role_permission
+  set function_permissions = function_permissions  - 'restore_activity_changelog';
+
+drop procedure metadata.check_merge_permissions(_function metadata.function_permission_key, _permission metadata.permission, _plan_id_receiving integer, _plan_id_supplying integer, _user text);
+drop procedure metadata.check_merge_permissions(_function metadata.function_permission_key, _merge_request_id integer, hasura_session json);
+drop function metadata.raise_if_plan_merge_permission(_function metadata.function_permission_key, _permission metadata.permission);
+drop procedure metadata.check_general_permissions(_function metadata.function_permission_key, _permission metadata.permission, _plan_id integer, _user text);
+drop function metadata.get_function_permissions(_function metadata.function_permission_key, hasura_session json);
+
+drop type metadata.function_permission_key;
+create type metadata.function_permission_key
+  as enum ('apply_preset', 'branch_plan', 'create_merge_rq', 'withdraw_merge_rq', 'begin_merge', 'cancel_merge',
+    'commit_merge', 'deny_merge', 'get_conflicting_activities', 'get_non_conflicting_activities', 'set_resolution',
+    'set_resolution_bulk', 'delete_activity_subtree', 'delete_activity_subtree_bulk', 'delete_activity_reanchor_plan',
+    'delete_activity_reanchor_plan_bulk', 'delete_activity_reanchor', 'delete_activity_reanchor_bulk', 'get_plan_history');
+
+create function metadata.get_function_permissions(_function metadata.function_permission_key, hasura_session json)
+  returns metadata.permission
+  stable
+  language plpgsql as $$
+  declare
+    _role text;
+    _function_permission metadata.permission;
+  begin
+    _role := metadata.get_role(hasura_session);
+    -- The aerie_admin role is always treated as having NO_CHECK permissions on all functions.
+    if _role = 'aerie_admin' then return 'NO_CHECK'; end if;
+
+    select (function_permissions ->> _function::text)::metadata.permission
+    from metadata.user_role_permission urp
+    where urp.role = _role
+    into _function_permission;
+
+    -- The absence of the function key means that the role does not have permission to perform the function.
+    if _function_permission is null then
+      raise insufficient_privilege
+        using message = 'User with role '''|| _role ||''' is not permitted to run '''|| _function ||'''';
+    end if;
+
+    return _function_permission::metadata.permission;
+  end
+  $$;
+
+create procedure metadata.check_general_permissions(_function metadata.function_permission_key, _permission metadata.permission, _plan_id integer, _user text)
+language plpgsql as $$
+declare
+  _mission_model_id integer;
+  _plan_name text;
+begin
+  select name from public.plan where id = _plan_id into _plan_name;
+
+  -- MISSION_MODEL_OWNER: The user must own the relevant Mission Model
+  if _permission = 'MISSION_MODEL_OWNER' then
+    select id from public.mission_model mm
+    where mm.id = (select model_id from plan p where p.id = _plan_id)
+    into _mission_model_id;
+
+    if not exists(select * from public.mission_model mm where mm.id = _mission_model_id and mm.owner =_user) then
+        raise insufficient_privilege
+        using message = 'Cannot run '''|| _function ||''': '''|| _user ||''' is not MISSION_MODEL_OWNER on Model ' || _mission_model_id ||'.';
+    end if;
+
+  -- OWNER: The user must be the owner of all relevant objects directly used by the KEY
+  -- In most cases, OWNER is equivalent to PLAN_OWNER. Use a custom solution when that is not true.
+  elseif _permission = 'OWNER' then
+		if not exists(select * from public.plan p where p.id = _plan_id and p.owner = _user) then
+      raise insufficient_privilege
+        using message = 'Cannot run '''|| _function ||''': '''|| _user ||''' is not OWNER on Plan ' || _plan_id ||' ('|| _plan_name ||').';
+    end if;
+
+  -- PLAN_OWNER: The user must be the Owner of the relevant Plan
+  elseif _permission = 'PLAN_OWNER' then
+    if not exists(select * from public.plan p where p.id = _plan_id and p.owner = _user) then
+      raise insufficient_privilege
+        using message = 'Cannot run '''|| _function ||''': '''|| _user ||''' is not PLAN_OWNER on Plan '|| _plan_id ||' ('|| _plan_name ||').';
+    end if;
+
+  -- PLAN_COLLABORATOR:	The user must be a Collaborator of the relevant Plan. The Plan Owner is NOT considered a Collaborator of the Plan
+  elseif _permission = 'PLAN_COLLABORATOR' then
+    if not exists(select * from public.plan_collaborators pc where pc.plan_id = _plan_id and pc.collaborator = _user) then
+      raise insufficient_privilege
+        using message = 'Cannot run '''|| _function ||''': '''|| _user ||''' is not PLAN_COLLABORATOR on Plan '|| _plan_id ||' ('|| _plan_name ||').';
+    end if;
+
+  -- PLAN_OWNER_COLLABORATOR:	The user must be either the Owner or a Collaborator of the relevant Plan
+  elseif _permission = 'PLAN_OWNER_COLLABORATOR' then
+    if not exists(select * from public.plan p where p.id = _plan_id and p.owner = _user) then
+      if not exists(select * from public.plan_collaborators pc where pc.plan_id = _plan_id and pc.collaborator = _user) then
+        raise insufficient_privilege
+          using message = 'Cannot run '''|| _function ||''': '''|| _user ||''' is not PLAN_OWNER_COLLABORATOR on Plan '|| _plan_id ||' ('|| _plan_name ||').';
+      end if;
+    end if;
+  end if;
+end
+$$;
+
+create function metadata.raise_if_plan_merge_permission(_function metadata.function_permission_key, _permission metadata.permission)
+returns void
+immutable
+language plpgsql as $$
+begin
+  if _permission::text = any(array['PLAN_OWNER_SOURCE', 'PLAN_COLLABORATOR_SOURCE', 'PLAN_OWNER_COLLABORATOR_SOURCE',
+    'PLAN_OWNER_TARGET', 'PLAN_COLLABORATOR_TARGET', 'PLAN_OWNER_COLLABORATOR_TARGET'])
+  then
+    raise 'Invalid Permission: The Permission ''%'' may not be applied to function ''%''', _permission, _function;
+  end if;
+end
+$$;
+create procedure metadata.check_merge_permissions(_function metadata.function_permission_key, _merge_request_id integer, hasura_session json)
+language plpgsql as $$
+declare
+  _plan_id_receiving_changes integer;
+  _plan_id_supplying_changes integer;
+  _function_permission metadata.permission;
+  _user text;
+begin
+  select plan_id_receiving_changes
+  from merge_request mr
+  where mr.id = _merge_request_id
+  into _plan_id_receiving_changes;
+
+  select plan_id
+  from public.plan_snapshot ps, merge_request mr
+  where mr.id = _merge_request_id and ps.snapshot_id = mr.snapshot_id_supplying_changes
+  into _plan_id_supplying_changes;
+
+  _user := (hasura_session ->> 'x-hasura-user-id');
+  _function_permission := metadata.get_function_permissions('get_non_conflicting_activities', hasura_session);
+  call metadata.check_merge_permissions(_function, _function_permission, _plan_id_receiving_changes,
+    _plan_id_supplying_changes, _user);
+end
+$$;
+
+create procedure metadata.check_merge_permissions(_function metadata.function_permission_key, _permission metadata.permission, _plan_id_receiving integer, _plan_id_supplying integer, _user text)
+language plpgsql as $$
+declare
+  _supplying_plan_name text;
+  _receiving_plan_name text;
+begin
+  select name from public.plan where id = _plan_id_supplying into _supplying_plan_name;
+  select name from public.plan where id = _plan_id_receiving into _receiving_plan_name;
+
+  -- MISSION_MODEL_OWNER: The user must own the relevant Mission Model
+  if _permission = 'MISSION_MODEL_OWNER' then
+    call metadata.check_general_permissions(_function, _permission, _plan_id_receiving, _user);
+
+  -- OWNER: The user must be the Owner of both Plans
+  elseif _permission = 'OWNER' then
+    if not (exists(select * from public.plan p where p.id = _plan_id_receiving and p.owner = _user)) then
+      raise insufficient_privilege
+        using message = 'Cannot run '''|| _function ||''': '''
+                          || _user ||''' is not OWNER on Plan '|| _plan_id_receiving
+                          ||' ('|| _receiving_plan_name ||').';
+    elseif not (exists(select * from public.plan p2 where p2.id = _plan_id_supplying and p2.owner = _user)) then
+      raise insufficient_privilege
+        using message = 'Cannot run '''|| _function ||''': '''
+                          || _user ||''' is not OWNER on Plan '|| _plan_id_supplying
+                          ||' ('|| _supplying_plan_name ||').';
+    end if;
+
+  -- PLAN_OWNER: The user must be the Owner of either Plan
+  elseif _permission = 'PLAN_OWNER' then
+    if not exists(select *
+                  from public.plan p
+                  where (p.id = _plan_id_receiving or p.id = _plan_id_supplying)
+                    and p.owner = _user) then
+      raise insufficient_privilege
+        using message = 'Cannot run '''|| _function ||''': '''
+                          || _user ||''' is not PLAN_OWNER on either Plan '|| _plan_id_receiving
+                          ||' ('|| _receiving_plan_name ||') or Plan '|| _plan_id_supplying ||' ('|| _supplying_plan_name ||').';
+    end if;
+
+  -- PLAN_COLLABORATOR:	The user must be a Collaborator of either Plan. The Plan Owner is NOT considered a Collaborator of the Plan
+  elseif _permission = 'PLAN_COLLABORATOR' then
+    if not exists(select *
+                  from public.plan_collaborators pc
+                  where (pc.plan_id = _plan_id_receiving or pc.plan_id = _plan_id_supplying)
+                    and pc.collaborator = _user) then
+      raise insufficient_privilege
+        using message = 'Cannot run '''|| _function ||''': '''
+                          || _user ||''' is not PLAN_COLLABORATOR on either Plan '|| _plan_id_receiving
+                          ||' ('|| _receiving_plan_name ||') or Plan '|| _plan_id_supplying ||' ('|| _supplying_plan_name ||').';
+    end if;
+
+  -- PLAN_OWNER_COLLABORATOR:	The user must be either the Owner or a Collaborator of either Plan
+  elseif _permission = 'PLAN_OWNER_COLLABORATOR' then
+    if not exists(select *
+                  from public.plan p
+                  where (p.id = _plan_id_receiving or p.id = _plan_id_supplying)
+                    and p.owner = _user) then
+      if not exists(select *
+                    from public.plan_collaborators pc
+                    where (pc.plan_id = _plan_id_receiving or pc.plan_id = _plan_id_supplying)
+                      and pc.collaborator = _user) then
+        raise insufficient_privilege
+        using message = 'Cannot run '''|| _function ||''': '''
+                          || _user ||''' is not PLAN_OWNER_COLLABORATOR on either Plan '|| _plan_id_receiving
+                          ||' ('|| _receiving_plan_name ||') or Plan '|| _plan_id_supplying ||' ('|| _supplying_plan_name ||').';
+
+      end if;
+    end if;
+
+  -- PLAN_OWNER_SOURCE:	The user must be the Owner of the Supplying Plan
+  elseif _permission = 'PLAN_OWNER_SOURCE' then
+    if not exists(select *
+                  from public.plan p
+                  where p.id = _plan_id_supplying and p.owner = _user) then
+      raise insufficient_privilege
+        using message = 'Cannot run '''|| _function ||''': '''|| _user ||''' is not PLAN_OWNER on Source Plan '
+                          || _plan_id_supplying ||' ('|| _supplying_plan_name ||').';
+    end if;
+
+  -- PLAN_COLLABORATOR_SOURCE: The user must be a Collaborator of the Supplying Plan.
+  elseif _permission = 'PLAN_COLLABORATOR_SOURCE' then
+    if not exists(select *
+                  from public.plan_collaborators pc
+                  where pc.plan_id = _plan_id_supplying and pc.collaborator = _user) then
+      raise insufficient_privilege
+        using message = 'Cannot run '''|| _function ||''': '''|| _user ||''' is not PLAN_COLLABORATOR on Source Plan '
+                          || _plan_id_supplying ||' ('|| _supplying_plan_name ||').';
+    end if;
+
+  -- PLAN_OWNER_COLLABORATOR_SOURCE:	The user must be either the Owner or a Collaborator of the Supplying Plan.
+  elseif _permission = 'PLAN_OWNER_COLLABORATOR_SOURCE' then
+    if not exists(select *
+                  from public.plan p
+                  where p.id = _plan_id_supplying and p.owner = _user) then
+      if not exists(select *
+                    from public.plan_collaborators pc
+                    where pc.plan_id = _plan_id_supplying and pc.collaborator = _user) then
+        raise insufficient_privilege
+          using message = 'Cannot run '''|| _function ||''': '''|| _user ||''' is not PLAN_OWNER_COLLABORATOR on Source Plan '
+                          || _plan_id_supplying ||' ('|| _supplying_plan_name ||').';
+      end if;
+    end if;
+
+  -- PLAN_OWNER_TARGET: The user must be the Owner of the Receiving Plan.
+  elseif _permission = 'PLAN_OWNER_TARGET' then
+    if not exists(select *
+                  from public.plan p
+                  where p.id = _plan_id_receiving and p.owner = _user) then
+      raise insufficient_privilege
+        using message = 'Cannot run '''|| _function ||''': '''|| _user ||''' is not PLAN_OWNER on Target Plan '
+                          || _plan_id_receiving ||' ('|| _receiving_plan_name ||').';
+    end if;
+
+  -- PLAN_COLLABORATOR_TARGET: The user must be a Collaborator of the Receiving Plan.
+  elseif _permission = 'PLAN_COLLABORATOR_TARGET' then
+    if not exists(select *
+                  from public.plan_collaborators pc
+                  where pc.plan_id = _plan_id_receiving and pc.collaborator = _user) then
+      raise insufficient_privilege
+        using message = 'Cannot run '''|| _function ||''': '''|| _user ||''' is not PLAN_COLLABORATOR on Target Plan '
+                          || _plan_id_receiving ||' ('|| _receiving_plan_name ||').';
+    end if;
+
+  -- PLAN_OWNER_COLLABORATOR_TARGET: The user must be either the Owner or a Collaborator of the Receiving Plan.
+  elseif _permission = 'PLAN_OWNER_COLLABORATOR_TARGET' then
+    if not exists(select *
+                  from public.plan p
+                  where p.id = _plan_id_receiving and p.owner = _user) then
+      if not exists(select *
+                    from public.plan_collaborators pc
+                    where pc.plan_id = _plan_id_receiving and pc.collaborator = _user) then
+        raise insufficient_privilege
+          using message = 'Cannot run '''|| _function ||''': '''|| _user ||''' is not PLAN_OWNER_COLLABORATOR on Target Plan '
+                          || _plan_id_receiving ||' ('|| _receiving_plan_name ||').';
+      end if;
+    end if;
+  end if;
+end
+$$;
+
+-- drop activity_directive_changelog table and functions
+drop function hasura_functions.restore_activity_changelog(
+  _plan_id integer,
+  _activity_directive_id integer,
+  _revision integer,
+  hasura_session json);
+drop trigger delete_min_activity_directive_revision_trigger on activity_directive_changelog;
+drop function delete_min_activity_directive_revision;
+drop trigger store_activity_directive_change_trigger on activity_directive;
+drop function store_activity_directive_change;
+drop table activity_directive_changelog;
+
+create or replace function duplicate_plan(_plan_id integer, new_plan_name text, new_owner text)
+  returns integer -- plan_id of the new plan
+  security definer
+  language plpgsql as $$
+  declare
+    validate_plan_id integer;
+    new_plan_id integer;
+    created_snapshot_id integer;
+begin
+  select id from plan where plan.id = _plan_id into validate_plan_id;
+  if(validate_plan_id is null) then
+    raise exception 'Plan % does not exist.', _plan_id;
+  end if;
+
+  select create_snapshot(_plan_id) into created_snapshot_id;
+
+  insert into plan(revision, name, model_id, duration, start_time, parent_id, owner, updated_by)
+    select
+        0, new_plan_name, model_id, duration, start_time, _plan_id, new_owner, new_owner
+    from plan where id = _plan_id
+    returning id into new_plan_id;
+  insert into activity_directive(
+      id, plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+      last_modified_arguments_at, metadata, anchor_id, anchored_to_start)
+    select
+      id, new_plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+      last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+    from activity_directive where activity_directive.plan_id = _plan_id;
+
+  with source_plan as (
+    select simulation_template_id, arguments, simulation_start_time, simulation_end_time
+    from simulation
+    where simulation.plan_id = _plan_id
+  )
+  update simulation s
+  set simulation_template_id = source_plan.simulation_template_id,
+      arguments = source_plan.arguments,
+      simulation_start_time = source_plan.simulation_start_time,
+      simulation_end_time = source_plan.simulation_end_time
+  from source_plan
+  where s.plan_id = new_plan_id;
+
+  insert into preset_to_directive(preset_id, activity_id, plan_id)
+    select preset_id, activity_id, new_plan_id
+    from preset_to_directive ptd where ptd.plan_id = _plan_id;
+
+  insert into metadata.plan_tags(plan_id, tag_id)
+    select new_plan_id, tag_id
+    from metadata.plan_tags pt where pt.plan_id = _plan_id;
+  insert into metadata.activity_directive_tags(plan_id, directive_id, tag_id)
+    select new_plan_id, directive_id, tag_id
+    from metadata.activity_directive_tags adt where adt.plan_id = _plan_id;
+
+  insert into plan_latest_snapshot(plan_id, snapshot_id) values(new_plan_id, created_snapshot_id);
+  return new_plan_id;
+end
+$$;
+
+create or replace function create_snapshot(_plan_id integer)
+  returns integer -- snapshot id inserted into the table
+  language plpgsql as $$
+  declare
+    validate_plan_id integer;
+    inserted_snapshot_id integer;
+begin
+  select id from plan where plan.id = _plan_id into validate_plan_id;
+  if validate_plan_id is null then
+    raise exception 'Plan % does not exist.', _plan_id;
+  end if;
+
+  insert into plan_snapshot(plan_id, revision, name, duration, start_time)
+    select id, revision, name, duration, start_time
+    from plan where id = _plan_id
+    returning snapshot_id into inserted_snapshot_id;
+  insert into plan_snapshot_activities(
+                snapshot_id, id, name, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
+                arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start)
+    select
+      inserted_snapshot_id,                              -- this is the snapshot id
+      id, name, source_scheduling_goal_id, created_at,   -- these are the rest of the data for an activity row
+      last_modified_at, start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+    from activity_directive where activity_directive.plan_id = _plan_id;
+  insert into preset_to_snapshot_directive(preset_id, activity_id, snapshot_id)
+    select ptd.preset_id, ptd.activity_id, inserted_snapshot_id
+    from preset_to_directive ptd
+    where ptd.plan_id = _plan_id;
+  insert into metadata.snapshot_activity_tags(snapshot_id, directive_id, tag_id)
+    select inserted_snapshot_id, directive_id, tag_id
+    from metadata.activity_directive_tags adt
+    where adt.plan_id = _plan_id;
+
+  --all snapshots in plan_latest_snapshot for plan plan_id become the parent of the current snapshot
+  insert into plan_snapshot_parent(snapshot_id, parent_snapshot_id)
+    select inserted_snapshot_id, snapshot_id
+    from plan_latest_snapshot where plan_latest_snapshot.plan_id = _plan_id;
+
+  --remove all of those entries from plan_latest_snapshot and add this new snapshot.
+  delete from plan_latest_snapshot where plan_latest_snapshot.plan_id = _plan_id;
+  insert into plan_latest_snapshot(plan_id, snapshot_id) values (_plan_id, inserted_snapshot_id);
+
+  return inserted_snapshot_id;
+  end;
+$$;
+
+create or replace procedure commit_merge(_request_id integer)
+  language plpgsql as $$
+  declare
+    validate_noConflicts integer;
+    plan_id_R integer;
+    snapshot_id_S integer;
+begin
+  if(select id from merge_request where id = _request_id) is null then
+    raise exception 'Invalid merge request id %.', _request_id;
+  end if;
+
+  -- Stop if this merge is not 'in-progress'
+  if (select status from merge_request where id = _request_id) != 'in-progress' then
+    raise exception 'Cannot commit a merge request that is not in-progress.';
+  end if;
+
+  -- Stop if any conflicts have not been resolved
+  select * from conflicting_activities
+  where merge_request_id = _request_id and resolution = 'none'
+  limit 1
+  into validate_noConflicts;
+
+  if(validate_noConflicts is not null) then
+    raise exception 'There are unresolved conflicts in merge request %. Cannot commit merge.', _request_id;
+  end if;
+
+  select plan_id_receiving_changes from merge_request mr where mr.id = _request_id into plan_id_R;
+  select snapshot_id_supplying_changes from merge_request mr where mr.id = _request_id into snapshot_id_S;
+
+  insert into merge_staging_area(
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type)
+    -- gather delete data from the opposite tables
+    select  _request_id, activity_id, name, metadata.tag_ids_activity_directive(ca.activity_id, ad.plan_id),
+            source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
+            'delete'::activity_change_type
+      from  conflicting_activities ca
+      join  activity_directive ad
+        on  ca.activity_id = ad.id
+      where ca.resolution = 'supplying'
+        and ca.merge_request_id = _request_id
+        and plan_id = plan_id_R
+        and ca.change_type_supplying = 'delete'
+    union
+    select  _request_id, activity_id, name, metadata.tag_ids_activity_snapshot(ca.activity_id, psa.snapshot_id),
+            source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
+            'delete'::activity_change_type
+      from  conflicting_activities ca
+      join  plan_snapshot_activities psa
+        on  ca.activity_id = psa.id
+      where ca.resolution = 'receiving'
+        and ca.merge_request_id = _request_id
+        and snapshot_id = snapshot_id_S
+        and ca.change_type_receiving = 'delete'
+    union
+    select  _request_id, activity_id, name, metadata.tag_ids_activity_directive(ca.activity_id, ad.plan_id),
+            source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
+            'none'::activity_change_type
+      from  conflicting_activities ca
+      join  activity_directive ad
+        on  ca.activity_id = ad.id
+      where ca.resolution = 'receiving'
+        and ca.merge_request_id = _request_id
+        and plan_id = plan_id_R
+        and ca.change_type_receiving = 'modify'
+    union
+    select  _request_id, activity_id, name, metadata.tag_ids_activity_snapshot(ca.activity_id, psa.snapshot_id),
+            source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
+            'modify'::activity_change_type
+      from  conflicting_activities ca
+      join  plan_snapshot_activities psa
+        on  ca.activity_id = psa.id
+      where ca.resolution = 'supplying'
+        and ca.merge_request_id = _request_id
+        and snapshot_id = snapshot_id_S
+        and ca.change_type_supplying = 'modify';
+
+  -- Unlock so that updates can be written
+  update plan
+  set is_locked = false
+  where id = plan_id_R;
+
+  -- Update the plan's activities to match merge-staging-area's activities
+  -- Add
+  insert into activity_directive(
+                id, plan_id, name, source_scheduling_goal_id, created_at,
+                start_offset, type, arguments, metadata, anchor_id, anchored_to_start )
+  select  activity_id, plan_id_R, name, source_scheduling_goal_id, created_at,
+            start_offset, type, arguments, metadata, anchor_id, anchored_to_start
+   from merge_staging_area
+  where merge_staging_area.merge_request_id = _request_id
+    and change_type = 'add';
+
+  -- Modify
+  insert into activity_directive(
+    id, plan_id, "name", source_scheduling_goal_id, created_at,
+    start_offset, "type", arguments, metadata, anchor_id, anchored_to_start )
+  select  activity_id, plan_id_R, "name", source_scheduling_goal_id, created_at,
+          start_offset, "type", arguments, metadata, anchor_id, anchored_to_start
+  from merge_staging_area
+  where merge_staging_area.merge_request_id = _request_id
+    and change_type = 'modify'
+  on conflict (id, plan_id)
+  do update
+  set name = excluded.name,
+      source_scheduling_goal_id = excluded.source_scheduling_goal_id,
+      created_at = excluded.created_at,
+      start_offset = excluded.start_offset,
+      type = excluded.type,
+      arguments = excluded.arguments,
+      metadata = excluded.metadata,
+      anchor_id = excluded.anchor_id,
+      anchored_to_start = excluded.anchored_to_start;
+
+  -- Tags
+  delete from metadata.activity_directive_tags adt
+    using merge_staging_area msa
+    where adt.directive_id = msa.activity_id
+      and adt.plan_id = plan_id_R
+      and msa.merge_request_id = _request_id
+      and msa.change_type = 'modify';
+
+  insert into metadata.activity_directive_tags(plan_id, directive_id, tag_id)
+    select plan_id_R, activity_id, t.id
+    from merge_staging_area msa
+    inner join metadata.tags t -- Inner join because it's specifically inserting into a tags-association table, so if there are no valid tags we do not want a null value for t.id
+    on t.id = any(msa.tags)
+    where msa.merge_request_id = _request_id
+      and (change_type = 'modify'
+       or change_type = 'add')
+    on conflict (directive_id, plan_id, tag_id) do nothing;
+  -- Presets
+  insert into preset_to_directive(preset_id, activity_id, plan_id)
+  select pts.preset_id, pts.activity_id, plan_id_R
+  from merge_staging_area msa, preset_to_snapshot_directive pts
+  where msa.activity_id = pts.activity_id
+    and msa.change_type = 'add'
+     or msa.change_type = 'modify'
+  on conflict (activity_id, plan_id)
+    do update
+    set preset_id = excluded.preset_id;
+
+  -- Delete
+  delete from activity_directive ad
+  using merge_staging_area msa
+  where ad.id = msa.activity_id
+    and ad.plan_id = plan_id_R
+    and msa.merge_request_id = _request_id
+    and msa.change_type = 'delete';
+
+  -- Clean up
+  delete from conflicting_activities where merge_request_id = _request_id;
+  delete from merge_staging_area where merge_staging_area.merge_request_id = _request_id;
+
+  update merge_request
+  set status = 'accepted'
+  where id = _request_id;
+
+  -- Attach snapshot history
+  insert into plan_latest_snapshot(plan_id, snapshot_id)
+  select plan_id_receiving_changes, snapshot_id_supplying_changes
+  from merge_request
+  where id = _request_id;
+end
+$$;
+
+create or replace procedure begin_merge(_merge_request_id integer, review_username text)
+  language plpgsql as $$
+  declare
+    validate_id integer;
+    validate_status merge_request_status;
+    validate_non_no_op_status activity_change_type;
+    snapshot_id_supplying integer;
+    plan_id_receiving integer;
+    merge_base_id integer;
+begin
+  -- validate id and status
+  select id, status
+    from merge_request
+    where _merge_request_id = id
+    into validate_id, validate_status;
+
+  if validate_id is null then
+    raise exception 'Request ID % is not present in merge_request table.', _merge_request_id;
+  end if;
+
+  if validate_status != 'pending' then
+    raise exception 'Cannot begin request. Merge request % is not in pending state.', _merge_request_id;
+  end if;
+
+  -- select from merge-request the snapshot_sc (s_sc) and plan_rc (p_rc) ids
+  select plan_id_receiving_changes, snapshot_id_supplying_changes
+    from merge_request
+    where id = _merge_request_id
+    into plan_id_receiving, snapshot_id_supplying;
+
+  -- ensure the plan receiving changes isn't locked
+  if (select is_locked from plan where plan.id=plan_id_receiving) then
+    raise exception 'Cannot begin merge request. Plan to receive changes is locked.';
+  end if;
+
+  -- lock plan_rc
+  update plan
+    set is_locked = true
+    where plan.id = plan_id_receiving;
+
+  -- get merge base (mb)
+  select get_merge_base(plan_id_receiving, snapshot_id_supplying)
+    into merge_base_id;
+
+  -- update the status to "in progress"
+  update merge_request
+    set status = 'in-progress',
+    merge_base_snapshot_id = merge_base_id,
+    reviewer_username = review_username
+    where id = _merge_request_id;
+
+
+  -- perform diff between mb and s_sc (s_diff)
+    -- delete is B minus A on key
+    -- add is A minus B on key
+    -- A intersect B is no op
+    -- A minus B on everything except everything currently in the table is modify
+  create temp table supplying_diff(
+    activity_id integer,
+    change_type activity_change_type not null
+  );
+
+  insert into supplying_diff (activity_id, change_type)
+  select activity_id, 'delete'
+  from(
+    select id as activity_id
+    from plan_snapshot_activities
+      where snapshot_id = merge_base_id
+    except
+    select id as activity_id
+    from plan_snapshot_activities
+      where snapshot_id = snapshot_id_supplying) a;
+
+  insert into supplying_diff (activity_id, change_type)
+  select activity_id, 'add'
+  from(
+    select id as activity_id
+    from plan_snapshot_activities
+      where snapshot_id = snapshot_id_supplying
+    except
+    select id as activity_id
+    from plan_snapshot_activities
+      where snapshot_id = merge_base_id) a;
+
+  insert into supplying_diff (activity_id, change_type)
+    select activity_id, 'none'
+      from(
+        select psa.id as activity_id, name, metadata.tag_ids_activity_snapshot(psa.id, merge_base_id),
+               source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+               last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+        from plan_snapshot_activities psa
+        where psa.snapshot_id = merge_base_id
+    intersect
+      select id as activity_id, name, metadata.tag_ids_activity_snapshot(psa.id, snapshot_id_supplying),
+             source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+             last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+        from plan_snapshot_activities psa
+        where psa.snapshot_id = snapshot_id_supplying) a;
+
+  insert into supplying_diff (activity_id, change_type)
+    select activity_id, 'modify'
+    from(
+      select id as activity_id from plan_snapshot_activities
+        where snapshot_id = merge_base_id or snapshot_id = snapshot_id_supplying
+      except
+      select activity_id from supplying_diff) a;
+
+  -- perform diff between mb and p_rc (r_diff)
+  create temp table receiving_diff(
+     activity_id integer,
+     change_type activity_change_type not null
+  );
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'delete'
+  from(
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id
+        except
+        select id as activity_id
+        from activity_directive
+        where plan_id = plan_id_receiving) a;
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'add'
+  from(
+        select id as activity_id
+        from activity_directive
+        where plan_id = plan_id_receiving
+        except
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id) a;
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'none'
+  from(
+        select id as activity_id, name, metadata.tag_ids_activity_snapshot(id, merge_base_id),
+               source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+               last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+        from plan_snapshot_activities psa
+        where psa.snapshot_id = merge_base_id
+        intersect
+        select id as activity_id, name, metadata.tag_ids_activity_directive(id, plan_id_receiving),
+               source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+               last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+        from activity_directive ad
+        where ad.plan_id = plan_id_receiving) a;
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'modify'
+  from (
+        (select id as activity_id
+         from plan_snapshot_activities
+         where snapshot_id = merge_base_id
+         union
+         select id as activity_id
+         from activity_directive
+         where plan_id = plan_id_receiving)
+        except
+        select activity_id
+        from receiving_diff) a;
+
+
+  -- perform diff between s_diff and r_diff
+      -- upload the non-conflicts into merge_staging_area
+      -- upload conflict into conflicting_activities
+  create temp table diff_diff(
+    activity_id integer,
+    change_type_supplying activity_change_type not null,
+    change_type_receiving activity_change_type not null
+  );
+
+  -- this is going to require us to do the "none" operation again on the remaining modifies
+  -- but otherwise we can just dump the 'adds' and 'none' into the merge staging area table
+
+  -- 'delete' against a 'delete' does not enter the merge staging area table
+  -- receiving 'delete' against supplying 'none' does not enter the merge staging area table
+
+  insert into merge_staging_area (
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type
+         )
+  -- 'adds' can go directly into the merge staging area table
+  select _merge_request_id, activity_id, name, metadata.tag_ids_activity_snapshot(s_diff.activity_id, psa.snapshot_id),  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type
+    from supplying_diff as  s_diff
+    join plan_snapshot_activities psa
+      on s_diff.activity_id = psa.id
+    where snapshot_id = snapshot_id_supplying and change_type = 'add'
+  union
+  -- an 'add' between the receiving plan and merge base is actually a 'none'
+  select _merge_request_id, activity_id, name, metadata.tag_ids_activity_directive(r_diff.activity_id, ad.plan_id),  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'::activity_change_type
+    from receiving_diff as r_diff
+    join activity_directive ad
+      on r_diff.activity_id = ad.id
+    where plan_id = plan_id_receiving and change_type = 'add';
+
+  -- put the rest in diff_diff
+  insert into diff_diff (activity_id, change_type_supplying, change_type_receiving)
+  select activity_id, supplying_diff.change_type as change_type_supplying, receiving_diff.change_type as change_type_receiving
+    from receiving_diff
+    join supplying_diff using (activity_id)
+  where receiving_diff.change_type != 'add' or supplying_diff.change_type != 'add';
+
+  -- ...except for that which is not recorded
+  delete from diff_diff
+    where (change_type_receiving = 'delete' and  change_type_supplying = 'delete')
+       or (change_type_receiving = 'delete' and change_type_supplying = 'none');
+
+  insert into merge_staging_area (
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type
+  )
+  -- receiving 'none' and 'modify' against 'none' in the supplying side go into the merge staging area as 'none'
+  select _merge_request_id, activity_id, name, metadata.tag_ids_activity_directive(diff_diff.activity_id, plan_id),  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'
+    from diff_diff
+    join activity_directive
+      on activity_id=id
+    where plan_id = plan_id_receiving
+      and change_type_supplying = 'none'
+      and (change_type_receiving = 'modify' or change_type_receiving = 'none')
+  union
+  -- supplying 'modify' against receiving 'none' go into the merge staging area as 'modify'
+  select _merge_request_id, activity_id, name, metadata.tag_ids_activity_snapshot(diff_diff.activity_id, snapshot_id),  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type_supplying
+    from diff_diff
+    join plan_snapshot_activities p
+      on diff_diff.activity_id = p.id
+    where snapshot_id = snapshot_id_supplying
+      and (change_type_receiving = 'none' and diff_diff.change_type_supplying = 'modify')
+  union
+  -- supplying 'delete' against receiving 'none' go into the merge staging area as 'delete'
+    select _merge_request_id, activity_id, name, metadata.tag_ids_activity_directive(diff_diff.activity_id, plan_id),  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type_supplying
+    from diff_diff
+    join activity_directive p
+      on diff_diff.activity_id = p.id
+    where plan_id = plan_id_receiving
+      and (change_type_receiving = 'none' and diff_diff.change_type_supplying = 'delete')
+  union
+  -- 'modify' against a 'modify' must be checked for equality first.
+  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
+         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'
+  from (
+    select activity_id, name, metadata.tag_ids_activity_directive(dd.activity_id, psa.snapshot_id) as tags,
+           source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start
+      from plan_snapshot_activities psa
+      join diff_diff dd
+        on dd.activity_id = psa.id
+      where psa.snapshot_id = snapshot_id_supplying
+        and (dd.change_type_receiving = 'modify' and dd.change_type_supplying = 'modify')
+    intersect
+    select activity_id, name, metadata.tag_ids_activity_directive(dd.activity_id, ad.plan_id) as tags,
+           source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start
+      from diff_diff dd
+      join activity_directive ad
+        on dd.activity_id = ad.id
+      where ad.plan_id = plan_id_receiving
+        and (dd.change_type_supplying = 'modify' and dd.change_type_receiving = 'modify')
+  ) a;
+
+  -- 'modify' against 'delete' and inequal 'modify' against 'modify' goes into conflict table (aka everything left in diff_diff)
+  insert into conflicting_activities (merge_request_id, activity_id, change_type_supplying, change_type_receiving)
+  select begin_merge._merge_request_id, activity_id, change_type_supplying, change_type_receiving
+  from (select begin_merge._merge_request_id, activity_id
+        from diff_diff
+        except
+        select msa.merge_request_id, activity_id
+        from merge_staging_area msa) a
+  join diff_diff using (activity_id);
+
+  -- Fail if there are no differences between the snapshot and the plan getting merged
+  validate_non_no_op_status := null;
+  select change_type_receiving
+  from conflicting_activities
+  where merge_request_id = _merge_request_id
+  limit 1
+  into validate_non_no_op_status;
+
+  if validate_non_no_op_status is null then
+    select change_type
+    from merge_staging_area msa
+    where merge_request_id = _merge_request_id
+    and msa.change_type != 'none'
+    limit 1
+    into validate_non_no_op_status;
+
+    if validate_non_no_op_status is null then
+      raise exception 'Cannot begin merge. The contents of the two plans are identical.';
+    end if;
+  end if;
+
+
+  -- clean up
+  drop table supplying_diff;
+  drop table receiving_diff;
+  drop table diff_diff;
+end
+$$;
+
+-- drop new last_modified_by column
+alter table plan_snapshot_activities
+  drop column last_modified_by;
+
+alter table merge_staging_area
+  drop column last_modified_by;
+
+-- redefine anchor deletion functions since we need to revert one line change
+create or replace function hasura_functions.delete_activity_by_pk_delete_subtree(_activity_id int, _plan_id int, hasura_session json)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+  volatile
+  language plpgsql as $$
+declare
+  _function_permission metadata.permission;
+begin
+  _function_permission := metadata.get_function_permissions('delete_activity_subtree', hasura_session);
+  perform metadata.raise_if_plan_merge_permission('delete_activity_subtree', _function_permission);
+  if not _function_permission = 'NO_CHECK' then
+    call metadata.check_general_permissions('delete_activity_subtree', _function_permission, _plan_id, (hasura_session ->> 'x-hasura-user-id'));
+  end if;
+
+  if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+    raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+  end if;
+
+  return query
+    with recursive
+      descendents(activity_id, p_id) as (
+          select _activity_id, _plan_id
+          from activity_directive ad
+          where (ad.id, ad.plan_id) = (_activity_id, _plan_id)
+        union
+          select ad.id, ad.plan_id
+          from activity_directive ad, descendents d
+          where (ad.anchor_id, ad.plan_id) = (d.activity_id, d.p_id)
+      ),
+      deleted as (
+          delete from activity_directive ad
+            using descendents
+            where (ad.plan_id, ad.id) = (_plan_id, descendents.activity_id)
+            returning *
+      )
+      select (deleted.id, deleted.plan_id, deleted.name, deleted.source_scheduling_goal_id,
+              deleted.created_at, deleted.last_modified_at, deleted.start_offset, deleted.type, deleted.arguments,
+              deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
+end
+$$;
+
+create or replace function hasura_functions.delete_activity_by_pk_reanchor_to_anchor(_activity_id int, _plan_id int, hasura_session json)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+  volatile
+  language plpgsql as $$
+declare
+    _function_permission metadata.permission;
+begin
+    _function_permission := metadata.get_function_permissions('delete_activity_reanchor', hasura_session);
+    perform metadata.raise_if_plan_merge_permission('delete_activity_reanchor', _function_permission);
+    if not _function_permission = 'NO_CHECK' then
+      call metadata.check_general_permissions('delete_activity_reanchor', _function_permission, _plan_id, (hasura_session ->> 'x-hasura-user-id'));
+    end if;
+
+    if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+      raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+    end if;
+
+    return query
+      with updated as (
+        select public.anchor_direct_descendents_to_ancestor(_activity_id := _activity_id, _plan_id := _plan_id)
+      )
+      select updated.*, 'updated'
+        from updated;
+    return query
+      with deleted as (
+        delete from activity_directive where (id, plan_id) = (_activity_id, _plan_id) returning *
+      )
+      select (deleted.id, deleted.plan_id, deleted.name, deleted.source_scheduling_goal_id,
+              deleted.created_at, deleted.last_modified_at, deleted.start_offset, deleted.type, deleted.arguments,
+              deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
+end
+$$;
+
+create or replace function hasura_functions.delete_activity_by_pk_reanchor_plan_start(_activity_id int, _plan_id int, hasura_session json)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+  volatile
+language plpgsql as $$
+  declare
+    _function_permission metadata.permission;
+  begin
+    _function_permission := metadata.get_function_permissions('delete_activity_reanchor_plan', hasura_session);
+    perform metadata.raise_if_plan_merge_permission('delete_activity_reanchor_plan', _function_permission);
+    if not _function_permission = 'NO_CHECK' then
+      call metadata.check_general_permissions('delete_activity_reanchor_plan', _function_permission, _plan_id, (hasura_session ->> 'x-hasura-user-id'));
+    end if;
+
+    if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+      raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+    end if;
+
+    return query
+      with updated as (
+        select public.anchor_direct_descendents_to_plan(_activity_id := _activity_id, _plan_id := _plan_id)
+      )
+      select updated.*, 'updated'
+        from updated;
+
+    return query
+      with deleted as (
+        delete from activity_directive where (id, plan_id) = (_activity_id, _plan_id) returning *
+      )
+      select (deleted.id, deleted.plan_id, deleted.name, deleted.source_scheduling_goal_id,
+              deleted.created_at, deleted.last_modified_at, deleted.start_offset, deleted.type, deleted.arguments,
+              deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
+  end
+$$;
+
+-- revert change to activity_directive_extended view
+drop view activity_directive_extended;
+create view activity_directive_extended as
+(
+  select
+    -- Activity Directive Properties
+    ad.id as id,
+    ad.plan_id as plan_id,
+    -- Additional Properties
+    ad.name as name,
+    get_tags(ad.id, ad.plan_id) as tags,
+    ad.source_scheduling_goal_id as source_scheduling_goal_id,
+    ad.created_at as created_at,
+    ad.last_modified_at as last_modified_at,
+    ad.start_offset as start_offset,
+    ad.type as type,
+    ad.arguments as arguments,
+    ad.last_modified_arguments_at as last_modified_arguments_at,
+    ad.metadata as metadata,
+    ad.anchor_id as anchor_id,
+    ad.anchored_to_start as anchored_to_start,
+    -- Derived Properties
+    get_approximate_start_time(ad.id, ad.plan_id) as approximate_start_time,
+    ptd.preset_id as preset_id,
+    ap.arguments as preset_arguments
+   from activity_directive ad
+   left join preset_to_directive ptd on ad.id = ptd.activity_id and ad.plan_id = ptd.plan_id
+   left join activity_presets ap on ptd.preset_id = ap.id
+);
+
+alter table activity_directive
+  drop constraint activity_directive_last_modified_by_exists,
+  drop column last_modified_by;
+
+call migrations.mark_migration_rolled_back('23');

--- a/deployment/hasura/migrations/AerieMerlin/23_activity_directive_changelog/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/23_activity_directive_changelog/up.sql
@@ -1,0 +1,910 @@
+-- add last_modified_by to activity_directive
+alter table activity_directive
+  add column last_modified_by text,
+
+  add constraint activity_directive_last_modified_by_exists
+    foreign key (last_modified_by)
+    references metadata.users
+    on update cascade
+    on delete set null;
+
+comment on column activity_directive.last_modified_by is e''
+  'The user who last modified this activity_directive.';
+
+-- add last_modified_by to activity_directive_extended view
+drop view activity_directive_extended;
+create view activity_directive_extended as
+(
+  select
+    -- Activity Directive Properties
+    ad.id as id,
+    ad.plan_id as plan_id,
+    -- Additional Properties
+    ad.name as name,
+    get_tags(ad.id, ad.plan_id) as tags,
+    ad.source_scheduling_goal_id as source_scheduling_goal_id,
+    ad.created_at as created_at,
+    ad.last_modified_at as last_modified_at,
+    ad.last_modified_by as last_modified_by,
+    ad.start_offset as start_offset,
+    ad.type as type,
+    ad.arguments as arguments,
+    ad.last_modified_arguments_at as last_modified_arguments_at,
+    ad.metadata as metadata,
+    ad.anchor_id as anchor_id,
+    ad.anchored_to_start as anchored_to_start,
+    -- Derived Properties
+    get_approximate_start_time(ad.id, ad.plan_id) as approximate_start_time,
+    ptd.preset_id as preset_id,
+    ap.arguments as preset_arguments
+   from activity_directive ad
+   left join preset_to_directive ptd on ad.id = ptd.activity_id and ad.plan_id = ptd.plan_id
+   left join activity_presets ap on ptd.preset_id = ap.id
+);
+
+-- redefine anchor deletion functions since we need to change one line
+create or replace function hasura_functions.delete_activity_by_pk_reanchor_plan_start(_activity_id int, _plan_id int, hasura_session json)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+  volatile
+language plpgsql as $$
+  declare
+    _function_permission metadata.permission;
+  begin
+    _function_permission := metadata.get_function_permissions('delete_activity_reanchor_plan', hasura_session);
+    perform metadata.raise_if_plan_merge_permission('delete_activity_reanchor_plan', _function_permission);
+    if not _function_permission = 'NO_CHECK' then
+      call metadata.check_general_permissions('delete_activity_reanchor_plan', _function_permission, _plan_id, (hasura_session ->> 'x-hasura-user-id'));
+    end if;
+
+    if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+      raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+    end if;
+
+    return query
+      with updated as (
+        select public.anchor_direct_descendents_to_plan(_activity_id := _activity_id, _plan_id := _plan_id)
+      )
+      select updated.*, 'updated'
+        from updated;
+
+    return query
+      with deleted as (
+        delete from activity_directive where (id, plan_id) = (_activity_id, _plan_id) returning *
+      )
+      select (deleted.id, deleted.plan_id, deleted.name, deleted.source_scheduling_goal_id,
+              deleted.created_at, deleted.last_modified_at, deleted.last_modified_by, deleted.start_offset, deleted.type, deleted.arguments,
+              deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
+  end
+$$;
+
+create or replace function hasura_functions.delete_activity_by_pk_reanchor_to_anchor(_activity_id int, _plan_id int, hasura_session json)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+  volatile
+  language plpgsql as $$
+declare
+    _function_permission metadata.permission;
+begin
+    _function_permission := metadata.get_function_permissions('delete_activity_reanchor', hasura_session);
+    perform metadata.raise_if_plan_merge_permission('delete_activity_reanchor', _function_permission);
+    if not _function_permission = 'NO_CHECK' then
+      call metadata.check_general_permissions('delete_activity_reanchor', _function_permission, _plan_id, (hasura_session ->> 'x-hasura-user-id'));
+    end if;
+
+    if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+      raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+    end if;
+
+    return query
+      with updated as (
+        select public.anchor_direct_descendents_to_ancestor(_activity_id := _activity_id, _plan_id := _plan_id)
+      )
+      select updated.*, 'updated'
+        from updated;
+    return query
+      with deleted as (
+        delete from activity_directive where (id, plan_id) = (_activity_id, _plan_id) returning *
+      )
+      select (deleted.id, deleted.plan_id, deleted.name, deleted.source_scheduling_goal_id,
+              deleted.created_at, deleted.last_modified_at, deleted.last_modified_by, deleted.start_offset, deleted.type, deleted.arguments,
+              deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
+end
+$$;
+
+create or replace function hasura_functions.delete_activity_by_pk_delete_subtree(_activity_id int, _plan_id int, hasura_session json)
+  returns setof hasura_functions.delete_anchor_return_value
+  strict
+  volatile
+  language plpgsql as $$
+declare
+  _function_permission metadata.permission;
+begin
+  _function_permission := metadata.get_function_permissions('delete_activity_subtree', hasura_session);
+  perform metadata.raise_if_plan_merge_permission('delete_activity_subtree', _function_permission);
+  if not _function_permission = 'NO_CHECK' then
+    call metadata.check_general_permissions('delete_activity_subtree', _function_permission, _plan_id, (hasura_session ->> 'x-hasura-user-id'));
+  end if;
+
+  if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_id, _plan_id)) then
+    raise exception 'Activity Directive % does not exist in Plan %', _activity_id, _plan_id;
+  end if;
+
+  return query
+    with recursive
+      descendents(activity_id, p_id) as (
+          select _activity_id, _plan_id
+          from activity_directive ad
+          where (ad.id, ad.plan_id) = (_activity_id, _plan_id)
+        union
+          select ad.id, ad.plan_id
+          from activity_directive ad, descendents d
+          where (ad.anchor_id, ad.plan_id) = (d.activity_id, d.p_id)
+      ),
+      deleted as (
+          delete from activity_directive ad
+            using descendents
+            where (ad.plan_id, ad.id) = (_plan_id, descendents.activity_id)
+            returning *
+      )
+      select (deleted.id, deleted.plan_id, deleted.name, deleted.source_scheduling_goal_id,
+              deleted.created_at, deleted.last_modified_at, deleted.last_modified_by, deleted.start_offset, deleted.type, deleted.arguments,
+              deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
+end
+$$;
+
+alter table merge_staging_area
+  add column last_modified_by text;
+
+alter table plan_snapshot_activities
+  add column last_modified_by text;
+
+create or replace procedure begin_merge(_merge_request_id integer, review_username text)
+  language plpgsql as $$
+  declare
+    validate_id integer;
+    validate_status merge_request_status;
+    validate_non_no_op_status activity_change_type;
+    snapshot_id_supplying integer;
+    plan_id_receiving integer;
+    merge_base_id integer;
+begin
+  -- validate id and status
+  select id, status
+    from merge_request
+    where _merge_request_id = id
+    into validate_id, validate_status;
+
+  if validate_id is null then
+    raise exception 'Request ID % is not present in merge_request table.', _merge_request_id;
+  end if;
+
+  if validate_status != 'pending' then
+    raise exception 'Cannot begin request. Merge request % is not in pending state.', _merge_request_id;
+  end if;
+
+  -- select from merge-request the snapshot_sc (s_sc) and plan_rc (p_rc) ids
+  select plan_id_receiving_changes, snapshot_id_supplying_changes
+    from merge_request
+    where id = _merge_request_id
+    into plan_id_receiving, snapshot_id_supplying;
+
+  -- ensure the plan receiving changes isn't locked
+  if (select is_locked from plan where plan.id=plan_id_receiving) then
+    raise exception 'Cannot begin merge request. Plan to receive changes is locked.';
+  end if;
+
+  -- lock plan_rc
+  update plan
+    set is_locked = true
+    where plan.id = plan_id_receiving;
+
+  -- get merge base (mb)
+  select get_merge_base(plan_id_receiving, snapshot_id_supplying)
+    into merge_base_id;
+
+  -- update the status to "in progress"
+  update merge_request
+    set status = 'in-progress',
+    merge_base_snapshot_id = merge_base_id,
+    reviewer_username = review_username
+    where id = _merge_request_id;
+
+
+  -- perform diff between mb and s_sc (s_diff)
+    -- delete is B minus A on key
+    -- add is A minus B on key
+    -- A intersect B is no op
+    -- A minus B on everything except everything currently in the table is modify
+  create temp table supplying_diff(
+    activity_id integer,
+    change_type activity_change_type not null
+  );
+
+  insert into supplying_diff (activity_id, change_type)
+  select activity_id, 'delete'
+  from(
+    select id as activity_id
+    from plan_snapshot_activities
+      where snapshot_id = merge_base_id
+    except
+    select id as activity_id
+    from plan_snapshot_activities
+      where snapshot_id = snapshot_id_supplying) a;
+
+  insert into supplying_diff (activity_id, change_type)
+  select activity_id, 'add'
+  from(
+    select id as activity_id
+    from plan_snapshot_activities
+      where snapshot_id = snapshot_id_supplying
+    except
+    select id as activity_id
+    from plan_snapshot_activities
+      where snapshot_id = merge_base_id) a;
+
+  insert into supplying_diff (activity_id, change_type)
+    select activity_id, 'none'
+      from(
+        select psa.id as activity_id, name, metadata.tag_ids_activity_snapshot(psa.id, merge_base_id),
+               source_scheduling_goal_id, created_at, start_offset, type, arguments,
+               metadata, anchor_id, anchored_to_start
+        from plan_snapshot_activities psa
+        where psa.snapshot_id = merge_base_id
+    intersect
+      select id as activity_id, name, metadata.tag_ids_activity_snapshot(psa.id, snapshot_id_supplying),
+             source_scheduling_goal_id, created_at, start_offset, type, arguments,
+             metadata, anchor_id, anchored_to_start
+        from plan_snapshot_activities psa
+        where psa.snapshot_id = snapshot_id_supplying) a;
+
+  insert into supplying_diff (activity_id, change_type)
+    select activity_id, 'modify'
+    from(
+      select id as activity_id from plan_snapshot_activities
+        where snapshot_id = merge_base_id or snapshot_id = snapshot_id_supplying
+      except
+      select activity_id from supplying_diff) a;
+
+  -- perform diff between mb and p_rc (r_diff)
+  create temp table receiving_diff(
+     activity_id integer,
+     change_type activity_change_type not null
+  );
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'delete'
+  from(
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id
+        except
+        select id as activity_id
+        from activity_directive
+        where plan_id = plan_id_receiving) a;
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'add'
+  from(
+        select id as activity_id
+        from activity_directive
+        where plan_id = plan_id_receiving
+        except
+        select id as activity_id
+        from plan_snapshot_activities
+        where snapshot_id = merge_base_id) a;
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'none'
+  from(
+        select id as activity_id, name, metadata.tag_ids_activity_snapshot(id, merge_base_id),
+               source_scheduling_goal_id, created_at, start_offset, type, arguments,
+               metadata, anchor_id, anchored_to_start
+        from plan_snapshot_activities psa
+        where psa.snapshot_id = merge_base_id
+        intersect
+        select id as activity_id, name, metadata.tag_ids_activity_directive(id, plan_id_receiving),
+               source_scheduling_goal_id, created_at, start_offset, type, arguments,
+               metadata, anchor_id, anchored_to_start
+        from activity_directive ad
+        where ad.plan_id = plan_id_receiving) a;
+
+  insert into receiving_diff (activity_id, change_type)
+  select activity_id, 'modify'
+  from (
+        (select id as activity_id
+         from plan_snapshot_activities
+         where snapshot_id = merge_base_id
+         union
+         select id as activity_id
+         from activity_directive
+         where plan_id = plan_id_receiving)
+        except
+        select activity_id
+        from receiving_diff) a;
+
+
+  -- perform diff between s_diff and r_diff
+      -- upload the non-conflicts into merge_staging_area
+      -- upload conflict into conflicting_activities
+  create temp table diff_diff(
+    activity_id integer,
+    change_type_supplying activity_change_type not null,
+    change_type_receiving activity_change_type not null
+  );
+
+  -- this is going to require us to do the "none" operation again on the remaining modifies
+  -- but otherwise we can just dump the 'adds' and 'none' into the merge staging area table
+
+  -- 'delete' against a 'delete' does not enter the merge staging area table
+  -- receiving 'delete' against supplying 'none' does not enter the merge staging area table
+
+  insert into merge_staging_area (
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_by,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type
+         )
+  -- 'adds' can go directly into the merge staging area table
+  select _merge_request_id, activity_id, name, metadata.tag_ids_activity_snapshot(s_diff.activity_id, psa.snapshot_id),  source_scheduling_goal_id, created_at,
+         last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type
+    from supplying_diff as  s_diff
+    join plan_snapshot_activities psa
+      on s_diff.activity_id = psa.id
+    where snapshot_id = snapshot_id_supplying and change_type = 'add'
+  union
+  -- an 'add' between the receiving plan and merge base is actually a 'none'
+  select _merge_request_id, activity_id, name, metadata.tag_ids_activity_directive(r_diff.activity_id, ad.plan_id),  source_scheduling_goal_id, created_at,
+         last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'::activity_change_type
+    from receiving_diff as r_diff
+    join activity_directive ad
+      on r_diff.activity_id = ad.id
+    where plan_id = plan_id_receiving and change_type = 'add';
+
+  -- put the rest in diff_diff
+  insert into diff_diff (activity_id, change_type_supplying, change_type_receiving)
+  select activity_id, supplying_diff.change_type as change_type_supplying, receiving_diff.change_type as change_type_receiving
+    from receiving_diff
+    join supplying_diff using (activity_id)
+  where receiving_diff.change_type != 'add' or supplying_diff.change_type != 'add';
+
+  -- ...except for that which is not recorded
+  delete from diff_diff
+    where (change_type_receiving = 'delete' and  change_type_supplying = 'delete')
+       or (change_type_receiving = 'delete' and change_type_supplying = 'none');
+
+  insert into merge_staging_area (
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_by,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type
+  )
+  -- receiving 'none' and 'modify' against 'none' in the supplying side go into the merge staging area as 'none'
+  select _merge_request_id, activity_id, name, metadata.tag_ids_activity_directive(diff_diff.activity_id, plan_id),  source_scheduling_goal_id, created_at,
+         last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'
+    from diff_diff
+    join activity_directive
+      on activity_id=id
+    where plan_id = plan_id_receiving
+      and change_type_supplying = 'none'
+      and (change_type_receiving = 'modify' or change_type_receiving = 'none')
+  union
+  -- supplying 'modify' against receiving 'none' go into the merge staging area as 'modify'
+  select _merge_request_id, activity_id, name, metadata.tag_ids_activity_snapshot(diff_diff.activity_id, snapshot_id),  source_scheduling_goal_id, created_at,
+         last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type_supplying
+    from diff_diff
+    join plan_snapshot_activities p
+      on diff_diff.activity_id = p.id
+    where snapshot_id = snapshot_id_supplying
+      and (change_type_receiving = 'none' and diff_diff.change_type_supplying = 'modify')
+  union
+  -- supplying 'delete' against receiving 'none' go into the merge staging area as 'delete'
+    select _merge_request_id, activity_id, name, metadata.tag_ids_activity_directive(diff_diff.activity_id, plan_id),  source_scheduling_goal_id, created_at,
+         last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type_supplying
+    from diff_diff
+    join activity_directive p
+      on diff_diff.activity_id = p.id
+    where plan_id = plan_id_receiving
+      and (change_type_receiving = 'none' and diff_diff.change_type_supplying = 'delete');
+
+  -- 'modify' against a 'modify' must be checked for equality first.
+  with false_modify as (
+    select activity_id, name, metadata.tag_ids_activity_directive(dd.activity_id, psa.snapshot_id) as tags,
+           source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start
+    from plan_snapshot_activities psa
+    join diff_diff dd
+      on dd.activity_id = psa.id
+    where psa.snapshot_id = snapshot_id_supplying
+      and (dd.change_type_receiving = 'modify' and dd.change_type_supplying = 'modify')
+    intersect
+    select activity_id, name, metadata.tag_ids_activity_directive(dd.activity_id, ad.plan_id) as tags,
+           source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start
+    from diff_diff dd
+    join activity_directive ad
+      on dd.activity_id = ad.id
+    where ad.plan_id = plan_id_receiving
+      and (dd.change_type_supplying = 'modify' and dd.change_type_receiving = 'modify'))
+  insert into merge_staging_area (
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_by,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type)
+  select _merge_request_id, ad.id, ad.name, tags,  ad.source_scheduling_goal_id, ad.created_at,
+         ad.last_modified_by, ad.start_offset, ad.type, ad.arguments, ad.metadata, ad.anchor_id, ad.anchored_to_start, 'none'
+  from false_modify fm left join activity_directive ad on (ad.plan_id, ad.id) = (plan_id_receiving, fm.activity_id);
+
+  -- 'modify' against 'delete' and inequal 'modify' against 'modify' goes into conflict table (aka everything left in diff_diff)
+  insert into conflicting_activities (merge_request_id, activity_id, change_type_supplying, change_type_receiving)
+  select begin_merge._merge_request_id, activity_id, change_type_supplying, change_type_receiving
+  from (select begin_merge._merge_request_id, activity_id
+        from diff_diff
+        except
+        select msa.merge_request_id, activity_id
+        from merge_staging_area msa) a
+  join diff_diff using (activity_id);
+
+  -- Fail if there are no differences between the snapshot and the plan getting merged
+  validate_non_no_op_status := null;
+  select change_type_receiving
+  from conflicting_activities
+  where merge_request_id = _merge_request_id
+  limit 1
+  into validate_non_no_op_status;
+
+  if validate_non_no_op_status is null then
+    select change_type
+    from merge_staging_area msa
+    where merge_request_id = _merge_request_id
+    and msa.change_type != 'none'
+    limit 1
+    into validate_non_no_op_status;
+
+    if validate_non_no_op_status is null then
+      raise exception 'Cannot begin merge. The contents of the two plans are identical.';
+    end if;
+  end if;
+
+
+  -- clean up
+  drop table supplying_diff;
+  drop table receiving_diff;
+  drop table diff_diff;
+end
+$$;
+
+create or replace procedure commit_merge(_request_id integer)
+  language plpgsql as $$
+  declare
+    validate_noConflicts integer;
+    plan_id_R integer;
+    snapshot_id_S integer;
+begin
+  if(select id from merge_request where id = _request_id) is null then
+    raise exception 'Invalid merge request id %.', _request_id;
+  end if;
+
+  -- Stop if this merge is not 'in-progress'
+  if (select status from merge_request where id = _request_id) != 'in-progress' then
+    raise exception 'Cannot commit a merge request that is not in-progress.';
+  end if;
+
+  -- Stop if any conflicts have not been resolved
+  select * from conflicting_activities
+  where merge_request_id = _request_id and resolution = 'none'
+  limit 1
+  into validate_noConflicts;
+
+  if(validate_noConflicts is not null) then
+    raise exception 'There are unresolved conflicts in merge request %. Cannot commit merge.', _request_id;
+  end if;
+
+  select plan_id_receiving_changes from merge_request mr where mr.id = _request_id into plan_id_R;
+  select snapshot_id_supplying_changes from merge_request mr where mr.id = _request_id into snapshot_id_S;
+
+  insert into merge_staging_area(
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_by,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type)
+    -- gather delete data from the opposite tables
+    select  _request_id, activity_id, name, metadata.tag_ids_activity_directive(ca.activity_id, ad.plan_id),
+            source_scheduling_goal_id, created_at, last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
+            'delete'::activity_change_type
+      from  conflicting_activities ca
+      join  activity_directive ad
+        on  ca.activity_id = ad.id
+      where ca.resolution = 'supplying'
+        and ca.merge_request_id = _request_id
+        and plan_id = plan_id_R
+        and ca.change_type_supplying = 'delete'
+    union
+    select  _request_id, activity_id, name, metadata.tag_ids_activity_snapshot(ca.activity_id, psa.snapshot_id),
+            source_scheduling_goal_id, created_at, last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
+            'delete'::activity_change_type
+      from  conflicting_activities ca
+      join  plan_snapshot_activities psa
+        on  ca.activity_id = psa.id
+      where ca.resolution = 'receiving'
+        and ca.merge_request_id = _request_id
+        and snapshot_id = snapshot_id_S
+        and ca.change_type_receiving = 'delete'
+    union
+    select  _request_id, activity_id, name, metadata.tag_ids_activity_directive(ca.activity_id, ad.plan_id),
+            source_scheduling_goal_id, created_at, last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
+            'none'::activity_change_type
+      from  conflicting_activities ca
+      join  activity_directive ad
+        on  ca.activity_id = ad.id
+      where ca.resolution = 'receiving'
+        and ca.merge_request_id = _request_id
+        and plan_id = plan_id_R
+        and ca.change_type_receiving = 'modify'
+    union
+    select  _request_id, activity_id, name, metadata.tag_ids_activity_snapshot(ca.activity_id, psa.snapshot_id),
+            source_scheduling_goal_id, created_at, last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
+            'modify'::activity_change_type
+      from  conflicting_activities ca
+      join  plan_snapshot_activities psa
+        on  ca.activity_id = psa.id
+      where ca.resolution = 'supplying'
+        and ca.merge_request_id = _request_id
+        and snapshot_id = snapshot_id_S
+        and ca.change_type_supplying = 'modify';
+
+  -- Unlock so that updates can be written
+  update plan
+  set is_locked = false
+  where id = plan_id_R;
+
+  -- Update the plan's activities to match merge-staging-area's activities
+  -- Add
+  insert into activity_directive(
+                id, plan_id, name, source_scheduling_goal_id, created_at, last_modified_by,
+                start_offset, type, arguments, metadata, anchor_id, anchored_to_start )
+  select  activity_id, plan_id_R, name, source_scheduling_goal_id, created_at, last_modified_by,
+            start_offset, type, arguments, metadata, anchor_id, anchored_to_start
+   from merge_staging_area
+  where merge_staging_area.merge_request_id = _request_id
+    and change_type = 'add';
+
+  -- Modify
+  insert into activity_directive(
+    id, plan_id, "name", source_scheduling_goal_id, created_at, last_modified_by,
+    start_offset, "type", arguments, metadata, anchor_id, anchored_to_start )
+  select  activity_id, plan_id_R, "name", source_scheduling_goal_id, created_at, last_modified_by,
+          start_offset, "type", arguments, metadata, anchor_id, anchored_to_start
+  from merge_staging_area
+  where merge_staging_area.merge_request_id = _request_id
+    and change_type = 'modify'
+  on conflict (id, plan_id)
+  do update
+  set name = excluded.name,
+      source_scheduling_goal_id = excluded.source_scheduling_goal_id,
+      created_at = excluded.created_at,
+      last_modified_by = excluded.last_modified_by,
+      start_offset = excluded.start_offset,
+      type = excluded.type,
+      arguments = excluded.arguments,
+      metadata = excluded.metadata,
+      anchor_id = excluded.anchor_id,
+      anchored_to_start = excluded.anchored_to_start;
+
+  -- Tags
+  delete from metadata.activity_directive_tags adt
+    using merge_staging_area msa
+    where adt.directive_id = msa.activity_id
+      and adt.plan_id = plan_id_R
+      and msa.merge_request_id = _request_id
+      and msa.change_type = 'modify';
+
+  insert into metadata.activity_directive_tags(plan_id, directive_id, tag_id)
+    select plan_id_R, activity_id, t.id
+    from merge_staging_area msa
+    inner join metadata.tags t -- Inner join because it's specifically inserting into a tags-association table, so if there are no valid tags we do not want a null value for t.id
+    on t.id = any(msa.tags)
+    where msa.merge_request_id = _request_id
+      and (change_type = 'modify'
+       or change_type = 'add')
+    on conflict (directive_id, plan_id, tag_id) do nothing;
+  -- Presets
+  insert into preset_to_directive(preset_id, activity_id, plan_id)
+  select pts.preset_id, pts.activity_id, plan_id_R
+  from merge_staging_area msa, preset_to_snapshot_directive pts
+  where msa.activity_id = pts.activity_id
+    and msa.change_type = 'add'
+     or msa.change_type = 'modify'
+  on conflict (activity_id, plan_id)
+    do update
+    set preset_id = excluded.preset_id;
+
+  -- Delete
+  delete from activity_directive ad
+  using merge_staging_area msa
+  where ad.id = msa.activity_id
+    and ad.plan_id = plan_id_R
+    and msa.merge_request_id = _request_id
+    and msa.change_type = 'delete';
+
+  -- Clean up
+  delete from conflicting_activities where merge_request_id = _request_id;
+  delete from merge_staging_area where merge_staging_area.merge_request_id = _request_id;
+
+  update merge_request
+  set status = 'accepted'
+  where id = _request_id;
+
+  -- Attach snapshot history
+  insert into plan_latest_snapshot(plan_id, snapshot_id)
+  select plan_id_receiving_changes, snapshot_id_supplying_changes
+  from merge_request
+  where id = _request_id;
+end
+$$;
+
+create or replace function create_snapshot(_plan_id integer)
+  returns integer -- snapshot id inserted into the table
+  language plpgsql as $$
+  declare
+    validate_plan_id integer;
+    inserted_snapshot_id integer;
+begin
+  select id from plan where plan.id = _plan_id into validate_plan_id;
+  if validate_plan_id is null then
+    raise exception 'Plan % does not exist.', _plan_id;
+  end if;
+
+  insert into plan_snapshot(plan_id, revision, name, duration, start_time)
+    select id, revision, name, duration, start_time
+    from plan where id = _plan_id
+    returning snapshot_id into inserted_snapshot_id;
+  insert into plan_snapshot_activities(
+                snapshot_id, id, name, source_scheduling_goal_id, created_at,
+                last_modified_at, last_modified_by, start_offset, type,
+                arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start)
+    select
+      inserted_snapshot_id,                              -- this is the snapshot id
+      id, name, source_scheduling_goal_id, created_at,   -- these are the rest of the data for an activity row
+      last_modified_at, last_modified_by, start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+    from activity_directive where activity_directive.plan_id = _plan_id;
+  insert into preset_to_snapshot_directive(preset_id, activity_id, snapshot_id)
+    select ptd.preset_id, ptd.activity_id, inserted_snapshot_id
+    from preset_to_directive ptd
+    where ptd.plan_id = _plan_id;
+  insert into metadata.snapshot_activity_tags(snapshot_id, directive_id, tag_id)
+    select inserted_snapshot_id, directive_id, tag_id
+    from metadata.activity_directive_tags adt
+    where adt.plan_id = _plan_id;
+
+  --all snapshots in plan_latest_snapshot for plan plan_id become the parent of the current snapshot
+  insert into plan_snapshot_parent(snapshot_id, parent_snapshot_id)
+    select inserted_snapshot_id, snapshot_id
+    from plan_latest_snapshot where plan_latest_snapshot.plan_id = _plan_id;
+
+  --remove all of those entries from plan_latest_snapshot and add this new snapshot.
+  delete from plan_latest_snapshot where plan_latest_snapshot.plan_id = _plan_id;
+  insert into plan_latest_snapshot(plan_id, snapshot_id) values (_plan_id, inserted_snapshot_id);
+
+  return inserted_snapshot_id;
+  end;
+$$;
+
+create or replace function duplicate_plan(_plan_id integer, new_plan_name text, new_owner text)
+  returns integer -- plan_id of the new plan
+  security definer
+  language plpgsql as $$
+  declare
+    validate_plan_id integer;
+    new_plan_id integer;
+    created_snapshot_id integer;
+begin
+  select id from plan where plan.id = _plan_id into validate_plan_id;
+  if(validate_plan_id is null) then
+    raise exception 'Plan % does not exist.', _plan_id;
+  end if;
+
+  select create_snapshot(_plan_id) into created_snapshot_id;
+
+  insert into plan(revision, name, model_id, duration, start_time, parent_id, owner, updated_by)
+    select
+        0, new_plan_name, model_id, duration, start_time, _plan_id, new_owner, new_owner
+    from plan where id = _plan_id
+    returning id into new_plan_id;
+  insert into activity_directive(
+      id, plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, last_modified_by, start_offset, type, arguments,
+      last_modified_arguments_at, metadata, anchor_id, anchored_to_start)
+    select
+      id, new_plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, last_modified_by, start_offset, type, arguments,
+      last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+    from activity_directive where activity_directive.plan_id = _plan_id;
+
+  with source_plan as (
+    select simulation_template_id, arguments, simulation_start_time, simulation_end_time
+    from simulation
+    where simulation.plan_id = _plan_id
+  )
+  update simulation s
+  set simulation_template_id = source_plan.simulation_template_id,
+      arguments = source_plan.arguments,
+      simulation_start_time = source_plan.simulation_start_time,
+      simulation_end_time = source_plan.simulation_end_time
+  from source_plan
+  where s.plan_id = new_plan_id;
+
+  insert into preset_to_directive(preset_id, activity_id, plan_id)
+    select preset_id, activity_id, new_plan_id
+    from preset_to_directive ptd where ptd.plan_id = _plan_id;
+
+  insert into metadata.plan_tags(plan_id, tag_id)
+    select new_plan_id, tag_id
+    from metadata.plan_tags pt where pt.plan_id = _plan_id;
+  insert into metadata.activity_directive_tags(plan_id, directive_id, tag_id)
+    select new_plan_id, directive_id, tag_id
+    from metadata.activity_directive_tags adt where adt.plan_id = _plan_id;
+
+  insert into plan_latest_snapshot(plan_id, snapshot_id) values(new_plan_id, created_snapshot_id);
+  return new_plan_id;
+end
+$$;
+
+create table activity_directive_changelog (
+  revision integer not null,
+  plan_id integer not null,
+  activity_directive_id integer not null,
+
+  name text,
+  source_scheduling_goal_id integer,
+  changed_at timestamptz not null default now(),
+  changed_by text,
+  start_offset interval not null,
+  type text not null,
+  arguments merlin_argument_set not null,
+  changed_arguments_at timestamptz not null default now(),
+  metadata merlin_activity_directive_metadata_set default '{}'::jsonb,
+
+  anchor_id integer default null,
+  anchored_to_start boolean default true not null,
+
+  constraint activity_directive_changelog_natural_key
+      primary key (plan_id, activity_directive_id, revision),
+  constraint changelog_references_activity_directive
+      foreign key (activity_directive_id, plan_id)
+      references activity_directive
+      on update cascade
+      on delete cascade,
+  constraint changed_by_exists
+    foreign key (changed_by)
+    references metadata.users
+    on update cascade
+    on delete set null
+);
+
+comment on table activity_directive_changelog is e''
+    'A changelog that captures the 10 most recent revisions for each activity directive\n'
+    'See activity_directive comments for descriptions of shared fields';
+
+create function store_activity_directive_change()
+  returns trigger
+  language plpgsql as $$
+begin
+  insert into activity_directive_changelog (
+    revision,
+    plan_id,
+    activity_directive_id,
+    name,
+    start_offset,
+    type,
+    arguments,
+    changed_arguments_at,
+    metadata,
+    changed_by,
+    anchor_id,
+    anchored_to_start)
+  values (
+    (select coalesce(max(revision), -1) + 1
+     from activity_directive_changelog
+     where plan_id = new.plan_id
+      and activity_directive_id = new.id),
+    new.plan_id,
+    new.id,
+    new.name,
+    new.start_offset,
+    new.type,
+    new.arguments,
+    new.last_modified_arguments_at,
+    new.metadata,
+    new.last_modified_by,
+    new.anchor_id,
+    new.anchored_to_start);
+
+  return new;
+end
+$$;
+
+create trigger store_activity_directive_change_trigger
+  after update or insert on activity_directive
+  for each row
+  execute function store_activity_directive_change();
+
+create function delete_min_activity_directive_revision()
+  returns trigger
+  language plpgsql as $$
+begin
+  delete from activity_directive_changelog
+  where activity_directive_id = new.activity_directive_id
+    and plan_id = new.plan_id
+    and revision = (select min(revision)
+                    from activity_directive_changelog
+                    where activity_directive_id = new.activity_directive_id
+                      and plan_id = new.plan_id);
+  return new;
+end$$;
+
+create trigger delete_min_activity_directive_revision_trigger
+  after insert on activity_directive_changelog
+  for each row
+  when (new.revision > 10)
+  execute function delete_min_activity_directive_revision();
+
+create function hasura_functions.restore_activity_changelog(
+  _plan_id integer,
+  _activity_directive_id integer,
+  _revision integer,
+  hasura_session json
+)
+  returns setof activity_directive
+  volatile
+  language plpgsql as $$
+declare
+  _function_permission metadata.permission;
+begin
+  _function_permission :=
+      metadata.get_function_permissions('restore_activity_changelog', hasura_session);
+  if not _function_permission = 'NO_CHECK' then
+    call metadata.check_general_permissions(
+      'restore_activity_changelog',
+      _function_permission, _plan_id,
+      (hasura_session ->> 'x-hasura-user-id')
+    );
+  end if;
+
+  if not exists(select id from public.plan where id = _plan_id) then
+    raise exception 'Plan % does not exist', _plan_id;
+  end if;
+
+  if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_directive_id, _plan_id)) then
+    raise exception 'Activity Directive % does not exist in Plan %', _activity_directive_id, _plan_id;
+  end if;
+
+  if not exists(select revision
+                from public.activity_directive_changelog
+                where (plan_id, activity_directive_id, revision) =
+                      (_plan_id, _activity_directive_id, _revision))
+  then
+    raise exception 'Changelog Revision % does not exist for Plan % and Activity Directive %', _revision, _plan_id, _activity_directive_id;
+  end if;
+
+  return query
+  update activity_directive as ad
+  set name                       = c.name,
+      source_scheduling_goal_id  = c.source_scheduling_goal_id,
+      start_offset               = c.start_offset,
+      type                       = c.type,
+      arguments                  = c.arguments,
+      last_modified_arguments_at = c.changed_arguments_at,
+      metadata                   = c.metadata,
+      anchor_id                  = c.anchor_id,
+      anchored_to_start          = c.anchored_to_start,
+      last_modified_at           = c.changed_at,
+      last_modified_by           = c.changed_by
+  from activity_directive_changelog as c
+  where ad.id                    = _activity_directive_id
+    and c.activity_directive_id  = _activity_directive_id
+    and ad.plan_id               = _plan_id
+    and c.plan_id                = _plan_id
+    and c.revision               = _revision
+  returning ad.*;
+end
+$$;
+
+-- add new function key for restore_activity_changelog
+alter type metadata.function_permission_key add value 'restore_activity_changelog';
+
+-- add new key to user role
+update metadata.user_role_permission
+  set function_permissions = function_permissions
+                               || jsonb_build_object('restore_activity_changelog', 'PLAN_OWNER_COLLABORATOR')
+where role = 'user';
+
+call migrations.mark_migration_applied('23');

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -25,3 +25,4 @@ call migrations.mark_migration_applied('19');
 call migrations.mark_migration_applied('20');
 call migrations.mark_migration_applied('21');
 call migrations.mark_migration_applied('22');
+call migrations.mark_migration_applied('23');

--- a/merlin-server/sql/merlin/domain-types/permissions.sql
+++ b/merlin-server/sql/merlin/domain-types/permissions.sql
@@ -11,4 +11,5 @@ create type metadata.function_permission_key
   as enum ('apply_preset', 'branch_plan', 'create_merge_rq', 'withdraw_merge_rq', 'begin_merge', 'cancel_merge',
     'commit_merge', 'deny_merge', 'get_conflicting_activities', 'get_non_conflicting_activities', 'set_resolution',
     'set_resolution_bulk', 'delete_activity_subtree', 'delete_activity_subtree_bulk', 'delete_activity_reanchor_plan',
-    'delete_activity_reanchor_plan_bulk', 'delete_activity_reanchor', 'delete_activity_reanchor_bulk', 'get_plan_history');
+    'delete_activity_reanchor_plan_bulk', 'delete_activity_reanchor', 'delete_activity_reanchor_bulk', 'get_plan_history',
+    'restore_activity_changelog');

--- a/merlin-server/sql/merlin/functions/hasura/delete_anchor_functions.sql
+++ b/merlin-server/sql/merlin/functions/hasura/delete_anchor_functions.sql
@@ -33,7 +33,7 @@ language plpgsql as $$
         delete from activity_directive where (id, plan_id) = (_activity_id, _plan_id) returning *
       )
       select (deleted.id, deleted.plan_id, deleted.name, deleted.source_scheduling_goal_id,
-              deleted.created_at, deleted.last_modified_at, deleted.start_offset, deleted.type, deleted.arguments,
+              deleted.created_at, deleted.last_modified_at, deleted.last_modified_by, deleted.start_offset, deleted.type, deleted.arguments,
               deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
   end
 $$;
@@ -67,7 +67,7 @@ begin
         delete from activity_directive where (id, plan_id) = (_activity_id, _plan_id) returning *
       )
       select (deleted.id, deleted.plan_id, deleted.name, deleted.source_scheduling_goal_id,
-              deleted.created_at, deleted.last_modified_at, deleted.start_offset, deleted.type, deleted.arguments,
+              deleted.created_at, deleted.last_modified_at, deleted.last_modified_by, deleted.start_offset, deleted.type, deleted.arguments,
               deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
 end
 $$;
@@ -108,7 +108,7 @@ begin
             returning *
       )
       select (deleted.id, deleted.plan_id, deleted.name, deleted.source_scheduling_goal_id,
-              deleted.created_at, deleted.last_modified_at, deleted.start_offset, deleted.type, deleted.arguments,
+              deleted.created_at, deleted.last_modified_at, deleted.last_modified_by, deleted.start_offset, deleted.type, deleted.arguments,
               deleted.last_modified_arguments_at, deleted.metadata, deleted.anchor_id, deleted.anchored_to_start)::activity_directive, 'deleted' from deleted;
 end
 $$;

--- a/merlin-server/sql/merlin/functions/hasura/hasura_functions.sql
+++ b/merlin-server/sql/merlin/functions/hasura/hasura_functions.sql
@@ -27,3 +27,64 @@ begin
 	  order by p.name, ps.start_offset desc;
 end
 $$;
+
+create function hasura_functions.restore_activity_changelog(
+  _plan_id integer,
+  _activity_directive_id integer,
+  _revision integer,
+  hasura_session json
+)
+  returns setof activity_directive
+  volatile
+  language plpgsql as $$
+declare
+  _function_permission metadata.permission;
+begin
+  _function_permission :=
+      metadata.get_function_permissions('restore_activity_changelog', hasura_session);
+  if not _function_permission = 'NO_CHECK' then
+    call metadata.check_general_permissions(
+      'restore_activity_changelog',
+      _function_permission, _plan_id,
+      (hasura_session ->> 'x-hasura-user-id')
+    );
+  end if;
+
+  if not exists(select id from public.plan where id = _plan_id) then
+    raise exception 'Plan % does not exist', _plan_id;
+  end if;
+
+  if not exists(select id from public.activity_directive where (id, plan_id) = (_activity_directive_id, _plan_id)) then
+    raise exception 'Activity Directive % does not exist in Plan %', _activity_directive_id, _plan_id;
+  end if;
+
+  if not exists(select revision
+                from public.activity_directive_changelog
+                where (plan_id, activity_directive_id, revision) =
+                      (_plan_id, _activity_directive_id, _revision))
+  then
+    raise exception 'Changelog Revision % does not exist for Plan % and Activity Directive %', _revision, _plan_id, _activity_directive_id;
+  end if;
+
+  return query
+  update activity_directive as ad
+  set name                       = c.name,
+      source_scheduling_goal_id  = c.source_scheduling_goal_id,
+      start_offset               = c.start_offset,
+      type                       = c.type,
+      arguments                  = c.arguments,
+      last_modified_arguments_at = c.changed_arguments_at,
+      metadata                   = c.metadata,
+      anchor_id                  = c.anchor_id,
+      anchored_to_start          = c.anchored_to_start,
+      last_modified_at           = c.changed_at,
+      last_modified_by           = c.changed_by
+  from activity_directive_changelog as c
+  where ad.id                    = _activity_directive_id
+    and c.activity_directive_id  = _activity_directive_id
+    and ad.plan_id               = _plan_id
+    and c.plan_id                = _plan_id
+    and c.revision               = _revision
+  returning ad.*;
+end
+$$;

--- a/merlin-server/sql/merlin/functions/public/begin_merge.sql
+++ b/merlin-server/sql/merlin/functions/public/begin_merge.sql
@@ -108,14 +108,14 @@ begin
     select activity_id, 'none'
       from(
         select psa.id as activity_id, name, metadata.tag_ids_activity_snapshot(psa.id, merge_base_id),
-               source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
-               last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+               source_scheduling_goal_id, created_at, start_offset, type, arguments,
+               metadata, anchor_id, anchored_to_start
         from plan_snapshot_activities psa
         where psa.snapshot_id = merge_base_id
     intersect
       select id as activity_id, name, metadata.tag_ids_activity_snapshot(psa.id, snapshot_id_supplying),
-             source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
-             last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+             source_scheduling_goal_id, created_at, start_offset, type, arguments,
+             metadata, anchor_id, anchored_to_start
         from plan_snapshot_activities psa
         where psa.snapshot_id = snapshot_id_supplying) a;
 
@@ -159,14 +159,14 @@ begin
   select activity_id, 'none'
   from(
         select id as activity_id, name, metadata.tag_ids_activity_snapshot(id, merge_base_id),
-               source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
-               last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+               source_scheduling_goal_id, created_at, start_offset, type, arguments,
+               metadata, anchor_id, anchored_to_start
         from plan_snapshot_activities psa
         where psa.snapshot_id = merge_base_id
         intersect
         select id as activity_id, name, metadata.tag_ids_activity_directive(id, plan_id_receiving),
-               source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
-               last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+               source_scheduling_goal_id, created_at, start_offset, type, arguments,
+               metadata, anchor_id, anchored_to_start
         from activity_directive ad
         where ad.plan_id = plan_id_receiving) a;
 
@@ -201,12 +201,12 @@ begin
   -- receiving 'delete' against supplying 'none' does not enter the merge staging area table
 
   insert into merge_staging_area (
-    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_by,
     start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type
          )
   -- 'adds' can go directly into the merge staging area table
   select _merge_request_id, activity_id, name, metadata.tag_ids_activity_snapshot(s_diff.activity_id, psa.snapshot_id),  source_scheduling_goal_id, created_at,
-         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type
+         last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type
     from supplying_diff as  s_diff
     join plan_snapshot_activities psa
       on s_diff.activity_id = psa.id
@@ -214,7 +214,7 @@ begin
   union
   -- an 'add' between the receiving plan and merge base is actually a 'none'
   select _merge_request_id, activity_id, name, metadata.tag_ids_activity_directive(r_diff.activity_id, ad.plan_id),  source_scheduling_goal_id, created_at,
-         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'::activity_change_type
+         last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'::activity_change_type
     from receiving_diff as r_diff
     join activity_directive ad
       on r_diff.activity_id = ad.id
@@ -233,12 +233,12 @@ begin
        or (change_type_receiving = 'delete' and change_type_supplying = 'none');
 
   insert into merge_staging_area (
-    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_by,
     start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type
   )
   -- receiving 'none' and 'modify' against 'none' in the supplying side go into the merge staging area as 'none'
   select _merge_request_id, activity_id, name, metadata.tag_ids_activity_directive(diff_diff.activity_id, plan_id),  source_scheduling_goal_id, created_at,
-         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'
+         last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'
     from diff_diff
     join activity_directive
       on activity_id=id
@@ -248,7 +248,7 @@ begin
   union
   -- supplying 'modify' against receiving 'none' go into the merge staging area as 'modify'
   select _merge_request_id, activity_id, name, metadata.tag_ids_activity_snapshot(diff_diff.activity_id, snapshot_id),  source_scheduling_goal_id, created_at,
-         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type_supplying
+         last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type_supplying
     from diff_diff
     join plan_snapshot_activities p
       on diff_diff.activity_id = p.id
@@ -257,33 +257,36 @@ begin
   union
   -- supplying 'delete' against receiving 'none' go into the merge staging area as 'delete'
     select _merge_request_id, activity_id, name, metadata.tag_ids_activity_directive(diff_diff.activity_id, plan_id),  source_scheduling_goal_id, created_at,
-         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type_supplying
+         last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type_supplying
     from diff_diff
     join activity_directive p
       on diff_diff.activity_id = p.id
     where plan_id = plan_id_receiving
-      and (change_type_receiving = 'none' and diff_diff.change_type_supplying = 'delete')
-  union
+      and (change_type_receiving = 'none' and diff_diff.change_type_supplying = 'delete');
+
   -- 'modify' against a 'modify' must be checked for equality first.
-  select _merge_request_id, activity_id, name, tags,  source_scheduling_goal_id, created_at,
-         start_offset, type, arguments, metadata, anchor_id, anchored_to_start, 'none'
-  from (
+  with false_modify as (
     select activity_id, name, metadata.tag_ids_activity_directive(dd.activity_id, psa.snapshot_id) as tags,
            source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start
-      from plan_snapshot_activities psa
-      join diff_diff dd
-        on dd.activity_id = psa.id
-      where psa.snapshot_id = snapshot_id_supplying
-        and (dd.change_type_receiving = 'modify' and dd.change_type_supplying = 'modify')
+    from plan_snapshot_activities psa
+    join diff_diff dd
+      on dd.activity_id = psa.id
+    where psa.snapshot_id = snapshot_id_supplying
+      and (dd.change_type_receiving = 'modify' and dd.change_type_supplying = 'modify')
     intersect
     select activity_id, name, metadata.tag_ids_activity_directive(dd.activity_id, ad.plan_id) as tags,
            source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start
-      from diff_diff dd
-      join activity_directive ad
-        on dd.activity_id = ad.id
-      where ad.plan_id = plan_id_receiving
-        and (dd.change_type_supplying = 'modify' and dd.change_type_receiving = 'modify')
-  ) a;
+    from diff_diff dd
+    join activity_directive ad
+      on dd.activity_id = ad.id
+    where ad.plan_id = plan_id_receiving
+      and (dd.change_type_supplying = 'modify' and dd.change_type_receiving = 'modify'))
+  insert into merge_staging_area (
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_by,
+    start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type)
+  select _merge_request_id, ad.id, ad.name, tags,  ad.source_scheduling_goal_id, ad.created_at,
+         ad.last_modified_by, ad.start_offset, ad.type, ad.arguments, ad.metadata, ad.anchor_id, ad.anchored_to_start, 'none'
+  from false_modify fm left join activity_directive ad on (ad.plan_id, ad.id) = (plan_id_receiving, fm.activity_id);
 
   -- 'modify' against 'delete' and inequal 'modify' against 'modify' goes into conflict table (aka everything left in diff_diff)
   insert into conflicting_activities (merge_request_id, activity_id, change_type_supplying, change_type_receiving)

--- a/merlin-server/sql/merlin/functions/public/commit_merge.sql
+++ b/merlin-server/sql/merlin/functions/public/commit_merge.sql
@@ -32,11 +32,11 @@ begin
   select snapshot_id_supplying_changes from merge_request mr where mr.id = _request_id into snapshot_id_S;
 
   insert into merge_staging_area(
-    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at,
+    merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at, last_modified_by,
     start_offset, type, arguments, metadata, anchor_id, anchored_to_start, change_type)
     -- gather delete data from the opposite tables
     select  _request_id, activity_id, name, metadata.tag_ids_activity_directive(ca.activity_id, ad.plan_id),
-            source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
+            source_scheduling_goal_id, created_at, last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
             'delete'::activity_change_type
       from  conflicting_activities ca
       join  activity_directive ad
@@ -47,7 +47,7 @@ begin
         and ca.change_type_supplying = 'delete'
     union
     select  _request_id, activity_id, name, metadata.tag_ids_activity_snapshot(ca.activity_id, psa.snapshot_id),
-            source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
+            source_scheduling_goal_id, created_at, last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
             'delete'::activity_change_type
       from  conflicting_activities ca
       join  plan_snapshot_activities psa
@@ -58,7 +58,7 @@ begin
         and ca.change_type_receiving = 'delete'
     union
     select  _request_id, activity_id, name, metadata.tag_ids_activity_directive(ca.activity_id, ad.plan_id),
-            source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
+            source_scheduling_goal_id, created_at, last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
             'none'::activity_change_type
       from  conflicting_activities ca
       join  activity_directive ad
@@ -69,7 +69,7 @@ begin
         and ca.change_type_receiving = 'modify'
     union
     select  _request_id, activity_id, name, metadata.tag_ids_activity_snapshot(ca.activity_id, psa.snapshot_id),
-            source_scheduling_goal_id, created_at, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
+            source_scheduling_goal_id, created_at, last_modified_by, start_offset, type, arguments, metadata, anchor_id, anchored_to_start,
             'modify'::activity_change_type
       from  conflicting_activities ca
       join  plan_snapshot_activities psa
@@ -87,9 +87,9 @@ begin
   -- Update the plan's activities to match merge-staging-area's activities
   -- Add
   insert into activity_directive(
-                id, plan_id, name, source_scheduling_goal_id, created_at,
+                id, plan_id, name, source_scheduling_goal_id, created_at, last_modified_by,
                 start_offset, type, arguments, metadata, anchor_id, anchored_to_start )
-  select  activity_id, plan_id_R, name, source_scheduling_goal_id, created_at,
+  select  activity_id, plan_id_R, name, source_scheduling_goal_id, created_at, last_modified_by,
             start_offset, type, arguments, metadata, anchor_id, anchored_to_start
    from merge_staging_area
   where merge_staging_area.merge_request_id = _request_id
@@ -97,9 +97,9 @@ begin
 
   -- Modify
   insert into activity_directive(
-    id, plan_id, "name", source_scheduling_goal_id, created_at,
+    id, plan_id, "name", source_scheduling_goal_id, created_at, last_modified_by,
     start_offset, "type", arguments, metadata, anchor_id, anchored_to_start )
-  select  activity_id, plan_id_R, "name", source_scheduling_goal_id, created_at,
+  select  activity_id, plan_id_R, "name", source_scheduling_goal_id, created_at, last_modified_by,
           start_offset, "type", arguments, metadata, anchor_id, anchored_to_start
   from merge_staging_area
   where merge_staging_area.merge_request_id = _request_id
@@ -109,6 +109,7 @@ begin
   set name = excluded.name,
       source_scheduling_goal_id = excluded.source_scheduling_goal_id,
       created_at = excluded.created_at,
+      last_modified_by = excluded.last_modified_by,
       start_offset = excluded.start_offset,
       type = excluded.type,
       arguments = excluded.arguments,

--- a/merlin-server/sql/merlin/functions/public/create_snapshot.sql
+++ b/merlin-server/sql/merlin/functions/public/create_snapshot.sql
@@ -16,12 +16,13 @@ begin
     from plan where id = _plan_id
     returning snapshot_id into inserted_snapshot_id;
   insert into plan_snapshot_activities(
-                snapshot_id, id, name, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
+                snapshot_id, id, name, source_scheduling_goal_id, created_at,
+                last_modified_at, last_modified_by, start_offset, type,
                 arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start)
     select
       inserted_snapshot_id,                              -- this is the snapshot id
       id, name, source_scheduling_goal_id, created_at,   -- these are the rest of the data for an activity row
-      last_modified_at, start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
+      last_modified_at, last_modified_by, start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start
     from activity_directive where activity_directive.plan_id = _plan_id;
   insert into preset_to_snapshot_directive(preset_id, activity_id, snapshot_id)
     select ptd.preset_id, ptd.activity_id, inserted_snapshot_id

--- a/merlin-server/sql/merlin/functions/public/duplicate_plan.sql
+++ b/merlin-server/sql/merlin/functions/public/duplicate_plan.sql
@@ -23,10 +23,10 @@ begin
     from plan where id = _plan_id
     returning id into new_plan_id;
   insert into activity_directive(
-      id, plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+      id, plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, last_modified_by, start_offset, type, arguments,
       last_modified_arguments_at, metadata, anchor_id, anchored_to_start)
     select
-      id, new_plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type, arguments,
+      id, new_plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, last_modified_by, start_offset, type, arguments,
       last_modified_arguments_at, metadata, anchor_id, anchored_to_start
     from activity_directive where activity_directive.plan_id = _plan_id;
 

--- a/merlin-server/sql/merlin/init.sql
+++ b/merlin-server/sql/merlin/init.sql
@@ -35,6 +35,7 @@ begin;
   \ir tables/plan.sql
   \ir tables/plan_collaborators.sql
   \ir tables/activity_directive.sql
+  \ir tables/activity_directive_changelog.sql
   \ir tables/activity_directive_validations.sql
   \ir tables/anchor_validation_status.sql
   \ir tables/simulation_template.sql

--- a/merlin-server/sql/merlin/tables/activity_directive.sql
+++ b/merlin-server/sql/merlin/tables/activity_directive.sql
@@ -6,6 +6,7 @@ create table activity_directive (
   source_scheduling_goal_id integer,
   created_at timestamptz not null default now(),
   last_modified_at timestamptz not null default now(),
+  last_modified_by text,
   start_offset interval not null,
   type text not null,
   arguments merlin_argument_set not null,
@@ -26,7 +27,12 @@ create table activity_directive (
     foreign key (anchor_id, plan_id)
       references activity_directive
       on update cascade
-      on delete restrict
+      on delete restrict,
+  constraint activity_directive_last_modified_by_exists
+    foreign key (last_modified_by)
+    references metadata.users
+    on update cascade
+    on delete set null
 );
 
 create index activity_directive_plan_id_index on activity_directive (plan_id);
@@ -48,6 +54,8 @@ comment on column activity_directive.created_at is e''
   'The time at which this activity_directive was created.';
 comment on column activity_directive.last_modified_at is e''
   'The time at which this activity_directive was last modified.';
+comment on column activity_directive.last_modified_by is e''
+  'The user who last modified this activity_directive.';
 comment on column activity_directive.last_modified_arguments_at is e''
   'The time at which this activity_directive.arguments was last modified.';
 comment on column activity_directive.start_offset is e''

--- a/merlin-server/sql/merlin/tables/activity_directive_changelog.sql
+++ b/merlin-server/sql/merlin/tables/activity_directive_changelog.sql
@@ -1,0 +1,98 @@
+create table activity_directive_changelog (
+  revision integer not null,
+  plan_id integer not null,
+  activity_directive_id integer not null,
+
+  name text,
+  source_scheduling_goal_id integer,
+  changed_at timestamptz not null default now(),
+  changed_by text,
+  start_offset interval not null,
+  type text not null,
+  arguments merlin_argument_set not null,
+  changed_arguments_at timestamptz not null default now(),
+  metadata merlin_activity_directive_metadata_set default '{}'::jsonb,
+
+  anchor_id integer default null,
+  anchored_to_start boolean default true not null,
+
+  constraint activity_directive_changelog_natural_key
+    primary key (plan_id, activity_directive_id, revision),
+  constraint changelog_references_activity_directive
+    foreign key (activity_directive_id, plan_id)
+    references activity_directive
+    on update cascade
+    on delete cascade,
+  constraint changed_by_exists
+    foreign key (changed_by)
+    references metadata.users
+    on update cascade
+    on delete set null
+);
+
+comment on table activity_directive_changelog is e''
+  'A changelog that captures the 10 most recent revisions for each activity directive\n'
+  'See activity_directive comments for descriptions of shared fields';
+
+create function store_activity_directive_change()
+  returns trigger
+  language plpgsql as $$
+begin
+  insert into activity_directive_changelog (
+    revision,
+    plan_id,
+    activity_directive_id,
+    name,
+    start_offset,
+    type,
+    arguments,
+    changed_arguments_at,
+    metadata,
+    changed_by,
+    anchor_id,
+    anchored_to_start)
+  values (
+    (select coalesce(max(revision), -1) + 1
+     from activity_directive_changelog
+     where plan_id = new.plan_id
+      and activity_directive_id = new.id),
+    new.plan_id,
+    new.id,
+    new.name,
+    new.start_offset,
+    new.type,
+    new.arguments,
+    new.last_modified_arguments_at,
+    new.metadata,
+    new.last_modified_by,
+    new.anchor_id,
+    new.anchored_to_start);
+
+  return new;
+end
+$$;
+
+create trigger store_activity_directive_change_trigger
+  after update or insert on activity_directive
+  for each row
+  execute function store_activity_directive_change();
+
+create function delete_min_activity_directive_revision()
+  returns trigger
+  language plpgsql as $$
+begin
+  delete from activity_directive_changelog
+  where activity_directive_id = new.activity_directive_id
+    and plan_id = new.plan_id
+    and revision = (select min(revision)
+                    from activity_directive_changelog
+                    where activity_directive_id = new.activity_directive_id
+                      and plan_id = new.plan_id);
+  return new;
+end$$;
+
+create trigger delete_min_activity_directive_revision_trigger
+  after insert on activity_directive_changelog
+  for each row
+  when (new.revision > 10)
+  execute function delete_min_activity_directive_revision();

--- a/merlin-server/sql/merlin/tables/merge_staging_area.sql
+++ b/merlin-server/sql/merlin/tables/merge_staging_area.sql
@@ -22,6 +22,7 @@ create table merge_staging_area(
     tags int[] default '{}',
     source_scheduling_goal_id integer,
     created_at timestamptz not null,
+    last_modified_by text,
     start_offset interval not null,
     type text not null,
     arguments merlin_argument_set not null,

--- a/merlin-server/sql/merlin/tables/metadata/user_role_permission.sql
+++ b/merlin-server/sql/merlin/tables/metadata/user_role_permission.sql
@@ -54,7 +54,8 @@ values
       "delete_activity_reanchor_plan_bulk": "PLAN_OWNER_COLLABORATOR",
       "delete_activity_reanchor": "PLAN_OWNER_COLLABORATOR",
       "delete_activity_reanchor_bulk": "PLAN_OWNER_COLLABORATOR",
-      "get_plan_history": "NO_CHECK"
+      "get_plan_history": "NO_CHECK",
+      "restore_activity_changelog": "PLAN_OWNER_COLLABORATOR"
     }' ),
   ('viewer',
    '{

--- a/merlin-server/sql/merlin/tables/plan_snapshot_activities.sql
+++ b/merlin-server/sql/merlin/tables/plan_snapshot_activities.sql
@@ -8,6 +8,7 @@ create table plan_snapshot_activities(
     source_scheduling_goal_id integer,
     created_at timestamptz not null,
     last_modified_at timestamptz not null,
+    last_modified_by text,
     start_offset interval not null,
     type text not null,
     arguments merlin_argument_set not null,

--- a/merlin-server/sql/merlin/views/activity_directive_extended.sql
+++ b/merlin-server/sql/merlin/views/activity_directive_extended.sql
@@ -77,6 +77,7 @@ create view activity_directive_extended as
     ad.source_scheduling_goal_id as source_scheduling_goal_id,
     ad.created_at as created_at,
     ad.last_modified_at as last_modified_at,
+    ad.last_modified_by as last_modified_by,
     ad.start_offset as start_offset,
     ad.type as type,
     ad.arguments as arguments,


### PR DESCRIPTION
* **Tickets addressed:** closes #1016 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->


## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
As a PR reviewer, I would start looking at the main changes in `merlin-server/sql/merlin/tables/activity_directive_changelog.sql`, which is a new table that stores revisions of `activity_directive`'s. The other ~2000 or so lines of this PR are to make migrations happy, and a handful of basic database trigger tests.

This new changelog table is automatically populated by inserts / updates to the `activity_directive` table. Each revision in uniquely identified by the tuple `(plan_id, activity_directive_id, revision)`. The largest revision number of this table (for a given `(plan_id, activity_directive_id)`) is the current activity_directive state. This means users can revert to the second largest revision for a given `activity_directive` to achieve a traditional "undo".

This new file also adds a handful of `plpgsql` triggers:

- `store_activity_directive_change`, which inserts a new changelog entry whenever `activity_directive` is updated.
- `delete_activity_directive_revisions_past_limit`, which deletes all entries from the changelog older than the latest 10 revisions.

Finally, it exposes a new function `restore_activity_changelog`, exposed by Hasura as `restoreActivityFromChangelog`, which gives Aerie clients a simple interface to revert some activity directive to a certain revision by providing `(plan_id, activity_directive_id, revision)`. 

Additionally, the `activity_directive` table was updated to add a new column, `last_modifed_by`. This new column allows `activity_directive_changlog` entries to track who made which changes, which will be useful for the frontend to display this changelog (see https://github.com/NASA-AMMOS/aerie-ui/issues/738).

Unfortunately, this new column required one line changes to many existing stored functions for the anchor logic and plan merge, and the only way to update a function in postgres is to copy and paste the entire function definition into a `create or replace function` statement, so the database migrations for this PR cause an extra ~1500 lines of changes that aren't actually changes.

### Using this new feature
Get a list of previous revisions for a given activity directive and plan:

```graphql
query revisions {
  activity_directive_changelog(where: {
    plan_id: {_eq: 1}, 
    _and: {activity_directive_id: {_eq: 1}}}, 
    order_by: {revision: desc}) {
    revision
    start_offset
    name
    arguments
    changed_by
    changed_at
    ...
  }
}
```

Restore activity directives to an existing revision in the changelog using the following mutation:
```graphql
mutation restore {
  restoreActivityFromChangelog(args: {
    _activity_directive_id: 1, 
    _plan_id: 1, 
    _revision: 1}) {
    id
    ...
  }
}
```

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Added a handful of basic tests (check insert on insert, check insert on update, check revert, etc) in `ActivityDirectiveChangelogTests.java`

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None, although we can add new documentation for the new exposed SQL function.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Maybe add a changelog for more things (e.g. plan)