### PR TITLE
Load simulation results from DB before scheduling + performance improvements 

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Interval.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Interval.java
@@ -288,6 +288,14 @@ public final class Interval implements Comparable<Interval>{
     return 0;
   }
 
+  public static boolean hasSameStart(Interval x, Interval y){
+    return compareStartToStart(x,y) == 0;
+  }
+
+  public static boolean hasSameEnd(Interval x, Interval y){
+    return compareEndToEnd(x,y) == 0;
+  }
+
   public static int compareStartToEnd(final Interval x, final Interval y) {
     // First, order by absolute time.
     if (!x.start.isEqualTo(y.end)) {

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
@@ -496,14 +496,18 @@ public final class Windows implements Iterable<Segment<Boolean>>, IntervalContai
     boolean boundsStartContained = false;
     boolean boundsEndContained = false;
     if(this.segments.size() == 1){
-      if (segments.get(0).interval().contains(bounds.start)) boundsStartContained = true;
-      if (segments.get(0).interval().contains(bounds.end)) boundsEndContained = true;
+      if (segments.get(0).interval().contains(bounds.start) ||
+          Interval.hasSameStart(segments.get(0).interval(), bounds)) boundsStartContained = true;
+      if (segments.get(0).interval().contains(bounds.end) ||
+          Interval.hasSameEnd(segments.get(0).interval(), bounds)) boundsEndContained = true;
     }
     for (int i = 0; i < this.segments.size() - 1; i++) {
       final var leftInterval = this.segments.get(i).interval();
       final var rightInterval = this.segments.get(i+1).interval();
-      if (leftInterval.contains(bounds.start) || rightInterval.contains(bounds.start)) boundsStartContained = true;
-      if (leftInterval.contains(bounds.end) || rightInterval.contains(bounds.end)) boundsEndContained = true;
+      if((leftInterval.contains(bounds.start) || rightInterval.contains(bounds.start)) ||
+         Interval.hasSameStart(leftInterval, bounds) || Interval.hasSameStart(rightInterval, bounds)) boundsStartContained = true;
+      if((leftInterval.contains(bounds.end) || rightInterval.contains(bounds.end)) ||
+         Interval.hasSameEnd(leftInterval, bounds) || Interval.hasSameEnd(rightInterval, bounds)) boundsEndContained = true;
       if (leftInterval.isStrictlyBefore(bounds)) continue;
       if (rightInterval.isStrictlyAfter(bounds)) continue;
       if (!leftInterval.adjacent(rightInterval)) {

--- a/e2e-tests/src/tests/scheduler-with-sim.test.ts
+++ b/e2e-tests/src/tests/scheduler-with-sim.test.ts
@@ -1,0 +1,319 @@
+
+import {expect, test} from "@playwright/test";
+import req, {awaitScheduling, awaitSimulation} from "../utilities/requests.js";
+import time from "../utilities/time.js";
+
+/*
+This is testing the check on Plan Revision before loading initial simulation results. We inject results associated with an old plan revision.
+In these results, there is only one GrowBanana activity instead of the actual 2 present in the latest plan revision.
+A coexistence goal attaching to GrowBanana activities shows that the scheduler did not use the stale sim results.
+*/
+test.describe.serial('Scheduling with initial sim results', () => {
+  const rd = Math.random() * 100;
+  const plan_start_timestamp = "2021-001T00:00:00.000";
+  const plan_end_timestamp = "2021-001T12:00:00.000";
+
+  test('Main', async ({ request }) => {
+    //upload bananation jar
+    const jar_id = await req.uploadJarFile(request);
+
+    const model: MissionModelInsertInput = {
+      jar_id,
+      mission: 'aerie_e2e_tests' + rd,
+      name: 'Banananation (e2e tests)' + rd,
+      version: '0.0.0' + rd,
+    };
+    const mission_model_id = await req.createMissionModel(request, model);
+    //delay for generation
+    await delay(2000);
+    const plan_input : CreatePlanInput = {
+      model_id : mission_model_id,
+      name : 'test_plan' + rd,
+      start_time : plan_start_timestamp,
+      duration : time.getIntervalFromDoyRange(plan_start_timestamp, plan_end_timestamp)
+    };
+    const plan_id = await req.createPlan(request, plan_input);
+
+    const firstGrowBananaToInsert : ActivityInsertInput =
+        {
+          //no arguments to ensure that the scheduler is getting effective arguments
+          arguments : {},
+          plan_id: plan_id,
+          type : "GrowBanana",
+          start_offset : "1h"
+        };
+
+    await req.insertActivity(request, firstGrowBananaToInsert);
+
+    await awaitSimulation(request, plan_id);
+
+    const secondGrowBananaToInsert : ActivityInsertInput =
+        {
+          //no arguments to ensure that the scheduler is getting effective arguments
+          arguments : {},
+          plan_id: plan_id,
+          type : "GrowBanana",
+          start_offset : "2h"
+        };
+
+    await req.insertActivity(request, secondGrowBananaToInsert);
+
+    const schedulingGoal1 : SchedulingGoalInsertInput =
+        {
+          description: "Test goal",
+          model_id: mission_model_id,
+          name: "ForEachGrowPeel"+rd,
+          definition: `export default function myGoal() {
+                  return Goal.CoexistenceGoal({
+                    forEach: ActivityExpression.ofType(ActivityType.GrowBanana),
+                    activityTemplate: ActivityTemplates.BiteBanana({
+                      biteSize: 1,
+                    }),
+                    startsAt:TimingConstraint.singleton(WindowProperty.END)
+                  })
+                }`
+        };
+
+    const first_goal_id = await req.insertSchedulingGoal(request, schedulingGoal1);
+
+    let plan_revision = await req.getPlanRevision(request, plan_id);
+
+    const schedulingSpecification : SchedulingSpecInsertInput = {
+      // @ts-ignore
+      horizon_end: plan_end_timestamp,
+      horizon_start: plan_start_timestamp,
+      plan_id : plan_id,
+      plan_revision : plan_revision,
+      simulation_arguments : {},
+      analysis_only: false
+    }
+    const scheduling_specification_id = await req.insertSchedulingSpecification(request, schedulingSpecification);
+
+    const priority = 0;
+    const specGoal: SchedulingSpecGoalInsertInput = {
+      goal_id: first_goal_id,
+      priority: priority,
+      specification_id: scheduling_specification_id,
+    };
+    await req.createSchedulingSpecGoal(request, specGoal);
+
+    const { status, datasetId } = await awaitScheduling(request, scheduling_specification_id);
+
+    expect(status).toEqual("complete")
+    expect(datasetId).not.toBeNull();
+
+    const plan = await req.getPlan(request, plan_id)
+    expect(plan.activity_directives.length).toEqual(4);
+
+    //delete plan
+    const deleted_plan_id = await req.deletePlan(request, plan_id);
+    expect(deleted_plan_id).not.toBeNull();
+    expect(deleted_plan_id).toBeDefined();
+    expect(deleted_plan_id).toEqual(plan_id);
+
+    //delete mission model
+    const deleted_mission_model_id = await req.deleteMissionModel(request, mission_model_id)
+    expect(deleted_mission_model_id).not.toBeNull();
+    expect(deleted_mission_model_id).toBeDefined();
+    expect(deleted_mission_model_id).toEqual(mission_model_id);
+  });
+
+
+  /* In this test, we load simulation results with the current plan revision but with a different sim config. If the
+   injected results are picked up, the goal will not be satisfied and the number of activities will stay at its original value.
+   */
+  test('Scheduling sim results 2', async ({ request }) => {
+    const rd = Math.random() * 100;
+    const plan_start_timestamp = "2021-001T00:00:00.000";
+    const plan_end_timestamp = "2021-001T12:00:00.000";
+
+    //upload bananation jar
+    const jar_id = await req.uploadJarFile(request);
+
+    const model: MissionModelInsertInput = {
+      jar_id,
+      mission: 'aerie_e2e_tests' + rd,
+      name: 'Banananation (e2e tests)' + rd,
+      version: '0.0.0' + rd,
+    };
+    const mission_model_id = await req.createMissionModel(request, model);
+    //delay for generation
+    await delay(2000);
+    const plan_input : CreatePlanInput = {
+      model_id : mission_model_id,
+      name : 'test_plan' + rd,
+      start_time : plan_start_timestamp,
+      duration : time.getIntervalFromDoyRange(plan_start_timestamp, plan_end_timestamp)
+    };
+    const plan_id = await req.createPlan(request, plan_input);
+
+    const simulation_id = await req.getSimulationId(request, plan_id);
+
+    const simulation_template : InsertSimulationTemplateInput = {
+      model_id: mission_model_id,
+      arguments: {
+        "initialPlantCount": 400,
+      },
+      description: 'Template for Plan ' +plan_id
+    };
+
+    await req.insertAndAssociateSimulationTemplate(request, simulation_template, simulation_id);
+
+    await awaitSimulation(request, plan_id);
+
+    const empty_simulation_template : InsertSimulationTemplateInput = {
+      model_id: mission_model_id,
+      arguments: {
+      },
+      description: 'Template for Plan ' +plan_id
+    };
+
+    await req.insertAndAssociateSimulationTemplate(request, empty_simulation_template, simulation_id);
+
+    const schedulingGoal1 : SchedulingGoalInsertInput =
+        {
+          description: "Test goal",
+          model_id: mission_model_id,
+          name: "ForEachPlanLessThan300"+rd,
+          definition: `export default () => Goal.CoexistenceGoal({
+            forEach: Real.Resource("/plant").lessThan(300),
+            activityTemplate: ActivityTemplates.GrowBanana({quantity: 10, growingDuration: Temporal.Duration.from({minutes:1}) }),
+            startsAt: TimingConstraint.singleton(WindowProperty.START)
+          })`
+        };
+
+    const first_goal_id = await req.insertSchedulingGoal(request, schedulingGoal1);
+
+    const plan_revision = await req.getPlanRevision(request, plan_id);
+
+    const schedulingSpecification : SchedulingSpecInsertInput = {
+      // @ts-ignore
+      horizon_end: plan_end_timestamp,
+      horizon_start: plan_start_timestamp,
+      plan_id : plan_id,
+      plan_revision : plan_revision,
+      simulation_arguments : {},
+      analysis_only: false
+    }
+    const specification_id = await req.insertSchedulingSpecification(request, schedulingSpecification);
+
+    const priority = 0;
+    const specGoal: SchedulingSpecGoalInsertInput = {
+      goal_id: first_goal_id,
+      priority: priority,
+      specification_id: specification_id,
+    };
+    await req.createSchedulingSpecGoal(request, specGoal);
+
+    await awaitScheduling(request, specification_id);
+
+    const plan = await req.getPlan(request, plan_id)
+    expect(plan.activity_directives.length).toEqual(1);
+
+    //delete plan
+    const deleted_plan_id = await req.deletePlan(request, plan_id);
+    expect(deleted_plan_id).not.toBeNull();
+    expect(deleted_plan_id).toBeDefined();
+    expect(deleted_plan_id).toEqual(plan_id);
+
+    //delete mission model
+    const deleted_mission_model_id = await req.deleteMissionModel(request, mission_model_id)
+    expect(deleted_mission_model_id).not.toBeNull();
+    expect(deleted_mission_model_id).toBeDefined();
+    expect(deleted_mission_model_id).toEqual(mission_model_id);
+  });
+
+  /* In this test, we inject simulation results to test that the scheduler is loading them properly. If they are picked up,
+  there should be no activity in the plan (plant>300). Otherwise, there should be one activity.
+   */
+  test('Scheduling sim results 3', async ({ request }) => {
+    const rd = Math.random() * 100;
+    const plan_start_timestamp = "2021-001T00:00:00.000";
+    const plan_end_timestamp = "2021-001T12:00:00.000";
+    //upload bananation jar
+    const jar_id = await req.uploadJarFile(request);
+
+    const model: MissionModelInsertInput = {
+      jar_id,
+      mission: 'aerie_e2e_tests' + rd,
+      name: 'Banananation (e2e tests)' + rd,
+      version: '0.0.0' + rd,
+    };
+    const mission_model_id = await req.createMissionModel(request, model);
+    //delay for generation
+    await delay(2000);
+    const plan_input : CreatePlanInput = {
+      model_id : mission_model_id,
+      name : 'test_plan' + rd,
+      start_time : plan_start_timestamp,
+      duration : time.getIntervalFromDoyRange(plan_start_timestamp, plan_end_timestamp)
+    };
+    const plan_id = await req.createPlan(request, plan_input);
+
+    const simId = await req.getSimulationId(request, plan_id);
+    let plan_revision = await req.getPlanRevision(request, plan_id);
+
+    const datasetId = await req.insertSimulationDataset(
+        request,
+        simId,
+        plan_start_timestamp,
+        plan_end_timestamp,
+        "success",
+        {},
+        plan_revision);
+
+    const profileId = await req.insertProfile(request, datasetId, "12h", "/plant", { "type": "discrete", "schema": { "type": "int" } });
+    await req.insertProfileSegment(request, datasetId, 400, false, profileId, "0h");
+
+    const schedulingGoal1 : SchedulingGoalInsertInput =
+        {
+          description: "Test goal",
+          model_id: mission_model_id,
+          name: "ForEachPlanLessThan300"+rd,
+          definition: `export default () => Goal.CoexistenceGoal({
+            forEach: Real.Resource("/plant").lessThan(300),
+            activityTemplate: ActivityTemplates.GrowBanana({quantity: 10, growingDuration: Temporal.Duration.from({minutes:1}) }),
+            startsAt: TimingConstraint.singleton(WindowProperty.START)
+          })`
+        };
+
+    const first_goal_id = await req.insertSchedulingGoal(request, schedulingGoal1);
+
+    plan_revision = await req.getPlanRevision(request, plan_id);
+
+    const schedulingSpecification : SchedulingSpecInsertInput = {
+      // @ts-ignore
+      horizon_end: plan_end_timestamp,
+      horizon_start: plan_start_timestamp,
+      plan_id : plan_id,
+      plan_revision : plan_revision,
+      simulation_arguments : {},
+      analysis_only: false
+    }
+    const specification_id = await req.insertSchedulingSpecification(request, schedulingSpecification);
+
+    const priority = 0;
+    const specGoal: SchedulingSpecGoalInsertInput = {
+      goal_id: first_goal_id,
+      priority: priority,
+      specification_id: specification_id,
+    };
+    await req.createSchedulingSpecGoal(request, specGoal);
+
+    await awaitScheduling(request, specification_id);
+
+    const plan = await req.getPlan(request, plan_id)
+    expect(plan.activity_directives.length).toEqual(0);
+
+    //delete plan
+    await req.deletePlan(request, plan_id);
+
+    //delete mission model
+    await req.deleteMissionModel(request, mission_model_id)
+  });
+});
+
+
+function delay(ms: number) {
+  return new Promise( resolve => setTimeout(resolve, ms) );
+}

--- a/e2e-tests/src/tests/scheduler.test.ts
+++ b/e2e-tests/src/tests/scheduler.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import req from '../utilities/requests.js';
+import req, {awaitScheduling} from '../utilities/requests.js';
 import time from '../utilities/time.js';
 
 const eqSet = (xs, ys) =>
@@ -173,34 +173,13 @@ test.describe.serial('Scheduling', () => {
   });
 
   test('Run scheduling', async ({ request }) => {
-    let status_local: string;
-    let analysisId_local: number;
-    const { reason, status, analysisId } = await req.schedule(request, specification_id);
-    expect(status).not.toBeNull();
-    expect(status).toBeDefined();
+    const schedulingResults = await awaitScheduling(request, specification_id);
+    const { analysisId, status, datasetId } = schedulingResults;
+    dataset_id = datasetId
+    expect(status).toEqual("complete")
     expect(analysisId).not.toBeNull();
-    expect(analysisId).toBeDefined();
+    expect(datasetId).not.toBeNull();
     expect(typeof analysisId).toEqual("number")
-    analysisId_local = analysisId;
-    const max_it = 10;
-    let it = 0;
-    let reason_local: string;
-    while (it++ < max_it && (status == 'pending' || status == 'incomplete')) {
-      const { reason, status, analysisId, datasetId } = await req.schedule(request, specification_id);
-      status_local = status;
-      reason_local = reason;
-      expect(status).not.toBeNull();
-      expect(status).toBeDefined();
-      dataset_id = datasetId
-      await delay(1000);
-    }
-    if (status_local == "failed") {
-      console.error(reason_local)
-      throw new Error(reason_local);
-    }
-    expect(status_local).toEqual("complete")
-    expect(analysisId_local).toEqual(analysisId)
-    expect(dataset_id).not.toBeNull();
   });
 
   test('Verify posting of simulation results', async ({ request }) => {

--- a/e2e-tests/src/utilities/gql.ts
+++ b/e2e-tests/src/utilities/gql.ts
@@ -273,6 +273,46 @@ const gql = {
     }
   `,
 
+  INSERT_SPAN:`#graphql
+  mutation InsertSpan(
+    $parentId: Int!,
+    $duration: interval,
+    $datasetId: Int!,
+    $type: String,
+    $startOffset: interval,
+    $attributes: jsonb
+  ){
+  insert_span_one(object: {parent_id: $parentId, duration: $duration, dataset_id: $datasetId, type: $type, start_offset: $startOffset, attributes: $attributes}) {
+    id
+  }
+}
+`,
+
+INSERT_SIMULATION_DATASET:`#graphql
+    mutation InsertSimulationDataset($simulationDatasetInsertInput:simulation_dataset_insert_input!
+      ){
+      insert_simulation_dataset_one(object: $simulationDatasetInsertInput) {
+        dataset_id
+      }
+    }
+  `,
+
+  INSERT_PROFILE: `#graphql
+  mutation insertProfile($datasetId: Int!, $duration:interval, $name:String, $type:jsonb){
+    insert_profile_one(object: {dataset_id: $datasetId, duration: $duration, name: $name, type: $type}) {
+      id
+    }
+  }
+  `,
+
+  INSERT_PROFILE_SEGMENT:`#graphql
+  mutation insertProfileSegment($datasetId: Int!, $dynamics:jsonb, $isGap: Boolean, $profileId:Int!, $startOffset:interval){
+    insert_profile_segment_one(object: {dataset_id: $datasetId, dynamics: $dynamics, is_gap: $isGap, profile_id: $profileId, start_offset: $startOffset}){
+      dataset_id
+    }
+  }
+  `,
+
   INSERT_SIMULATION_TEMPLATE: `#graphql
     mutation CreateSimulationTemplate($simulationTemplateInsertInput: simulation_template_insert_input!) {
       insert_simulation_template_one(object: $simulationTemplateInsertInput) {

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
@@ -72,6 +72,10 @@ public final class MissionModel<Model> {
     return this.topics;
   }
 
+  public boolean hasDaemons(){
+    return !this.daemons.isEmpty();
+  }
+
   public record SerializableTopic<EventType> (
       String name,
       Topic<EventType> topic,

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/conflicts/MissingActivityTemplateConflict.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/conflicts/MissingActivityTemplateConflict.java
@@ -2,12 +2,14 @@ package gov.nasa.jpl.aerie.scheduler.conflicts;
 
 import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate;
 import gov.nasa.jpl.aerie.scheduler.goals.ActivityTemplateGoal;
 
+import java.util.Optional;
+
 /**
  * describes plan problem due to lack of a matching instance for a template
- *
  * such conflicts are typically addressed by scheduling additional activities
  * using the corresponding creation template
  */
@@ -16,16 +18,20 @@ public class MissingActivityTemplateConflict extends MissingActivityConflict {
   /**
    * ctor creates a new conflict regarding a missing activity
    *
-   * @param goal IN STORED the dissatisfied goal that issued the conflict
-   * @param temporalContext IN STORED the times in the plan when the goal was
-   *     disatisfied enough to induce this conflict (including just the
-   *     desired start times of the activity, not necessarily the end time)
+   * @param goal  the dissatisfied goal that issued the conflict
+   * @param temporalContext  the times in the plan when the goal was
+   * @param template  desired activity template
+   * @param evaluationEnvironment the evaluation environment at the time of creation so variables can be retrieved later at instantiation
+   * @param cardinality the desired number of times the activity template should be inserted
+   * @param totalDuration the desired total duration
    */
   public MissingActivityTemplateConflict(
       ActivityTemplateGoal goal,
       Windows temporalContext,
       ActivityCreationTemplate template,
-      EvaluationEnvironment evaluationEnvironment)
+      EvaluationEnvironment evaluationEnvironment,
+      int cardinality,
+      Optional<Duration> totalDuration)
   {
     super(goal, evaluationEnvironment);
 
@@ -35,6 +41,22 @@ public class MissingActivityTemplateConflict extends MissingActivityConflict {
     }
     this.temporalContext = temporalContext;
     this.template = template;
+    this.cardinality = cardinality;
+    this.totalDuration = totalDuration;
+  }
+
+  //the number of times the activity needs to be inserted
+  int cardinality;
+
+  //the desired total duration over the number of activities needed
+  Optional<Duration> totalDuration;
+
+  public int getCardinality(){
+    return cardinality;
+  }
+
+  public Optional<Duration> getTotalDuration(){
+    return totalDuration;
   }
 
   /**

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CardinalityGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CardinalityGoal.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -194,17 +195,15 @@ public class CardinalityGoal extends ActivityTemplateGoal {
           conflicts.add(new MissingAssociationConflict(this, List.of(act)));
         }
       }
-      //1) solve occurence part, we just need a certain number of activities
-      for (int i = 0; i < nbToSchedule; i++) {
-        conflicts.add(new MissingActivityTemplateConflict(this, subIntervalWindows, this.desiredActTemplate, new EvaluationEnvironment()));
-      }
-      /*
-       * 2) solve duration part: we can't assume stuff about duration, we post one conflict. The scheduler will solve this conflict by inserting one
-       * activity then the conflict will be reevaluated and if the scheduled duration so far is less than needed, another
-       * conflict will be posted and so on
-       * */
-      if (nbToSchedule == 0 && durToSchedule.isPositive()) {
-        conflicts.add(new MissingActivityTemplateConflict(this, subIntervalWindows, this.desiredActTemplate, new EvaluationEnvironment()));
+
+      if(nbToSchedule>0 || durToSchedule.isPositive()) {
+        conflicts.add(new MissingActivityTemplateConflict(
+            this,
+            subIntervalWindows,
+            this.desiredActTemplate,
+            new EvaluationEnvironment(),
+            nbToSchedule,
+            durToSchedule.isPositive() ? Optional.of(durToSchedule) : Optional.empty()));
       }
     }
 

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CoexistenceGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CoexistenceGoal.java
@@ -272,7 +272,7 @@ public class CoexistenceGoal extends ActivityTemplateGoal {
       if (!alreadyOneActivityAssociated) {
         //create conflict if no matching target activity found
         if (existingActs.isEmpty()) {
-          conflicts.add(new MissingActivityTemplateConflict(this, this.temporalContext.evaluate(simulationResults), temp, createEvaluationEnvironmentFromAnchor(window)));
+          conflicts.add(new MissingActivityTemplateConflict(this, this.temporalContext.evaluate(simulationResults), temp, createEvaluationEnvironmentFromAnchor(window), 1, Optional.empty()));
         } else {
           conflicts.add(new MissingAssociationConflict(this, missingActAssociations));
         }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/RecurrenceGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/RecurrenceGoal.java
@@ -16,6 +16,7 @@ import gov.nasa.jpl.aerie.scheduler.conflicts.MissingAssociationConflict;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * describes the desired recurrence of an activity every time period
@@ -211,7 +212,7 @@ public class RecurrenceGoal extends ActivityTemplateGoal {
     ) {
       final var windows = new Windows(false).set(Interval.betweenClosedOpen(intervalT.minus(recurrenceInterval.max), Duration.min(intervalT, end)), true);
       if(windows.iterateEqualTo(true).iterator().hasNext()){
-        conflicts.add(new MissingActivityTemplateConflict(this, windows, this.getActTemplate(), new EvaluationEnvironment()));
+        conflicts.add(new MissingActivityTemplateConflict(this, windows, this.getActTemplate(), new EvaluationEnvironment(), 1, Optional.empty()));
       }
       else{
         System.out.println();

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationData.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationData.java
@@ -1,0 +1,11 @@
+package gov.nasa.jpl.aerie.scheduler.simulation;
+
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
+import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
+
+import java.util.Collection;
+
+public record SimulationData(
+    SimulationResults driverResults,
+    gov.nasa.jpl.aerie.constraints.model.SimulationResults constraintsResults,
+    Collection<SchedulingActivityDirective> activitiesInPlan){}

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -110,6 +110,7 @@ public class SimulationFacade implements AutoCloseable{
   public Map<SchedulingActivityDirective, SchedulingActivityDirectiveId> getAllChildActivities(final Duration endTime)
   throws SimulationException
   {
+    if(insertedActivities.size() == 0) return Map.of();
     computeSimulationResultsUntil(endTime);
     final Map<SchedulingActivityDirective, SchedulingActivityDirectiveId> childActivities = new HashMap<>();
     this.lastSimDriverResults.simulatedActivities.forEach( (activityInstanceId, activity) -> {

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -241,7 +241,7 @@ public class SimulationFacade implements AutoCloseable{
       //compare references
       if(results != lastSimDriverResults) {
         //simulation results from the last simulation, as converted for use by the constraint evaluation engine
-        lastSimConstraintResults = SimulationResultsConverter.convertToConstraintModelResults(results, planningHorizon.getAerieHorizonDuration());
+        lastSimConstraintResults = SimulationResultsConverter.convertToConstraintModelResults(results);
         lastSimDriverResults = results;
       }
     } catch (Exception e){

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -47,7 +47,6 @@ public class SimulationFacade implements AutoCloseable{
   private final Map<SchedulingActivityDirectiveId, ActivityDirectiveId>
       planActDirectiveIdToSimulationActivityDirectiveId = new HashMap<>();
   private final Map<SchedulingActivityDirective, ActivityDirective> insertedActivities;
-  private static final Duration MARGIN = Duration.of(5, MICROSECONDS);
   //counts the total number of simulation restarts, used as performance metric in the scheduler
   private int pastSimulationRestarts;
 
@@ -149,7 +148,7 @@ public class SimulationFacade implements AutoCloseable{
     }
     final var allActivitiesToSimulate = new ArrayList<>(activitiesToAdd);
     //reset resumable simulation
-    if(atLeastOneActualRemoval || earliestActStartTime.shorterThan(this.driver.getCurrentSimulationEndTime())){
+    if(atLeastOneActualRemoval || earliestActStartTime.noLongerThan(this.driver.getCurrentSimulationEndTime())){
       allActivitiesToSimulate.addAll(insertedActivities.keySet());
       insertedActivities.clear();
       planActDirectiveIdToSimulationActivityDirectiveId.clear();
@@ -236,12 +235,8 @@ public class SimulationFacade implements AutoCloseable{
   }
 
   public void computeSimulationResultsUntil(final Duration endTime) throws SimulationException {
-    var endTimeWithMargin = endTime;
-    if(endTime.noLongerThan(Duration.MAX_VALUE.minus(MARGIN))){
-      endTimeWithMargin = endTime.plus(MARGIN);
-    }
     try {
-      final var results = driver.getSimulationResultsUpTo(this.planningHorizon.getStartInstant(), endTimeWithMargin);
+      final var results = driver.getSimulationResultsUpTo(this.planningHorizon.getStartInstant(), endTime);
       //compare references
       if(results != lastSimDriverResults) {
         //simulation results from the last simulation, as converted for use by the constraint evaluation engine

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationResultsConverter.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationResultsConverter.java
@@ -20,17 +20,15 @@ public class SimulationResultsConverter {
    * convert a simulation driver SimulationResult to a constraint evaluation engine SimulationResult
    *
    * @param driverResults the recorded results of a simulation run from the simulation driver
-   * @param planDuration the duration of the plan
    * @return the same results rearranged to be suitable for use by the constraint evaluation engine
    */
-  public static gov.nasa.jpl.aerie.constraints.model.SimulationResults convertToConstraintModelResults(
-      SimulationResults driverResults, Duration planDuration){
+  public static gov.nasa.jpl.aerie.constraints.model.SimulationResults convertToConstraintModelResults(SimulationResults driverResults){
     final var activities =  driverResults.simulatedActivities.entrySet().stream()
                                                              .map(e -> convertToConstraintModelActivityInstance(e.getKey().id(), e.getValue(), driverResults.startTime))
                                                              .collect(Collectors.toList());
     return new gov.nasa.jpl.aerie.constraints.model.SimulationResults(
         driverResults.startTime,
-        Interval.betweenClosedOpen(Duration.ZERO, planDuration),
+        Interval.betweenClosedOpen(Duration.ZERO, driverResults.duration),
         activities,
         Maps.transformValues(driverResults.realProfiles, $ -> LinearProfile.fromSimulatedProfile($.getRight())),
         Maps.transformValues(driverResults.discreteProfiles, $ -> DiscreteProfile.fromSimulatedProfile($.getRight()))

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationResultsConverter.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationResultsConverter.java
@@ -30,7 +30,7 @@ public class SimulationResultsConverter {
                                                              .collect(Collectors.toList());
     return new gov.nasa.jpl.aerie.constraints.model.SimulationResults(
         driverResults.startTime,
-        Interval.between(Duration.ZERO, planDuration),
+        Interval.betweenClosedOpen(Duration.ZERO, planDuration),
         activities,
         Maps.transformValues(driverResults.realProfiles, $ -> LinearProfile.fromSimulatedProfile($.getRight())),
         Maps.transformValues(driverResults.discreteProfiles, $ -> DiscreteProfile.fromSimulatedProfile($.getRight()))

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.scheduler.solver;
 
 import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Segment;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
@@ -114,6 +115,9 @@ public class PrioritySolver implements Solver {
       //on first call to solver; setup fresh solution workspace for problem
       try {
         initializePlan();
+        if(problem.getInitialSimulationResults().isPresent()) {
+          simulationFacade.loadInitialSimResults(problem.getInitialSimulationResults().get());
+        }
       } catch (SimulationFacade.SimulationException e) {
         logger.error("Tried to initializePlan but at least one activity could not be instantiated", e);
         return Optional.empty();
@@ -155,7 +159,7 @@ public class PrioritySolver implements Solver {
       }
       if(checkSimBeforeInsertingActivities) {
         try {
-          simulationFacade.simulateActivity(act);
+          simulationFacade.removeAndInsertActivitiesFromSimulation(List.of(), List.of(act));
         } catch (SimulationFacade.SimulationException e) {
           allGood = false;
           logger.error("Tried to simulate {} but the activity could not be instantiated", act, e);
@@ -178,6 +182,7 @@ public class PrioritySolver implements Solver {
     final var finalSetOfActsInserted = new ArrayList<SchedulingActivityDirective>();
 
     if(allGood) {
+      if(!acts.isEmpty()) simulationFacade.initialSimulationResultsAreStale();
       //update plan with regard to simulation
       for(var act: acts) {
         plan.add(act);
@@ -222,14 +227,7 @@ public class PrioritySolver implements Solver {
 
     evaluation = new Evaluation();
     plan.addEvaluation(evaluation);
-
-    //if backed by real models, initialize the simulation states/resources/profiles for the plan so state queries work
-    if (problem.getMissionModel() != null) {
-      simulationFacade.simulateActivities(plan.getActivities());
-      final var allGeneratedActivities = simulationFacade.getAllChildActivities(problem.getPlanningHorizon().getEndAerie());
-      processNewGeneratedActivities(allGeneratedActivities);
-      pullActivityDurationsIfNecessary();
-    }
+    if(simulationFacade != null) simulationFacade.addInitialPlan(this.plan.getActivitiesByTime());
   }
 
   /**
@@ -528,7 +526,6 @@ public class PrioritySolver implements Solver {
       //determine the best activities to satisfy the conflict
       if (!analysisOnly && (missing instanceof MissingActivityInstanceConflict missingActivityInstanceConflict)) {
         final var acts = getBestNewActivities(missingActivityInstanceConflict);
-        assert acts != null;
         //add the activities to the output plan
         if (!acts.isEmpty()) {
           final var insertionResult = checkAndInsertActs(acts);
@@ -537,9 +534,6 @@ public class PrioritySolver implements Solver {
             evaluation.forGoal(goal).associate(insertionResult.activitiesInserted(), true);
             itConflicts.remove();
             //REVIEW: really association should be via the goal's own query...
-
-            //NB: repropagation of new activity effects occurs on demand
-            //    at next constraint query, if relevant
           }
         }
       }
@@ -560,9 +554,6 @@ public class PrioritySolver implements Solver {
 
               evaluation.forGoal(goal).associate(insertionResult.activitiesInserted(), true);
               //REVIEW: really association should be via the goal's own query...
-
-              //NB: repropagation of new activity effects occurs on demand
-              //    at next constraint query, if relevant
               cardinalityLeft--;
               durationLeft = durationLeft.minus(insertionResult
                                                     .activitiesInserted()
@@ -621,16 +612,8 @@ public class PrioritySolver implements Solver {
     assert goal != null;
     assert plan != null;
     //REVIEW: maybe should have way to request only certain kinds of conflicts
-    var lastSimResults = this.simulationFacade.getLatestConstraintSimulationResults();
-    if (lastSimResults == null || this.checkSimBeforeEvaluatingGoal) {
-      try {
-        this.simulationFacade.computeSimulationResultsUntil(this.problem.getPlanningHorizon().getEndAerie());
-      } catch (SimulationFacade.SimulationException e) {
-        throw new RuntimeException("Exception while running simulation before evaluating conflicts", e);
-      }
-      lastSimResults = this.simulationFacade.getLatestConstraintSimulationResults();
-    }
-    final var rawConflicts = goal.getConflicts(plan, lastSimResults);
+    final var lastSimulationResults = this.getLatestSimResultsUpTo(this.problem.getPlanningHorizon().getEndAerie());
+    final var rawConflicts = goal.getConflicts(plan, lastSimulationResults);
     assert rawConflicts != null;
     return rawConflicts;
   }
@@ -779,16 +762,12 @@ public class PrioritySolver implements Solver {
 
     final var totalDomain = Interval.between(windows.minTrueTimePoint().get().getKey(), windows.maxTrueTimePoint().get().getKey());
     //make sure the simulation results cover the domain
-    try {
-      simulationFacade.computeSimulationResultsUntil(totalDomain.end);
-    } catch (SimulationFacade.SimulationException e) {
-      throw new RuntimeException("Exception while running simulation before evaluating resource constraints", e);
-    }
+    final var latestSimulationResults = this.getLatestSimResultsUpTo(totalDomain.end);
     //iteratively narrow the windows from each constraint
     //REVIEW: could be some optimization in constraint ordering (smallest domain first to fail fast)
     for (final var constraint : constraints) {
       //REVIEW: loop through windows more efficient than enveloppe(windows) ?
-      final var validity = constraint.evaluate(simulationFacade.getLatestConstraintSimulationResults(), totalDomain);
+      final var validity = constraint.evaluate(latestSimulationResults, totalDomain);
       ret = ret.and(validity);
       //short-circuit if no possible windows left
       if (ret.stream().noneMatch(Segment::value)) {
@@ -796,6 +775,24 @@ public class PrioritySolver implements Solver {
       }
     }
   return ret;
+  }
+
+
+  private SimulationResults getLatestSimResultsUpTo(Duration time){
+    SimulationResults lastSimulationResults = null;
+    var lastSimResultsFromFacade = this.simulationFacade.getLatestConstraintSimulationResults();
+    if (lastSimResultsFromFacade.isEmpty() || lastSimResultsFromFacade.get().bounds.end.shorterThan(time)) {
+      try {
+        this.simulationFacade.computeSimulationResultsUntil(time);
+        final var allGeneratedActivities = simulationFacade.getAllChildActivities(time);
+        processNewGeneratedActivities(allGeneratedActivities);
+        pullActivityDurationsIfNecessary();
+      } catch (SimulationFacade.SimulationException e) {
+        throw new RuntimeException("Exception while running simulation before evaluating conflicts", e);
+      }
+    }
+    lastSimulationResults = this.simulationFacade.getLatestConstraintSimulationResults().get();
+    return lastSimulationResults;
   }
 
   private Windows narrowGlobalConstraints(
@@ -809,18 +806,14 @@ public class PrioritySolver implements Solver {
       return tmp;
     }
     //make sure the simulation results cover the domain
-    try {
-      simulationFacade.computeSimulationResultsUntil(tmp.maxTrueTimePoint().get().getKey());
-    } catch(SimulationFacade.SimulationException e){
-      throw new RuntimeException("Exception while running simulation before evaluating global constraints", e);
-    }
+    final var latestSimulationResults = this.getLatestSimResultsUpTo(tmp.maxTrueTimePoint().get().getKey());
     for (GlobalConstraint gc : constraints) {
       if (gc instanceof GlobalConstraintWithIntrospection c) {
         tmp = c.findWindows(
             plan,
             tmp,
             mac,
-            simulationFacade.getLatestConstraintSimulationResults(),
+            latestSimulationResults,
             evaluationEnvironment);
       } else {
         throw new Error("Unhandled variant of GlobalConstraint: %s".formatted(gc));

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/LongDurationPlanTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/LongDurationPlanTest.java
@@ -79,7 +79,7 @@ public class LongDurationPlanTest {
     Truth.assertThat(plan.get().getActivitiesByTime())
          .comparingElementsUsing(equalExceptInName)
          .containsExactlyElementsIn(expectedPlan.getActivitiesByTime());
-    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(1, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
@@ -136,7 +136,7 @@ public class PrioritySolverTest {
     assertThat(plan.get().getActivitiesByTime())
         .comparingElementsUsing(equalExceptInName)
         .containsExactlyElementsIn(expectedPlan.getActivitiesByTime());
-    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(1, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -246,7 +246,7 @@ public class PrioritySolverTest {
     assertThat(plan.getActivitiesByTime())
         .comparingElementsUsing(equalExceptInName)
         .containsAtLeastElementsIn(expectedPlan.getActivitiesByTime());
-    assertEquals(5, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   /**
@@ -288,7 +288,7 @@ public class PrioritySolverTest {
     assertThat(plan.getActivitiesByTime())
         .comparingElementsUsing(equalExceptInName)
         .containsAtLeastElementsIn(expectedPlan.getActivitiesByTime());
-    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
@@ -40,8 +40,8 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import static com.google.common.truth.Truth.assertThat;
 import static gov.nasa.jpl.aerie.constraints.time.Interval.Inclusivity.Exclusive;
@@ -179,28 +179,28 @@ public class SimulationFacadeTest {
 
   @Test
   public void getValueAtTimeDoubleOnSimplePlanMidpoint() throws SimulationFacade.SimulationException {
-    facade.simulateActivities(makeTestPlanP0B1().getActivities());
+    facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
     final var stateQuery = new StateQueryParam(getFruitRes().name, new TimeExpressionConstant(t1_5));
-    final var actual = stateQuery.getValue(facade.getLatestConstraintSimulationResults(), null, horizon.getHor());
+    final var actual = stateQuery.getValue(facade.getLatestConstraintSimulationResults().get(), null, horizon.getHor());
     assertThat(actual).isEqualTo(SerializedValue.of(3.0));
   }
 
   @Test
   public void getValueAtTimeDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
-    facade.simulateActivities(makeTestPlanP0B1().getActivities());
+    facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
     final var stateQuery = new StateQueryParam(getFruitRes().name, new TimeExpressionConstant(t2));
-    final var actual = stateQuery.getValue(facade.getLatestConstraintSimulationResults(), null, horizon.getHor());
+    final var actual = stateQuery.getValue(facade.getLatestConstraintSimulationResults().get(), null, horizon.getHor());
     assertThat(actual).isEqualTo(SerializedValue.of(2.9));
     assertEquals(1, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
   public void whenValueAboveDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
-    facade.simulateActivities(makeTestPlanP0B1().getActivities());
+    facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
-    var actual = new GreaterThan(getFruitRes(), new RealValue(2.9)).evaluate(facade.getLatestConstraintSimulationResults());
+    var actual = new GreaterThan(getFruitRes(), new RealValue(2.9)).evaluate(facade.getLatestConstraintSimulationResults().get());
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 2, Exclusive, SECONDS), true),
         Segment.of(interval(2, Inclusive,5, Exclusive, SECONDS), false)
@@ -210,9 +210,9 @@ public class SimulationFacadeTest {
 
   @Test
   public void whenValueBelowDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
-    facade.simulateActivities(makeTestPlanP0B1().getActivities());
+    facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
-    var actual = new LessThan(getFruitRes(), new RealValue(3.0)).evaluate(facade.getLatestConstraintSimulationResults());
+    var actual = new LessThan(getFruitRes(), new RealValue(3.0)).evaluate(facade.getLatestConstraintSimulationResults().get());
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 2, Exclusive, SECONDS), false),
         Segment.of(interval(2, Inclusive, 5, Exclusive, SECONDS), true)
@@ -222,9 +222,9 @@ public class SimulationFacadeTest {
 
   @Test
   public void whenValueBetweenDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
-    facade.simulateActivities(makeTestPlanP0B1().getActivities());
+    facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
-    var actual = new And(new GreaterThanOrEqual(getFruitRes(), new RealValue(3.0)), new LessThanOrEqual(getFruitRes(), new RealValue(3.99))).evaluate(facade.getLatestConstraintSimulationResults());
+    var actual = new And(new GreaterThanOrEqual(getFruitRes(), new RealValue(3.0)), new LessThanOrEqual(getFruitRes(), new RealValue(3.99))).evaluate(facade.getLatestConstraintSimulationResults().get());
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 1, Exclusive, SECONDS), false),
         Segment.of(interval(1, Inclusive, 2, Exclusive, SECONDS), true),
@@ -235,9 +235,9 @@ public class SimulationFacadeTest {
 
   @Test
   public void whenValueEqualDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
-    facade.simulateActivities(makeTestPlanP0B1().getActivities());
+    facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
-    var actual = new Equal<>(getFruitRes(), new RealValue(3.0)).evaluate(facade.getLatestConstraintSimulationResults());
+    var actual = new Equal<>(getFruitRes(), new RealValue(3.0)).evaluate(facade.getLatestConstraintSimulationResults().get());
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 1, Exclusive, SECONDS), false),
         Segment.of(interval(1, Inclusive, 2, Exclusive, SECONDS), true),
@@ -248,9 +248,9 @@ public class SimulationFacadeTest {
 
   @Test
   public void whenValueNotEqualDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
-    facade.simulateActivities(makeTestPlanP0B1().getActivities());
+    facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
-    var actual = new NotEqual<>(getFruitRes(), new RealValue(3.0)).evaluate(facade.getLatestConstraintSimulationResults());
+    var actual = new NotEqual<>(getFruitRes(), new RealValue(3.0)).evaluate(facade.getLatestConstraintSimulationResults().get());
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 1, Exclusive, SECONDS), true),
         Segment.of(interval(1, Inclusive, 2, Exclusive, SECONDS), false),
@@ -261,7 +261,7 @@ public class SimulationFacadeTest {
 
   @Test
   public void testCoexistenceGoalWithResourceConstraint() throws SimulationFacade.SimulationException {
-    facade.simulateActivities(makeTestPlanP0B1().getActivities());
+    facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
 
     /**
     * reminder for PB1
@@ -299,10 +299,9 @@ public class SimulationFacadeTest {
     assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
-
   @Test
   public void testProceduralGoalWithResourceConstraint() throws SimulationFacade.SimulationException {
-    facade.simulateActivities(makeTestPlanP0B1().getActivities());
+    facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
 
     final var constraint = new And(
         new LessThanOrEqual(new RealResource("/peel"), new RealValue(3.0)),
@@ -344,7 +343,7 @@ public class SimulationFacadeTest {
 
   @Test
   public void testActivityTypeWithResourceConstraint() throws SimulationFacade.SimulationException {
-    facade.simulateActivities(makeTestPlanP0B1().getActivities());
+    facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
 
     final var constraint = new And(
         new LessThanOrEqual(new RealResource("/peel"), new RealValue(3.0)),

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
@@ -203,7 +203,7 @@ public class SimulationFacadeTest {
     var actual = new GreaterThan(getFruitRes(), new RealValue(2.9)).evaluate(facade.getLatestConstraintSimulationResults());
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 2, Exclusive, SECONDS), true),
-        Segment.of(interval(2, 5, SECONDS), false)
+        Segment.of(interval(2, Inclusive,5, Exclusive, SECONDS), false)
     );
     assertThat(actual).isEqualTo(expected);
   }
@@ -215,7 +215,7 @@ public class SimulationFacadeTest {
     var actual = new LessThan(getFruitRes(), new RealValue(3.0)).evaluate(facade.getLatestConstraintSimulationResults());
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 2, Exclusive, SECONDS), false),
-        Segment.of(interval(2, 5, SECONDS), true)
+        Segment.of(interval(2, Inclusive, 5, Exclusive, SECONDS), true)
     );
     assertThat(actual).isEqualTo(expected);
   }
@@ -228,7 +228,7 @@ public class SimulationFacadeTest {
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 1, Exclusive, SECONDS), false),
         Segment.of(interval(1, Inclusive, 2, Exclusive, SECONDS), true),
-        Segment.of(interval(2, Inclusive, 5, Inclusive, SECONDS), false)
+        Segment.of(interval(2, Inclusive, 5, Exclusive, SECONDS), false)
     );
     assertThat(actual).isEqualTo(expected);
   }
@@ -241,7 +241,7 @@ public class SimulationFacadeTest {
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 1, Exclusive, SECONDS), false),
         Segment.of(interval(1, Inclusive, 2, Exclusive, SECONDS), true),
-        Segment.of(interval(2, Inclusive, 5, Inclusive, SECONDS), false)
+        Segment.of(interval(2, Inclusive, 5, Exclusive, SECONDS), false)
     );
     assertThat(actual).isEqualTo(expected);
   }
@@ -254,7 +254,7 @@ public class SimulationFacadeTest {
     var expected = new Windows(
         Segment.of(interval(0, Inclusive, 1, Exclusive, SECONDS), true),
         Segment.of(interval(1, Inclusive, 2, Exclusive, SECONDS), false),
-        Segment.of(interval(2, Inclusive, 5, Inclusive, SECONDS), true)
+        Segment.of(interval(2, Inclusive, 5, Exclusive, SECONDS), true)
     );
     assertThat(actual).isEqualTo(expected);
   }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
@@ -28,7 +28,10 @@ import gov.nasa.jpl.aerie.scheduler.goals.CoexistenceGoal;
 import gov.nasa.jpl.aerie.scheduler.constraints.resources.StateQueryParam;
 import gov.nasa.jpl.aerie.scheduler.goals.ChildCustody;
 import gov.nasa.jpl.aerie.scheduler.goals.ProceduralCreationGoal;
-import gov.nasa.jpl.aerie.scheduler.model.*;
+import gov.nasa.jpl.aerie.scheduler.model.Plan;
+import gov.nasa.jpl.aerie.scheduler.model.PlanInMemory;
+import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
+import gov.nasa.jpl.aerie.scheduler.model.Problem;
 import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
 import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
 import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
@@ -40,7 +43,6 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -260,8 +262,8 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void testCoexistenceGoalWithResourceConstraint() throws SimulationFacade.SimulationException {
-    facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
+  public void testCoexistenceGoalWithResourceConstraint() {
+    problem.setInitialPlan(makeTestPlanP0B1());
 
     /**
     * reminder for PB1
@@ -300,8 +302,8 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void testProceduralGoalWithResourceConstraint() throws SimulationFacade.SimulationException {
-    facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
+  public void testProceduralGoalWithResourceConstraint() {
+    problem.setInitialPlan(makeTestPlanP0B1());
 
     final var constraint = new And(
         new LessThanOrEqual(new RealResource("/peel"), new RealValue(3.0)),
@@ -342,8 +344,8 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void testActivityTypeWithResourceConstraint() throws SimulationFacade.SimulationException {
-    facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
+  public void testActivityTypeWithResourceConstraint() {
+    problem.setInitialPlan(makeTestPlanP0B1());
 
     final var constraint = new And(
         new LessThanOrEqual(new RealResource("/peel"), new RealValue(3.0)),

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
@@ -453,7 +453,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan,Duration.of(6, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(11, Duration.SECONDS), activityType));
     assertFalse(TestUtility.activityStartingAtTime(plan,Duration.of(16, Duration.SECONDS), activityType));
-    assertEquals(13, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(8, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 
@@ -644,7 +644,7 @@ public class TestApplyWhen {
                             .reduce(Duration.ZERO, Duration::plus);
     assertTrue(size >= 3 && size <= 10);
     assertTrue(totalDuration.dividedBy(Duration.SECOND) >= 16 && totalDuration.dividedBy(Duration.SECOND) <= 19);
-    assertEquals(17, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(9, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 
@@ -698,7 +698,7 @@ public class TestApplyWhen {
       logger.debug(a.startOffset().toString() + ", " + a.duration().toString());
     }
     assertEquals(4, plan.get().getActivitiesByTime().size());
-    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -753,7 +753,7 @@ public class TestApplyWhen {
       logger.debug(a.startOffset().toString() + ", " + a.duration().toString());
     }
     assertEquals(5, plan.get().getActivitiesByTime().size());
-    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -817,7 +817,7 @@ public class TestApplyWhen {
     assertEquals(2, plan.get().getActivitiesByTime()
                         .stream().filter($ -> $.duration().dividedBy(Duration.SECOND) == 2).toList()
                         .size());
-    assertEquals(6, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -1027,7 +1027,7 @@ public class TestApplyWhen {
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(1, Duration.SECONDS), actTypeA));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(8, Duration.SECONDS), actTypeA));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(10, Duration.SECONDS), actTypeA));
-    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -1095,7 +1095,7 @@ public class TestApplyWhen {
     assertFalse(TestUtility.activityStartingAtTime(plan.get(), Duration.of(5, Duration.SECONDS), actTypeA));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(9, Duration.SECONDS), actTypeA));
     assertFalse(TestUtility.activityStartingAtTime(plan.get(), Duration.of(14, Duration.SECONDS), actTypeA));
-    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -1150,7 +1150,7 @@ public class TestApplyWhen {
       logger.debug(a.startOffset().toString() + ", " + a.duration().toString());
     }
     assertEquals(5, plan.get().getActivitiesByTime().size());
-    assertEquals(6, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/UncontrollableDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/UncontrollableDurationTest.java
@@ -96,7 +96,7 @@ public class UncontrollableDurationTest {
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT0S"), planningHorizon.fromStart("PT1M29S"), problem.getActivityType("SolarPanelNonLinear")));
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT16M40S"), planningHorizon.fromStart("PT18M9S"), problem.getActivityType("SolarPanelNonLinear")));
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT33M20S"), planningHorizon.fromStart("PT34M49S"), problem.getActivityType("SolarPanelNonLinear")));
-    assertEquals(31, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(13, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -149,7 +149,7 @@ public class UncontrollableDurationTest {
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT33M20S"), planningHorizon.fromStart("PT36M47S"), problem.getActivityType("SolarPanelNonLinearTimeDependent")));
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT0S"), planningHorizon.fromStart("PT2M21S"), problem.getActivityType("SolarPanelNonLinearTimeDependent")));
     assertTrue(TestUtility.containsActivity(plan, planningHorizon.fromStart("PT16M40S"), planningHorizon.fromStart("PT17M18S"), problem.getActivityType("SolarPanelNonLinearTimeDependent")));
-    assertEquals(41, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(21, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -223,7 +223,7 @@ public class UncontrollableDurationTest {
                                             planningHorizon.fromStart("PT120S"),
                                             planningHorizon.fromStart("PT120S"),
                                             problem.getActivityType("LateRiser")));
-    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
   }
 
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/AnchorSchedulerTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/AnchorSchedulerTest.java
@@ -222,7 +222,7 @@ public class AnchorSchedulerTest {
       final var actualSimResults = driver.getSimulationResultsUpTo(planStart, tenDays);
 
       assertEqualsSimulationResults(expectedSimResults, actualSimResults);
-      assertEquals(2, driver.getCountSimulationRestarts());
+      assertEquals(1, driver.getCountSimulationRestarts());
     }
 
     @Test
@@ -578,7 +578,7 @@ public class AnchorSchedulerTest {
 
       // We have examined all the children
       assertTrue(childSimulatedActivities.isEmpty());
-      assertEquals(2, driver.getCountSimulationRestarts());
+      assertEquals(1, driver.getCountSimulationRestarts());
     }
 
     @Test
@@ -623,7 +623,7 @@ public class AnchorSchedulerTest {
 
       assertEquals(3906, expectedSimResults.simulatedActivities.size());
       assertEqualsSimulationResults(expectedSimResults, actualSimResults);
-      assertEquals(2, driver.getCountSimulationRestarts());
+      assertEquals(1, driver.getCountSimulationRestarts());
     }
   }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/graphql/GraphQLParsers.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/graphql/GraphQLParsers.java
@@ -2,32 +2,32 @@ package gov.nasa.jpl.aerie.scheduler.server.graphql;
 
 import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.json.Unit;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.scheduler.server.models.ActivityAttributesRecord;
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.scheduler.server.models.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;
+import org.postgresql.util.PGInterval;
 
+import java.sql.SQLException;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
-import java.util.Optional;
-import java.util.regex.Pattern;
 
 import static gov.nasa.jpl.aerie.json.BasicParsers.doubleP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.literalP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.longP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.mapP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
 import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
 import static gov.nasa.jpl.aerie.merlin.driver.json.SerializedValueJsonParser.serializedValueP;
 import static gov.nasa.jpl.aerie.merlin.driver.json.ValueSchemaJsonParser.valueSchemaP;
-
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
 
 /**
@@ -44,17 +44,6 @@ public class GraphQLParsers {
   public static final DateTimeFormatter timestampFormat = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
   /**
-   * the formatting expected in interval scalars returned by graphql queries
-   */
-  //TODO: inconsistent with bare microseconds used elsewhere
-  public static final Pattern intervalPattern = Pattern.compile(
-      "^(?<sign>[+-])?" //optional sign prefix, as in +322:21:15
-      + "(((?<hr>\\d+):)?" //optional hours field, as in  322:21:15
-      + "(?<min>\\d+):)?" //optional minutes field, as in 22:15
-      + "(?<sec>\\d+" //required seconds field, as in 15
-      + "(\\.\\d*)?)$"); //optional decimal sub-seconds, as in 15. or 15.111
-
-  /**
    * parse the given graphQL formatted timestamptz scalar string (eg 2021-01-01T00:00:00+00:00)
    *
    * @param in the input graphql formatted timestamptz scalar string to parse
@@ -63,34 +52,6 @@ public class GraphQLParsers {
   //TODO: unify with wherever this translation must already exist in merlin
   public static Timestamp parseGraphQLTimestamp(final String in) {
     return new Timestamp(ZonedDateTime.parse(in, timestampFormat).toInstant());
-  }
-
-  /**
-   * parse the given graphQL formatted interval scalar string (eg 322:21:15.250)
-   *
-   * supports up to microsecond precision
-   *
-   * @param in the input graphql formatted interval scalar string to parse
-   * @return the interval object represented by the input string
-   */
-  public static Duration parseGraphQLInterval(final String in) {
-
-    final var matcher = intervalPattern.matcher(in);
-    if (!matcher.matches()) {
-      throw new DateTimeParseException("unable to parse HH:MM:SS.sss duration from \"" + in + "\"", in, 0);
-    }
-    final var signValues = Map.of("+", 1, "-", -1);
-    final var sign = Optional.ofNullable(matcher.group("sign")).map(signValues::get).orElse(1);
-    final var hr = Optional.ofNullable(matcher.group("hr")).map(Integer::parseInt)
-                           .map(java.time.Duration::ofHours).orElse(java.time.Duration.ZERO);
-    final var min = Optional.ofNullable(matcher.group("min")).map(Integer::parseInt)
-                            .map(java.time.Duration::ofMinutes).orElse(java.time.Duration.ZERO);
-    final var sec = Optional.ofNullable(matcher.group("sec")).map(Double::parseDouble)
-                            .map(s -> (long) (s * 1000 * 1000))//seconds->millis->micros
-                            .map(us -> java.time.Duration.of(us, ChronoUnit.MICROS))
-                            .orElse(java.time.Duration.ZERO);
-    final var total = hr.plus(min).plus(sec).multipliedBy(sign);
-    return Duration.of((total.getNano() / 1000) + (total.getSeconds() * 1000_000), MICROSECONDS);
   }
 
   public static final JsonParser<Map<String, SerializedValue>> simulationArgumentsP = mapP(serializedValueP);
@@ -129,5 +90,48 @@ public class GraphQLParsers {
       .map(
           untuple(ActivityAttributesRecord::new),
           $ -> tuple($.directiveId(), $.arguments(), $.computedAttributes()));
+
+  public static final JsonParser<Duration> durationP =
+      stringP
+          .map(
+              GraphQLParsers::durationFromPGInterval,
+              duration -> graphQLIntervalFromDuration(duration).getValue());
+
+  public static Duration durationFromPGInterval(final String pgInterval) {
+    try {
+      final PGInterval asInterval = new PGInterval(pgInterval);
+      if(asInterval.getYears() != 0 ||
+         asInterval.getMonths() != 0) throw new RuntimeException("Years or months found in a pginterval");
+      final var asDuration = java.time.Duration.ofDays(asInterval.getDays())
+                                               .plusHours(asInterval.getHours())
+                                               .plusMinutes(asInterval.getMinutes())
+                                               .plusSeconds(asInterval.getWholeSeconds())
+                                               .plusNanos(asInterval.getMicroSeconds()*1000);
+      return Duration.of(asDuration.toNanos()/1000, MICROSECONDS);
+    }catch(SQLException e){
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static PGInterval graphQLIntervalFromDuration(final Duration duration) {
+    try {
+      final var micros = duration.in(MICROSECONDS);
+      return new PGInterval("PT%d.%06dS".formatted(micros / 1_000_000, micros % 1_000_000));
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+  public static PGInterval graphQLIntervalFromDuration(final Instant instant1, final Instant instant2) {
+    try {
+      final var micros = java.time.Duration.between(instant1, instant2).toNanos() / 1000;
+      return new PGInterval("PT%d.%06dS".formatted(micros / 1_000_000, micros % 1_000_000));
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static Instant instantFromStart(Instant start, Duration duration){
+    return start.plus(java.time.Duration.of(duration.in(Duration.MICROSECONDS), ChronoUnit.MICROS));
+  }
 
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/graphql/ProfileParsers.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/graphql/ProfileParsers.java
@@ -1,0 +1,79 @@
+package gov.nasa.jpl.aerie.scheduler.server.graphql;
+
+import gov.nasa.jpl.aerie.json.JsonParser;
+import gov.nasa.jpl.aerie.json.Unit;
+import gov.nasa.jpl.aerie.merlin.driver.engine.ProfileSegment;
+import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.List;
+
+import static gov.nasa.jpl.aerie.json.BasicParsers.doubleP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.listP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.literalP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
+import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
+import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
+import static gov.nasa.jpl.aerie.merlin.driver.json.SerializedValueJsonParser.serializedValueP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.ValueSchemaJsonParser.valueSchemaP;
+import static gov.nasa.jpl.aerie.scheduler.server.graphql.GraphQLParsers.durationP;
+
+public final class ProfileParsers {
+  public static final JsonParser<RealDynamics> realDynamicsP
+      = productP
+      . field("initial", doubleP)
+      . field("rate", doubleP)
+      . map(
+          untuple(RealDynamics::linear),
+          $ -> tuple($.initial, $.rate));
+
+  public static final JsonParser<ProfileSegment<RealDynamics>> realProfileSegmentP
+      = productP
+      . field("start_offset", durationP)
+      . field("dynamics", realDynamicsP)
+      . map(
+          untuple((start_offset, dynamics) -> new ProfileSegment<RealDynamics>(start_offset, dynamics)),
+          $ -> tuple($.extent(), $.dynamics()));
+
+  public static final JsonParser<ProfileSegment<SerializedValue>> discreteProfileSegmentP
+      = productP
+      . field("start_offset", durationP)
+      . field("dynamics", serializedValueP)
+      . map(
+          untuple( ProfileSegment::new),
+          $ -> tuple($.extent(), $.dynamics()));
+
+  public static final JsonParser<ValueSchema> discreteValueSchemaTypeP = productP
+      .field("type", literalP("discrete"))
+      .field("schema", valueSchemaP)
+      .map(untuple((type, schema) -> schema),
+      $ -> tuple(Unit.UNIT, $));
+
+  public static final JsonParser<ValueSchema> realValueSchemaTypeP = productP
+      .field("type", literalP("real"))
+      .field("schema", valueSchemaP)
+      .map(untuple((type, schema) -> schema),
+           $ -> tuple(Unit.UNIT, $));
+
+  public static final JsonParser<Pair<ValueSchema, List<ProfileSegment<RealDynamics>>>> realProfileP
+      = productP
+      . field("name", stringP)
+      . field("type", realValueSchemaTypeP)
+      . field("profile_segments", listP(realProfileSegmentP))
+      . map(
+          untuple((name, type, segments) -> Pair.of(type, segments)),
+          $ -> tuple("", $.getLeft(), $.getRight()));
+
+  public static final JsonParser<Pair<ValueSchema, List<ProfileSegment<SerializedValue>>>> discreteProfileP
+      = productP
+      . field("name", stringP)
+      . field("type", discreteValueSchemaTypeP)
+      . field("profile_segments", listP(discreteProfileSegmentP))
+      . map(
+          untuple((name, type, segments) -> Pair.of(type, segments)),
+          $ -> tuple("", $.getLeft(), $.getRight()));
+
+}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/PlanService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/PlanService.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
 
 public interface PlanService {
   interface ReaderRole {
@@ -64,6 +65,14 @@ public interface PlanService {
     //TODO: (defensive) should combine such checks into the mutations they are guarding, but not possible in graphql?
     void ensurePlanExists(final PlanId planId)
     throws IOException, NoSuchPlanException, PlanServiceException;
+
+    /**
+     * Gets existing simulation results for current plan if they exist and are suitable for scheduling purposes (current revision, covers the entire planning horizon)
+     * These simulation results do not include events and topics.
+     * @param planMetadata the plan metadata
+     * @return simulation results, optionally
+     */
+    Optional<SimulationResults> getSimulationResults(PlanMetadata planMetadata) throws PlanServiceException, IOException, InvalidJsonException;
   }
 
   interface WriterRole {

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/graphql/GraphQLParsersTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/graphql/GraphQLParsersTest.java
@@ -28,15 +28,7 @@ class GraphQLParsersTest {
         Arguments.of("322:21:15.", parseDurationISO8601("PT322H21M15S")),
         Arguments.of("322:21:15", parseDurationISO8601("PT322H21M15S")),
         Arguments.of("+322:21:15", parseDurationISO8601("PT322H21M15S")),
-        Arguments.of("-322:21:15", parseDurationISO8601("PT-322H-21M-15S")),
-        Arguments.of("21:15.111", parseDurationISO8601("PT21M15.111S")),
-        Arguments.of("+21:15.111", parseDurationISO8601("PT21M15.111S")),
-        Arguments.of("-21:15.111", parseDurationISO8601("PT-21M-15.111S")),
-        Arguments.of("15.111", parseDurationISO8601("PT15.111S")),
-        Arguments.of("15.", parseDurationISO8601("PT15S")),
-        Arguments.of("15", parseDurationISO8601("PT15S")),
-        Arguments.of("-15", parseDurationISO8601("PT-15S")),
-        Arguments.of("+15", parseDurationISO8601("PT15S"))
+        Arguments.of("-322:21:15", parseDurationISO8601("PT-322H-21M-15S"))
     );
   }
 
@@ -50,7 +42,7 @@ class GraphQLParsersTest {
   @ParameterizedTest
   @MethodSource
   void parseGraphQLInterval(String input, Duration expected) {
-    final var actual = GraphQLParsers.parseGraphQLInterval(input);
+    final var actual = GraphQLParsers.durationFromPGInterval(input);
     assertEquals(expected, actual);
   }
 

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/MockMerlinService.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/MockMerlinService.java
@@ -1,5 +1,29 @@
 package gov.nasa.jpl.aerie.scheduler.worker.services;
 
+import gov.nasa.jpl.aerie.merlin.driver.ActivityDirective;
+import gov.nasa.jpl.aerie.merlin.driver.ActivityDirectiveId;
+import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.scheduler.TimeUtility;
+import gov.nasa.jpl.aerie.scheduler.model.Plan;
+import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
+import gov.nasa.jpl.aerie.scheduler.model.Problem;
+import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
+import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirectiveId;
+import gov.nasa.jpl.aerie.scheduler.server.http.InvalidJsonException;
+import gov.nasa.jpl.aerie.scheduler.server.models.DatasetId;
+import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
+import gov.nasa.jpl.aerie.scheduler.server.models.MerlinPlan;
+import gov.nasa.jpl.aerie.scheduler.server.models.MissionModelId;
+import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
+import gov.nasa.jpl.aerie.scheduler.server.models.PlanMetadata;
+import gov.nasa.jpl.aerie.scheduler.server.services.MissionModelService;
+import gov.nasa.jpl.aerie.scheduler.server.services.PlanService;
+import gov.nasa.jpl.aerie.scheduler.server.services.PlanServiceException;
+import org.apache.commons.lang3.tuple.Pair;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -8,27 +32,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-
-import gov.nasa.jpl.aerie.merlin.driver.ActivityDirective;
-import gov.nasa.jpl.aerie.merlin.driver.ActivityDirectiveId;
-import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
-import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
-import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
-import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
-import gov.nasa.jpl.aerie.scheduler.TimeUtility;
-import gov.nasa.jpl.aerie.scheduler.model.*;
-import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
-import gov.nasa.jpl.aerie.scheduler.server.models.DatasetId;
-import gov.nasa.jpl.aerie.scheduler.server.models.GoalId;
-import gov.nasa.jpl.aerie.scheduler.server.models.MerlinPlan;
-import gov.nasa.jpl.aerie.scheduler.server.models.MissionModelId;
-import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
-import gov.nasa.jpl.aerie.scheduler.server.models.PlanMetadata;
-import gov.nasa.jpl.aerie.scheduler.server.services.GraphQLMerlinService;
-import gov.nasa.jpl.aerie.scheduler.server.services.MissionModelService;
-import gov.nasa.jpl.aerie.scheduler.server.services.PlanService;
-import gov.nasa.jpl.aerie.scheduler.server.services.PlanServiceException;
-import org.apache.commons.lang3.tuple.Pair;
 
 class MockMerlinService implements MissionModelService, PlanService.OwnerRole {
 
@@ -130,6 +133,12 @@ class MockMerlinService implements MissionModelService, PlanService.OwnerRole {
   @Override
   public void ensurePlanExists(final PlanId planId) {
 
+  }
+
+  @Override
+  public Optional<SimulationResults> getSimulationResults(final PlanMetadata planMetadata)
+  {
+    return Optional.empty();
   }
 
   @Override


### PR DESCRIPTION
* **Tickets addressed:** #748 #913 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

As usual, on my way to the feature, I get distracted by other improvements and fixes. Some of those are really worth it, in commits (4) and (5) especially. The last commit shows a performance improvement in 20+ tests.  About 30-50% less simulations in these test cases.

In (1), I removed the need for an ugly artificial time buffer in the scheduler simulation by fixing an issue in `Windows`: if the last interval of a profile was closed-open, `Windows` considered that there was a gap because it only used `Interval.contains` and that contains does not care about the open/closed property. The detected gap prevented from turning these windows into spans and so on. Hopefully, that is now squared. 

In (2), I have added a small optimization that may spare us a simulation if not needed.

In (3), a small fix regarding the domain of converted simulation results.

In (4), a significant change. I removed the conflict detection _after_ goal solving. After solving a goal, we ran conflict detection to check that we effectively solved it. This resulted in a simulation runs that could be avoided. The only goal which was taking advantage of this mechanism was the cardinality goal in the case of activities with uncontrollable duration. It was posting one conflict at a time and kept posting conflict until the duration and cardinality conditions were not satisfied. The `MissingActivityTemplateConflict` (and its processing by `PrioritySolver`) has been generalized to handle duration and cardinality thus removing the need for the second conflict detection after goal solving. 

In (5), I fixed a boundary reset condition that were causing more simulations than needed. This bound had been set conservatively because at some point, the driver was dropping some tasks. But this has been fixed a few month ago. 

In (6), I have modified the scheduler so that it is able to use initial simulation results coming from the DB. 
- the solver keeps the initial simulation results and returns them when needed if the associated initial plan has not been modified. 
- a field has been added to the `SimulationFacade` to hold an initial plan until a simulation is needed. This is to avoid simulating a plan that will not be needed. Rootfinding needs the facade to have the current plan "loaded" but if external simulation results have been loaded, there is no need for a first simulation before the first rootfinding try. 

In (7) I pull the simulation results from the DB and pass them to scheduling. DB simulation results are considered useful if they correspond to the current revision of the plan and if they cover the entire plan horizon. We do not pull events and topics to save time (and they are useless to the scheduler right now).  

In (8), I have fixed some tests. The results are the same but the data path as well as the in-memory state was wrong. 

In (9) I have added a test to show how loading initial simulation results allows to remove the first simulation. The test is the same as its neighbor and displays a lower number of simulations (-1) for the same results. 

In (10), I have updated the simulation performance of the scheduler tests. These improvements are mostly due to (4) (and a little bit (5)). 
 
## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Existing tests are passing.  Only one new test. Testing the graphql requests/scheduler-worker is not easy, I am open to suggestions. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None. 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None.