### PR TITLE
Make workers exit when unexpectedly shutdown

### DIFF
--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/ListenSimulationCapability.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/ListenSimulationCapability.java
@@ -28,8 +28,8 @@ public class ListenSimulationCapability {
     this.notificationQueue = notificationQueue;
   }
 
-  public void registerListener() {
-    new Thread(() -> {
+  public Thread registerListener() {
+    final var listenThread = new Thread(() -> {
       try (final var connection = this.dataSource.getConnection()) {
         try (final var listenSimulationStatusAction = new ListenSimulationStatusAction(connection)) {
           listenSimulationStatusAction.apply();
@@ -37,7 +37,7 @@ public class ListenSimulationCapability {
           throw new DatabaseException("Failed to register as LISTEN to postgres database.", ex);
         }
 
-        while (true) {
+        while (!Thread.currentThread().isInterrupted()) {
           final var pgConnection = connection.unwrap(PGConnection.class);
           final var notifications = pgConnection.getNotifications(10000);
           if (notifications != null) {
@@ -54,16 +54,20 @@ public class ListenSimulationCapability {
                 try {
                   this.notificationQueue.put(notificationPayload);
                 } catch (InterruptedException e) {
-                  // We do not expect this thread to be interrupted. If it is, exit gracefully:
+                  // This thread will be interrupted when the worker's main loop exits, so it should exit gracefully:
+                  logger.info("Listener has been interrupted");
                   return;
                 }
               }
             }
           }
         }
+        logger.info("Listener has received interrupted signal");
       } catch (SQLException e) {
         throw new DatabaseException("Listener encountered exception", e);
       }
-    }).start();
+    });
+    listenThread.start();
+    return listenThread;
   }
 }

--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 public final class MerlinWorkerAppDriver {
   public static void main(String[] args) throws InterruptedException {
@@ -67,8 +68,9 @@ public final class MerlinWorkerAppDriver {
     try (final var app = Javalin.create().start(8080)) {
       app.get("/health", ctx -> ctx.status(200));
 
-      while (true) {
-        final var notification = notificationQueue.take();
+      while (listenThread.isAlive()) {
+        final var notification = notificationQueue.poll(1, TimeUnit.MINUTES);
+        if(notification == null) continue;
         final var planId = new PlanId(notification.planId());
         final var datasetId = notification.datasetId();
 

--- a/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/SchedulerWorkerAppDriver.java
+++ b/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/SchedulerWorkerAppDriver.java
@@ -5,6 +5,8 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import gov.nasa.jpl.aerie.scheduler.server.ResultsProtocol;
@@ -76,8 +78,9 @@ public final class SchedulerWorkerAppDriver {
     try(final var app = Javalin.create().start(8080)) {
       app.get("/health", ctx -> ctx.status(200));
 
-      while (true) {
-        final var notification = notificationQueue.take();
+      while (listenThread.isAlive()) {
+        final var notification = notificationQueue.poll(1, TimeUnit.MINUTES);
+        if (notification == null) continue;
         final var specificationRevision = notification.specificationRevision();
         final var specificationId = new SpecificationId(notification.specificationId());
 


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Currently, our workers do not properly shut down when something goes wrong (ie a DB exception) in either the main thread or the listener thread, causing the workers to appear alive but unresponsive. This fixes that in two steps:

Commit 1: When the main thread exits, close the Javalin server and the listenerThread. Currently, neither of these threads are exited when the main thread stops, meaning the Java process is kept alive. Because the process is still alive, the container doesn't exit, preventing Docker from restarting it.

Commit 2: If the listener thread dies, kill the main thread. The worker cannot pick up any new work if its listener goes down, so if the listener dies, we need to restart the container and try to reconnect. This could also be achieved by trying to make a new listener thread if the original goes down, but by shutting down the container, the worker will accurately appear as struggling/restarting when viewed in Docker/AWS. This change **does not** affect any running simulations. Those will still complete (or attempt to complete).

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Both changes were verified manually.
For commit 1 (main loop terminates):
 - Checkout and compose up #1180. Run the `./gradlew e2e-tests:e2eTest --rerun-tasks` twice back to back. You should notice tests begin failing because of timeout errors during `awaitSimulation` and/or `awaitScheduling`.
 - Checkout and compose up this PR. Checkout #1180. Run `./gradlew e2e-tests:e2eTest --rerun-tasks` twice back to back. There should be no timeout errors. Open the logs for one of the workers and search for the messages `Listener has been interrupted` and `Listener has received interrupted signal`. One or both of the messages should appear in the logs.

For commit 2 (listener thread terminates):
- Checkout and compose up develop. Create a plan and simulate, then kill the postgres container. Start the Postgres container. Attempt to simulate. The simulation should remain stuck in 'pending'.
- Checkout and compose up this PR. Create a plan and simulate to prove that the workers are working. Kill the Postgres container. Start the Postgres container. Attempt to simulate. The simulation should be processed.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs need to be updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
