### PR TITLE
Add line of code count to CI

### DIFF
--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -1,0 +1,33 @@
+name: Count Lines of Code
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+    tags:
+      - v*
+
+jobs:
+  cloc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Install cloc
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes cloc
+      - name: Run cloc
+        run: |
+          for f in $(ls -D); do
+            echo "======================="
+            echo "$f"
+            echo "======================="
+            cloc \
+              --include-lang "TypeScript,SQL,Java" \
+              --by-percent cmb \
+              $(git ls-files "$f")
+          done


### PR DESCRIPTION
* **Tickets addressed:** closes #518 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Uses [cloc](https://github.com/AlDanial/cloc) to count lines of code per module in Aerie. An `by-percent` option was added to `cloc` to output comment and blank as a percentage of total lines.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
`cloc` can output to several data formats (csv, json, sql), so we can add this additional output if we require further analysis.