### PR TITLE
Add justAfter and justBefore operators to scheduling eDSL

### DIFF
--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -329,6 +329,9 @@ public class SimulationFacade implements AutoCloseable{
       }
     }
     final var serializedActivity = new SerializedActivity(activity.getType().getName(), arguments);
+    if(activity.anchorId()!= null && !planActDirectiveIdToSimulationActivityDirectiveId.containsKey(activity.anchorId())){
+      throw new RuntimeException("Activity with id "+ activity.anchorId() + " referenced as an anchor by activity " + activity.toString() + " is not present in the plan");
+    }
     return new ActivityDirective(
         activity.startOffset(),
         serializedActivity,

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationResultsConverter.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationResultsConverter.java
@@ -47,9 +47,7 @@ public class SimulationResultsConverter {
   {
     final var startT = Duration.of(startTime.until(driverActivity.start(), ChronoUnit.MICROS), MICROSECONDS);
     final var endT = startT.plus(driverActivity.duration());
-    final var activityInterval = startT.isEqualTo(endT)
-        ? Interval.between(startT, endT)
-        : Interval.betweenClosedOpen(startT, endT);
+    final var activityInterval = Interval.between(startT, endT);
     return new gov.nasa.jpl.aerie.constraints.model.ActivityInstance(
         id, driverActivity.type(), driverActivity.arguments(),
         activityInterval);

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
@@ -901,7 +901,8 @@ public class TestApplyWhen {
 
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(1, Duration.SECONDS), actTypeA));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(14, Duration.SECONDS), actTypeA));
-    assertEquals(3, problem.getSimulationFacade().countSimulationRestarts());
+    assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(12, Duration.SECONDS), actTypeA));
+    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test
@@ -971,12 +972,13 @@ public class TestApplyWhen {
     for(SchedulingActivityDirective a : plan.get().getActivitiesByTime()){
       logger.debug(a.startOffset().toString() + ", " + a.duration().toString());
     }
-
+    assertEquals(10, plan.get().getActivitiesById().size());
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(2, Duration.SECONDS), actTypeB));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(10, Duration.SECONDS), actTypeB));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(16, Duration.SECONDS), actTypeB));
+    assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(23, Duration.SECONDS), actTypeB));
     assertTrue(TestUtility.activityStartingAtTime(plan.get(), Duration.of(25, Duration.SECONDS), actTypeB));
