### PR TITLE
Add gradle dependency submission action

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
+      contents: write
       security-events: write
 
     strategy:
@@ -43,6 +43,33 @@ jobs:
           ./gradlew testClasses
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+      - name: Gradle Dependency Submission
+        uses: mikepenz/gradle-dependency-submission@v0.9.0
+        with:
+          gradle-build-module: |-
+            :merlin-sdk
+            :merlin-driver
+            :merlin-framework
+            :merlin-framework-junit
+            :merlin-framework-processor
+            :contrib
+            :parsing-utilities
+            :permissions
+            :merlin-server
+            :merlin-worker
+            :scheduler-server
+            :scheduler-worker
+            :sequencing-server
+            :constraints
+            :scheduler-driver
+            :db-tests
+            :e2e-tests
+            :examples:banananation
+            :examples:foo-missionmodel
+            :examples:config-with-defaults
+            :examples:config-without-defaults
+            :examples:minimal-mission-model
+          sub-module-mode: "COMBINED"
       - name: NASA Scrub
         run: |
           python3 -m pip install nasa-scrub


### PR DESCRIPTION
* **Tickets addressed:** closes #1066 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Adds [the following Github Action](https://github.com/marketplace/actions/gradle-dependency-submission) that automatically uploads our dependencies for all gradle subprojects to Github's [dependency submission API](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api), which should then provide security alerts (i.e. dependabot) for these dependencies.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
This action should upload our current dependencies and show the vulnerabilities discussed in https://github.com/NASA-AMMOS/aerie/issues/1066

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None