### PR TITLE
Add scheduler simulation restart count

### DIFF
--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
@@ -53,10 +53,15 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
   //List of activities simulated since the last reset
   private final Map<ActivityDirectiveId, ActivityDirective> activitiesInserted = new HashMap<>();
 
+  //counts the number of simulation restarts, used as performance metric in the scheduler
+  //effectively counting the number of calls to initSimulation()
+  private int countSimulationRestarts;
+
   public ResumableSimulationDriver(MissionModel<Model> missionModel, Duration planDuration){
     this.missionModel = missionModel;
     plannedDirectiveToTask = new HashMap<>();
     this.planDuration = planDuration;
+    countSimulationRestarts = 0;
     initSimulation();
     batch = null;
   }
@@ -93,6 +98,15 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
       final var commit = engine.performJobs(batch.jobs(), cells, curTime, Duration.MAX_VALUE);
       timeline.add(commit);
     }
+    countSimulationRestarts++;
+  }
+
+  /**
+   * Return the number of simulation restarts
+   * @return the number of simulation restarts
+   */
+  public int getCountSimulationRestarts(){
+    return countSimulationRestarts;
   }
 
   @Override

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/FixedDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/FixedDurationTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FixedDurationTest {
@@ -57,6 +58,7 @@ public class FixedDurationTest {
     final var plan = solver.getNextSolution().get();
     solver.printEvaluation();
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT1M"), planningHorizon.fromStart("PT1H1M"), problem.getActivityType("BananaNap")));
+    assertEquals(1, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 
@@ -86,6 +88,7 @@ public class FixedDurationTest {
     final var plan = solver.getNextSolution().get();
     solver.printEvaluation();
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT1M"), planningHorizon.fromStart("P2DT1M"), problem.getActivityType("RipenBanana")));
+    assertEquals(1, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/LongDurationPlanTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/LongDurationPlanTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.google.common.truth.Truth8.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LongDurationPlanTest {
 
@@ -78,6 +79,7 @@ public class LongDurationPlanTest {
     Truth.assertThat(plan.get().getActivitiesByTime())
          .comparingElementsUsing(equalExceptInName)
          .containsExactlyElementsIn(expectedPlan.getActivitiesByTime());
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -98,5 +100,6 @@ public class LongDurationPlanTest {
     Truth.assertThat(plan.getActivitiesByTime())
          .comparingElementsUsing(equalExceptInName)
          .containsExactlyElementsIn(expectedPlan.getActivitiesByTime());
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/ParametricDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/ParametricDurationTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ParametricDurationTest {
@@ -61,6 +62,7 @@ public class ParametricDurationTest {
     final var plan = solver.getNextSolution().get();
     solver.printEvaluation();
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT1M"), planningHorizon.fromStart("PT2M"), problem.getActivityType("DownloadBanana")));
+    assertEquals(1, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -90,5 +92,6 @@ public class ParametricDurationTest {
     final var plan = solver.getNextSolution().get();
     solver.printEvaluation();
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT2M"), planningHorizon.fromStart("PT12M"), problem.getActivityType("DownloadBanana")));
+    assertEquals(1, problem.getSimulationFacade().countSimulationRestarts());
   }
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PrioritySolverTest {
   private static PrioritySolver makeEmptyProblemSolver() {
@@ -127,6 +128,7 @@ public class PrioritySolverTest {
     assertThat(plan.get().getActivitiesByTime())
         .comparingElementsUsing(equalExceptInName)
         .containsExactlyElementsIn(expectedPlan.getActivitiesByTime());
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -147,6 +149,7 @@ public class PrioritySolverTest {
     assertThat(plan.getActivitiesByTime())
         .comparingElementsUsing(equalExceptInName)
         .containsExactlyElementsIn(expectedPlan.getActivitiesByTime());
+    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -170,6 +173,7 @@ public class PrioritySolverTest {
     assertThat(eval.getAssociatedActivities())
         .comparingElementsUsing(equalExceptInName)
         .containsExactlyElementsIn(expectedPlan.getActivitiesByTime());
+    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -200,6 +204,7 @@ public class PrioritySolverTest {
     assertThat(plan.getActivitiesByTime())
         .comparingElementsUsing(equalExceptInName)
         .containsExactlyElementsIn(expectedPlan.getActivitiesByTime()).inOrder();
+    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -233,6 +238,7 @@ public class PrioritySolverTest {
     assertThat(plan.getActivitiesByTime())
         .comparingElementsUsing(equalExceptInName)
         .containsAtLeastElementsIn(expectedPlan.getActivitiesByTime());
+    assertEquals(5, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 
@@ -274,6 +280,7 @@ public class PrioritySolverTest {
     var plan = solver.getNextSolution().orElseThrow();
     //will insert an activity at the beginning of the plan in addition of the two already-present activities
     assertThat(plan.getActivities().size()).isEqualTo(3);
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
@@ -48,6 +48,7 @@ import static gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity.Exclusive
 import static gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity.Inclusive;
 import static gov.nasa.jpl.aerie.constraints.time.Interval.interval;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SimulationFacadeTest {
@@ -173,6 +174,7 @@ public class SimulationFacadeTest {
     final var actAssociatedInSecondRun = plan2.get().getEvaluation().forGoal(goal).getAssociatedActivities();
     assertThat(actAssociatedInSecondRun.size()).isEqualTo(1);
     assertThat(actAssociatedInFirstRun.iterator().next().equalsInProperties(actAssociatedInSecondRun.iterator().next())).isTrue();
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -191,6 +193,7 @@ public class SimulationFacadeTest {
     final var stateQuery = new StateQueryParam(getFruitRes().name, new TimeExpressionConstant(t2));
     final var actual = stateQuery.getValue(facade.getLatestConstraintSimulationResults(), null, horizon.getHor());
     assertThat(actual).isEqualTo(SerializedValue.of(2.9));
+    assertEquals(1, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -293,6 +296,7 @@ public class SimulationFacadeTest {
     final var solver = new PrioritySolver(this.problem);
     final var plan = solver.getNextSolution().orElseThrow();
     assertTrue(TestUtility.containsActivity(plan, t2, t2, actTypePeel));
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 
@@ -335,6 +339,7 @@ public class SimulationFacadeTest {
 
     assertTrue(TestUtility.containsExactlyActivity(plan, act2));
     assertTrue(TestUtility.doesNotContainActivity(plan, act1));
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -376,5 +381,6 @@ public class SimulationFacadeTest {
     final var plan = solver.getNextSolution().orElseThrow();
     assertTrue(TestUtility.containsExactlyActivity(plan, act2));
     assertTrue(TestUtility.doesNotContainActivity(plan, act1));
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
@@ -73,6 +73,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -108,6 +109,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
+    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -143,6 +145,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
+    assertEquals(5, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -178,6 +181,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
+    assertEquals(5, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -226,6 +230,7 @@ public class TestApplyWhen {
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -271,7 +276,7 @@ public class TestApplyWhen {
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
-
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -317,6 +322,7 @@ public class TestApplyWhen {
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -364,6 +370,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(8, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(17, Duration.SECONDS), activityType)); //interval (len 4) needs to be 2 longer than the recurrence repeatingEvery (len 3)
+    assertEquals(5, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -411,6 +418,7 @@ public class TestApplyWhen {
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     //assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));  //should fail, won't work if cutoff mid-activity - interval expected to be longer than activity duration!!!
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -445,6 +453,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
+    assertEquals(13, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 
@@ -488,6 +497,7 @@ public class TestApplyWhen {
     assertEquals(plan.get().getActivitiesByTime().stream()
                      .map(SchedulingActivityDirective::duration)
                      .reduce(Duration.ZERO, Duration::plus), Duration.of(4, Duration.SECOND)); //1 gets added, then throws 4 warnings meaning it tried to schedule 5 in total, not the expected 8...
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -537,7 +547,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(3, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(13, Duration.SECONDS), activityType));
-
+    assertEquals(5, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -588,6 +598,7 @@ public class TestApplyWhen {
     //assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(7, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(9, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -633,6 +644,7 @@ public class TestApplyWhen {
                             .reduce(Duration.ZERO, Duration::plus);
     assertTrue(size >= 3 && size <= 10);
     assertTrue(totalDuration.dividedBy(Duration.SECOND) >= 16 && totalDuration.dividedBy(Duration.SECOND) <= 19);
+    assertEquals(17, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 
@@ -686,7 +698,7 @@ public class TestApplyWhen {
       logger.debug(a.startOffset().toString() + ", " + a.duration().toString());
     }
     assertEquals(4, plan.get().getActivitiesByTime().size());
-
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -741,7 +753,7 @@ public class TestApplyWhen {
       logger.debug(a.startOffset().toString() + ", " + a.duration().toString());
     }
     assertEquals(5, plan.get().getActivitiesByTime().size());
-
+    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -805,6 +817,7 @@ public class TestApplyWhen {
     assertEquals(2, plan.get().getActivitiesByTime()
                         .stream().filter($ -> $.duration().dividedBy(Duration.SECOND) == 2).toList()
                         .size());
+    assertEquals(6, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -870,7 +883,7 @@ public class TestApplyWhen {
 
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(1, Duration.SECONDS), actTypeA));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(14, Duration.SECONDS), actTypeA));
-
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -945,6 +958,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(10, Duration.SECONDS), actTypeB));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(16, Duration.SECONDS), actTypeB));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(25, Duration.SECONDS), actTypeB));
+    assertEquals(5, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -1013,6 +1027,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(1, Duration.SECONDS), actTypeA));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(8, Duration.SECONDS), actTypeA));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(10, Duration.SECONDS), actTypeA));
+    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -1080,6 +1095,7 @@ public class TestApplyWhen {
     assertFalse(TestUtility.activityStartingAtTime(plan.get(), Duration.of(5, Duration.SECONDS), actTypeA));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(9, Duration.SECONDS), actTypeA));
     assertFalse(TestUtility.activityStartingAtTime(plan.get(), Duration.of(14, Duration.SECONDS), actTypeA));
+    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -1134,6 +1150,7 @@ public class TestApplyWhen {
       logger.debug(a.startOffset().toString() + ", " + a.duration().toString());
     }
     assertEquals(5, plan.get().getActivitiesByTime().size());
+    assertEquals(6, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -1210,6 +1227,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(13, Duration.SECONDS), activityTypeDependent));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(15, Duration.SECONDS), activityTypeDependent));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(17, Duration.SECONDS), activityTypeDependent));
+    assertEquals(11, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -1287,7 +1305,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(13, Duration.SECONDS), activityTypeDependent));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(15, Duration.SECONDS), activityTypeDependent));
     assertFalse(TestUtility.activityStartingAtTime(plan.get(), Duration.of(17, Duration.SECONDS), activityTypeDependent));
-
+    assertEquals(10, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -1372,6 +1390,6 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(13, Duration.SECONDS), activityTypeDependent));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(15, Duration.SECONDS), activityTypeDependent));
     assertFalse(TestUtility.activityStartingAtTime(plan.get(), Duration.of(17, Duration.SECONDS), activityTypeDependent));
-
+    assertEquals(10, problem.getSimulationFacade().countSimulationRestarts());
   }
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
@@ -53,5 +53,6 @@ public class TestCardinalityGoal {
     assertEquals(plan.get().getActivitiesByTime().stream()
                      .map(SchedulingActivityDirective::duration)
                      .reduce(Duration.ZERO, Duration::plus), Duration.of(12, Duration.SECOND));
+    assertEquals(7, problem.getSimulationFacade().countSimulationRestarts());
   }
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -48,6 +49,7 @@ public class TestRecurrenceGoal {
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
+    assertEquals(5, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -83,6 +85,7 @@ public class TestRecurrenceGoal {
     catch (Exception e) {
       fail(e.getMessage());
     }
+    assertEquals(1, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoalExtended.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoalExtended.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -51,6 +52,7 @@ public class TestRecurrenceGoalExtended {
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
+    assertEquals(5, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   /**
@@ -82,6 +84,7 @@ public class TestRecurrenceGoalExtended {
 
     var plan = solver.getNextSolution().orElseThrow();
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType) && (plan.getActivities().size() == 1));
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   /**
@@ -113,6 +116,7 @@ public class TestRecurrenceGoalExtended {
 
     var plan = solver.getNextSolution().orElseThrow();
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType));
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   /**
@@ -150,6 +154,7 @@ public class TestRecurrenceGoalExtended {
     var plan = solver.getNextSolution().orElseThrow();
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(1, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(8, Duration.SECONDS), activityType));
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 
@@ -182,6 +187,7 @@ public class TestRecurrenceGoalExtended {
 
     var plan = solver.getNextSolution().orElseThrow();
     assertTrue(TestUtility.emptyPlan(plan));
+    assertEquals(1, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 
@@ -214,6 +220,7 @@ public class TestRecurrenceGoalExtended {
 
     var plan = solver.getNextSolution().orElseThrow();
     assertTrue(TestUtility.emptyPlan(plan));
+    assertEquals(1, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 
@@ -265,5 +272,6 @@ public class TestRecurrenceGoalExtended {
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(5, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(10, Duration.SECONDS), activityType));
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(15, Duration.SECONDS), activityType));
+    assertEquals(5, problem.getSimulationFacade().countSimulationRestarts());
   }
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUnsatisfiableCompositeGoals.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUnsatisfiableCompositeGoals.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestUnsatisfiableCompositeGoals {
 
@@ -104,7 +105,8 @@ public class TestUnsatisfiableCompositeGoals {
     Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeBar));
     Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeBasic));
     Assertions.assertEquals(plan.getActivities().size(), 5);
-    }
+    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
+  }
 
   @Test
   public void testAndWithBackTrack(){
@@ -136,6 +138,7 @@ public class TestUnsatisfiableCompositeGoals {
     Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t1hr, actTypeControllable));
     Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeControllable));
     Assertions.assertEquals(plan.getActivities().size(), 2);
+    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -175,6 +178,7 @@ public class TestUnsatisfiableCompositeGoals {
     Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeBar));
     Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeBasic));
     Assertions.assertEquals(plan.getActivities().size(), 4);
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -209,6 +213,7 @@ public class TestUnsatisfiableCompositeGoals {
     Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t1hr, actTypeControllable));
     Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeControllable));
     Assertions.assertEquals(plan.getActivities().size(), 2);
+    assertEquals(1, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -250,5 +255,6 @@ public class TestUnsatisfiableCompositeGoals {
 
     var plan = solver.getNextSolution().orElseThrow();
     assertThat(plan.getActivities().size()).isEqualTo(0);
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/UncontrollableDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/UncontrollableDurationTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UncontrollableDurationTest {
@@ -95,6 +96,7 @@ public class UncontrollableDurationTest {
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT0S"), planningHorizon.fromStart("PT1M29S"), problem.getActivityType("SolarPanelNonLinear")));
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT16M40S"), planningHorizon.fromStart("PT18M9S"), problem.getActivityType("SolarPanelNonLinear")));
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT33M20S"), planningHorizon.fromStart("PT34M49S"), problem.getActivityType("SolarPanelNonLinear")));
+    assertEquals(31, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -147,6 +149,7 @@ public class UncontrollableDurationTest {
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT33M20S"), planningHorizon.fromStart("PT36M47S"), problem.getActivityType("SolarPanelNonLinearTimeDependent")));
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT0S"), planningHorizon.fromStart("PT2M21S"), problem.getActivityType("SolarPanelNonLinearTimeDependent")));
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT16M40S"), planningHorizon.fromStart("PT17M18S"), problem.getActivityType("SolarPanelNonLinearTimeDependent")));
+    assertEquals(41, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -184,6 +187,7 @@ public class UncontrollableDurationTest {
                                             planningHorizon.fromStart("PT0.000004S"),
                                             planningHorizon.fromStart("PT0.000004S"),
                                             problem.getActivityType("ZeroDurationUncontrollableActivity")));
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -219,6 +223,7 @@ public class UncontrollableDurationTest {
                                             planningHorizon.fromStart("PT120S"),
                                             planningHorizon.fromStart("PT120S"),
                                             problem.getActivityType("LateRiser")));
+    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/AnchorSchedulerTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/AnchorSchedulerTest.java
@@ -222,6 +222,7 @@ public class AnchorSchedulerTest {
       final var actualSimResults = driver.getSimulationResultsUpTo(planStart, tenDays);
 
       assertEqualsSimulationResults(expectedSimResults, actualSimResults);
+      assertEquals(2, driver.getCountSimulationRestarts());
     }
 
     @Test
@@ -334,6 +335,7 @@ public class AnchorSchedulerTest {
       final var actualSimResults = driver.getSimulationResults(planStart);
 
       assertEqualsSimulationResults(expectedSimResults, actualSimResults);
+      assertEquals(1, driver.getCountSimulationRestarts());
     }
 
     @Test
@@ -576,6 +578,7 @@ public class AnchorSchedulerTest {
 
       // We have examined all the children
       assertTrue(childSimulatedActivities.isEmpty());
+      assertEquals(2, driver.getCountSimulationRestarts());
     }
 
     @Test
@@ -620,6 +623,7 @@ public class AnchorSchedulerTest {
 
       assertEquals(3906, expectedSimResults.simulatedActivities.size());
       assertEqualsSimulationResults(expectedSimResults, actualSimResults);
+      assertEquals(2, driver.getCountSimulationRestarts());
     }
   }
 


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
We have been working on trying to "improve" the performance of the scheduler for some time (currently finishing #748). I got frustrated at how to measure these improvements. In this PR, I am adding a simple restart counter to the scheduler simulation so we can track whether our changes improve the performance or not.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I have updated most of the scheduler-driver tests to track this performance metric. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No impact.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Benchmark tasks on GH ?