### PR TITLE
Allow Users to cancel pending Sim/Scheduling RQs

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation_dataset.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation_dataset.yaml
@@ -61,8 +61,12 @@ select_permissions:
 update_permissions:
   - role: aerie_admin
     permission:
-      columns: [requested_by]
+      columns: [requested_by, canceled]
       filter: {}
+  - role: user
+    permission:
+      columns: [canceled]
+      filter: {"simulation":{"plan":{"_or":[{"owner":{"_eq":"X-Hasura-User-Id"}},{"collaborators":{"collaborator":{"_eq":"X-Hasura-User-Id"}}}]}}}
 delete_permissions:
   - role: aerie_admin
     permission:

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_request.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_request.yaml
@@ -21,9 +21,16 @@ select_permissions:
 update_permissions:
   - role: aerie_admin
     permission:
-      columns: [requested_by]
+      columns: [requested_by, canceled]
+      filter: {}
+  - role: user
+    permission:
+      columns: [canceled]
       filter: {}
 delete_permissions:
   - role: aerie_admin
+    permission:
+      filter: {}
+  - role: user
     permission:
       filter: {}


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

Noticed that admins couldn't cancel pending sim/sched rqs. Cancelling permission has been granted to the roles `aerie_admin` and `user`. Additionally, the `user` role couldn't delete Scheduling Requests, despite it being able to delete Sim Requests. That has been fixed.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Spun up Hasura and confirmed the metadata was as expected.


## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

The queries to cancel a Simulation RQ and a Scheduling RQ need to be added to the API docs.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
