### PR TITLE
Fix Interval.Horizon

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/AbsoluteInterval.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/AbsoluteInterval.java
@@ -25,15 +25,15 @@ public record AbsoluteInterval(
   public Interval evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
     final Duration relativeStart = start
         .map(instant -> Duration.of(results.planStart.until(instant, ChronoUnit.MICROS), Duration.MICROSECOND))
-        .orElse(Duration.MIN_VALUE);
+        .orElse(results.bounds.start);
     final Duration relativeEnd = end
         .map(instant -> Duration.of(results.planStart.until(instant, ChronoUnit.MICROS), Duration.MICROSECOND))
-        .orElse(Duration.MAX_VALUE);
+        .orElse(results.bounds.end);
     return Interval.between(
         relativeStart,
-        startInclusivity.orElse(Interval.Inclusivity.Inclusive),
+        startInclusivity.orElse(start.isPresent() ? Interval.Inclusivity.Inclusive : results.bounds.startInclusivity),
         relativeEnd,
-        endInclusivity.orElse(Interval.Inclusivity.Inclusive)
+        endInclusivity.orElse(end.isPresent() ? Interval.Inclusivity.Inclusive : results.bounds.endInclusivity)
     );
   }
 

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -1059,6 +1059,24 @@ public class ASTTests {
   }
 
   @Test
+  public void testHorizonInterval() {
+    final var simResults = new SimulationResults(
+        Instant.EPOCH, Interval.between(0, Inclusive, 20, Exclusive, SECONDS),
+        List.of(),
+        Map.of(),
+        Map.of()
+    );
+
+    final var interval = new AbsoluteInterval(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+
+    final var result = interval.evaluate(simResults);
+
+    final var expected = Interval.between(0, Inclusive, 20, Exclusive, SECONDS);
+
+    assertEquals(expected, result);
+  }
+
+  @Test
   public void testShiftByBoundsAdjustment() {
     final var simResults = new SimulationResults(
         Instant.EPOCH, Interval.between(0, 20, SECONDS),


### PR DESCRIPTION
* **Tickets addressed:** none
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The result currently returned by `Interval.Horizon()` is an interval from `Duration.MIN_VALUE` to `Duration.MAX_VALUE`. I wrote that code, and I cannot fathom why I made that decision, when the planning horizon is readily accessible in that function already. I'm here to atone for my mistakes.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Wrote an AST test to make sure the result equals the plan bounds.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
