### PR TITLE
Remove tags trigger from GH pages workflow

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - develop
-    tags:
-      - v*
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
* GH does not allow deploying from tags for environments with branch protection rules that match the tag
* https://github.com/orgs/community/discussions/39054

For example the following `v*` rule used to work for tags, but does not anymore (for the `github-pages` environment rules): 

<img width="785" alt="Screenshot 2023-09-06 at 4 05 44 PM" src="https://github.com/NASA-AMMOS/aerie/assets/683355/92d02240-6299-4a60-95e0-5e048f3de3bf">
