### PR TITLE
Fix Scheduling DSL Typescript Action

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -89,7 +89,7 @@ type Query {
 }
 
 type Query {
-  schedulingDslTypescript(missionModelId: Int!): DslTypescriptResponse
+  schedulingDslTypescript(missionModelId: Int!, planId: Int): DslTypescriptResponse
 }
 
 type Query {

--- a/e2e-tests/src/utilities/gql.ts
+++ b/e2e-tests/src/utilities/gql.ts
@@ -185,8 +185,8 @@ const gql = {
   `,
 
   GET_SCHEDULING_DSL_TYPESCRIPT: `#graphql
-    query GetSchedulingDslTypeScript($missionModelId: Int!) {
-      schedulingDslTypescript(missionModelId: $missionModelId) {
+    query GetSchedulingDslTypeScript($missionModelId: Int!, $planId: Int) {
+      schedulingDslTypescript(missionModelId: $missionModelId, planId: $planId) {
         reason
         status
         typescriptFiles {

--- a/e2e-tests/src/utilities/requests.ts
+++ b/e2e-tests/src/utilities/requests.ts
@@ -278,8 +278,9 @@ const req = {
   async getSchedulingDslTypeScript(
     request: APIRequestContext,
     missionModelId: number,
+    planId?: number
   ): Promise<SchedulingDslTypesResponse> {
-    const data = await req.hasura(request, gql.GET_SCHEDULING_DSL_TYPESCRIPT, { missionModelId: missionModelId });
+    const data = await req.hasura(request, gql.GET_SCHEDULING_DSL_TYPESCRIPT, { missionModelId: missionModelId, planId: planId });
     const { schedulingDslTypescript } = data;
     return schedulingDslTypescript;
   },

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
@@ -7,7 +7,7 @@ import java.io.StringReader;
 import java.util.List;
 import java.util.Objects;
 import static gov.nasa.jpl.aerie.scheduler.server.http.ResponseSerializers.*;
-import static gov.nasa.jpl.aerie.scheduler.server.http.SchedulerParsers.hasuraMissionModelIdActionP;
+import static gov.nasa.jpl.aerie.scheduler.server.http.SchedulerParsers.hasuraSchedulingDSLTypescriptActionP;
 import static gov.nasa.jpl.aerie.scheduler.server.http.SchedulerParsers.hasuraSpecificationActionP;
 import static io.javalin.apibuilder.ApiBuilder.*;
 import gov.nasa.jpl.aerie.json.JsonParser;
@@ -116,7 +116,7 @@ public record SchedulerBindings(
    */
   private void getSchedulingDslTypescript(final Context ctx) {
     try {
-      final var body = parseJson(ctx.body(), hasuraMissionModelIdActionP);
+      final var body = parseJson(ctx.body(), hasuraSchedulingDSLTypescriptActionP);
       final var missionModelId = body.input().missionModelId();
       final var planId = body.input().planId();
       final var response = this.generateSchedulingLibAction.run(missionModelId, planId);

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
@@ -99,7 +99,7 @@ public final class SchedulerParsers {
   /**
    * parser for a hasura action that accepts a mission model id as its sole input, along with normal hasura session details
    */
-  public static final JsonParser<HasuraAction<HasuraAction.MissionModelIdInput>> hasuraMissionModelIdActionP
+  public static final JsonParser<HasuraAction<HasuraAction.MissionModelIdInput>> hasuraSchedulingDSLTypescriptActionP
       = hasuraActionF(productP
                           .field("missionModelId", missionModelIdP)
                           .optionalField("planId", nullableP(planIdP))

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerParsers.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 import static gov.nasa.jpl.aerie.json.BasicParsers.anyP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.longP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.nullableP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
@@ -101,8 +102,8 @@ public final class SchedulerParsers {
   public static final JsonParser<HasuraAction<HasuraAction.MissionModelIdInput>> hasuraMissionModelIdActionP
       = hasuraActionF(productP
                           .field("missionModelId", missionModelIdP)
-                          .optionalField("planId", planIdP)
+                          .optionalField("planId", nullableP(planIdP))
       .map(
-          untuple(HasuraAction.MissionModelIdInput::new),
-          input -> tuple(input.missionModelId(), input.planId())));
+          untuple((missionModelId, planId) -> new HasuraAction.MissionModelIdInput(missionModelId, planId.flatMap($->$))),
+          input -> tuple(input.missionModelId(), Optional.of(input.planId()))));
 }


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Two bugs were fixed:
1. The optional `planId` parameter for `schedulingDSLTypscript` was added to the Action definition. Because this parameter is optional, this change is not breaking (verified manually).
2. The parser has been fixed to properly handle `planId` not being specified. With fix (1), it was unable to parse a `null` `planId`.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Re: 1: The GQL query has been updated with the action.

Re: 2: We already have two tests for that endpoint, one which provides the `planId` and one which doesn't. The reason this slipped by is the one that provides the `planId` was a Bindings Test, meaning it was hitting the scheduler directly instead of using a GQL query. I have corrected this in my work for #1057 by splitting the tests into two tests, a BindingsTest and a ScheudlingDSLTest. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs need to be updated.