### PR TITLE
eDSL Convert Unbalanced Times

### DIFF
--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.spec.ts
@@ -525,7 +525,7 @@ describe('Time Validation', () => {
     });
   });
 
-  it('should have invalid Relative Times', () => {
+  it('should have invalid Times', () => {
 
     try {
       CommandStem.new({
@@ -545,6 +545,220 @@ describe('Time Validation', () => {
     }catch (e: any) {
       expect(e.message).toEqual('Day (DDD) is not allowed for Relative Times: 009T03:01:34.284')
     }
+    try {
+      CommandStem.new({
+        stem: 'TEST',
+        arguments: {},
+        epochTime: hmsToDuration('365T23:59:60' as HMS_STRING,true),
+      })
+    }catch (e: any) {
+      expect(e.message).toEqual('Days cannot exceed 365: 365T23:59:60')
+    }
   });
+
+  it('should balance unbalance durations', () => {
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      relativeTime: hmsToDuration('12:34:70' as HMS_STRING),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "12:35:10.000",
+        "type": "COMMAND_RELATIVE"
+      },
+      type: 'command',
+    });
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      relativeTime: hmsToDuration('12:70:56' as HMS_STRING),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "13:10:56.000",
+        "type": "COMMAND_RELATIVE"
+      },
+      type: 'command',
+    });
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      epochTime: hmsToDuration('25:34:56' as HMS_STRING,true),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "001T01:34:56.000",
+        "type": "EPOCH_RELATIVE"
+      },
+      type: 'command',
+    });
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      epochTime: hmsToDuration('23:59:60' as HMS_STRING,true),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "001T00:00:00.000",
+        "type": "EPOCH_RELATIVE"
+      },
+      type: 'command',
+    });
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      epochTime: hmsToDuration('-23:59:60' as HMS_STRING,true),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "-001T00:00:00.000",
+        "type": "EPOCH_RELATIVE"
+      },
+      type: 'command',
+    });
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      epochTime: hmsToDuration('-000T24:60:60' as HMS_STRING,true),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "-001T01:01:00.000",
+        "type": "EPOCH_RELATIVE"
+      },
+      type: 'command',
+    });
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      epochTime: hmsToDuration('-000T20:90:90' as HMS_STRING,true),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "-21:31:30.000",
+        "type": "EPOCH_RELATIVE"
+      },
+      type: 'command',
+    });
+
+  });
+
+  it('should balance unbalance instants', () => {
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      absoluteTime: doyToInstant('2022-001T24:00:00' as DOY_STRING),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "2022-002T00:00:00.000",
+        "type": "ABSOLUTE"
+      },
+      type: 'command',
+    });
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      absoluteTime: doyToInstant('2022-365T00:00:00' as DOY_STRING),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "2022-365T00:00:00.000",
+        "type": "ABSOLUTE"
+      },
+      type: 'command',
+    });
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      absoluteTime: doyToInstant('2022-365T23:59:60' as DOY_STRING),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "2023-001T00:00:00.000",
+        "type": "ABSOLUTE"
+      },
+      type: 'command',
+    });
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      absoluteTime: doyToInstant('2023-365T23:59:60.789' as DOY_STRING),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "2024-001T00:00:00.789",
+        "type": "ABSOLUTE"
+      },
+      type: 'command',
+    });
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      absoluteTime: doyToInstant('2022-001T00:00:90' as DOY_STRING),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "2022-001T00:01:30.000",
+        "type": "ABSOLUTE"
+      },
+      type: 'command',
+    });
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      absoluteTime: doyToInstant('2024-366T00:00:00.789' as DOY_STRING),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "2024-366T00:00:00.789",
+        "type": "ABSOLUTE"
+      },
+      type: 'command',
+    });
+
+    expect(CommandStem.new({
+      stem: 'TEST',
+      arguments: {},
+      absoluteTime: doyToInstant('2024-366T23:60:60.789' as DOY_STRING),
+    }).toSeqJson()).toEqual({
+      args: [],
+      stem: 'TEST',
+      time: {
+        "tag": "2025-001T00:01:00.789",
+        "type": "ABSOLUTE"
+      },
+      type: 'command',
+    });
+  });
+
+
 
 });

