### PR TITLE
Make GQLMerlinService query table instead of deprecated action

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -717,7 +717,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI, String hasuraGraphQlAdm
   {
     final var request = """
         query GetResourceTypes {
-           resourceTypes(missionModelId: "%d") {
+           resource_type(where: {model_id: {_eq: %d}}) {
              name
              schema
            }
@@ -726,7 +726,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI, String hasuraGraphQlAdm
     final JsonObject response;
     response = postRequest(request).get();
     final var data = response.getJsonObject("data");
-    final var resourceTypesJsonArray = data.getJsonArray("resourceTypes");
+    final var resourceTypesJsonArray = data.getJsonArray("resource_type");
 
     final var resourceTypes = new ArrayList<ResourceType>();
 
@@ -746,7 +746,6 @@ public record GraphQLMerlinService(URI merlinGraphqlURI, String hasuraGraphQlAdm
    * @param planId the plan id
    * @return
    * @throws IOException
-   * @throws MissionModelServiceException
    * @throws MerlinServiceException
    * @throws NoSuchPlanException
    */


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Update the `GQLMerlinService` in the scheduler to get the model's types from the `resource_type` table instead of the deprecated action `resourceTypes`.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
No tests were updated, as no behavior changed in the scheduler.
