### PR TITLE
Add TrampoliningTask

### DIFF
--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/Mission.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/Mission.java
@@ -11,7 +11,6 @@ import gov.nasa.jpl.aerie.foomissionmodel.models.Imager;
 import gov.nasa.jpl.aerie.foomissionmodel.models.ImagerMode;
 import gov.nasa.jpl.aerie.foomissionmodel.models.SimpleData;
 import gov.nasa.jpl.aerie.foomissionmodel.models.TimeTrackerDaemon;
-import gov.nasa.jpl.aerie.merlin.framework.ModelActions;
 import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.resources.real.RealResource;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -19,6 +18,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import java.time.Instant;
 
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.*;
+import static gov.nasa.jpl.aerie.merlin.framework.TrampoliningTask.RepeatingTaskStatus.delayed;
 
 public final class Mission {
   // Need a way to pose constraints against activities, and generally modeling activity behavior with resources.
@@ -74,13 +74,11 @@ public final class Mission {
     registrar.real("/simple_data/b/rate", this.simpleData.b.rate);
     registrar.real("/simple_data/total_volume", this.simpleData.totalVolume);
 
-    spawn(timeTrackerDaemon::run);
+    timeTrackerDaemon.run();
 
-    spawn(() -> { // Register a never-ending daemon task
-      while (true) {
-        ModelActions.delay(Duration.SECOND);
-      }
-    });
+    spawn(repeating(() -> { // Register a never-ending daemon task
+      return delayed(Duration.SECOND);
+    }));
   }
 
   public void test() {

--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/models/TimeTrackerDaemon.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/models/TimeTrackerDaemon.java
@@ -1,8 +1,10 @@
 package gov.nasa.jpl.aerie.foomissionmodel.models;
 
 import gov.nasa.jpl.aerie.contrib.models.counters.Counter;
-import gov.nasa.jpl.aerie.merlin.framework.ModelActions;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.*;
+import static gov.nasa.jpl.aerie.merlin.framework.TrampoliningTask.RepeatingTaskStatus.delayed;
 
 /**
  * A daemon task that tracks the number of minutes since plan start
@@ -16,12 +18,11 @@ public class TimeTrackerDaemon {
 
   public TimeTrackerDaemon(){ minutesElapsed = Counter.ofInteger(0);}
 
-  public void run(){
-    minutesElapsed.add(-minutesElapsed.get());
-    while(true) {
-      ModelActions.delay(Duration.MINUTE);
-      minutesElapsed.add(1);
-    }
+  public void run() {
+    defer(Duration.MINUTE, () ->
+        spawn(repeating(() -> {
+          minutesElapsed.add(1);
+          return delayed(Duration.MINUTE);
+        })));
   }
-
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
@@ -1,5 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.framework;
 
+import gov.nasa.jpl.aerie.merlin.framework.TrampoliningTask.RepeatingTaskStatus;
+import gov.nasa.jpl.aerie.merlin.framework.TrampoliningTask.TrampoliningTaskStatus;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -34,6 +36,15 @@ public /*non-final*/ class ModelActions {
       task.run();
       return Unit.UNIT;
     });
+  }
+
+
+  public static <T> TaskFactory<T> trampolining(final Supplier<TrampoliningTaskStatus<T>> task) {
+    return executor -> new TrampoliningTask<>(ModelActions.context, task);
+  }
+
+  public static <T> TaskFactory<T> repeating(final Supplier<RepeatingTaskStatus<T>> task) {
+    return executor -> new TrampoliningTask<>(ModelActions.context, TrampoliningTask.repeating(task));
   }
 
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/TrampoliningTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/TrampoliningTask.java
@@ -1,0 +1,145 @@
+package gov.nasa.jpl.aerie.merlin.framework;
+
+import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
+import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
+import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class TrampoliningTask<Return> implements Task<Return> {
+  private final Scoped<Context> rootContext;
+  private final Supplier<TrampoliningTaskStatus<Return>> task;
+
+  public TrampoliningTask(final Scoped<Context> rootContext, Supplier<TrampoliningTaskStatus<Return>> task) {
+    this.rootContext = rootContext;
+    this.task = task;
+  }
+
+  public static <Return> Supplier<TrampoliningTaskStatus<Return>> repeating(Supplier<RepeatingTaskStatus<Return>> task) {
+    return () -> task.get().match(
+        completed -> new TrampoliningTaskStatus.Completed<>(completed.result),
+        delayed -> new TrampoliningTaskStatus.Delayed<>(delayed.delay, repeating(task)),
+        awaiting -> new TrampoliningTaskStatus.AwaitingCondition<>(awaiting.condition, repeating(task)));
+  }
+
+  @Override
+  public TaskStatus<Return> step(final Scheduler scheduler) {
+    final var context = new ThreadedReactionContext(rootContext, scheduler, new TrampoliningTaskHandle());
+
+    try (final var restore = this.rootContext.set(context)) {
+      final var status = this.task.get();
+
+      return status.match(
+          completed -> TaskStatus.completed(completed.result),
+          delayed -> TaskStatus.delayed(delayed.delay, new TrampoliningTask<>(rootContext, delayed.continuation)),
+          awaiting -> TaskStatus.awaiting(
+              (now, atLatest) -> {
+                try (final var restoreQuery = this.rootContext.set(new QueryContext(now))) {
+                  return awaiting.condition.nextSatisfied(true, Duration.ZERO, atLatest);
+                }
+              },
+              new TrampoliningTask<>(rootContext, awaiting.continuation)));
+    }
+  }
+
+  public sealed interface TrampoliningTaskStatus<Return> {
+    <T> T match(Function<Completed<Return>, T> f, Function<Delayed<Return>, T> g, Function<AwaitingCondition<Return>, T> h);
+
+    record Completed<Return>(Return result) implements TrampoliningTaskStatus<Return> {
+      @Override
+      public <T> T match(
+          final Function<Completed<Return>, T> f,
+          final Function<Delayed<Return>, T> g,
+          final Function<AwaitingCondition<Return>, T> h)
+      {
+        return f.apply(this);
+      }
+    }
+    record Delayed<Return>(Duration delay, Supplier<TrampoliningTaskStatus<Return>> continuation) implements TrampoliningTaskStatus<Return> {
+      @Override
+      public <T> T match(
+          final Function<Completed<Return>, T> f,
+          final Function<Delayed<Return>, T> g,
+          final Function<AwaitingCondition<Return>, T> h)
+      {
+        return g.apply(this);
+      }
+    }
+    record AwaitingCondition<Return>(Condition condition, Supplier<TrampoliningTaskStatus<Return>> continuation) implements TrampoliningTaskStatus<Return> {
+      @Override
+      public <T> T match(
+          final Function<Completed<Return>, T> f,
+          final Function<Delayed<Return>, T> g,
+          final Function<AwaitingCondition<Return>, T> h)
+      {
+        return h.apply(this);
+      }
+    }
+  }
+
+  public sealed interface RepeatingTaskStatus<Return> {
+    <T> T match(Function<Completed<Return>, T> f, Function<Delayed<Return>, T> g, Function<AwaitingCondition<Return>, T> h);
+
+    record Completed<Return>(Return result) implements RepeatingTaskStatus<Return> {
+      @Override
+      public <T> T match(
+          final Function<Completed<Return>, T> f,
+          final Function<Delayed<Return>, T> g,
+          final Function<AwaitingCondition<Return>, T> h)
+      {
+        return f.apply(this);
+      }
+    }
+    record Delayed<Return>(Duration delay) implements RepeatingTaskStatus<Return> {
+      @Override
+      public <T> T match(
+          final Function<Completed<Return>, T> f,
+          final Function<Delayed<Return>, T> g,
+          final Function<AwaitingCondition<Return>, T> h)
+      {
+        return g.apply(this);
+      }
+    }
+    record AwaitingCondition<Return>(Condition condition) implements RepeatingTaskStatus<Return> {
+      @Override
+      public <T> T match(
+          final Function<Completed<Return>, T> f,
+          final Function<Delayed<Return>, T> g,
+          final Function<AwaitingCondition<Return>, T> h)
+      {
+        return h.apply(this);
+      }
+    }
+
+    static <Return> RepeatingTaskStatus<Return> completed(Return value) {
+      return new Completed<>(value);
+    }
+    static <Return> RepeatingTaskStatus<Return> delayed(Duration delay) {
+      return new Delayed<>(delay);
+    }
+    static <Return> RepeatingTaskStatus<Return> awaiting(Condition condition) {
+      return new AwaitingCondition<>(condition);
+    }
+  }
+
+  // Trampolining tasks don't support interrupting the flow of control.
+  private static final class TrampoliningTaskHandle implements TaskHandle {
+    @Override
+    public Scheduler delay(final Duration delay) {
+      throw new RuntimeException("delay is not supported from within a trampolining task");
+    }
+
+    @Override
+    public Scheduler call(final TaskFactory<?> child) {
+      throw new RuntimeException("call is not supported from within a trampolining task");
+    }
+
+    @Override
+    public Scheduler await(final gov.nasa.jpl.aerie.merlin.protocol.model.Condition condition) {
+      throw new RuntimeException("await is not supported from within a trampolining task");
+    }
+  }
+}