--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -3098,8 +3098,8 @@ export function doyToInstant(doy: DOY_STRING): Temporal.Instant {
   ];
 
   //use to convert doy to month and day
-  const doyDate = new Date(parseInt(year, 10), 0, parseInt(doyStr, 10));
-  // convert to UTC Date
+  const doyDate = new Date(Date.UTC(parseInt(year, 10), 0, parseInt(doyStr, 10), parseInt(hour, 10),parseInt(minute,10),parseInt(second,10),parseInt(millisecond ? millisecond : '0',10)));
+  // Convert to UTC Date
   const utcDoyDate = new Date(
     Date.UTC(
       doyDate.getUTCFullYear(),
@@ -3113,13 +3113,13 @@ export function doyToInstant(doy: DOY_STRING): Temporal.Instant {
   );
 
   return Temporal.ZonedDateTime.from({
-    year: parseInt(year, 10),
+    year: utcDoyDate.getUTCFullYear(),
     month: utcDoyDate.getUTCMonth() + 1,
     day: utcDoyDate.getUTCDate(),
-    hour: parseInt(hour, 10),
-    minute: parseInt(minute, 10),
-    second: parseInt(second, 10),
-    millisecond: parseInt(millisecond ?? '0', 10),
+    hour: utcDoyDate.getUTCHours(),
+    minute: utcDoyDate.getUTCMinutes(),
+    second: utcDoyDate.getUTCSeconds(),
+    millisecond: utcDoyDate.getUTCMilliseconds(),
     timeZone: 'UTC',
   }).toInstant();
 }
@@ -3139,26 +3139,57 @@ export function durationToHms(time: Temporal.Duration): HMS_STRING {
 
 export function hmsToDuration(hms: HMS_STRING, epoch: boolean = false): Temporal.Duration {
   const match = hms.match(HMS_REGEX);
-  if (match === null) {
+  if (!match) {
     throw new Error(`Invalid HMS string: ${hms}`);
   }
 
-  const [, sign, days = '0', hours = "0", minutes = "0", seconds = "0", milliseconds = '0'] = match;
-  const isPositive = sign !== '-';
-  const parseNumber = (value: string) => (isPositive ? 1 : -1) * parseInt(value, 10);
+  const [, sign, days = '0', hours = '0', minutes = '0', seconds = '0', milliseconds = '0'] = match;
+  const isNegative = sign === '-';
+
+  let daysNum = parseInt(days.replace('T', ''),10)
+  let hoursNum = parseInt(hours,10)
+  let minuteNum = parseInt(minutes,10)
+  let secondsNum = parseInt(seconds,10)
+  let millisecondNum = parseInt(milliseconds,10)
+
+  // Normalize milliseconds, seconds, minutes, and hours iteratively
+  if (isNegative) {
+    daysNum = Math.abs(daysNum);
+    hoursNum = Math.abs(hoursNum);
+    minuteNum = Math.abs(minuteNum);
+    secondsNum = Math.abs(secondsNum);
+    millisecondNum = Math.abs(millisecondNum);
+  }
+  // Normalize milliseconds and seconds
+  secondsNum += Math.floor(secondsNum / 1000);
+  millisecondNum = millisecondNum % 1000;
+
+  // Normalize seconds and minutes
+  minuteNum += Math.floor(secondsNum / 60);
+  secondsNum = secondsNum % 60;
+
+  // Normalize minutes and hours
+  hoursNum += Math.floor(minuteNum / 60);
+  minuteNum = minuteNum % 60;
+
+  // Normalize hours and days
+  daysNum += Math.floor(hoursNum / 24);
+  hoursNum = hoursNum % 24;
+
+  if (daysNum > 365){
+    throw new Error(`Days cannot exceed 365: ${hms}`);
+  }
 
   if (!epoch) {
-    if(!isPositive)
-      throw new Error(`Signed time (+/-) is not allowed for Relative Times: ${hms}`);
-    if(days !== '0')
-      throw new Error(`Day (DDD) is not allowed for Relative Times: ${hms}`);
+    if (isNegative) {throw new Error(`Signed time (+/-) is not allowed for Relative Times: ${hms}`);}
+    if (daysNum !== 0) {throw new Error(`Day (DDD) is not allowed for Relative Times: ${hms}`);}
   }
   return Temporal.Duration.from({
-    days: parseNumber(days.replace('T', '')),
-    hours: parseNumber(hours),
-    minutes: parseNumber(minutes),
-    seconds: parseNumber(seconds),
-    milliseconds: parseNumber(milliseconds),
+    days: isNegative ? -daysNum : daysNum,
+    hours: isNegative ? -hoursNum : hoursNum,
+    minutes: isNegative ? -minuteNum : minuteNum,
+    seconds: isNegative ? -secondsNum : secondsNum,
+    milliseconds: isNegative ? -millisecondNum : millisecondNum ,
   });
 }
 

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -3101,8 +3101,8 @@ export function doyToInstant(doy: DOY_STRING): Temporal.Instant {
   ];
 
   //use to convert doy to month and day
-  const doyDate = new Date(parseInt(year, 10), 0, parseInt(doyStr, 10));
-  // convert to UTC Date
+  const doyDate = new Date(Date.UTC(parseInt(year, 10), 0, parseInt(doyStr, 10), parseInt(hour, 10),parseInt(minute,10),parseInt(second,10),parseInt(millisecond ? millisecond : '0',10)));
+  // Convert to UTC Date
   const utcDoyDate = new Date(
     Date.UTC(
       doyDate.getUTCFullYear(),
@@ -3116,13 +3116,13 @@ export function doyToInstant(doy: DOY_STRING): Temporal.Instant {
   );
 
   return Temporal.ZonedDateTime.from({
-    year: parseInt(year, 10),
+    year: utcDoyDate.getUTCFullYear(),
     month: utcDoyDate.getUTCMonth() + 1,
     day: utcDoyDate.getUTCDate(),
-    hour: parseInt(hour, 10),
-    minute: parseInt(minute, 10),
-    second: parseInt(second, 10),
-    millisecond: parseInt(millisecond ?? '0', 10),
+    hour: utcDoyDate.getUTCHours(),
+    minute: utcDoyDate.getUTCMinutes(),
+    second: utcDoyDate.getUTCSeconds(),
+    millisecond: utcDoyDate.getUTCMilliseconds(),
     timeZone: 'UTC',
   }).toInstant();
 }
@@ -3142,26 +3142,57 @@ export function durationToHms(time: Temporal.Duration): HMS_STRING {
 
 export function hmsToDuration(hms: HMS_STRING, epoch: boolean = false): Temporal.Duration {
   const match = hms.match(HMS_REGEX);
-  if (match === null) {
+  if (!match) {
     throw new Error(\`Invalid HMS string: \${hms}\`);
   }
 
-  const [, sign, days = '0', hours = "0", minutes = "0", seconds = "0", milliseconds = '0'] = match;
-  const isPositive = sign !== '-';
-  const parseNumber = (value: string) => (isPositive ? 1 : -1) * parseInt(value, 10);
+  const [, sign, days = '0', hours = '0', minutes = '0', seconds = '0', milliseconds = '0'] = match;
+  const isNegative = sign === '-';
+
+  let daysNum = parseInt(days.replace('T', ''),10)
+  let hoursNum = parseInt(hours,10)
+  let minuteNum = parseInt(minutes,10)
+  let secondsNum = parseInt(seconds,10)
+  let millisecondNum = parseInt(milliseconds,10)
+
+  // Normalize milliseconds, seconds, minutes, and hours iteratively
+  if (isNegative) {
+    daysNum = Math.abs(daysNum);
+    hoursNum = Math.abs(hoursNum);
+    minuteNum = Math.abs(minuteNum);
+    secondsNum = Math.abs(secondsNum);
+    millisecondNum = Math.abs(millisecondNum);
+  }
+  // Normalize milliseconds and seconds
+  secondsNum += Math.floor(secondsNum / 1000);
+  millisecondNum = millisecondNum % 1000;
+
+  // Normalize seconds and minutes
+  minuteNum += Math.floor(secondsNum / 60);
+  secondsNum = secondsNum % 60;
+
+  // Normalize minutes and hours
+  hoursNum += Math.floor(minuteNum / 60);
+  minuteNum = minuteNum % 60;
+
+  // Normalize hours and days
+  daysNum += Math.floor(hoursNum / 24);
+  hoursNum = hoursNum % 24;
+
+  if (daysNum > 365){
+    throw new Error(\`Days cannot exceed 365: \${hms}\`);
+  }
 
   if (!epoch) {
-    if(!isPositive)
-      throw new Error(\`Signed time (+/-) is not allowed for Relative Times: \${hms}\`);
-    if(days !== '0')
-      throw new Error(\`Day (DDD) is not allowed for Relative Times: \${hms}\`);
+    if (isNegative) {throw new Error(\`Signed time (+/-) is not allowed for Relative Times: \${hms}\`);}
+    if (daysNum !== 0) {throw new Error(\`Day (DDD) is not allowed for Relative Times: \${hms}\`);}
   }
   return Temporal.Duration.from({
-    days: parseNumber(days.replace('T', '')),
-    hours: parseNumber(hours),
-    minutes: parseNumber(minutes),
-    seconds: parseNumber(seconds),
-    milliseconds: parseNumber(milliseconds),
+    days: isNegative ? -daysNum : daysNum,
+    hours: isNegative ? -hoursNum : hoursNum,
+    minutes: isNegative ? -minuteNum : minuteNum,
+    seconds: isNegative ? -secondsNum : secondsNum,
+    milliseconds: isNegative ? -millisecondNum : millisecondNum ,
   });
 }
 


### PR DESCRIPTION
* **Tickets addressed:** Closes #814 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The eDSL now includes support for unbalanced times. When an unbalanced time is entered in sequencing, the eDSL will automatically convert it to a proper balanced time. The generated SeqJson now contains the correct balanced time, resolving the issue downstream with Seqgen, which previously did not handle unbalanced times correctly. Additionally, leap years are taken into account during the conversion process.

The UI has been updated with PR:
https://github.com/NASA-AMMOS/aerie-ui/pull/820

```ts
export default () =>
  Sequence.new({
    seqId: '',
    metadata: {},
       steps: [
       A("2021-366T00:00:00").ACTIVATE(''),       // convert to 2022-001T00:00:00.000
        A("2024-366T48:59:60.234").ACTIVATE(''),  // Leap year convert to 2025-002T01:00:00.234
        E("00:59:60").ACTIVATE(''),              // convert to 01:00:00.000
        R("00:90:90").ACTIVATE(''),              // convert to 01:31:30.000
        ]     
  });
```


```json
{
  "id": "",
  "metadata": {},
  "steps": [
    {
      "sequence": "",
      "time": {
        "tag": "2022-001T00:00:00.000",
        "type": "ABSOLUTE"
      },
      "type": "activate"
    },
    {
      "sequence": "",
      "time": {
        "tag": "2025-002T01:00:00.234",
        "type": "ABSOLUTE"
      },
      "type": "activate"
    },
    {
      "sequence": "",
      "time": {
        "tag": "01:00:00.000",
        "type": "EPOCH_RELATIVE"
      },
      "type": "activate"
    },
    {
      "sequence": "",
      "time": {
        "tag": "01:31:30.000",
        "type": "COMMAND_RELATIVE"
      },
      "type": "activate"
    }
  ]
}
```

## Verification
This PR also includes a comprehensive set of time test cases to cover various edge cases, ensuring robustness and accuracy in handling different time scenarios.

## Documentation
none

## Future work
none
