### PR TITLE
Implement dedicated rollingwindow constraint node

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
@@ -617,9 +617,26 @@ public final class ConstraintParsers {
               untuple((kind, expression) -> new ViolationsOfWindows(expression)),
               $ -> tuple(Unit.UNIT, $.expression));
 
+  public static final JsonParser<RollingThreshold.RollingThresholdAlgorithm> rollingThresholdAlgorithmP =
+      enumP(RollingThreshold.RollingThresholdAlgorithm.class, Enum::name);
+
+  static final JsonParser<RollingThreshold> rollingThresholdP =
+      productP
+          .field("kind", literalP("RollingThreshold"))
+          .field("spans", spansExpressionP)
+          .field("width", durationExprP)
+          .field("threshold", durationExprP)
+          .field("algorithm", rollingThresholdAlgorithmP)
+          .map(
+              untuple((kind, spans, width, threshold, alg) -> new RollingThreshold(spans, width, threshold, alg)),
+              $ -> tuple(Unit.UNIT, $.spans(), $.width(), $.threshold(), $.algorithm())
+          );
+
+
   public static final JsonParser<Expression<ConstraintResult>> constraintP =
       recursiveP(selfP -> chooseP(
           forEachActivityViolationsF(selfP),
           windowsExpressionP.map(ViolationsOfWindows::new, $ -> $.expression),
-          violationsOfP));
+          violationsOfP,
+          rollingThresholdP));
 }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RollingThreshold.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RollingThreshold.java
