### PR TITLE
Fix signature of `create_snapshot`

### DIFF
--- a/deployment/hasura/migrations/AerieMerlin/26_create_snapshot_signature_change/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/26_create_snapshot_signature_change/down.sql
@@ -1,13 +1,5 @@
--- Captures the state of a plan and all of its activities
-create function create_snapshot(_plan_id integer)
-	returns integer
-	language plpgsql as $$
-begin
-	return create_snapshot(_plan_id, null, null);
-end
-$$;
-
-create function create_snapshot(_plan_id integer, _snapshot_name text, _user text)
+drop function create_snapshot(integer, text, text);
+create function create_snapshot(_plan_id integer, _user text, _snapshot_name text)
   returns integer -- snapshot id inserted into the table
   language plpgsql as $$
   declare
@@ -54,10 +46,6 @@ begin
   return inserted_snapshot_id;
   end;
 $$;
-
-comment on function create_snapshot(integer) is e''
-	'See comment on create_snapshot(integer, text, text)';
-
 comment on function create_snapshot(integer, text, text) is e''
   'Create a snapshot of the specified plan. A snapshot consists of:'
   '  - The plan''s id and revision'

--- a/deployment/hasura/migrations/AerieMerlin/26_create_snapshot_signature_change/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/26_create_snapshot_signature_change/up.sql
@@ -1,12 +1,4 @@
--- Captures the state of a plan and all of its activities
-create function create_snapshot(_plan_id integer)
-	returns integer
-	language plpgsql as $$
-begin
-	return create_snapshot(_plan_id, null, null);
-end
-$$;
-
+drop function create_snapshot(integer, text, text);
 create function create_snapshot(_plan_id integer, _snapshot_name text, _user text)
   returns integer -- snapshot id inserted into the table
   language plpgsql as $$
@@ -54,10 +46,6 @@ begin
   return inserted_snapshot_id;
   end;
 $$;
-
-comment on function create_snapshot(integer) is e''
-	'See comment on create_snapshot(integer, text, text)';
-
 comment on function create_snapshot(integer, text, text) is e''
   'Create a snapshot of the specified plan. A snapshot consists of:'
   '  - The plan''s id and revision'

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -28,3 +28,4 @@ call migrations.mark_migration_applied('22');
 call migrations.mark_migration_applied('23');
 call migrations.mark_migration_applied('24');
 call migrations.mark_migration_applied('25');
+call migrations.mark_migration_applied('26');


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

The initial signature of `create_snapshot` (_plan_id, _user, _snapshot_name), had `_user` and `_snapshot_name` in the opposite order to how the pair is written elsewhere in the database, including in the function itself. This caused a bug in the Hasura Function due to it supplying the parameters in the order `(_plan_id, _snapshot_name, _user)`. Since the underlying function's signature was off, I chose to fix that rather than fix its callsites.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Three new DB tests were created in `PlanSnapshotTests`.
