### PR TITLE
Improve ConstraintAction Error Messages

### DIFF
--- a/e2e-tests/src/tests/bindings.test.ts
+++ b/e2e-tests/src/tests/bindings.test.ts
@@ -182,6 +182,20 @@ test.describe('Merlin Bindings', () => {
     expect(response.status()).toEqual(404);
     expect((await response.json()).message).toEqual('no such plan');
 
+    // Returns a 404 if the SimulationDataset id is invalid
+    // message is "input mismatch exception"
+    response = await request.post(`${urls.MERLIN_URL}/constraintViolations`, {
+      data: {
+        action: {name: "check_constraints"},
+        input: {planId: plan_id, simulationDatasetId: -1},
+        request_query: "",
+        session_variables: admin.session}});
+    expect(response.status()).toEqual(404);
+    expect((await response.json())).toEqual({
+      message: "input mismatch exception",
+      cause: "simulation dataset with id `-1` does not exist"
+    });
+
     // Returns a 403 if unauthorized
     response = await request.post(`${urls.MERLIN_URL}/constraintViolations`, {
       data: {
@@ -204,7 +218,7 @@ test.describe('Merlin Bindings', () => {
     expect(response.status()).toEqual(404);
     expect((await response.json())).toEqual({
       message: "input mismatch exception",
-      cause: "no simulation datasets found for plan id " + plan_id
+      cause: "plan with id " + plan_id +" has not yet been simulated at its current revision"
     });
 
     // Returns a 404 if given an invalid simulation dataset id
@@ -218,7 +232,7 @@ test.describe('Merlin Bindings', () => {
         session_variables: admin.session}});
     expect(response.status()).toEqual(404);
     expect((await response.json())).toEqual({
-      message: "input mismatch exception",
+      message: "simulation dataset mismatch exception",
       cause: "Simulation Dataset with id `" + invalidSimDatasetId + "` does not belong to Plan with id `"+plan_id+"`"
     });
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -471,7 +471,7 @@ public final class ResponseSerializers {
 
   public static JsonValue serializeSimulationDatasetMismatchException(final SimulationDatasetMismatchException ex){
      return Json.createObjectBuilder()
-               .add("message", "input mismatch exception")
+               .add("message", "simulation dataset mismatch exception")
                .add("cause", ex.getMessage())
                .build();
   }


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Follow up to #1169. 

The action will now correctly distinguish between a plan never being simulated and a specified sim dataset not existing when erroring on `resultsHandle$` being empty. 

Additionally, the serializer for SimDatasetMismatch now refers to the correct extension.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
A bindings test has been added. The bindings test fo the `SimDatasetMismatch` exception has been updated.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs changes needed.