### PR DESCRIPTION
Adds a new kind of Task, called TrampoliningTask.
This task directly uses the continuation pattern in the Task interface, without using a different thread like ThreadedTask or exceptions like ReplayingTask. Instead, TrampoliningTask doesn't support operations that would break the normal flow of control.

The main use case for trampolining tasks are daemon tasks spawned by a mission model which do very little work per iteration but run for many iterations. Since they do very little work per iteration, using a separate thread incurs large overhead. Since they run for many iterations, using a replaying task requires time quadratic in the plan length.

However, these daemon tasks also tend not to require arbitrary interruptions to the flow of control. Instead, they tend to follow a simple pattern of doing a small amount of work and then repeating pending a delay or condition. This lends itself well to trampolining.

It is possible to implement trampolining with replaying tasks, without modifying Merlin. However, this requires registering a brand new task with every iteration. As such, the SimulationEngine consumes memory linear in the length of the plan to track these tasks. By implementing the trampolining tasks directly in Merlin, we avoid this memory creep.

Finally, we demonstrate the use of trampolining tasks in the Foo mission model. Performance testing suggests that this change increases the simulation-to-real-time ratio for this model from ~10,000 when using threaded tasks, to ~1.6 million using trampolining tasks, without significantly changing the memory usage.

* **Tickets addressed:** N/A
* **Review:** By file  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
(see above)
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

## Verification
The Foo mission model was changed to use trampolining repeating tasks for its daemon tasks. Locally, I also exposed the timeTrackerDaemon's minutesElapsed resource and verified that it was updated correctly, though this change wasn't committed. I also measured the time the model took to run on 1-year plans, and used a profiler to ensure that the engine wasn't storing large numbers of task-related objects.

Additionally, I copied the trampolining strategy I use in the Clipper model over to the Foo model for comparison. In this case, memory usage was so high that 1-year plans ran out of memory before being completed. Profiling confirmed that large amounts of memory were used to track tasks, replicating the behavior from the Clipper model. This code was not committed.

I'd like to have more careful unit testing around the trampolining tasks, but I'm not sure how to implement that testing within the Aerie repo; any suggestions here would be appreciated.
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

## Documentation
No documentation is included yet, beyond comments in the code itself. However, it may be helpful to have some additional discussion for modelers around the pros and cons of each kind of task, and when to use each type. Suggestions on where to put such a discussion would be appreciated.
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
N/A - This feature is self-contained.
<!-- What next steps can we anticipate from here, if any? -->
