### PR TITLE
Add missing Endpoints to Whitelist

### DIFF
--- a/sequencing-server/src/utils/hasura.ts
+++ b/sequencing-server/src/utils/hasura.ts
@@ -30,6 +30,8 @@ export const ENDPOINTS_WHITELIST = new Set([
   '/seqjson/bulk-get-seqjson-for-sequence-standalone',
   '/seqjson/get-seqjson-for-sequence-standalone',
   '/seqjson/get-seqjson-for-seqid-and-simulation-dataset',
+  '/seqjson/bulk-get-edsl-for-seqjson',
+  '/seqjson/get-edsl-for-seqjson'
 ]);
 
 /**


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The endpoints `/seqjson/bulk-get-edsl-for-seqjson` and `/seqjson/get-edsl-for-seqjson` were not included in the sequencing server's endpoint whitelist. This would cause all non-`aerie-admin` requests to these endpoints to fail with an exception when the server tried to check fine-grained permissions on the incoming request, which these endpoints don't take. The error message can be found in [this Slack Thread](https://jpl.slack.com/archives/C0163E42UBF/p1692921687425109?thread_ts=1692921643.916089&cid=C0163E42UBF).

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I have manually tested uploading a seqjson while as the `user` role. Additionally, I have checked that all of the endpoints are now in either `ENDPOINTS_WHITELIST` or `ENDPOINTS_TO_ACTION_KEY`.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

No docs need to be updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
