### PR TITLE
Make claim actions respect `canceled` status

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ClaimSimulationAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ClaimSimulationAction.java
@@ -11,7 +11,7 @@ import java.sql.SQLException;
     update simulation_dataset
       set
         status = 'incomplete'
-      where (dataset_id = ? and status = 'pending');
+      where (dataset_id = ? and status = 'pending' and not canceled);
   """;
 
   private final PreparedStatement statement;

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/ClaimRequestAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/ClaimRequestAction.java
@@ -10,7 +10,7 @@ import org.intellij.lang.annotations.Language;
     update scheduling_request
       set
         status = 'incomplete'
-      where (specification_id = ? and status = 'pending');
+      where (specification_id = ? and status = 'pending' and not canceled);
   """;
 
   private final PreparedStatement statement;


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Currently, neither the Scheduler nor the Simulation Workers would respect that an incoming request had been canceled.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Manual testing via:
1. Freezing the worker with a debugger,
2. Setting up the DB with multiple requests, some canceled, others not,
3. Resuming the worker
4. Validating that it received all of the requests but only claimed the ones that weren't canceled.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No documentation updates are needed.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