-    assertEquals(5, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(6, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test

--- a/scheduler-worker/build.gradle
+++ b/scheduler-worker/build.gradle
@@ -126,7 +126,6 @@ dependencies {
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
   testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.0'
   testImplementation 'org.assertj:assertj-core:3.24.2'
-  testImplementation 'junit:junit:4.13.2'
   testImplementation 'javax.json.bind:javax.json.bind-api:1.0'
   testImplementation 'org.glassfish:javax.json:1.1.4'
 }

--- a/scheduler-worker/build.gradle
+++ b/scheduler-worker/build.gradle
@@ -124,6 +124,7 @@ dependencies {
   testImplementation project(':examples:foo-missionmodel')
   testImplementation testFixtures(project(':scheduler-server'))
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+  testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.0'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'javax.json.bind:javax.json.bind-api:1.0'

--- a/scheduler-worker/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
+++ b/scheduler-worker/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
@@ -592,6 +592,9 @@ export class ActivityExpression<T extends WindowsEDSL.Gen.ActivityType> {
 }
 
 export class TimingConstraint {
+
+  public static defaultPadding: Temporal.Duration = Temporal.Duration.from({microseconds:1});
+
   /** @internal **/
   private constructor() {}
   /**
@@ -632,6 +635,23 @@ export class TimingConstraint {
       upperBound: upperBound.__astNode,
       singleton: false
     })
+  }
+
+  /**
+   *  Represents a precise time point at a defined offset (default: 1 microseconds, can be modified) from the start or end of a window.
+   *  Equivalent to TimingConstraint.singleton(windowProperty).plus(TimingConstraint.defaultPadding)
+   * @param windowProperty either WindowProperty.START or WindowProperty.END
+   */
+  public static justAfter(windowProperty: WindowProperty): SingletonTimingConstraint {
+    return this.singleton(windowProperty).plus(this.defaultPadding);
+  }
+  /**
+   *  Represents a precise time point at a defined offset (default: -1 microseconds, can be modified) from the start or end of a window.
+   *  Equivalent to TimingConstraint.singleton(windowProperty).minus(TimingConstraint.defaultPadding)
+   * @param windowProperty either WindowProperty.START or WindowProperty.END
+   */
+  public static justBefore(windowProperty: WindowProperty): SingletonTimingConstraint {
+    return this.singleton(windowProperty).minus(this.defaultPadding);
   }
 }
 
@@ -837,6 +857,7 @@ declare global {
                                                                 matchingArgs: WindowsEDSL.Gen.ActivityTypeParameterMapWithUndefined[T]): ActivityExpression<T>
   }
   class TimingConstraint {
+    public static defaultPadding: Temporal.Duration;
     /**
      * The singleton timing constraint represents a precise time point
      * at some offset from either the start or end of a window.
@@ -862,6 +883,18 @@ declare global {
      * @param upperBound represents the (inclusive) upper bound of the time interval
      */
     public static bounds(lowerBound: SingletonTimingConstraint, upperBound: SingletonTimingConstraint): FlexibleRangeTimingConstraint
+    /**
+     *  Represents a precise time point at a defined offset (default: 1 microseconds, can be modified) from the start or end of a window.
+     *  Equivalent to TimingConstraint.singleton(windowProperty).plus(TimingConstraint.defaultPadding)
+     * @param windowProperty either WindowProperty.START or WindowProperty.END
+     */
+    public static justAfter(windowProperty: WindowProperty): SingletonTimingConstraint
+    /**
+     *  Represents a precise time point at a defined offset (default: -1 microseconds, can be modified) from the start or end of a window.
+     *  Equivalent to TimingConstraint.singleton(windowProperty).minus(TimingConstraint.defaultPadding)
+     * @param windowProperty either WindowProperty.START or WindowProperty.END
+     */
+    public static justBefore(windowProperty: WindowProperty): SingletonTimingConstraint
   }
   var WindowProperty: typeof AST.WindowProperty
   var Operator: typeof AST.TimingConstraintOperator

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
@@ -16,14 +16,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.HOUR;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.HOURS;
-import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECOND;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MILLISECONDS;
-import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MINUTE;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MINUTES;
-import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECOND;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
 import static org.junit.jupiter.api.Assertions.*;
 
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
@@ -414,7 +411,7 @@ public class SchedulingIntegrationTests {
                 "GrowBanana",
                 Map.of(
                     "quantity", SerializedValue.of(1),
-                    "growingDuration", SerializedValue.of(Duration.MINUTE.in(MICROSECOND))
+                    "growingDuration", SerializedValue.of(Duration.MINUTE.in(MICROSECONDS))
                 ),
                 null,
                 true
@@ -448,7 +445,7 @@ public class SchedulingIntegrationTests {
         "GrowBanana",
         Map.of(
             "quantity", SerializedValue.of(1),
-            "growingDuration", SerializedValue.of(Duration.MINUTE.times(2).in(MICROSECOND))
+            "growingDuration", SerializedValue.of(Duration.MINUTE.times(2).in(MICROSECONDS))
         ),
         null,
         true
@@ -476,7 +473,7 @@ public class SchedulingIntegrationTests {
                 "GrowBanana",
                 Map.of(
                     "quantity", SerializedValue.of(2),
-                    "growingDuration", SerializedValue.of(Duration.MINUTE.times(2).in(MICROSECOND))
+                    "growingDuration", SerializedValue.of(Duration.MINUTE.times(2).in(MICROSECONDS))
                 ),
                 null,
                 true
@@ -514,12 +511,12 @@ public class SchedulingIntegrationTests {
     final var growBananas = planByActivityType.get("GrowBanana");
     assertEquals(3, growBananas.size());
     final var planByTime = partitionByStartTime(results.updatedPlan());
-    assertEquals(2, planByTime.get(MINUTE.times(10)).size());
+    assertEquals(2, planByTime.get(MINUTES.times(10)).size());
     var lookingFor = false;
     final var expectedCreation = new SerializedActivity("GrowBanana",
                                             Map.of("quantity", SerializedValue.of(1),
-                                                   "growingDuration", SerializedValue.of(MINUTES.in(MICROSECOND))));
-    for(final var actAtTime10: planByTime.get(MINUTE.times(10))){
+                                                   "growingDuration", SerializedValue.of(MINUTES.in(MICROSECONDS))));
+    for(final var actAtTime10: planByTime.get(MINUTES.times(10))){
       if(actAtTime10.serializedActivity().equals(expectedCreation)){
         lookingFor = true;
       }
@@ -530,11 +527,11 @@ public class SchedulingIntegrationTests {
   @Test
   void testRecurrenceWithActivityFinder() {
     final var expectedMatch1 =  new ActivityDirective(
-        Duration.of(0, Duration.SECONDS),
+        Duration.of(0, SECONDS),
         "GrowBanana",
         Map.of(
             "quantity", SerializedValue.of(2),
-            "growingDuration", SerializedValue.of(Duration.of(1, Duration.SECONDS).in(Duration.MICROSECONDS))),
+            "growingDuration", SerializedValue.of(Duration.of(1, SECONDS).in(Duration.MICROSECONDS))),
         null,
         true);
     final var expectedMatch2 = new ActivityDirective(
@@ -542,7 +539,7 @@ public class SchedulingIntegrationTests {
         "GrowBanana",
         Map.of(
             "quantity", SerializedValue.of(2),
-            "growingDuration", SerializedValue.of(Duration.of(2, Duration.SECONDS).in(Duration.MICROSECONDS))),
+            "growingDuration", SerializedValue.of(Duration.of(2, SECONDS).in(Duration.MICROSECONDS))),
         null,
         true);
 
@@ -556,7 +553,7 @@ public class SchedulingIntegrationTests {
                 "GrowBanana",
                 Map.of(
                     "quantity", SerializedValue.of(3),
-                    "growingDuration", SerializedValue.of(Duration.of(3, Duration.SECONDS).in(Duration.MICROSECONDS))),
+                    "growingDuration", SerializedValue.of(Duration.of(3, SECONDS).in(Duration.MICROSECONDS))),
                 null,
                 true)
         ),
@@ -593,11 +590,11 @@ public class SchedulingIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(new ActivityDirective(
-            Duration.of(0, Duration.SECONDS),
+            Duration.of(0, SECONDS),
             "GrowBanana",
             Map.of(
                 "quantity", SerializedValue.of(2),
-                "growingDuration", SerializedValue.of(Duration.of(5, Duration.SECONDS).in(Duration.MICROSECONDS))),
+                "growingDuration", SerializedValue.of(Duration.of(5, SECONDS).in(Duration.MICROSECONDS))),
             null,
             true)),
         List.of(new SchedulingGoal(new GoalId(0L),
@@ -689,7 +686,7 @@ public class SchedulingIntegrationTests {
                 "GrowBanana",
                 Map.of(
                     "quantity", SerializedValue.of(1),
-                    "growingDuration", SerializedValue.of(Duration.MINUTE.in(MICROSECOND))
+                    "growingDuration", SerializedValue.of(Duration.MINUTE.in(MICROSECONDS))
                 ),
                 null,
                 true
@@ -726,7 +723,7 @@ public class SchedulingIntegrationTests {
     final var created = iterator.next();
 
     assertEquals(SerializedValue.of(10), created.serializedActivity().getArguments().get("quantity"));
-    assertEquals(SerializedValue.of(Duration.of(2, Duration.MINUTES).in(MICROSECOND)), created.serializedActivity().getArguments().get("growingDuration"));
+    assertEquals(SerializedValue.of(Duration.of(2, Duration.MINUTES).in(MICROSECONDS)), created.serializedActivity().getArguments().get("growingDuration"));
     assertEquals(Duration.of(7, Duration.MINUTES), created.startOffset());
   }
 
@@ -1721,7 +1718,7 @@ public class SchedulingIntegrationTests {
 
     final var myBooleanResource = new DiscreteProfile(
         List.of(
-            new Segment<>(Interval.between(HOUR.times(2), HOUR.times(4)), SerializedValue.of(true))
+            new Segment<>(Interval.between(HOURS.times(2), HOURS.times(4)), SerializedValue.of(true))
         )
     ).assignGaps(new DiscreteProfile(List.of(new Segment(Interval.FOREVER, SerializedValue.of(false)))));
 
@@ -1749,18 +1746,18 @@ public class SchedulingIntegrationTests {
     assertEquals(1, results.updatedPlan().size());
     final var planByActivityType = partitionByActivityType(results.updatedPlan());
     final var peelBanana = planByActivityType.get("PeelBanana").iterator().next();
-    assertEquals(HOUR.times(2), peelBanana.startOffset());
+    assertEquals(HOURS.times(2), peelBanana.startOffset());
   }
 
   @Test
   void testApplyWhen() {
-    final var growBananaDuration = Duration.of(1, Duration.SECONDS);
+    final var growBananaDuration = Duration.of(1, SECONDS);
 
     final var results = runScheduler(
         BANANANATION,
         List.of(
             new ActivityDirective(
-                Duration.of(1, Duration.SECONDS),
+                Duration.of(1, SECONDS),
                 "GrowBanana",
                 Map.of(
                     "quantity", SerializedValue.of(1),
@@ -1768,7 +1765,7 @@ public class SchedulingIntegrationTests {
                 null,
                 true),
             new ActivityDirective(
-                Duration.of(2, Duration.SECONDS),
+                Duration.of(2, SECONDS),
                 "GrowBanana",
                 Map.of(
                     "quantity", SerializedValue.of(1),
@@ -1776,7 +1773,7 @@ public class SchedulingIntegrationTests {
                 null,
                 true),
             new ActivityDirective(
-                Duration.of(3, Duration.SECONDS),
+                Duration.of(3, SECONDS),
                 "GrowBanana",
                 Map.of(
                     "quantity", SerializedValue.of(1),
@@ -1866,7 +1863,7 @@ public class SchedulingIntegrationTests {
         BANANANATION,
         List.of(
             new ActivityDirective(
-                Duration.of(24, HOURS).minus(MICROSECOND),
+                Duration.of(24, HOURS).minus(MICROSECONDS),
                 "BiteBanana",
                 Map.of("biteSize", SerializedValue.of(1)),
                 null,
@@ -3201,7 +3198,7 @@ public class SchedulingIntegrationTests {
     final var daemonChecker = daemonCheckers.iterator().next();
 
     assertEquals(Duration.of(5, MINUTES), zeroDuration.startOffset());
-    assertEquals(Duration.of(10, MINUTES).plus(Duration.of(1, SECOND)), daemonChecker.startOffset());
+    assertEquals(Duration.of(10, MINUTES).plus(Duration.of(1, SECONDS)), daemonChecker.startOffset());
   }
 
   /**
@@ -3294,7 +3291,7 @@ public class SchedulingIntegrationTests {
 
     final var peels = planByActivityType.get("PeelBanana");
     assertEquals(1, peels.size());
-    assertEquals(peels.iterator().next().startOffset(), Duration.of(5, MINUTE).plus(Duration.of(2, activityDuration)));
+    assertEquals(peels.iterator().next().startOffset(), Duration.of(5, MINUTES).plus(Duration.of(2, activityDuration)));
   }
 
   @Test


### PR DESCRIPTION
* **Tickets addressed:** #1087 partially
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
- First commit: add `justAfter` and `justBefore` timing constraints in the scheduling edsl. The TimingConstraint.defaultPadding defines the default padding applied, 1 microsecond per default. The user can change it in the goal code.
- Second commit: Activities are now represented by closed-closed intervals. 
- The third commit is refactoring (collapsing) the `ActivityExpression` hierarchy 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
A few tests have been updated because of the first second commit. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
- [ ] Add documentation to aerie-docs

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None.