### PR TITLE
Pass user-id into Simulation/Scheduling Requests

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
@@ -30,7 +30,7 @@ public abstract class HasuraParsers {
       .field("x-hasura-role", stringP)
       .optionalField("x-hasura-user-id", stringP)
       .map(
-          untuple((role, userId) -> new HasuraAction.Session(role, userId.orElse(""))),
+          untuple((role, userId) -> new HasuraAction.Session(role, userId.orElse(null))),
           $ -> tuple($.hasuraRole(), Optional.ofNullable($.hasuraUserId())));
 
   private static <I extends HasuraAction.Input> JsonParser<HasuraAction<I>> hasuraActionF(final JsonParser<I> inputP) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -179,7 +179,7 @@ public final class MerlinBindings implements Plugin {
 
       this.checkPermissions(Action.simulate, body.session(), planId);
 
-      final var response = this.simulationAction.run(planId);
+      final var response = this.simulationAction.run(planId, body.session());
       ctx.result(ResponseSerializers.serializeSimulationResultsResponse(response).toString());
     } catch (final InvalidEntityException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
@@ -35,7 +35,7 @@ public final class InMemoryResultsCellRepository implements ResultsCellRepositor
   }
 
   @Override
-  public ResultsProtocol.OwnerRole allocate(final PlanId planId) {
+  public ResultsProtocol.OwnerRole allocate(final PlanId planId, final String requestedBy) {
     try {
       final var planRevision = planRepository.getPlanRevision(planId);
       final var cell = new InMemoryCell(planId, planRevision);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/ResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/ResultsCellRepository.java
@@ -6,7 +6,7 @@ import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import java.util.Optional;
 
 public interface ResultsCellRepository {
-  ResultsProtocol.OwnerRole allocate(PlanId planId);
+  ResultsProtocol.OwnerRole allocate(PlanId planId, String requestedBy);
 
   Optional<ResultsProtocol.OwnerRole> claim(PlanId planId, Long datasetId);
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateSimulationDatasetAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateSimulationDatasetAction.java
@@ -19,9 +19,10 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
         simulation_id,
         simulation_start_time,
         simulation_end_time,
-        arguments
+        arguments,
+        requested_by
       )
-    values(?, ?::timestamptz, ?::timestamptz, ?::jsonb)
+    values(?, ?::timestamptz, ?::timestamptz, ?::jsonb, ?)
     returning
       dataset_id,
       status,
@@ -40,12 +41,14 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
       final long simulationId,
       final Timestamp simulationStart,
       final Timestamp simulationEnd,
-      final Map<String, SerializedValue> arguments
+      final Map<String, SerializedValue> arguments,
+      final String requestedBy
   ) throws SQLException {
     this.statement.setLong(1, simulationId);
     PreparedStatements.setTimestamp(this.statement, 2, simulationStart);
     PreparedStatements.setTimestamp(this.statement, 3, simulationEnd);
     this.statement.setString(4, simulationArgumentsP.unparse(arguments).toString());
+    this.statement.setString(5, requestedBy);
 
     try (final var results = this.statement.executeQuery()) {
       if (!results.next()) throw new FailedInsertException("simulation_dataset");

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -44,7 +44,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
   }
 
   @Override
-  public ResultsProtocol.OwnerRole allocate(final PlanId planId) {
+  public ResultsProtocol.OwnerRole allocate(final PlanId planId, final String requestedBy) {
     try (final var connection = this.dataSource.getConnection()) {
       final SimulationRecord simulation = getSimulation(connection, planId);
       final SimulationTemplateRecord template;
@@ -73,7 +73,8 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
           simulation,
           startTime,
           endTime,
-          arguments);
+          arguments,
+          requestedBy);
 
       return new PostgresResultsCell(
           this.dataSource,
@@ -169,7 +170,8 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
       final SimulationRecord simulation,
       final Timestamp simulationStart,
       final Timestamp simulationEnd,
-      final Map<String, SerializedValue> arguments
+      final Map<String, SerializedValue> arguments,
+      final String requestedBy
   ) throws SQLException
   {
     try (final var createSimulationDatasetAction = new CreateSimulationDatasetAction(connection)) {
@@ -177,7 +179,8 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
           simulation.id(),
           simulationStart,
           simulationEnd,
-          arguments);
+          arguments,
+          requestedBy);
     }
   }
   /**

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
@@ -12,13 +12,13 @@ public record CachedSimulationService (
 ) implements SimulationService {
 
   @Override
-  public ResultsProtocol.State getSimulationResults(final PlanId planId, final RevisionData revisionData) {
+  public ResultsProtocol.State getSimulationResults(final PlanId planId, final RevisionData revisionData, final String requestedBy) {
     final var cell$ = this.store.lookup(planId);
     if (cell$.isPresent()) {
       return cell$.get().get();
     } else {
       // Allocate a fresh cell.
-      final var cell = this.store.allocate(planId);
+      final var cell = this.store.allocate(planId, requestedBy);
 
       // Return the current value of the reader; if it's incomplete, the caller can check it again later.
       return cell.get();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -5,6 +5,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.models.HasuraAction;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -34,10 +35,11 @@ public final class GetSimulationResultsAction {
     this.simulationService = Objects.requireNonNull(simulationService);
   }
 
-  public Response run(final PlanId planId) throws NoSuchPlanException, MissionModelService.NoSuchMissionModelException {
+  public Response run(final PlanId planId, final HasuraAction.Session session)
+  throws NoSuchPlanException, MissionModelService.NoSuchMissionModelException {
     final var revisionData = this.planService.getPlanRevisionData(planId);
 
-    final var response = this.simulationService.getSimulationResults(planId, revisionData);
+    final var response = this.simulationService.getSimulationResults(planId, revisionData, session.hasuraUserId());
 
     if (response instanceof ResultsProtocol.State.Pending r) {
       return new Response.Pending(r.simulationDatasetId());

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
@@ -7,6 +7,6 @@ import gov.nasa.jpl.aerie.merlin.server.models.SimulationResultsHandle;
 import java.util.Optional;
 
 public interface SimulationService {
-  ResultsProtocol.State getSimulationResults(PlanId planId, RevisionData revisionData);
+  ResultsProtocol.State getSimulationResults(PlanId planId, RevisionData revisionData, final String requestedBy);
   Optional<SimulationResultsHandle> get(PlanId planId, RevisionData revisionData);
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/UncachedSimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/UncachedSimulationService.java
@@ -13,7 +13,7 @@ public record UncachedSimulationService (
 ) implements SimulationService {
 
   @Override
-  public ResultsProtocol.State getSimulationResults(final PlanId planId, final RevisionData revisionData) {
+  public ResultsProtocol.State getSimulationResults(final PlanId planId, final RevisionData revisionData, final String requestedBy) {
     if (!(revisionData instanceof InMemoryRevisionData inMemoryRevisionData)) {
       throw new Error("UncachedSimulationService only accepts InMemoryRevisionData");
     }
@@ -39,7 +39,7 @@ public record UncachedSimulationService (
   @Override
   public Optional<SimulationResultsHandle> get(final PlanId planId, final RevisionData revisionData) {
     return Optional.ofNullable(
-        getSimulationResults(planId, revisionData) instanceof ResultsProtocol.State.Success s ?
+        getSimulationResults(planId, revisionData, null) instanceof ResultsProtocol.State.Success s ?
             s.results() :
             null);
   }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsersTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsersTest.java
@@ -109,7 +109,7 @@ public final class MerlinParsersTest {
       final var expected = new HasuraAction<>(
           "testAction",
           new HasuraAction.MissionModelInput("1"),
-          new HasuraAction.Session("aerie_admin", ""));
+          new HasuraAction.Session("aerie_admin", null));
 
       assertThat(hasuraMissionModelActionP.parse(json).getSuccessOrThrow()).isEqualTo(expected);
     }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
@@ -87,7 +87,7 @@ public record SchedulerBindings(
         ctx.status(500).result(ExceptionSerializers.serializeIOException(ex).toString());
       }
 
-      final var response = this.scheduleAction.run(specificationId);
+      final var response = this.scheduleAction.run(specificationId, session);
       ctx.result(serializeScheduleResultsResponse(response).toString());
     } catch (final IOException e) {
       log.error("low level input/output problem during scheduling", e);

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
@@ -53,7 +53,7 @@ public final class SchedulerParsers {
       .field("x-hasura-role", stringP)
       .optionalField("x-hasura-user-id", stringP)
       .map(
-          untuple((role, userId) -> new HasuraAction.Session(role, userId.orElse(""))),
+          untuple((role, userId) -> new HasuraAction.Session(role, userId.orElse(null))),
           session -> tuple(session.hasuraRole(), Optional.ofNullable(session.hasuraUserId())));
 
   /**

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/mocks/InMemoryResultsCellRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/mocks/InMemoryResultsCellRepository.java
@@ -8,7 +8,7 @@ import gov.nasa.jpl.aerie.scheduler.server.remotes.SpecificationRepository;
 
 public record InMemoryResultsCellRepository(SpecificationRepository specificationRepository) implements ResultsCellRepository {
   @Override
-  public ResultsProtocol.OwnerRole allocate(final SpecificationId specificationId)
+  public ResultsProtocol.OwnerRole allocate(final SpecificationId specificationId, final String requestedBy)
   {
     throw new UnsupportedOperationException(); // TODO stubbed method must be implemented
   }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/ResultsCellRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/ResultsCellRepository.java
@@ -5,7 +5,7 @@ import gov.nasa.jpl.aerie.scheduler.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
 
 public interface ResultsCellRepository {
-  ResultsProtocol.OwnerRole allocate(SpecificationId specificationId);
+  ResultsProtocol.OwnerRole allocate(SpecificationId specificationId, final String requestedBy);
 
   Optional<ResultsProtocol.OwnerRole> claim(SpecificationId specificationId);
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -31,11 +31,11 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
   }
 
   @Override
-  public ResultsProtocol.OwnerRole allocate(final SpecificationId specificationId)
+  public ResultsProtocol.OwnerRole allocate(final SpecificationId specificationId, final String requestedBy)
   {
     try (final var connection = this.dataSource.getConnection()) {
       final var spec = getSpecification(connection, specificationId);
-      final var request = createRequest(connection, spec);
+      final var request = createRequest(connection, spec, requestedBy);
 
       return new PostgresResultsCell(
           this.dataSource,
@@ -134,10 +134,11 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
 
   private static RequestRecord createRequest(
       final Connection connection,
-      final SpecificationRecord specification
+      final SpecificationRecord specification,
+      final String requestedBy
   ) throws SQLException {
     try (final var createRequestAction = new CreateRequestAction(connection)) {
-      return createRequestAction.apply(specification);
+      return createRequestAction.apply(specification, requestedBy);
     }
   }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/CachedSchedulerService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/CachedSchedulerService.java
@@ -8,14 +8,14 @@ public record CachedSchedulerService(
 ) implements SchedulerService {
 
   @Override
-  public ResultsProtocol.State getScheduleResults(final ScheduleRequest request) {
+  public ResultsProtocol.State getScheduleResults(final ScheduleRequest request, final String requestedBy) {
     final var specificationId = request.specificationId();
     final var cell$ = this.store.lookup(specificationId);
     if (cell$.isPresent()) {
       return cell$.get().get();
     } else {
       // Allocate a fresh cell.
-      final var cell = this.store.allocate(specificationId);
+      final var cell = this.store.allocate(specificationId, requestedBy);
 
       // Return the current value of the reader; if it's incomplete, the caller can check it again later.
       return cell.get();

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleAction.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/ScheduleAction.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import gov.nasa.jpl.aerie.scheduler.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchSpecificationException;
+import gov.nasa.jpl.aerie.scheduler.server.models.HasuraAction;
 import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
 
 /**
@@ -51,7 +52,7 @@ public record ScheduleAction(SpecificationService specificationService, Schedule
    * @return a response object wrapping summary results of the run (either successful or not)
    * @throws NoSuchSpecificationException if the target specification could not be found
    */
-  public Response run(final SpecificationId specificationId)
+  public Response run(final SpecificationId specificationId, final HasuraAction.Session session)
   throws NoSuchSpecificationException, IOException
   {
     //record the plan revision as of the scheduling request time (in case work commences much later eg in worker thread)
@@ -59,7 +60,7 @@ public record ScheduleAction(SpecificationService specificationService, Schedule
     final var specificationRev = this.specificationService.getSpecificationRevisionData(specificationId);
 
     //submit request to run scheduler (possibly asynchronously or even cached depending on service)
-    final var response = this.schedulerService.getScheduleResults(new ScheduleRequest(specificationId, specificationRev));
+    final var response = this.schedulerService.getScheduleResults(new ScheduleRequest(specificationId, specificationRev), session.hasuraUserId());
 
     return repackResponse(response);
   }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulerService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulerService.java
@@ -16,5 +16,5 @@ public interface SchedulerService {
    * @param request details of the scheduling request, including the target plan and goals to operate on
    * @return summary of the scheduling run, including goal satisfaction metrics and changes made
    */
-  ResultsProtocol.State getScheduleResults(final ScheduleRequest request);
+  ResultsProtocol.State getScheduleResults(final ScheduleRequest request, final String requestedBy);
 }


### PR DESCRIPTION
* **Tickets addressed:** Closes #1103.
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The Merlin Server and Scheduler Server now pass the `x-hasura-user-id` into the `requested_by` column of the Simulation/Scheduling Requests they make.

Additionally, the Hasura Session Parser was updated to set `userId` to `null` if the `x-hasura-user-id` header isn't included. This prevents this change from being breaking. It additionally makes Java, the DB, and the Sequencing Server consistent in how they handle this header being absent.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
`testHasuraActionParsers()` has been updated to reflect the parser change.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs need to be updated

## Future work
<!-- What next steps can we anticipate from here, if any? -->
