### PR TITLE
Scheduling edsl real resource tolerance

### DIFF
--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -35,6 +35,7 @@ export enum NodeKind {
   RealProfileLessThanOrEqual = 'RealProfileLessThanOrEqual',
   RealProfileGreaterThan = 'RealProfileGreaterThan',
   RealProfileGreaterThanOrEqual = 'RealProfileGreaterThanOrEqual',
+  RealProfileIsWithin = 'RealProfileIsWithin',
   WindowsExpressionAnd = 'WindowsExpressionAnd',
   WindowsExpressionOr = 'WindowsExpressionOr',
   WindowsExpressionNot = 'WindowsExpressionNot',
@@ -88,6 +89,7 @@ export type WindowsExpression =
   | RealProfileLessThanOrEqual
   | RealProfileGreaterThan
   | RealProfileGreaterThanOrEqual
+  | RealProfileIsWithin
   | DiscreteProfileTransition
   | ExpressionEqual<RealProfileExpression>
   | ExpressionEqual<DiscreteProfileExpression>
@@ -160,6 +162,13 @@ export interface RealProfileGreaterThanOrEqual {
   kind: NodeKind.RealProfileGreaterThanOrEqual;
   left: RealProfileExpression;
   right: RealProfileExpression;
+}
+
+export interface RealProfileIsWithin {
+  kind: NodeKind.RealProfileIsWithin;
+  left: RealProfileExpression;
+  right: RealProfileExpression;
+  margin: RealProfileExpression;
 }
 
 export interface RealProfileGreaterThan {

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -162,7 +162,6 @@ export interface RealProfileGreaterThanOrEqual {
   right: RealProfileExpression;
 }
 
-
 export interface RealProfileGreaterThan {
   kind: NodeKind.RealProfileGreaterThan;
   left: RealProfileExpression;

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -35,7 +35,6 @@ export enum NodeKind {
   RealProfileLessThanOrEqual = 'RealProfileLessThanOrEqual',
   RealProfileGreaterThan = 'RealProfileGreaterThan',
   RealProfileGreaterThanOrEqual = 'RealProfileGreaterThanOrEqual',
-  RealProfileIsWithin = 'RealProfileIsWithin',
   WindowsExpressionAnd = 'WindowsExpressionAnd',
   WindowsExpressionOr = 'WindowsExpressionOr',
   WindowsExpressionNot = 'WindowsExpressionNot',
@@ -89,7 +88,6 @@ export type WindowsExpression =
   | RealProfileLessThanOrEqual
   | RealProfileGreaterThan
   | RealProfileGreaterThanOrEqual
-  | RealProfileIsWithin
   | DiscreteProfileTransition
   | ExpressionEqual<RealProfileExpression>
   | ExpressionEqual<DiscreteProfileExpression>
@@ -164,12 +162,6 @@ export interface RealProfileGreaterThanOrEqual {
   right: RealProfileExpression;
 }
 
-export interface RealProfileIsWithin {
-  kind: NodeKind.RealProfileIsWithin;
-  left: RealProfileExpression;
-  right: RealProfileExpression;
-  margin: RealProfileExpression;
-}
 
 export interface RealProfileGreaterThan {
   kind: NodeKind.RealProfileGreaterThan;

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -682,6 +682,20 @@ export class Real {
   }
 
   /**
+   * Produce a window whenever this profile is equal to another real profile plus or minus the tolerance
+   */
+  public isWithin(other: Real | number, tolerance: Real | number): Windows{
+    if (!(other instanceof Real)) {
+      other = Real.Value(other);
+    }
+    if (!(tolerance instanceof Real)) {
+      tolerance = Real.Value(tolerance);
+    }
+
+    return Windows.And(this.lessThanOrEqual(other.plus(tolerance)), this.greaterThanOrEqual(other.minus(tolerance)));
+  }
+
+  /**
    * Produce an instantaneous window whenever this profile changes.
    */
   public changes(): Windows {
@@ -1356,6 +1370,13 @@ declare global {
      * @param other
      */
     public notEqual(other: Real | number): Windows;
+
+    /**
+     * Produce a window whenever this profile is equal to another real profile plus or minus the tolerance
+     * @param other
+     * @param tolerance
+     */
+    public isWithin(other: Real | number, tolerance: Real | number): Windows;
 
     /**
      * Produce an instantaneous window whenever this profile changes.

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -652,7 +652,7 @@ class ConstraintsDSLCompilationServiceTests {
   }
 
   @Test
-  void testReChanges() {
+  void testRealChanges() {
     checkSuccessfulCompilation(
         """
             export default () => {

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -633,7 +633,26 @@ class ConstraintsDSLCompilationServiceTests {
   }
 
   @Test
-  void testRealChanges() {
+  void testRealIsWithin() {
+    checkSuccessfulCompilation(
+        """
+        export default () => {
+          return Real.Resource("an integer").isWithin(Real.Value(10), Real.Value(1));
+        }
+        """,
+        new ViolationsOfWindows(
+            new And(
+                java.util.List.of(
+                    new LessThanOrEqual(new RealResource("an integer"), new Plus(new RealValue(10), new RealValue(1))),
+                    new GreaterThanOrEqual(new RealResource("an integer"), new Plus(new RealValue(10), new Times(new RealValue(1), -1)))
+                )
+            )
+        )
+    );
+  }
+
+  @Test
+  void testReChanges() {
     checkSuccessfulCompilation(
         """
             export default () => {


### PR DESCRIPTION
Closes https://github.com/NASA-AMMOS/aerie/issues/846

Adding a new EDSL fluent to express a real resource that has a value and a tolerance that acts as an error margin for the value.

The syntax is: 

```ts
Real.Resource("name").isWithin(value, tolerance)
```

The syntax uses already existing edsl constraints to represent the tolerance. The constraint is evaluated as follows:
- the resource value is less than or equal the value + tolerance
- the resource value is greater than or equal the value - tolerance

A test has been added to ConstraintsDSLCompilationServiceTests to demonstrate the correctness

