### PR TITLE
Replace Column List with '*' in Hasura Permissions

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/begin_merge_return_value.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/begin_merge_return_value.yaml
@@ -4,9 +4,9 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [merge_request_id, non_conflicting_activities, conflicting_activities]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [merge_request_id, non_conflicting_activities, conflicting_activities]
+      columns: '*'
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/cancel_merge_return_value.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/cancel_merge_return_value.yaml
@@ -4,9 +4,9 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [merge_request_id]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [merge_request_id]
+      columns: '*'
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/commit_merge_return_value.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/commit_merge_return_value.yaml
@@ -4,9 +4,9 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [merge_request_id]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [merge_request_id]
+      columns: '*'
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/create_merge_return_value.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/create_merge_return_value.yaml
@@ -4,9 +4,9 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [merge_request_id]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [merge_request_id]
+      columns: '*'
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/create_snapshot_return_value.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/create_snapshot_return_value.yaml
@@ -4,9 +4,9 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [snapshot_id]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [snapshot_id]
+      columns: '*'
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/delete_anchor_return_value.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/delete_anchor_return_value.yaml
@@ -4,9 +4,9 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [affected_row, change_type]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [affected_row, change_type]
+      columns: '*'
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/deny_merge_return_value.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/deny_merge_return_value.yaml
@@ -4,9 +4,9 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [merge_request_id]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [merge_request_id]
+      columns: '*'
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/duplicate_plan_return_value.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/duplicate_plan_return_value.yaml
@@ -4,9 +4,9 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [new_plan_id]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [new_plan_id]
+      columns: '*'
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/get_conflicting_activities_return_value.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/get_conflicting_activities_return_value.yaml
@@ -4,9 +4,9 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [activity_id, change_type_source, change_type_target, resolution, source, target, merge_base, source_tags, target_tags, merge_base_tags]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [activity_id, change_type_source, change_type_target, resolution, source, target, merge_base, source_tags, target_tags, merge_base_tags]
+      columns: '*'
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/get_non_conflicting_activities_return_value.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/get_non_conflicting_activities_return_value.yaml
@@ -4,9 +4,9 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [activity_id, change_type, source, target, source_tags, target_tags]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [activity_id, change_type, source, target, source_tags, target_tags]
+      columns: '*'
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/get_plan_history_return_value.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/get_plan_history_return_value.yaml
@@ -4,9 +4,9 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [plan_id]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [plan_id]
+      columns: '*'
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/resource_at_start_offset_return_value.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/resource_at_start_offset_return_value.yaml
@@ -4,9 +4,9 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [dataset_id, id, name, type, start_offset, dynamics, is_gap]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [dataset_id, id, name, type, start_offset, dynamics, is_gap]
+      columns: '*'
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/withdraw_merge_request_return_value.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/hasura_functions/withdraw_merge_request_return_value.yaml
@@ -4,9 +4,9 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [merge_request_id]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [merge_request_id]
+      columns: '*'
       filter: {}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/activity_directive_tags.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/activity_directive_tags.yaml