@@ -88,12 +88,10 @@ public record RollingThreshold(Expression<Spans> spans, Expression<Duration> wid
         }
       }
       if (this.algorithm == RollingThresholdAlgorithm.ExcessHull || this.algorithm == RollingThresholdAlgorithm.DeficitHull) {
-        final var hull = Interval.between(
-            violationIntervals.get(0).start,
-            violationIntervals.get(0).startInclusivity,
-            violationIntervals.get(violationIntervals.size() - 1).end,
-            violationIntervals.get(violationIntervals.size() - 1).endInclusivity
-        );
+        var hull = violationIntervals.get(0);
+        for (final var interval: violationIntervals.subList(1, violationIntervals.size())) {
+          hull = Interval.unify(hull, interval);
+        }
         violationIntervals.clear();
         violationIntervals.add(hull);
       }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RollingThreshold.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RollingThreshold.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-public record RollingThreshold(Expression<Spans> expression, Expression<Duration> width, Expression<Duration> threshold, RollingThresholdAlgorithm algorithm) implements Expression<ConstraintResult> {
+public record RollingThreshold(Expression<Spans> spans, Expression<Duration> width, Expression<Duration> threshold, RollingThresholdAlgorithm algorithm) implements Expression<ConstraintResult> {
 
   public enum RollingThresholdAlgorithm {
     InputSpans,
@@ -25,7 +25,7 @@ public record RollingThreshold(Expression<Spans> expression, Expression<Duration
   @Override
   public ConstraintResult evaluate(SimulationResults results, final Interval bounds, EvaluationEnvironment environment) {
     final var width = this.width.evaluate(results, bounds, environment);
-    var spans = this.expression.evaluate(results, bounds, environment);
+    var spans = this.spans.evaluate(results, bounds, environment);
     final var threshold = this.threshold.evaluate(results, bounds, environment);
 
     final var accDuration = spans.accumulatedDuration(threshold);
@@ -65,7 +65,7 @@ public record RollingThreshold(Expression<Spans> expression, Expression<Duration
 
   @Override
   public void extractResources(final Set<String> names) {
-    this.expression.extractResources(names);
+    this.spans.extractResources(names);
     this.width.extractResources(names);
     this.threshold.extractResources(names);
   }
@@ -75,7 +75,7 @@ public record RollingThreshold(Expression<Spans> expression, Expression<Duration
     return String.format(
         "\n%s(rolling-threshold on %s, width %s, threshold %s, algorithm %s)",
         prefix,
-        this.expression.prettyPrint(prefix + "  "),
+        this.spans.prettyPrint(prefix + "  "),
         this.width.prettyPrint(prefix + "  "),
         this.threshold.prettyPrint(prefix + "  "),
         this.algorithm

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RollingThreshold.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/RollingThreshold.java
@@ -1,0 +1,84 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.ConstraintResult;
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
+import gov.nasa.jpl.aerie.constraints.model.LinearEquation;
+import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.model.Violation;
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.Segment;
+import gov.nasa.jpl.aerie.constraints.time.Spans;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public record RollingThreshold(Expression<Spans> expression, Expression<Duration> width, Expression<Duration> threshold, RollingThresholdAlgorithm algorithm) implements Expression<ConstraintResult> {
+
+  public enum RollingThresholdAlgorithm {
+    InputSpans,
+    Hull
+  }
+
+  @Override
+  public ConstraintResult evaluate(SimulationResults results, final Interval bounds, EvaluationEnvironment environment) {
+    final var width = this.width.evaluate(results, bounds, environment);
+    var spans = this.expression.evaluate(results, bounds, environment);
+    final var threshold = this.threshold.evaluate(results, bounds, environment);
+
+    final var accDuration = spans.accumulatedDuration(threshold);
+    final var shiftedBack = accDuration.shiftBy(Duration.negate(width));
+
+    final var localAccDuration = shiftedBack.plus(accDuration.times(-1));
+
+    final var leftViolatingBounds = localAccDuration.greaterThan(new LinearProfile(Segment.of(Interval.FOREVER, new LinearEquation(Duration.ZERO, 1, 0))));
+
+    final var violations = new ArrayList<Violation>();
+    for (final var leftViolatingBound: leftViolatingBounds.iterateEqualTo(true)) {
+      final var expandedInterval = Interval.between(leftViolatingBound.start, leftViolatingBound.startInclusivity, leftViolatingBound.end.plus(width), leftViolatingBound.endInclusivity);
+      final var violationIntervals = new ArrayList<Interval>();
+      final var violationActivityIds = new ArrayList<Long>();
+      for (final var span: spans) {
+        if (!Interval.intersect(span.interval(), expandedInterval).isEmpty()) {
+          violationIntervals.add(span.interval());
+          span.value().ifPresent(m -> violationActivityIds.add(m.activityInstance().id));
+        }
+      }
+      if (this.algorithm == RollingThresholdAlgorithm.Hull) {
+        final var hull = Interval.between(
+            violationIntervals.get(0).start,
+            violationIntervals.get(0).startInclusivity,
+            violationIntervals.get(violationIntervals.size()-1).end,
+            violationIntervals.get(violationIntervals.size()-1).endInclusivity
+        );
+        violationIntervals.clear();
+        violationIntervals.add(hull);
+      }
+      final var violation = new Violation(violationIntervals, violationActivityIds);
+      violations.add(violation);
+    }
+
+    return new ConstraintResult(violations, List.of());
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {
+    this.expression.extractResources(names);
+    this.width.extractResources(names);
+    this.threshold.extractResources(names);
+  }
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return String.format(
+        "\n%s(rolling-threshold on %s, width %s, threshold %s, algorithm %s)",
+        prefix,
+        this.expression.prettyPrint(prefix + "  "),
+        this.width.prettyPrint(prefix + "  "),
+        this.threshold.prettyPrint(prefix + "  "),
+        this.algorithm
+    );
+  }
+}

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -1137,9 +1137,10 @@ public class ASTTests {
     );
 
     final var spans = new Spans(
+        // These two are out of order to make sure RollingThreshold's hull operation correctly handles unsorted spans.
+        Interval.between(4, 5, SECONDS),
         Interval.between(0, 1, SECONDS),
         Interval.between(2, 3, SECONDS),
-        Interval.between(4, 5, SECONDS),
 
         Interval.between(14, 15, SECONDS),
         Interval.between(16, 17, SECONDS),
@@ -1174,9 +1175,9 @@ public class ASTTests {
         List.of(
             new Violation(
                 List.of(
+                    Interval.between(4, 5, SECONDS),
                     Interval.between(0, 1, SECONDS),
-                    Interval.between(2, 3, SECONDS),
-                    Interval.between(4, 5, SECONDS)
+                    Interval.between(2, 3, SECONDS)
                 ), List.of()
             ),
             new Violation(

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -47,10 +47,11 @@ export enum NodeKind {
   ViolationsOf = 'ViolationsOf',
   AbsoluteInterval = 'AbsoluteInterval',
   IntervalAlias = 'IntervalAlias',
-  IntervalDuration = 'IntervalDuration'
+  IntervalDuration = 'IntervalDuration',
+  RollingThreshold = 'RollingThreshold'
 }
 
-export type Constraint = ViolationsOf | WindowsExpression | SpansExpression | ForEachActivityConstraints;
+export type Constraint = ViolationsOf | WindowsExpression | SpansExpression | ForEachActivityConstraints | RollingThreshold;
 
 export interface ViolationsOf {
   kind: NodeKind.ViolationsOf;
@@ -69,6 +70,14 @@ export interface ForEachActivitySpans {
   activityType: string;
   alias: string;
   expression: SpansExpression;
+}
+
+export interface RollingThreshold {
+  kind: NodeKind.RollingThreshold;
+  spans: SpansExpression,
+  width: Duration,
+  threshold: Duration,
+  algorithm: API.RollingThresholdAlgorithm
 }
 
 export interface AssignGapsExpression<P extends ProfileExpression> {

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -80,7 +80,7 @@ export class Constraint {
    *    contributed to the threshold violation in one interval.
    * - `DeficitSpans` detects times when the duration falls short of the threshold and highlights the individual gaps between spans
    *    that contributed to the threshold violation.
-   * - `ExcessHull` detects times when the duration falls short of the threshold and highlights the whole group of gaps between
+   * - `DeficitHull` detects times when the duration falls short of the threshold and highlights the whole group of gaps between
    *    spans that contributed to the threshold violation in one interval.
    *
    * @param spans spans object to detect threshold events on
@@ -1108,7 +1108,7 @@ declare global {
      *    contributed to the threshold violation in one interval.
      * - `DeficitSpans` detects times when the duration falls short of the threshold and highlights the individual gaps between spans
      *    that contributed to the threshold violation.
-     * - `ExcessHull` detects times when the duration falls short of the threshold and highlights the whole group of gaps between
+     * - `DeficitHull` detects times when the duration falls short of the threshold and highlights the whole group of gaps between
      *    spans that contributed to the threshold violation in one interval.
      *
      * @param spans spans object to detect threshold events on

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -71,11 +71,17 @@ export class Constraint {
   }
 
   /**
-   * Detect when a spans object's cumulative duration exceeds a threshold within any interval of a given width.
+   * Detect when a spans object's cumulative duration either exceeds or falls short of a threshold within any interval of a given width.
    *
-   * Violations can be reported in two different ways by setting the `algorithm` argument:
-   * - `RollingThresholdAlgorithm.Spans` highlights the individual spans that contributed to the threshold violation.
-   * - `RollingThresholdAlgorithm.Hull` highlights the single interval that contains all the violating spans.
+   * Violations can be reported in various ways by setting the `algorithm` argument:
+   * - `ExcessSpans` detects times when the duration exceeds the threshold and highlights the individual spans that
+   *    contributed to the threshold violation.
+   * - `ExcessHull` detects times when the duration exceeds the threshold and highlights the whole group of spans that
+   *    contributed to the threshold violation in one interval.
+   * - `DeficitSpans` detects times when the duration falls short of the threshold and highlights the individual gaps between spans
+   *    that contributed to the threshold violation.
+   * - `ExcessHull` detects times when the duration falls short of the threshold and highlights the whole group of gaps between
+   *    spans that contributed to the threshold violation in one interval.
    *
    * @param spans spans object to detect threshold events on
    * @param width width of the rolling interval
@@ -101,8 +107,10 @@ export class Constraint {
 
 /** Algorithm to use when reporting violations from rolling threshold */
 export enum RollingThresholdAlgorithm {
-  Spans = 'Spans',
-  Hull = 'Hull'
+  ExcessSpans = 'ExcessSpans',
+  ExcessHull = 'ExcessHull',
+  DeficitSpans = 'DeficitSpans',
+  DeficitHull = 'DeficitHull'
 }
 
 /** A boolean profile; a function from time to truth values. */
@@ -1091,11 +1099,17 @@ declare global {
     ): Constraint;
 
     /**
-     * Detect when a spans object's cumulative duration exceeds a threshold within any interval of a given width.
+     * Detect when a spans object's cumulative duration either exceeds or falls short of a threshold within any interval of a given width.
      *
-     * Violations can be reported in two different ways by setting the `algorithm` argument:
-     * - `RollingThresholdAlgorithm.Spans` highlights the individual spans that contributed to the threshold violation.
-     * - `RollingThresholdAlgorithm.Hull` highlights the single interval that contains all the violating spans.
+     * Violations can be reported in various ways by setting the `algorithm` argument:
+     * - `ExcessSpans` detects times when the duration exceeds the threshold and highlights the individual spans that
+     *    contributed to the threshold violation.
+     * - `ExcessHull` detects times when the duration exceeds the threshold and highlights the whole group of spans that
+     *    contributed to the threshold violation in one interval.
+     * - `DeficitSpans` detects times when the duration falls short of the threshold and highlights the individual gaps between spans
+     *    that contributed to the threshold violation.
+     * - `ExcessHull` detects times when the duration falls short of the threshold and highlights the whole group of gaps between
+     *    spans that contributed to the threshold violation in one interval.
      *
      * @param spans spans object to detect threshold events on
      * @param width width of the rolling interval
@@ -1113,9 +1127,11 @@ declare global {
 
   /** Algorithm to use when reporting violations from rolling threshold */
   export enum RollingThresholdAlgorithm {
-    Spans = 'Spans',
-    Hull = 'Hull'
-  }
+    ExcessSpans = 'ExcessSpans',
+    ExcessHull = 'ExcessHull',
+    DeficitSpans = 'DeficitSpans',
+    DeficitHull = 'DeficitHull'
+}
 
   /** A boolean profile; a function from time to truth values. */
   export class Windows {

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationServiceTests.java
@@ -31,6 +31,7 @@ import gov.nasa.jpl.aerie.constraints.tree.Rate;
 import gov.nasa.jpl.aerie.constraints.tree.RealParameter;
 import gov.nasa.jpl.aerie.constraints.tree.RealResource;
 import gov.nasa.jpl.aerie.constraints.tree.RealValue;
+import gov.nasa.jpl.aerie.constraints.tree.RollingThreshold;
 import gov.nasa.jpl.aerie.constraints.tree.ShiftBy;
 import gov.nasa.jpl.aerie.constraints.tree.ShiftWindowsEdges;
 import gov.nasa.jpl.aerie.constraints.tree.ShorterThan;
@@ -1271,6 +1272,32 @@ class ConstraintsDSLCompilationServiceTests {
         """,
         new ViolationsOfWindows(
             new Equal<>(new ShiftBy<>(new DiscreteResource("mode"), new DurationLiteral(Duration.of(2, Duration.MINUTE))), new DiscreteValue(SerializedValue.of("Option1")))
+        )
+    );
+  }
+
+  @Test
+  void testRollingThreshold() {
+    checkSuccessfulCompilation(
+        """
+        export default () => {
+          return Constraint.RollingThreshold(
+            Spans.ForEachActivity(ActivityType.activity),
+            Temporal.Duration.from({hours: 1}),
+            Temporal.Duration.from({minutes: 5}),
+            RollingThresholdAlgorithm.Hull
+          );
+        }
+        """,
+        new RollingThreshold(
+            new ForEachActivitySpans(
+                "activity",
+                "span activity alias 0",
+                new ActivitySpan("span activity alias 0")
+            ),
+            new DurationLiteral(Duration.of(1, Duration.HOUR)),
+            new DurationLiteral(Duration.of(5, Duration.MINUTE)),
+            RollingThreshold.RollingThresholdAlgorithm.Hull
         )
     );
   }


### PR DESCRIPTION
* **Tickets addressed:** closes #1015 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

Adds a new node `Constraint.RollingThreshold(spans, width, threshold, algorithm)` that detects when the cumulative duration of `spans` exceeds or falls short of `threshold` in any `width` interval. `algorithm` decides both whether violations are reported by highlighting the individual spans that caused the violation or by highlighting the whole interval over which it happened, and whether it looks for excess or deficit duration.

## Verification
- [x] ast and edsl compilation tests

## Documentation
- [ ] tutorial docs

I know that the constraints documentation is seriously lacking, especially in tutorials for common constraint patterns. I'll get that section started with this.

## Future work
- [x] gimmie just a minute I'm gonna add an algorithm option to require minimum cumulative duration
