### PR TITLE
Added a default empty object for parsed_json

### DIFF
--- a/deployment/hasura/migrations/AerieSequencing/4_add_parsed_json/up.sql
+++ b/deployment/hasura/migrations/AerieSequencing/4_add_parsed_json/up.sql
@@ -1,5 +1,5 @@
 alter table command_dictionary
-  add column parsed_json jsonb not null;
+  add column parsed_json jsonb not null default '{}';
 
 comment on column command_dictionary.parsed_json is e''
   'The XML that has been parsed and converted to JSON';

--- a/sequencing-server/sql/sequencing/tables/command_dictionary.sql
+++ b/sequencing-server/sql/sequencing/tables/command_dictionary.sql
@@ -4,7 +4,7 @@ create table command_dictionary (
   command_types_typescript_path text not null,
   mission text not null,
   version text not null,
-  parsed_json jsonb not null,
+  parsed_json jsonb not null default '{}',
 
   created_at timestamptz not null default now(),
 


### PR DESCRIPTION
* **Tickets addressed:** Closes #1107
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This was an error during a Clipper migration, `parsed_json` needs a default value for databases with existing command dictionaries that are being migrated to a newer version.

## Verification
Tests re-ran.

## Documentation
NA

## Future work
NA