@@ -13,17 +13,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [plan_id, directive_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [plan_id, directive_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [plan_id, directive_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/constraint_tags.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/constraint_tags.yaml
@@ -13,17 +13,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [constraint_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [constraint_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [constraint_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/plan_tags.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/plan_tags.yaml
@@ -13,17 +13,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [plan_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [plan_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [plan_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/snapshot_activity_tags.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/snapshot_activity_tags.yaml
@@ -13,17 +13,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [snapshot_id, directive_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [snapshot_id, directive_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [snapshot_id, directive_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/tags.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/tags.yaml
@@ -6,17 +6,17 @@ configuration:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, name, color, owner, created_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, name, color, owner, created_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, name, color, owner, created_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/user_role_permission.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/user_role_permission.yaml
@@ -6,17 +6,17 @@ configuration:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [role, action_permissions, function_permissions]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [role, action_permissions, function_permissions]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [role, action_permissions, function_permissions]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/user_roles.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/user_roles.yaml
@@ -7,17 +7,17 @@ is_enum: true
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [role, description]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [role, description]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [role, description]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/users.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/users.yaml
@@ -6,7 +6,7 @@ configuration:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [username, default_role]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/users_allowed_roles.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/users_allowed_roles.yaml
@@ -6,17 +6,17 @@ configuration:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [username, allowed_role]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [username, allowed_role]
+      columns: '*'
       filter: {"username":{"_eq":"X-Hasura-User-Id"}}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [username, allowed_role]
+      columns: '*'
       filter: {"username":{"_eq":"X-Hasura-User-Id"}}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/users_and_roles_view.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/metadata/users_and_roles_view.yaml
@@ -6,16 +6,16 @@ configuration:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [username, hasura_default_role, hasura_allowed_roles]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [username, hasura_default_role, hasura_allowed_roles]
+      columns: '*'
       filter: {"username":{"_eq":"X-Hasura-User-Id"}}
       allow_aggregations: false
   - role: viewer
     permission:
-      columns: [ username, hasura_default_role, hasura_allowed_roles ]
+      columns: '*'
       filter: { "username": { "_eq": "X-Hasura-User-Id" } }
       allow_aggregations: false

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive.yaml
@@ -76,21 +76,17 @@ remote_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [ id, plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
-                 arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start, last_modified_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      # Need to specify all columns manually
-      columns: [ id, plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
-                 arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start, last_modified_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [ id, plan_id, name, source_scheduling_goal_id, created_at, last_modified_at, start_offset, type,
-                 arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start, last_modified_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 update_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_changelog.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_changelog.yaml
@@ -14,59 +14,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns:
-       - revision
-       - plan_id
-       - activity_directive_id
-       - name
-       - source_scheduling_goal_id
-       - changed_at
-       - changed_by
-       - start_offset
-       - type
-       - arguments
-       - changed_arguments_at
-       - metadata
-       - anchor_id
-       - anchored_to_start
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns:
-       - revision
-       - plan_id
-       - activity_directive_id
-       - name
-       - source_scheduling_goal_id
-       - changed_at
-       - changed_by
-       - start_offset
-       - type
-       - arguments
-       - changed_arguments_at
-       - metadata
-       - anchor_id
-       - anchored_to_start
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns:
-       - revision
-       - plan_id
-       - activity_directive_id
-       - name
-       - source_scheduling_goal_id
-       - changed_at
-       - changed_by
-       - start_offset
-       - type
-       - arguments
-       - changed_arguments_at
-       - metadata
-       - anchor_id
-       - anchored_to_start
+      columns: '*'
       filter: {}
       allow_aggregations: true
 update_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_extended.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_extended.yaml
@@ -23,22 +23,16 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, last_modified_by, start_offset, type,
-                 arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start, approximate_start_time,
-                 preset_id, preset_arguments]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, last_modified_by, start_offset, type,
-                 arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start, approximate_start_time,
-                 preset_id, preset_arguments]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, plan_id, name, tags, source_scheduling_goal_id, created_at, last_modified_at, last_modified_by, start_offset, type,
-                 arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start, approximate_start_time,
-                 preset_id, preset_arguments]
+      columns: '*'
       filter: {}
       allow_aggregations: true

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_metadata_schema.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_metadata_schema.yaml
@@ -4,17 +4,17 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [key, schema, created_at, updated_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [key, schema, created_at, updated_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [key, schema, created_at, updated_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_validations.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_directive_validations.yaml
@@ -4,17 +4,17 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [directive_id, plan_id, last_modified_at, validations]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [directive_id, plan_id, last_modified_at, validations]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [directive_id, plan_id, last_modified_at, validations]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_presets.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_presets.yaml
@@ -4,17 +4,17 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, model_id, name, associated_activity_type, arguments, owner]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, model_id, name, associated_activity_type, arguments, owner]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, model_id, name, associated_activity_type, arguments, owner]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_type.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_activity_type.yaml
@@ -30,17 +30,17 @@ remote_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [model_id, name, parameters, required_parameters, computed_attributes_value_schema, subsystem]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [model_id, name, parameters, required_parameters, computed_attributes_value_schema, subsystem]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [model_id, name, parameters, required_parameters, computed_attributes_value_schema, subsystem]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_anchor_validation_status.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_anchor_validation_status.yaml
@@ -4,17 +4,17 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [activity_id, plan_id, reason_invalid]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [activity_id, plan_id, reason_invalid]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [activity_id, plan_id, reason_invalid]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_conflicting_activities.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_conflicting_activities.yaml
@@ -8,17 +8,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [merge_request_id, activity_id, change_type_supplying, change_type_receiving, resolution]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [merge_request_id, activity_id, change_type_supplying, change_type_receiving, resolution]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [merge_request_id, activity_id, change_type_supplying, change_type_receiving, resolution]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 update_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_constraint.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_constraint.yaml
@@ -19,17 +19,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, name, description, definition, plan_id, model_id, created_at, updated_at, owner, updated_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, name, description, definition, plan_id, model_id, created_at, updated_at, owner, updated_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, name, description, definition, plan_id, model_id, created_at, updated_at, owner, updated_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_constraint_run.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_constraint_run.yaml
@@ -11,17 +11,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [constraint_id, constraint_definition, simulation_dataset_id, definition_outdated, results, requested_by, requested_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [constraint_id, constraint_definition, simulation_dataset_id, definition_outdated, results, requested_by, requested_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [constraint_id, constraint_definition, simulation_dataset_id, definition_outdated, results, requested_by, requested_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_dataset.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_dataset.yaml
@@ -28,17 +28,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, revision]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, revision]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, revision]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_event.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_event.yaml
@@ -4,17 +4,17 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [dataset_id, real_time, transaction_index, causal_time, value, topic_index]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [dataset_id, real_time, transaction_index, causal_time, value, topic_index]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [dataset_id, real_time, transaction_index, causal_time, value, topic_index]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_merge_request.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_merge_request.yaml
@@ -47,17 +47,21 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, plan_id_receiving_changes, snapshot_id_supplying_changes, merge_base_snapshot_id, status, requester_username, reviewer_username]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, plan_id_receiving_changes, snapshot_id_supplying_changes, merge_base_snapshot_id, status, requester_username, reviewer_username]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, plan_id_receiving_changes, snapshot_id_supplying_changes, merge_base_snapshot_id, status, requester_username, reviewer_username]
+      columns: '*'
       filter: {}
       allow_aggregations: true
-# Insert, Update, and Delete Permissions are not included because these actions are only allowed via SQL functions
+# Insert/Update Permissions are not included because these actions are controlled via SQL functions
+delete_permissions:
+  - role: aerie_admin
+    permission:
+      filter: {"status":{"_neq":"in-progress"}}

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_merge_request_comment.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_merge_request_comment.yaml
@@ -8,17 +8,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [comment_id, merge_request_id, commenter_username, comment_text]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [comment_id, merge_request_id, commenter_username, comment_text]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [comment_id, merge_request_id, commenter_username, comment_text]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_merge_staging_area.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_merge_staging_area.yaml
@@ -8,19 +8,16 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at, start_offset, type,
-                arguments, metadata, anchor_id, anchored_to_start, change_type]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at, start_offset, type,
-                arguments, metadata, anchor_id, anchored_to_start, change_type]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [merge_request_id, activity_id, name, tags, source_scheduling_goal_id, created_at, start_offset, type,
-                arguments, metadata, anchor_id, anchored_to_start, change_type]
+      columns: '*'
       filter: {}
       allow_aggregations: true

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_mission_model.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_mission_model.yaml
@@ -44,17 +44,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, revision, mission, name, version, description, owner, jar_id, created_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, revision, mission, name, version, description, owner, jar_id, created_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, revision, mission, name, version, description, owner, jar_id, created_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_mission_model_parameters.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_mission_model_parameters.yaml
@@ -4,16 +4,16 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [model_id, revision, parameters]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [model_id, revision, parameters]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [model_id, revision, parameters]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 update_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan.yaml
@@ -80,20 +80,17 @@ remote_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, revision, name, model_id, duration, start_time, parent_id, is_locked,
-                 created_at, updated_at, owner, updated_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, revision, name, model_id, duration, start_time, parent_id, is_locked,
-                 created_at, updated_at, owner, updated_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, revision, name, model_id, duration, start_time, parent_id, is_locked,
-                 created_at, updated_at, owner, updated_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan_collaborators.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan_collaborators.yaml
@@ -8,17 +8,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [plan_id, collaborator]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [plan_id, collaborator]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [plan_id, collaborator]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan_dataset.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan_dataset.yaml
@@ -11,17 +11,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [plan_id, dataset_id, offset_from_plan_start, simulation_dataset_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [plan_id, dataset_id, offset_from_plan_start, simulation_dataset_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [plan_id, dataset_id, offset_from_plan_start, simulation_dataset_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan_snapshot.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan_snapshot.yaml
@@ -14,17 +14,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [snapshot_id, plan_id, revision, snapshot_name, taken_by, taken_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [snapshot_id, plan_id, revision, snapshot_name, taken_by, taken_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [snapshot_id, plan_id, revision, snapshot_name, taken_by, taken_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan_snapshot_activities.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan_snapshot_activities.yaml
@@ -19,20 +19,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [snapshot_id, id, name, source_scheduling_goal_id, created_at, last_modified_at, last_modified_by,
-                start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [snapshot_id, id, name, source_scheduling_goal_id, created_at, last_modified_at, last_modified_by,
-                start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [snapshot_id, id, name, source_scheduling_goal_id, created_at, last_modified_at, last_modified_by,
-                start_offset, type, arguments, last_modified_arguments_at, metadata, anchor_id, anchored_to_start]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_preset_to_directive.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_preset_to_directive.yaml
@@ -18,23 +18,23 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [preset_id, activity_id, plan_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [preset_id, activity_id, plan_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [preset_id, activity_id, plan_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:
   - role: aerie_admin
     permission:
-      columns: [preset_id, activity_id, plan_id]
+      columns: '*'
       check: {}
 delete_permissions:
   - role: aerie_admin

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_profile.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_profile.yaml
@@ -14,17 +14,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, dataset_id, name, type, duration]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, dataset_id, name, type, duration]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, dataset_id, name, type, duration]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_profile_segment.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_profile_segment.yaml
@@ -4,17 +4,17 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [dataset_id, profile_id, start_offset, dynamics, is_gap]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [dataset_id, profile_id, start_offset, dynamics, is_gap]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [dataset_id, profile_id, start_offset, dynamics, is_gap]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_resource_profile_view.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_resource_profile_view.yaml
@@ -21,17 +21,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [dataset_id, profile_id, start_offset, dynamics, start_time, end_time]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [dataset_id, profile_id, start_offset, dynamics, start_time, end_time]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [dataset_id, profile_id, start_offset, dynamics, start_time, end_time]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_resource_type.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_resource_type.yaml
@@ -4,17 +4,17 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [model_id, name, schema]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [model_id, name, schema]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [model_id, name, schema]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulated_activity_view.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulated_activity_view.yaml
@@ -30,19 +30,16 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, simulation_dataset_id, parent_id, start_offset, duration, attributes,
-                activity_type_name, directive_id, start_time, end_time]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, simulation_dataset_id, parent_id, start_offset, duration, attributes,
-                activity_type_name, directive_id, start_time, end_time]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, simulation_dataset_id, parent_id, start_offset, duration, attributes,
-                activity_type_name, directive_id, start_time, end_time]
+      columns: '*'
       filter: {}
       allow_aggregations: true

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation.yaml
@@ -26,17 +26,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, revision, simulation_template_id, plan_id, arguments, simulation_start_time, simulation_end_time]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, revision, simulation_template_id, plan_id, arguments, simulation_start_time, simulation_end_time]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, revision, simulation_template_id, plan_id, arguments, simulation_start_time, simulation_end_time]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 update_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation_dataset.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation_dataset.yaml
@@ -39,23 +39,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, simulation_id, dataset_id, offset_from_plan_start, plan_revision, model_revision,
-                simulation_template_revision, simulation_revision, dataset_revision, arguments, simulation_start_time,
-                simulation_end_time, status, reason, canceled, requested_by, requested_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, simulation_id, dataset_id, offset_from_plan_start, plan_revision, model_revision,
-                simulation_template_revision, simulation_revision, dataset_revision, arguments, simulation_start_time,
-                simulation_end_time, status, reason, canceled, requested_by, requested_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, simulation_id, dataset_id, offset_from_plan_start, plan_revision, model_revision,
-                simulation_template_revision, simulation_revision, dataset_revision, arguments, simulation_start_time,
-                simulation_end_time, status, reason, canceled, requested_by, requested_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 update_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation_extent.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation_extent.yaml
@@ -4,17 +4,17 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [simulation_dataset_id, extent]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [simulation_dataset_id, extent]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [simulation_dataset_id, extent]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation_template.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_simulation_template.yaml
@@ -8,17 +8,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, revision, model_id, description, arguments, owner]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, revision, model_id, description, arguments, owner]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, revision, model_id, description, arguments, owner]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_span.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_span.yaml
@@ -26,17 +26,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, duration, dataset_id, parent_id, start_offset, type, attributes]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, duration, dataset_id, parent_id, start_offset, type, attributes]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, duration, dataset_id, parent_id, start_offset, type, attributes]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_topic.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_topic.yaml
@@ -14,17 +14,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [dataset_id, topic_index, name, value_schema]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [dataset_id, topic_index, name, value_schema]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [dataset_id, topic_index, name, value_schema]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_uploaded_file.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_uploaded_file.yaml
@@ -4,17 +4,17 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, path, name, created_date, modified_date, deleted_date]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, path, name, created_date, modified_date, deleted_date]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, path, name, created_date, modified_date, deleted_date]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/metadata/scheduling_goal_tags.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/metadata/scheduling_goal_tags.yaml
@@ -21,17 +21,17 @@ remote_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [goal_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [goal_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [goal_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_condition.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_condition.yaml
@@ -12,17 +12,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 # TODO: Modify these once we have a solution for cross-db auth (These permissions should be based on plan ownership/collaboratorship)

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal.yaml
@@ -29,17 +29,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, revision, name, definition, model_id, description, author, last_modified_by, created_date, modified_date]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 # TODO: Modify these once we have a solution for cross-db auth (These permissions should be based on plan ownership/collaboratorship)

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal_analysis.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal_analysis.yaml
@@ -25,17 +25,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [analysis_id, goal_id, satisfied]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [analysis_id, goal_id, satisfied]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [analysis_id, goal_id, satisfied]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 update_permissions:

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal_analysis_created_activities.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal_analysis_created_activities.yaml
@@ -4,16 +4,16 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [analysis_id, goal_id, activity_id]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [analysis_id, goal_id, activity_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [analysis_id, goal_id, activity_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal_analysis_satisfying_activities.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_goal_analysis_satisfying_activities.yaml
@@ -4,16 +4,16 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [analysis_id, goal_id, activity_id]
+      columns: '*'
       filter: {}
   - role: user
     permission:
-      columns: [analysis_id, goal_id, activity_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [ analysis_id, goal_id, activity_id ]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_request.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_request.yaml
@@ -4,17 +4,17 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [specification_id, analysis_id, requested_by, requested_at, status, reason, canceled, dataset_id, specification_revision]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [specification_id, analysis_id, requested_by, requested_at, status, reason, canceled, dataset_id, specification_revision]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [specification_id, analysis_id, requested_by, requested_at, status, reason, canceled, dataset_id, specification_revision]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 # Inserting/Updating is handled via the AerieScheduler

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_specification.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_specification.yaml
@@ -4,17 +4,17 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, revision, plan_id, plan_revision, horizon_start, horizon_end, simulation_arguments, analysis_only]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, revision, plan_id, plan_revision, horizon_start, horizon_end, simulation_arguments, analysis_only]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, revision, plan_id, plan_revision, horizon_start, horizon_end, simulation_arguments, analysis_only]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 # TODO: Modify these once we have a solution for cross-db auth (These permissions should be based on plan ownership/collaboratorship)

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_specification_conditions.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_specification_conditions.yaml
@@ -11,17 +11,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [specification_id, condition_id, enabled]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [specification_id, condition_id, enabled]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [specification_id, condition_id, enabled]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 # TODO: Modify these once we have a solution for cross-db auth (These permissions should be based on plan ownership/collaboratorship)

--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_specification_goals.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_specification_goals.yaml
@@ -11,17 +11,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [specification_id, goal_id, priority, enabled, simulate_after]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [specification_id, goal_id, priority, enabled, simulate_after]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [specification_id, goal_id, priority, enabled, simulate_after]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 # TODO: Modify these once we have a solution for cross-db auth (These permissions should be based on plan ownership/collaboratorship)

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/metadata/expansion_rule_tags.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/metadata/expansion_rule_tags.yaml
@@ -21,17 +21,17 @@ remote_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [rule_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [rule_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [rule_id, tag_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_activity_instance_commands.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_activity_instance_commands.yaml
@@ -19,17 +19,17 @@ remote_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, activity_instance_id, commands, errors, expansion_run_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, activity_instance_id, commands, errors, expansion_run_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, activity_instance_id, commands, errors, expansion_run_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_command_dictionary.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_command_dictionary.yaml
@@ -12,17 +12,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, command_types_typescript_path, mission, version, created_at, parsed_json]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, command_types_typescript_path, mission, version, created_at, parsed_json]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, command_types_typescript_path, mission, version, created_at, parsed_json]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expanded_sequences.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expanded_sequences.yaml
@@ -18,17 +18,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, expansion_run_id, seq_id, simulation_dataset_id, expanded_sequence, edsl_string, created_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, expansion_run_id, seq_id, simulation_dataset_id, expanded_sequence, edsl_string, created_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, expansion_run_id, seq_id, simulation_dataset_id, expanded_sequence, edsl_string, created_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expansion_rule.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expansion_rule.yaml
@@ -23,20 +23,17 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, name, activity_type, expansion_logic, authoring_command_dict_id, authoring_mission_model_id,
-                 created_at, updated_at, owner, updated_by, description]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, name, activity_type, expansion_logic, authoring_command_dict_id, authoring_mission_model_id,
-                created_at, updated_at, owner, updated_by, description]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, name, activity_type, expansion_logic, authoring_command_dict_id, authoring_mission_model_id,
-                created_at, updated_at, owner, updated_by, description]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expansion_run.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expansion_run.yaml
@@ -34,17 +34,17 @@ remote_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, simulation_dataset_id, expansion_set_id, created_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, simulation_dataset_id, expansion_set_id, created_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, simulation_dataset_id, expansion_set_id, created_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expansion_set.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expansion_set.yaml
@@ -36,17 +36,17 @@ remote_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [id, name, description, command_dict_id, mission_model_id, created_at, updated_at, owner, updated_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [id, name, description, command_dict_id, mission_model_id, created_at, updated_at, owner, updated_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [id, name, description, command_dict_id, mission_model_id, created_at, updated_at, owner, updated_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 update_permissions:

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expansion_set_rule_view.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expansion_set_rule_view.yaml
@@ -14,19 +14,16 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [set_id, id, activity_type, expansion_logic, authoring_command_dict_id,
-                authoring_mission_model_id, created_at, updated_at, name, owner, updated_by, description]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [set_id, id, activity_type, expansion_logic, authoring_command_dict_id,
-                authoring_mission_model_id, created_at, updated_at, name, owner, updated_by, description]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [set_id, id, activity_type, expansion_logic, authoring_command_dict_id,
-                authoring_mission_model_id, created_at, updated_at, name, owner, updated_by, description]
+      columns: '*'
       filter: {}
       allow_aggregations: true

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expansion_set_to_rule.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_expansion_set_to_rule.yaml
@@ -23,16 +23,16 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [set_id, rule_id, activity_type]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [set_id, rule_id, activity_type]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [set_id, rule_id, activity_type]
+      columns: '*'
       filter: {}
       allow_aggregations: true

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_rule_expansion_set_view.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_rule_expansion_set_view.yaml
@@ -14,16 +14,16 @@ array_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [rule_id, id, name, owner, description, command_dict_id, mission_model_id, created_at, updated_at, updated_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [rule_id, id, name, owner, description, command_dict_id, mission_model_id, created_at, updated_at, updated_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [rule_id, id, name, owner, description, command_dict_id, mission_model_id, created_at, updated_at, updated_by]
+      columns: '*'
       filter: {}
       allow_aggregations: true

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_sequence.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_sequence.yaml
@@ -25,17 +25,17 @@ remote_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [seq_id, simulation_dataset_id, created_at, metadata]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [seq_id, simulation_dataset_id, created_at, metadata]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [seq_id, simulation_dataset_id, created_at, metadata]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_sequence_to_simulated_activity.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_sequence_to_simulated_activity.yaml
@@ -25,17 +25,17 @@ remote_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [simulated_activity_id, simulation_dataset_id, seq_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [simulated_activity_id, simulation_dataset_id, seq_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [simulated_activity_id, simulation_dataset_id, seq_id]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieSequencing/tables/public_user_sequence.yaml
+++ b/deployment/hasura/metadata/databases/AerieSequencing/tables/public_user_sequence.yaml
@@ -14,17 +14,17 @@ object_relationships:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [authoring_command_dict_id, created_at, definition, id, name, owner, updated_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [authoring_command_dict_id, created_at, definition, id, name, owner, updated_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [authoring_command_dict_id, created_at, definition, id, name, owner, updated_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:

--- a/deployment/hasura/metadata/databases/AerieUI/tables/public_view.yaml
+++ b/deployment/hasura/metadata/databases/AerieUI/tables/public_view.yaml
@@ -4,17 +4,17 @@ table:
 select_permissions:
   - role: aerie_admin
     permission:
-      columns: [created_at, definition, id, name, owner, updated_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: user
     permission:
-      columns: [created_at, definition, id, name, owner, updated_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
   - role: viewer
     permission:
-      columns: [created_at, definition, id, name, owner, updated_at]
+      columns: '*'
       filter: {}
       allow_aggregations: true
 insert_permissions:


### PR DESCRIPTION
* **Tickets addressed:** Closes #1119.
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

Replaces all select permissions where a role may select all columns with `'*'` rather than explicitly listing the column list. AKA all select permissions except for `viewer` and `user` on the `users` table.

Additionally, `merge_request` was missing a delete permission for `aerie_admin`. The role may now delete requests that are not in the middle of an active merge.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Brought up Hasura and verified that the permissions summaries for all DBs and their schemas had not change

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->


## Future work
<!-- What next steps can we anticipate from here, if any? -->
