### PR TITLE
Make Check Constraints Load Correct Sim Dataset

### DIFF
--- a/e2e-tests/src/tests/constraints-load-old-sim-results.test.ts
+++ b/e2e-tests/src/tests/constraints-load-old-sim-results.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from '@playwright/test';
+import req, { awaitSimulation } from '../utilities/requests.js';
+
+test.describe.serial('Check Constraints Against Specific Sim Datasets', () => {
+    const constraintName = 'fruit_equal_peel';
+    const activity_offset_hours = 1;
+
+    const plan_start_timestamp = "2023-01-01T00:00:00+00:00";
+
+    let mission_model_id: number;
+    let plan_id: number;
+    let constraint_id: number;
+    let violation: Violation;
+    let activity_id: number;
+
+    test.beforeAll(async ({request}) => {
+        let rd = Math.random() * 100000;
+        let jar_id = await req.uploadJarFile(request);
+        // Add Mission Model
+        const model: MissionModelInsertInput = {
+            jar_id,
+            mission: 'aerie_e2e_tests',
+            name: 'Banananation (e2e tests)',
+            version: rd + "",
+        };
+        mission_model_id = await req.createMissionModel(request, model);
+
+        // Add Plan
+        const plan_input: CreatePlanInput = {
+            model_id: mission_model_id,
+            name: 'test_plan' + rd,
+            start_time: plan_start_timestamp,
+            duration: "24:00:00"
+        };
+        plan_id = await req.createPlan(request, plan_input);
+
+        // Add Activity
+        const activityToInsert: ActivityInsertInput = {
+            arguments: {
+                biteSize: 2,
+            },
+            plan_id: plan_id,
+            type: 'BiteBanana',
+            start_offset: activity_offset_hours + 'h',
+        };
+        activity_id = await req.insertActivity(request, activityToInsert);
+
+        // Add Constraint
+        const constraint: ConstraintInsertInput = {
+            name: constraintName,
+            definition: 'export default (): Constraint => Real.Resource("/fruit").equal(Real.Resource("/peel"))',
+            description: '',
+            model_id: null,
+            plan_id,
+        };
+        constraint_id = await req.insertConstraint(request, constraint);
+    });
+
+    test.afterAll(async ({request}) => {
+        // Delete Constraint
+        await req.deleteConstraint(request, constraint_id);
+
+        // Deleting Plan and Model cascades the rest of the cleanup
+        await req.deleteMissionModel(request, mission_model_id);
+        await req.deletePlan(request, plan_id);
+    });
+
+    test('Constraints Loads Specified Outdated Sim Dataset', async ({request}) => {
+        // Simulate
+        const oldSimDatasetId = (await awaitSimulation(request, plan_id)).simulationDatasetId;
+
+        // Invalidate Results and Resim
+        await req.deleteActivity(request, plan_id, activity_id);
+        const newSimulationDatasetId = (await awaitSimulation(request, plan_id)).simulationDatasetId;
+
+        // Assert No Violations on Newest Results
+        const newConstraintResults = await req.checkConstraints(request, plan_id, newSimulationDatasetId);
+        expect(newConstraintResults).toHaveLength(0);
+
+        // Assert One Violation on Old Results
+        const oldConstraintResults = await req.checkConstraints(request, plan_id, oldSimDatasetId);
+        expect(oldConstraintResults).toHaveLength(1);
+
+        // Assert the Results to be as expected
+        const result = oldConstraintResults.pop();
+        expect(result.constraintName).toEqual(constraintName);
+        expect(result.constraintId).toEqual(constraint_id);
+
+        // Resources
+        expect(result.resourceIds).toHaveLength(2);
+        expect(result.resourceIds).toContain('/fruit');
+        expect(result.resourceIds).toContain('/peel');
+
+        // Violation
+        expect(result.violations).toHaveLength(1);
+
+        // Violation Window
+        const plan_duration_micro = 24 * 60 * 60 * 1000 * 1000;
+        const activity_offset_micro = activity_offset_hours * 60 * 60 * 1000 * 1000;
+
+        violation = result.violations[0];
+        expect(violation.windows[0].start).toEqual(activity_offset_micro);
+        expect(violation.windows[0].end).toEqual(plan_duration_micro);
+
+        // Gaps
+        expect(result.gaps).toHaveLength(0);
+    });
+});

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/SimulationDatasetMismatchException.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/SimulationDatasetMismatchException.java
@@ -1,0 +1,15 @@
+package gov.nasa.jpl.aerie.merlin.server.exceptions;
+
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
+
+public class SimulationDatasetMismatchException extends Exception {
+  public final SimulationDatasetId simDatasetId;
+  public final PlanId planId;
+
+  public SimulationDatasetMismatchException(final PlanId pid, final SimulationDatasetId sid) {
+    super("Simulation Dataset with id `" + sid.id() + "` does not belong to Plan with id `"+pid.id()+"`");
+    this.planId = pid;
+    this.simDatasetId = sid;
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -6,6 +6,7 @@ import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.SimulationDatasetMismatchException;
 import gov.nasa.jpl.aerie.merlin.server.services.ConstraintAction;
 import gov.nasa.jpl.aerie.merlin.server.models.HasuraAction;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
@@ -250,6 +251,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(404).result(ExceptionSerializers.serializeNoSuchPlanException(ex).toString());
     } catch (final InputMismatchException ex) {
       ctx.status(404).result(ResponseSerializers.serializeInputMismatchException(ex).toString());
+    } catch (SimulationDatasetMismatchException ex) {
+      ctx.status(404).result(ResponseSerializers.serializeSimulationDatasetMismatchException(ex).toString());
     } catch (final PermissionsServiceException ex) {
       ctx.status(503).result(ExceptionSerializers.serializePermissionsServiceException(ex).toString());
     } catch (final Unauthorized ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -16,6 +16,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.SimulationDatasetMismatchException;
 import gov.nasa.jpl.aerie.merlin.server.remotes.MissionModelAccessException;
 import gov.nasa.jpl.aerie.merlin.server.services.GetSimulationResultsAction;
 import gov.nasa.jpl.aerie.merlin.server.services.LocalMissionModelService;
@@ -463,6 +464,13 @@ public final class ResponseSerializers {
 
   public static JsonValue serializeInputMismatchException(final InputMismatchException ex) {
     return Json.createObjectBuilder()
+               .add("message", "input mismatch exception")
+               .add("cause", ex.getMessage())
+               .build();
+  }
+
+  public static JsonValue serializeSimulationDatasetMismatchException(final SimulationDatasetMismatchException ex){
+     return Json.createObjectBuilder()
                .add("message", "input mismatch exception")
                .add("cause", ex.getMessage())
                .build();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
@@ -61,6 +61,11 @@ public final class InMemoryResultsCellRepository implements ResultsCellRepositor
     }
   }
 
+  @Override
+  public Optional<ResultsProtocol.ReaderRole> lookup(final PlanId planId, final SimulationDatasetId simulationDatasetId) {
+    return lookup(planId);
+  }
+
   public boolean isEqualTo(final InMemoryResultsCellRepository other) {
     return this.cells.equals(other.cells);
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/ResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/ResultsCellRepository.java
@@ -1,7 +1,9 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes;
 
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.SimulationDatasetMismatchException;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 
 import java.util.Optional;
 
@@ -11,4 +13,6 @@ public interface ResultsCellRepository {
   Optional<ResultsProtocol.OwnerRole> claim(PlanId planId, Long datasetId);
 
   Optional<ResultsProtocol.ReaderRole> lookup(PlanId planId);
+
+  Optional<ResultsProtocol.ReaderRole> lookup(PlanId planId, SimulationDatasetId simulationDatasetId) throws SimulationDatasetMismatchException;
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationDatasetByIdAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationDatasetByIdAction.java
@@ -1,0 +1,71 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Optional;
+
+public class GetSimulationDatasetByIdAction implements AutoCloseable {
+  private static final @Language("Sql") String sql = """
+    select
+          d.simulation_id as simulation_id,
+          d.status as status,
+          d.reason as reason,
+          d.canceled as canceled,
+          to_char(d.simulation_start_time, 'YYYY-DDD"T"HH24:MI:SS.FF6') as simulation_start_time,
+          to_char(d.simulation_end_time, 'YYYY-DDD"T"HH24:MI:SS.FF6') as simulation_end_time,
+          d.dataset_id as dataset_id
+      from simulation_dataset as d
+      where
+        d.id = ?
+    """;
+
+  private final PreparedStatement statement;
+
+  public GetSimulationDatasetByIdAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public Optional<SimulationDatasetRecord> get(
+      final long simulationDatasetId
+  ) throws SQLException {
+    this.statement.setLong(1, simulationDatasetId);
+
+    try (final var results = this.statement.executeQuery()) {
+      if (!results.next()) return Optional.empty();
+
+      final SimulationStateRecord.Status status;
+      try {
+        status = SimulationStateRecord.Status.fromString(results.getString("status"));
+      } catch (final SimulationStateRecord.Status.InvalidSimulationStatusException ex) {
+        throw new Error("Simulation Dataset initialized with invalid state.");
+      }
+
+      final var simulationId = results.getLong("simulation_id");
+      final var reason = PreparedStatements.getFailureReason(results, 3);
+      final var canceled = results.getBoolean("canceled");
+      final var state = new SimulationStateRecord(status, reason);
+      final var simStartTime = Timestamp.fromString(results.getString("simulation_start_time"));
+      final var simEndTime = Timestamp.fromString(results.getString("simulation_end_time"));
+      final var datasetId = results.getLong("dataset_id");
+
+      return Optional.of(
+          new SimulationDatasetRecord(
+              simulationId,
+              datasetId,
+              state,
+              canceled,
+              simStartTime,
+              simEndTime,
+              simulationDatasetId));
+    }
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresConstraintRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresConstraintRepository.java
@@ -35,8 +35,9 @@ public class PostgresConstraintRepository implements ConstraintRepository {
 
   @Override
   public Map<Long, ConstraintRunRecord> getValidConstraintRuns(List<Long> constraintIds, SimulationDatasetId simulationDatasetId) {
-    try (final var connection = this.dataSource.getConnection()) {
-      final var constraintRuns = new GetValidConstraintRunsAction(connection, constraintIds, simulationDatasetId).get();
+    try (final var connection = this.dataSource.getConnection();
+         final var validConstraintRunAction = new GetValidConstraintRunsAction(connection, constraintIds, simulationDatasetId)) {
+      final var constraintRuns = validConstraintRunAction.get();
       final var validConstraintRuns = new HashMap<Long, ConstraintRunRecord>();
 
       for (final var constraintRun : constraintRuns) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -165,6 +165,16 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
     }
   }
 
+  private static Optional<SimulationDatasetRecord> getSimulationDatasetRecordById(
+      final Connection connection,
+      final long simulationDatasetId
+  ) throws SQLException
+  {
+    try (final var lookupSimulationDatasetAction = new GetSimulationDatasetByIdAction(connection)) {
+      return lookupSimulationDatasetAction.get(simulationDatasetId);
+    }
+  }
+
   private static SimulationDatasetRecord createSimulationDataset(
       final Connection connection,
       final SimulationRecord simulation,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -12,6 +12,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol.State;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.SimulationDatasetMismatchException;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.models.ProfileSet;
 import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
@@ -120,14 +121,32 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
   public Optional<ResultsProtocol.ReaderRole> lookup(final PlanId planId) {
     try (final var connection = this.dataSource.getConnection()) {
       final var simulation = getSimulation(connection, planId);
-      final var datasetRecord = lookupSimulationDatasetRecord(
-          connection,
-          simulation.id());
-      final var datasetId$ = datasetRecord.map(SimulationDatasetRecord::datasetId);
+      final var datasetRecord = lookupSimulationDatasetRecord(connection, simulation.id());
 
-      if (datasetId$.isEmpty()) return Optional.empty();
+      if (datasetRecord.isEmpty()) return Optional.empty();
 
-      final var datasetId = datasetId$.get();
+      final var datasetId = datasetRecord.get().datasetId();
+      return Optional.of(new PostgresResultsCell(this.dataSource, simulation, datasetId));
+    } catch (final SQLException ex) {
+      throw new DatabaseException("Failed to get simulation", ex);
+    }
+  }
+
+  @Override
+  public Optional<ResultsProtocol.ReaderRole> lookup(final PlanId planId, final SimulationDatasetId simulationDatasetId) throws SimulationDatasetMismatchException {
+    try (final var connection = this.dataSource.getConnection()) {
+      final var simulation = getSimulation(connection, planId);
+      final var datasetRecord = getSimulationDatasetRecordById(connection, simulationDatasetId.id());
+
+      if (datasetRecord.isEmpty()) return Optional.empty();
+      // If this check fails, then the specified sim dataset is not a simulation for the specified plan
+      if (datasetRecord.get().simulationId() != simulation.id()) {
+        throw new SimulationDatasetMismatchException(
+            planId,
+            new SimulationDatasetId(datasetRecord.get().simulationDatasetId()));
+      }
+
+      final var datasetId = datasetRecord.get().datasetId();
       return Optional.of(new PostgresResultsCell(this.dataSource, simulation, datasetId));
     } catch (final SQLException ex) {
       throw new DatabaseException("Failed to get simulation", ex);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
@@ -1,7 +1,9 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.SimulationDatasetMismatchException;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.SimulationResultsHandle;
 import gov.nasa.jpl.aerie.merlin.server.remotes.ResultsCellRepository;
 
@@ -28,6 +30,15 @@ public record CachedSimulationService (
   @Override
   public Optional<SimulationResultsHandle> get(final PlanId planId, final RevisionData revisionData) {
     return this.store.lookup(planId) // Only return results that have already been cached
+        .map(ResultsProtocol.ReaderRole::get)
+        .map(state -> state instanceof final ResultsProtocol.State.Success s ?
+            s.results() :
+            null);
+  }
+
+  @Override
+  public Optional<SimulationResultsHandle> get(final PlanId planId, final SimulationDatasetId simulationDatasetId) throws SimulationDatasetMismatchException {
+    return this.store.lookup(planId, simulationDatasetId) // Only return results that have already been cached
         .map(ResultsProtocol.ReaderRole::get)
         .map(state -> state instanceof final ResultsProtocol.State.Success s ?
             s.results() :

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
@@ -1,12 +1,17 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.SimulationDatasetMismatchException;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.SimulationResultsHandle;
 
 import java.util.Optional;
 
 public interface SimulationService {
   ResultsProtocol.State getSimulationResults(PlanId planId, RevisionData revisionData, final String requestedBy);
+
   Optional<SimulationResultsHandle> get(PlanId planId, RevisionData revisionData);
+
+  Optional<SimulationResultsHandle> get(PlanId planId, SimulationDatasetId simulationDatasetId) throws SimulationDatasetMismatchException;
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/UncachedSimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/UncachedSimulationService.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.merlin.server.mocks.InMemoryRevisionData;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.SimulationResultsHandle;
 import gov.nasa.jpl.aerie.merlin.server.remotes.InMemoryResultsCellRepository.InMemoryCell;
 
@@ -42,5 +43,10 @@ public record UncachedSimulationService (
         getSimulationResults(planId, revisionData, null) instanceof ResultsProtocol.State.Success s ?
             s.results() :
             null);
+  }
+
+  @Override
+  public Optional<SimulationResultsHandle> get(PlanId planId, SimulationDatasetId simulationDatasetId) {
+    throw new UnsupportedOperationException(); // Cannot get a cached result from an uncached service
   }
 }


### PR DESCRIPTION
* **Tickets addressed:** Closes #1168.
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Resolves the bug by allowing the Simulation Service to look up either a specific SimulationDataset, or the latest one if one isn't specified.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
An e2e Test has been added to validate that constraints loads the specified Simulation Results, even if those results are outdated. It was placed in its own file to avoid any potential caching issues with the existing constraints tests.

A bindings tests has been added to validate the error response if an invalid sim dataset id is passed.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs need to be updated

## Future work
<!-- What next steps can we anticipate from here, if any? -->
The `UncachedSimulationService` is not only unused, it's not representative of our system, which now generally expects results to have been cached. As a result, I'd like to flatten this interface.
