### PR TITLE
Fix Scheduler Dropping Activities Outside Plan Bounds

### DIFF
--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class ResumableSimulationDriver<Model> implements AutoCloseable {
   private static final Logger logger = LoggerFactory.getLogger(ResumableSimulationDriver.class);
@@ -223,9 +222,11 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
     // Get all activities as close as possible to absolute time, then schedule all activities.
     // Using HashMap explicitly because it allows `null` as a key.
     // `null` key means that an activity is not waiting on another activity to finish to know its start time
-    final HashMap<ActivityDirectiveId, List<Pair<ActivityDirectiveId, Duration>>> resolved = new StartOffsetReducer(
+    HashMap<ActivityDirectiveId, List<Pair<ActivityDirectiveId, Duration>>> resolved = new StartOffsetReducer(
         planDuration,
         schedule).compute();
+    // Filter out activities that are before the plan start
+    resolved = StartOffsetReducer.filterOutNegativeStartOffset(resolved);
 
     scheduleActivities(
         schedule,

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -133,10 +133,6 @@ public class PrioritySolver implements Solver {
 
   public record InsertActivityResult(boolean success, List<SchedulingActivityDirective> activitiesInserted){}
 
-  private InsertActivityResult checkAndInsertAct(SchedulingActivityDirective act){
-    return checkAndInsertActs(List.of(act));
-  }
-
   /**
    * Tries to insert a collection of activity instances in plan. Simulates each of the activity and checks whether the expected
    * duration is equal to the simulated duration.
@@ -220,10 +216,7 @@ public class PrioritySolver implements Solver {
     //turn off simulation checking for initial plan contents (must accept user input regardless)
     final var prevCheckFlag = this.checkSimBeforeInsertingActivities;
     this.checkSimBeforeInsertingActivities = false;
-    problem.getInitialPlan().getActivitiesByTime().stream()
-      .filter( act -> (act.startOffset()==null)
-               || problem.getPlanningHorizon().contains( act.startOffset() ) )
-      .forEach(this::checkAndInsertAct);
+    checkAndInsertActs(problem.getInitialPlan().getActivitiesByTime());
     this.checkSimBeforeInsertingActivities = prevCheckFlag;
 
     evaluation = new Evaluation();

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
@@ -5,6 +5,7 @@ import com.google.common.truth.Correspondence;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
+import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
@@ -31,7 +32,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PrioritySolverTest {
   private static PrioritySolver makeEmptyProblemSolver() {
-    return new PrioritySolver(new Problem(null, h, null, null));
+    MissionModel<?> bananaMissionModel = SimulationUtility.getBananaMissionModel();
+    return new PrioritySolver(
+            new Problem(
+                    bananaMissionModel,
+                    h,
+                    new SimulationFacade(h, bananaMissionModel),
+                    SimulationUtility.getBananaSchedulerModel()));
   }
 
   private static PrioritySolver makeProblemSolver(Problem problem) {


### PR DESCRIPTION
* **Tickets addressed:** Closes #1092 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
When the scheduler was setting the initial plan for the facade, it would preemptively filter out all activities which were outside of the plan bounds. Because these activities did not make it into the final plan, the scheduler would attempt to delete those filtered out activities when it went to upload the plan. 

Additionally, this filter was running on the raw `startOffsets`, meaning that activities that had a negative start anchor were being considered "outside of the plan", even if they really were inside the plan bounds once their anchors were resolved.

This PR fixes this by removing the filter from `PrioritySover::initializePlan` and instead filtering the to-be-simulated schedule in `ResumableSimulationDriver::simulateSchedule`. The Scheduler's driver now handles out of bounds activities in the same way as the Merlin's driver.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
New tests were added to `SchedulingIntegrationTests`.

`makeEmptyProblemSolver` in `PrioritySolverTests` was updated to create a solver with a defined model and facade. This change was done as we do not expect these values to be null during normal execution and updating `initializePlan` causes NullPointerExceptions when the SimFacade is `null`.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs need to be updated.
