### PR TITLE
Avoid timestamptz subtraction for span and event start offsets

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/InsertSpansAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/InsertSpansAction.java
@@ -10,16 +10,14 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
-import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.activityAttributesP;
 import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatements.setDuration;
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatements.setTimestamp;
 
-/*package-local*/ final class PostSpansAction implements AutoCloseable {
+/*package-local*/ final class InsertSpansAction implements AutoCloseable {
   private static final @Language("SQL") String sql = """
       insert into span (dataset_id, start_offset, duration, type, attributes)
       values (?, ?::interval, ?::interval, ?, ?::jsonb)
@@ -27,7 +25,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
 
   private final PreparedStatement statement;
 
-  public PostSpansAction(final Connection connection) throws SQLException {
+  public InsertSpansAction(final Connection connection) throws SQLException {
     this.statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -338,7 +338,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
       final Timestamp simulationStart
   ) throws SQLException {
     try (
-        final var postActivitiesAction = new PostSpansAction(connection);
+        final var insertSpansAction = new InsertSpansAction(connection);
         final var updateSimulatedActivityParentsAction = new UpdateSimulatedActivityParentsAction(connection)
     ) {
       final var simulatedActivityRecords = simulatedActivities.entrySet().stream()
@@ -352,7 +352,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
               e -> unfinishedActivityToRecord(e.getValue())));
       allActivityRecords.putAll(simulatedActivityRecords);
 
-      final var simIdToPgId = postActivitiesAction.apply(
+      final var simIdToPgId = insertSpansAction.apply(
           datasetId,
           allActivityRecords,
           simulationStart);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -298,7 +298,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
     ProfileRepository.postResourceProfiles(connection, datasetId, profileSet);
     postActivities(connection, datasetId, results.simulatedActivities, results.unfinishedActivities, simulationStart);
     insertSimulationTopics(connection, datasetId, results.topics);
-    insertSimulationEvents(connection, datasetId, results.events, simulationStart);
+    insertSimulationEvents(connection, datasetId, results.events);
 
     try (final var setSimulationStateAction = new SetSimulationStateAction(connection)) {
       setSimulationStateAction.apply(datasetId, SimulationStateRecord.success());
@@ -318,15 +318,15 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
   }
 
   private static void insertSimulationEvents(
-      Connection connection,
-      long datasetId,
-      Map<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>> events,
-      Timestamp simulationStart) throws SQLException
+      final Connection connection,
+      final long datasetId,
+      final Map<Duration, List<EventGraph<Pair<Integer, SerializedValue>>>> events
+  ) throws SQLException
   {
     try (
         final var insertSimulationEventsAction = new InsertSimulationEventsAction(connection)
     ) {
-        insertSimulationEventsAction.apply(datasetId, events, simulationStart);
+        insertSimulationEventsAction.apply(datasetId, events);
     }
   }
 


### PR DESCRIPTION
* **Tickets addressed:** #1045 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

Postgres stores intervals in tuples of (months, days, microseconds)  ([docs](https://www.postgresql.org/docs/current/datatype-datetime.html))
The first two are primarily needed for calendrical durations. For example, January 1st -> February 1st -> March 1st is 2 months. Noon on Sunday + 1 day is Noon on Monday, even if that crosses a daylight savings boundary (so a day can be 23, 24, or 25 hours, depending on when it is)

On Aerie, to the extent possible, we want to use the microseconds part of that tuple. This is primarily to canonicalize the representation of intervals in Aerie, to avoid the multiple representations `24:00:00.000` vs `24 days`.

This PR updates the `PostSpansAction` (renamed to `InsertSpansAction` to mirror database parlance) to write durations using `PreparedStatements.setDuration` rather than by doing subtraction between two timestamps. The primary purpose of this change is to avoid `start_offsets` that mix the days and microseconds portions of the `interval` type.

> Aside:
> I found [the code](https://github.com/postgres/postgres/blob/341996248e4d720556689e5fb3da7a408cf94228/src/backend/utils/adt/timestamp.c#L2649-L2693) that implements subtraction between two timestamptzs (it happens to be the same code to subtract regular timestamps). At the bottom, it calls interval_justify_hours ([code here](https://github.com/postgres/postgres/blob/341996248e4d720556689e5fb3da7a408cf94228/src/backend/utils/adt/timestamp.c#L2757-L2789)).
> 
> As far as I can tell, it:
> 1. Does the subtraction at the microsecond level, and gets the exact difference in microseconds
> 2. “Justifies” it so that the microsecond portion is less than 24 hours, by incrementing the day portion as much as possible

> Seconds aside:
> Another reason is to avoid calendrical durations, which could cause issues if we were to apply Aerie durations to calendrical time systems. In Aerie, we generally stick to UTC, and do not have a good story for leap seconds, so we can make the claim that days are always 24 hours long. However, it is not out of the question that one might overlay activity times on a more human time scale, e.g. operational meeting times. Using the microsecond representation guarantees that the offsets are correct even in the presence of daylight savings time or leap seconds.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I built Aerie on `develop`, ran simulation and saw that it inserted mixed days/microseconds intervals into the `span.start_offset` column. I then switched to this branch, rebuilt, and saw that it inserted only microsecond-based intervals.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
We definitely need a document on "Time in Aerie", since this is a topic that comes up often. I'll make a documentation ticket.

https://github.com/NASA-AMMOS/aerie-docs/issues/66

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Consider how to avoid the non-microseconds portions of the postgres `interval` type. Perhaps a domain type, or check constraints could help here, or moving to a different representation of offsets altogether.
