### PR TITLE
Support non-commands expansions

### DIFF
--- a/sequencing-server/src/types/seqBuilder.ts
+++ b/sequencing-server/src/types/seqBuilder.ts
@@ -1,12 +1,12 @@
 import type { UserCodeError } from '@nasa-jpl/aerie-ts-user-code-runner';
 
-import type { CommandStem, Sequence } from '../lib/codegen/CommandEDSLPreface.js';
+import type { CommandStem, LoadStep, ActivateStep, Sequence } from '../lib/codegen/CommandEDSLPreface.js';
 import type { SimulatedActivity } from '../lib/batchLoaders/simulatedActivityBatchLoader';
 
 export interface SeqBuilder {
   (
     sortedActivityInstancesWithCommands: (SimulatedActivity & {
-      commands: CommandStem[] | null;
+      commands: (CommandStem | ActivateStep | LoadStep)[] | null;
       errors: ReturnType<UserCodeError['toJSON']>[] | null;
     })[],
     seqId: string,

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -249,8 +249,6 @@ export type RequestOptions =
   metadata?: Metadata;
 };
 
-export type Arrayable<T> = T | Arrayable<T>[];
-
 /**-----------------------------
  *      GLOBAL eDSL Declarations
  * -----------------------------
@@ -388,7 +386,8 @@ declare global {
   }
 
   type Context = {};
-  type ExpansionReturn = Arrayable<CommandStem>;
+  // @ts-ignore : 'Description' found in JSON Spec
+  type ExpansionReturn = (Command | Load | Activate)[];
 
   type U<BitLength extends 8 | 16 | 32 | 64> = number;
   type U8 = U<8>;
@@ -1227,9 +1226,10 @@ export function ENUM<const N extends string, const E extends string>(
 // @ts-ignore : 'Args' found in JSON Spec
 export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}> implements Command {
   public readonly arguments: A;
-  public readonly absoluteTime: Temporal.Instant | null = null;
-  public readonly epochTime: Temporal.Duration | null = null;
-  public readonly relativeTime: Temporal.Duration | null = null;
+  private readonly _absoluteTime: Temporal.Instant | undefined = undefined;
+  private readonly _epochTime: Temporal.Duration | undefined = undefined;
+  private readonly _relativeTime: Temporal.Duration | undefined = undefined;
+
 
   public readonly stem: string;
   // @ts-ignore : 'Args' found in JSON Spec
@@ -1249,11 +1249,11 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
     this.arguments = opts.arguments;
 
     if ('absoluteTime' in opts) {
-      this.absoluteTime = opts.absoluteTime;
+      this._absoluteTime = opts.absoluteTime;
     } else if ('epochTime' in opts) {
-      this.epochTime = opts.epochTime;
+      this._epochTime = opts.epochTime;
     } else if ('relativeTime' in opts) {
-      this.relativeTime = opts.relativeTime;
+      this._relativeTime = opts.relativeTime;
     }
     this._metadata = opts.metadata;
     this._description = opts.description;
@@ -1289,9 +1289,9 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
       models: models,
       metadata: this._metadata,
       description: this._description,
-      ...(this.absoluteTime && { absoluteTime: this.absoluteTime }),
-      ...(this.epochTime && { epochTime: this.epochTime }),
-      ...(this.relativeTime && { relativeTime: this.relativeTime }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
     });
   }
 
@@ -1308,9 +1308,9 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
       models: this._models,
       metadata: metadata,
       description: this._description,
-      ...(this.absoluteTime && { absoluteTime: this.absoluteTime }),
-      ...(this.epochTime && { epochTime: this.epochTime }),
-      ...(this.relativeTime && { relativeTime: this.relativeTime }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
     });
   }
 
@@ -1327,14 +1327,26 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
       models: this._models,
       metadata: this._metadata,
       description: description,
-      ...(this.absoluteTime && { absoluteTime: this.absoluteTime }),
-      ...(this.epochTime && { epochTime: this.epochTime }),
-      ...(this.relativeTime && { relativeTime: this.relativeTime }),
+      ...(this._absoluteTime && { absoluteTime: this._absoluteTime }),
+      ...(this._epochTime && { epochTime: this._epochTime }),
+      ...(this._relativeTime && { relativeTime: this._relativeTime }),
     });
   }
   // @ts-ignore : 'Description' found in JSON Spec
   public GET_DESCRIPTION(): Description | undefined {
     return this._description;
+  }
+
+  public GET_ABSOLUTE_TIME(): Temporal.Instant | undefined {
+    return this._absoluteTime;
+  }
+
+  public GET_EPOCH_TIME(): Temporal.Duration | undefined {
+    return this._epochTime;
+  }
+
+  public GET_RELATIVE_TIME(): Temporal.Duration | undefined {
+    return this._relativeTime;
   }
 
   // @ts-ignore : 'Command' found in JSON Spec
@@ -1344,12 +1356,12 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
       stem: this.stem,
       // prettier-ignore
       time:
-          this.absoluteTime !== null
-              ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this.absoluteTime) }
-          : this.epochTime !== null
-              ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this.epochTime) }
-          : this.relativeTime !== null
-              ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this.relativeTime) }
+          this._absoluteTime
+              ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
+          : this._epochTime
+              ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
+          : this._relativeTime
+              ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
           : { type: TimingTypes.COMMAND_COMPLETE },
       type: this.type,
       ...(this._metadata ? { metadata: this._metadata } : {}),
@@ -1412,12 +1424,12 @@ export class CommandStem<A extends Args[] | { [argName: string]: any } = [] | {}
   }
 
   public toEDSLString(): string {
-    const timeString = this.absoluteTime
-        ? \`A\\\`\${instantToDoy(this.absoluteTime)}\\\`\`
-        : this.epochTime
-            ? \`E\\\`\${durationToHms(this.epochTime)}\\\`\`
-            : this.relativeTime
-                ? \`R\\\`\${durationToHms(this.relativeTime)}\\\`\`
+    const timeString = this._absoluteTime
+        ? \`A\\\`\${instantToDoy(this._absoluteTime)}\\\`\`
+        : this._epochTime
+            ? \`E\\\`\${durationToHms(this._epochTime)}\\\`\`
+            : this._relativeTime
+                ? \`R\\\`\${durationToHms(this._relativeTime)}\\\`\`
                 : 'C';
 
     const argsString =
@@ -1539,9 +1551,9 @@ export class Ground_Block implements GroundBlock {
   time!: Time;
   type: 'ground_block' = StepType.GroundBlock;
 
-  private readonly _absoluteTime: Temporal.Instant | null = null;
-  private readonly _epochTime: Temporal.Duration | null = null;
-  private readonly _relativeTime: Temporal.Duration | null = null;
+  private readonly _absoluteTime: Temporal.Instant | undefined = undefined;
+  private readonly _epochTime: Temporal.Duration | undefined = undefined;
+  private readonly _relativeTime: Temporal.Duration | undefined = undefined;
 
   // @ts-ignore : 'Args' found in JSON Spec
   private readonly _args: Args | undefined;
@@ -1681,17 +1693,29 @@ export class Ground_Block implements GroundBlock {
     return this._args;
   }
 
+  public GET_ABSOLUTE_TIME(): Temporal.Instant | undefined {
+    return this._absoluteTime;
+  }
+
+  public GET_EPOCH_TIME(): Temporal.Duration | undefined {
+    return this._epochTime;
+  }
+
+  public GET_RELATIVE_TIME(): Temporal.Duration | undefined {
+    return this._relativeTime;
+  }
+
   // @ts-ignore : 'GroundBlock' found in JSON Spec
   public toSeqJson(): GroundBlock {
     return {
       name: this.name,
       // prettier-ignore
       time:
-          this._absoluteTime !== null
+          this._absoluteTime
               ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
-          : this._epochTime !== null
+          : this._epochTime
               ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
-          : this._relativeTime !== null
+          : this._relativeTime
               ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
           : { type: TimingTypes.COMMAND_COMPLETE },
       ...(this._args ? { args: this._args } : {}),
@@ -1772,9 +1796,9 @@ export class Ground_Event implements GroundEvent {
   time!: Time;
   type: 'ground_event' = StepType.GroundEvent;
 
-  private readonly _absoluteTime: Temporal.Instant | null = null;
-  private readonly _epochTime: Temporal.Duration | null = null;
-  private readonly _relativeTime: Temporal.Duration | null = null;
+  private readonly _absoluteTime: Temporal.Instant | undefined = undefined;
+  private readonly _epochTime: Temporal.Duration | undefined = undefined;
+  private readonly _relativeTime: Temporal.Duration | undefined = undefined;
 
   // @ts-ignore : 'Args' found in JSON Spec
   private readonly _args: Args | undefined;
@@ -1914,16 +1938,28 @@ export class Ground_Event implements GroundEvent {
     return this._args;
   }
 
+  public GET_ABSOLUTE_TIME(): Temporal.Instant | undefined {
+    return this._absoluteTime;
+  }
+
+  public GET_EPOCH_TIME(): Temporal.Duration | undefined {
+    return this._epochTime;
+  }
+
+  public GET_RELATIVE_TIME(): Temporal.Duration | undefined {
+    return this._relativeTime;
+  }
+
   // @ts-ignore : 'Ground_Event' found in JSON Spec
   public toSeqJson(): GroundEvent {
     return {
       name: this.name,
       time:
-          this._absoluteTime !== null
+          this._absoluteTime
               ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
-              : this._epochTime !== null
+              : this._epochTime
                   ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
-                  : this._relativeTime !== null
+                  : this._relativeTime
                       ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
                       : { type: TimingTypes.COMMAND_COMPLETE },
       ...(this._args ? { args: this._args } : {}),
@@ -2004,9 +2040,9 @@ export class ActivateStep implements Activate {
   time!: Time;
   type: 'activate' = StepType.Activate;
 
-  private readonly _absoluteTime: Temporal.Instant | null = null;
-  private readonly _epochTime: Temporal.Duration | null = null;
-  private readonly _relativeTime: Temporal.Duration | null = null;
+  private readonly _absoluteTime: Temporal.Instant | undefined = undefined;
+  private readonly _epochTime: Temporal.Duration | undefined = undefined;
+  private readonly _relativeTime: Temporal.Duration | undefined = undefined;
 
   // @ts-ignore : 'Args' found in JSON Spec
   private readonly _args?: Args | undefined;
@@ -2200,16 +2236,28 @@ export class ActivateStep implements Activate {
     return this._models;
   }
 
+  public GET_ABSOLUTE_TIME(): Temporal.Instant | undefined {
+    return this._absoluteTime;
+  }
+
+  public GET_EPOCH_TIME(): Temporal.Duration | undefined {
+    return this._epochTime;
+  }
+
+  public GET_RELATIVE_TIME(): Temporal.Duration | undefined {
+    return this._relativeTime;
+  }
+
   // @ts-ignore : 'Activate' found in JSON Spec
   public toSeqJson(): Activate {
     return {
       sequence: this.sequence,
       time:
-          this._absoluteTime !== null
+          this._absoluteTime
               ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
-              : this._epochTime !== null
+              : this._epochTime
                   ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
-                  : this._relativeTime !== null
+                  : this._relativeTime
                       ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
                       : { type: TimingTypes.COMMAND_COMPLETE },
       type: this.type,
@@ -2298,9 +2346,9 @@ export class LoadStep implements Load {
   time!: Time;
   type: 'load' = StepType.Load;
 
-  private readonly _absoluteTime: Temporal.Instant | null = null;
-  private readonly _epochTime: Temporal.Duration | null = null;
-  private readonly _relativeTime: Temporal.Duration | null = null;
+  private readonly _absoluteTime: Temporal.Instant | undefined = undefined;
+  private readonly _epochTime: Temporal.Duration | undefined = undefined;
+  private readonly _relativeTime: Temporal.Duration | undefined = undefined;
 
   // @ts-ignore : 'Args' found in JSON Spec
   private readonly _args?: Args | undefined;
@@ -2494,16 +2542,28 @@ export class LoadStep implements Load {
     return this._models;
   }
 
+  public GET_ABSOLUTE_TIME(): Temporal.Instant | undefined {
+    return this._absoluteTime;
+  }
+
+  public GET_EPOCH_TIME(): Temporal.Duration | undefined {
+    return this._epochTime;
+  }
+
+  public GET_RELATIVE_TIME(): Temporal.Duration | undefined {
+    return this._relativeTime;
+  }
+
   // @ts-ignore : 'Load' found in JSON Spec
   public toSeqJson(): Load {
     return {
       sequence: this.sequence,
       time:
-          this._absoluteTime !== null
+          this._absoluteTime
               ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
-              : this._epochTime !== null
+              : this._epochTime
                   ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
-                  : this._relativeTime !== null
+                  : this._relativeTime
                       ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
                       : { type: TimingTypes.COMMAND_COMPLETE },
       type: this.type,
@@ -2788,9 +2848,9 @@ class RequestCommon {
   }
 }
 class RequestTime extends RequestCommon implements RequestWithTime {
-  private readonly _absoluteTime: Temporal.Instant | null = null;
-  private readonly _epochTime: Temporal.Duration | null = null;
-  private readonly _relativeTime: Temporal.Duration | null = null;
+  private readonly _absoluteTime: Temporal.Instant | undefined = undefined;
+  private readonly _epochTime: Temporal.Duration | undefined = undefined;
+  private readonly _relativeTime: Temporal.Duration | undefined = undefined;
 
   private constructor(opts: RequestOptions) {
     super(opts);
@@ -2864,8 +2924,20 @@ class RequestTime extends RequestCommon implements RequestWithTime {
       ...(this._relativeTime ? { relativeTime: this._relativeTime } : {}),
     });
   }
-  // @ts-ignore : 'Request' found in JSON Spec
 
+  public GET_ABSOLUTE_TIME(): Temporal.Instant | undefined {
+    return this._absoluteTime;
+  }
+
+  public GET_EPOCH_TIME(): Temporal.Duration | undefined {
+    return this._epochTime;
+  }
+
+  public GET_RELATIVE_TIME(): Temporal.Duration | undefined {
+    return this._relativeTime;
+  }
+
+  // @ts-ignore : 'Request' found in JSON Spec
   public static override fromSeqJson(json: Request): RequestTime {
     // prettier-ignore
     const timeValue = json.time
@@ -2928,11 +3000,11 @@ class RequestTime extends RequestCommon implements RequestWithTime {
       ...{
         // prettier-ignore
         time:
-            this._absoluteTime !== null
+            this._absoluteTime
                 ? { type: TimingTypes.ABSOLUTE, tag: instantToDoy(this._absoluteTime) }
-            : this._epochTime !== null
+            : this._epochTime
                 ? { type: TimingTypes.EPOCH_RELATIVE, tag: durationToHms(this._epochTime) }
-            : this._relativeTime !== null
+            : this._relativeTime
                 ? { type: TimingTypes.COMMAND_RELATIVE, tag: durationToHms(this._relativeTime) }
             : { type: TimingTypes.COMMAND_COMPLETE },
       },


### PR DESCRIPTION
* **Tickets addressed:** Closes #853 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
There are five **Step** that a user can define within a sequence **(Command, Load, Activate, Ground_Event, and Ground_Block)**. Initially, only the **Command** step was eligible for expansion during both the 'command expansion' and 'sequence generation' processes. In order to execute background sequences, users will utilize the **Load** and **Activate** steps to initiate a background sequence within the sequence engine. Furthermore, users are interested in being able to formulate expansion logic using both **Load** and **Activate** steps. 

Provided below is an illustrative example that demonstrates the utilization of Load, Activate, and Command within an Authored Expansion Logic.

```ts
export default function MyExpansion(props: {
  activityInstance: ActivityType
}): ExpansionReturn {
  const { activityInstance } = props;
  return [
          A("2022-203T00:00:00").LOAD("BACKGROUND-A").ARGUMENTS(props.activityInstance.attributes.arguments.temperature),
          A("2022-204T00:00:00").ACTIVATE("BACKGROUND-B"),
          R("00:00:90").ADD_WATER
          ];
}

```

The final sequence generated by expansion

```json
{
  "id": "banana00001",
  "metadata": {
    "planId": 1,
    "simulationDatasetId": 1,
    "timeSorted": false
  },
  "steps": [
    {
      "args": [
        {
          "name": "arg_0",
          "type": "number",
          "value": 350
        }
      ],
      "metadata": {
        "simulatedActivityId": 1
      },
      "sequence": "BACKGROUND-A",
      "time": {
        "tag": "2022-203T00:00:00.000",
        "type": "ABSOLUTE"
      },
      "type": "load"
    },
    {
      "metadata": {
        "simulatedActivityId": 1
      },
      "sequence": "BACKGROUND-B",
      "time": {
        "tag": "2022-204T00:00:00.000",
        "type": "ABSOLUTE"
      },
      "type": "activate"
    },
    {
      "args": [],
      "metadata": {
        "simulatedActivityId": 1
      },
      "stem": "ADD_WATER",
      "time": {
        "tag": "00:01:30.000",
        "type": "COMMAND_RELATIVE"
      },
      "type": "command"
    }
  ]
}
```

## Verification
Added and manually ran through command expansion and sequence generation with a plan.

## Documentation
none 

## Future work
none
