### PR TITLE
Standardize the cached Constraint results to match action results

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
@@ -299,7 +299,7 @@ public final class ConstraintParsers {
 
   public static final JsonParser<Violation> violationP =
       productP
-          .field("violationWindows", listP(intervalP))
+          .field("windows", listP(intervalP))
           .field("activityInstanceIds", listP(longP))
           .map(
               untuple(Violation::new),
@@ -310,8 +310,8 @@ public final class ConstraintParsers {
       productP
           .field("violations", listP(violationP))
           .field("gaps", listP(intervalP))
-          .field("constraintType", enumP(ConstraintType.class, Enum::name))
-          .field("resourceNames", listP(stringP))
+          .field("type", enumP(ConstraintType.class, Enum::name))
+          .field("resourceIds", listP(stringP))
           .field("constraintId", longP)
           .field("constraintName", stringP)
           .map(

--- a/deployment/hasura/migrations/AerieMerlin/29_synchronize_cache_schema/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/29_synchronize_cache_schema/down.sql
@@ -1,0 +1,4 @@
+-- The JSON schema of the constraint violations in constraint_run is changed.
+-- Because the table is a cache it is safer to clear it than to attempt to transform it using SQL
+truncate constraint_run;
+call migrations.mark_migration_rolled_back('29');

--- a/deployment/hasura/migrations/AerieMerlin/29_synchronize_cache_schema/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/29_synchronize_cache_schema/up.sql
@@ -1,0 +1,4 @@
+-- The JSON schema of the constraint violations in constraint_run is changed.
+-- Because the table is a cache it is safer to clear it than to attempt to transform it using SQL
+truncate constraint_run;
+call migrations.mark_migration_applied('29');

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -31,3 +31,4 @@ call migrations.mark_migration_applied('25');
 call migrations.mark_migration_applied('26');
 call migrations.mark_migration_applied('27');
 call migrations.mark_migration_applied('28');
+call migrations.mark_migration_applied('29');


### PR DESCRIPTION
* **Tickets addressed:** Closes #1150
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Updated the parser for constraint violations so that the cached run has the same key names as the action response.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Wrote a JSON parser while working on #1057 that successfully parses both the `checkConstraints` action response and the cached values from `constraint_run`.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs were invalidated

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None
