### PR TITLE
Allow users to insert Plan descriptions

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan.yaml
@@ -96,14 +96,14 @@ select_permissions:
 insert_permissions:
   - role: aerie_admin
     permission:
-      columns: [name, duration, model_id, parent_id, start_time]
+      columns: [name, duration, model_id, parent_id, start_time, description]
       check: {}
       set:
         owner: "x-hasura-user-id"
         updated_by: "x-hasura-user-id"
   - role: user
     permission:
-      columns: [name, duration, model_id, parent_id, start_time]
+      columns: [name, duration, model_id, parent_id, start_time, description]
       check: {}
       set:
         owner: "x-hasura-user-id"


### PR DESCRIPTION
* **Tickets addressed:**  Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
User and Admin roles were unable to insert a description when adding a plan. This has been fixed

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Spun up Hasura and vetted change.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs were invalidated, however, [this query](https://nasa-ammos.github.io/aerie-docs/api/examples/planning/introduction/#create-a-single-plan) ought to be updated to include `description` and any other missing fields