### PR TITLE
Array/List parameters are working again in scheduling

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
@@ -80,7 +80,7 @@ export function makeAllDiscreteProfile (argument: any) : any{
      }
   else if(Array.isArray(argument)){
    const arr: any[] = [];
-   argument.every((element) => { arr.push(makeAllDiscreteProfile(element))});
+   argument.forEach((element) => { arr.push(makeAllDiscreteProfile(element))});
    return Discrete.List(arr).__astNode;
  } else if (typeof argument === "object" ){
    const obj: { [k: string]: any } = {};

--- a/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
+++ b/scheduler-server/src/test/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationServiceTest.java
@@ -39,7 +39,7 @@ export function makeAllDiscreteProfile (argument: any) : any{
      }
   else if(Array.isArray(argument)){
    const arr: any[] = [];
-   argument.every((element) => { arr.push(makeAllDiscreteProfile(element))});
+   argument.forEach((element) => { arr.push(makeAllDiscreteProfile(element))});
    return Discrete.List(arr).__astNode;
  } else if (typeof argument === "object" ){
    const obj: { [k: string]: any } = {};


### PR DESCRIPTION
* **Tickets addressed:** Closes #981 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
An error in the algorithm transforming every user-provided typescript value into a profile was causing the transformation to stop after the first element of the array. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I added a test that was not passing before the fix was made.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None, it is a bug.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None.