### PR TITLE
Add cancel trigger to scheduling request

### DIFF
--- a/deployment/hasura/migrations/AerieScheduler/10_cancel_scheduling_trigger/down.sql
+++ b/deployment/hasura/migrations/AerieScheduler/10_cancel_scheduling_trigger/down.sql
@@ -1,0 +1,4 @@
+drop trigger cancel_pending_scheduling_rqs on scheduling_request;
+drop function cancel_pending_scheduling_rqs();
+
+call migrations.mark_migration_rolled_back('10');

--- a/deployment/hasura/migrations/AerieScheduler/10_cancel_scheduling_trigger/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/10_cancel_scheduling_trigger/up.sql
@@ -1,0 +1,19 @@
+create function cancel_pending_scheduling_rqs()
+returns trigger
+security definer
+language plpgsql as $$
+begin
+  update scheduling_request
+  set canceled = true
+  where status = 'pending'
+  and specification_id = new.specification_id;
+  return new;
+end
+$$;
+
+create trigger cancel_pending_scheduling_rqs
+  before insert on scheduling_request
+  for each row
+  execute function cancel_pending_scheduling_rqs();
+
+call migrations.mark_migration_applied('10');

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -12,3 +12,4 @@ call migrations.mark_migration_applied('6');
 call migrations.mark_migration_applied('7');
 call migrations.mark_migration_applied('8');
 call migrations.mark_migration_applied('9');
+call migrations.mark_migration_applied('10');

--- a/scheduler-server/sql/scheduler/tables/scheduling_request.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_request.sql
@@ -44,7 +44,7 @@ comment on column scheduling_request.requested_at is e''
 -- Scheduling request NOTIFY triggers
 -- These triggers NOTIFY LISTEN(ing) scheduler worker clients of pending scheduling requests
 
-create or replace function notify_scheduler_workers ()
+create function notify_scheduler_workers ()
 returns trigger
 security definer
 language plpgsql as $$
@@ -64,9 +64,25 @@ begin
   return null;
 end$$;
 
-do $$ begin
 create trigger notify_scheduler_workers
   after insert on scheduling_request
   for each row
   execute function notify_scheduler_workers();
-end $$;
+
+create function cancel_pending_scheduling_rqs()
+returns trigger
+security definer
+language plpgsql as $$
+begin
+  update scheduling_request
+  set canceled = true
+  where status = 'pending'
+  and specification_id = new.specification_id;
+  return new;
+end
+$$;
+
+create trigger cancel_pending_scheduling_rqs
+  before insert on scheduling_request
+  for each row
+  execute function cancel_pending_scheduling_rqs();


### PR DESCRIPTION
* **Tickets addressed:** Partially fixes #971
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

This fixes the bug where if the Schedule button is pressed too many times too quickly, Scheduling will break due to duplicate requests.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
1. Spin up Aerie
2. Stop the Scheduling Workers
3. Make a plan and a goal
4. Mash the "Schedule" button
5. Start the Scheduling Workers
6. Press the "Schedule" button

Result: Scheduling will succeed.

Result on `develop`: Scheduling will break due to duplicate requests.
## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs needed

## Future work
<!-- What next steps can we anticipate from here, if any? -->
As mentioned in the issue, part of the reason the bug was occurring was due to the structure of this part of the DB. The plan's revision, which should be part of `scheduling_request`, is instead on `scheduling_specification`. This means that the UI has to update the scheduling spec before it hits the `schedule` endpoint, which updates the specs revision, which allows for a duplicate request to be created (since the PK is currently `(spec_id, spec_revision)`). 

The correct design is to have `plan_revision` be on `scheduling_request`, as well as other changes to synchronize the design of the scheduling rq and sim rq tables. This is not possible, however, because plan revision data is stored in the Merlin DB. There are two solutions as possible future work: 
1. Merge the Databases. We can then grant the scheduler read permission on the `plan` table and it can properly fetch the plan's revision in the same way that sim rqs fetch revisions.
3. Create GraphQL requests in the Scheduler Server. This would require adding in additional envvars to the scheduler server container, and potentially duplicating some code from the `scheduler-driver` package. Additionally, the place this GQL request would be made would be in the middle of a section of code that is reading from and then writing to Postgres in `CachedSchedulerService`. 

Issue #1142 has been created to track this future work.