### PR TITLE
Fix DB Migrations

### DIFF
--- a/deployment/hasura/migrations/AerieMerlin/19_users/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/19_users/up.sql
@@ -296,6 +296,10 @@ comment on column merge_request.requester_username is e''
 comment on column merge_request.reviewer_username is e''
   'The user who reviews this merge request. Is empty until the request enters review.';
 
+-- REMOVE SYSTEM USERS IF THEY WERE MISTAKENLY ADDED ABOVE
+delete from metadata.users
+where username = 'Aerie Legacy' or username = 'Mission Model';
+
 -- UPDATE USERS ALLOWED ROLES
 insert into metadata.users_allowed_roles(username, allowed_role)
   select u.username, roles.role

--- a/deployment/hasura/migrations/AerieMerlin/26_create_snapshot_signature_change/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/26_create_snapshot_signature_change/down.sql
@@ -54,3 +54,5 @@ comment on function create_snapshot(integer, text, text) is e''
   '  - The tags on those activities'
 	'  - When the snapshot was taken'
 	'  - Optionally: who took the snapshot and a name';
+
+call migrations.mark_migration_rolled_back('26');

--- a/deployment/hasura/migrations/AerieScheduler/7_definition_consistency/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/7_definition_consistency/up.sql
@@ -1,9 +1,17 @@
 alter table scheduling_goal
-  alter column description set default '',
+  alter column description set default '';
+update scheduling_goal
+  set description = default
+  where description is null;
+alter table scheduling_goal
   alter column description set not null;
 
 alter table scheduling_condition
-  alter column description set default '',
+  alter column description set default '';
+update scheduling_condition
+  set description = default
+  where description is null;
+alter table scheduling_condition
   alter column description set not null;
 
 call migrations.mark_migration_applied('7');


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Resolves three bugs in our migrations:
1) In the AerieMerlin `users` migration, `Aerie Legacy` could accidentally get into the `users` table early. This would most likely occur as a side-effect of the `tags` migration using the username to indicate that a tag was from a version of Aerie prior to the `tags` table. This would cause a constraint violation when the migration went to assign allowed roles to all users added, and even if it didn't, there would be an on-insert conflict when the system users were properly added. This has been resolved by deleting the system users if they exist after all the insertions have occurred.
2) In the AerieScheduler `definition_consistency` migration, rows with a `null` `definition` field would violate the added `not null` constraint. This has been resolved by updating the rows with a `null` field to the `default` value for the row before setting the `not null`.
3) Migration 26 in AerieMerlin was missing a `mark_migration_rolled_back` call in the down.sql

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Manual Verification in two ways:
1. I spun up a fresh Aerie, reverted migrations until I had reverted the two problem migrations. I then applied the bug situations (adding two tags, one whose `owner` was `Aerie Legacy` and another whose `owner` was `Mission Model`; adding a scheduling goal and scheduling constraint with `null` `definition` fields). I then migrated the database up to the latest version. All migrations were done using our Python DB migration helper.
2. Clipper had a deployment that was encountering these bugs. After running (1), these migrations were used to successfully migrate that DB from 1.7.0 to 1.12.0.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs need to be updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Related to (3), I've created [this issue](https://github.com/NASA-AMMOS/aerie/issues/1162)
