### PR TITLE
User metadata annotations

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/TypescriptCodeGenerationService.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/TypescriptCodeGenerationService.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.constraints;
 
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
 import java.util.ArrayList;
@@ -220,6 +221,12 @@ public final class TypescriptCodeGenerationService {
         final var res = valueSchemaToTypescript(valueSchema);
         return "(%s | Discrete<%s>)".formatted(res, res);
       }
+
+      // TODO: Elevate annotation information
+      @Override
+      public String onMeta(final Map<String, SerializedValue> metadata, final ValueSchema value) {
+        return value.match(this);
+      }
     });
   }
 
@@ -287,6 +294,12 @@ public final class TypescriptCodeGenerationService {
       public String onVariant(final List<ValueSchema.Variant> variants) {
         final var res = valueSchemaToTypescript(valueSchema);
         return "(%s | Discrete<%s> | undefined)".formatted(res, res);
+      }
+
+      // TODO Elevate annotation information
+      @Override
+      public String onMeta(final Map<String, SerializedValue> metadata, final ValueSchema target) {
+        return target.match(this);
       }
     });
   }
@@ -357,6 +370,12 @@ public final class TypescriptCodeGenerationService {
 
         result.append(")");
         return result.toString();
+      }
+
+      // TODO Elevate annotation information
+      @Override
+      public String onMeta(final Map<String, SerializedValue> metadata, final ValueSchema target) {
+        return target.match(this);
       }
     });
   }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/TypescriptCodeGenerationService.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/TypescriptCodeGenerationService.java
@@ -392,6 +392,7 @@ public final class TypescriptCodeGenerationService {
   private static boolean valueSchemaIsNumeric(final ValueSchema valueSchema) {
     return valueSchema.equals(ValueSchema.INT)
         || valueSchema.equals(ValueSchema.REAL)
-        || valueSchema.equals(LINEAR_RESOURCE_SCHEMA);
+        || valueSchema.equals(LINEAR_RESOURCE_SCHEMA)
+        || valueSchema.asMeta().map($ -> valueSchemaIsNumeric($.target())).orElse(false);
   }
 }

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/metadata/Unit.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/metadata/Unit.java
@@ -1,0 +1,12 @@
+package gov.nasa.jpl.aerie.contrib.metadata;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE_USE)
+public @interface Unit {
+  String value();
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/metadata/UnitRegistrar.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/metadata/UnitRegistrar.java
@@ -1,0 +1,44 @@
+package gov.nasa.jpl.aerie.contrib.metadata;
+
+import gov.nasa.jpl.aerie.contrib.serialization.mappers.StringValueMapper;
+import gov.nasa.jpl.aerie.merlin.framework.MetadataValueMapper;
+import gov.nasa.jpl.aerie.merlin.framework.Registrar;
+import gov.nasa.jpl.aerie.merlin.framework.Resource;
+import gov.nasa.jpl.aerie.merlin.framework.Result;
+import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
+import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+
+import java.util.Map;
+
+public final class UnitRegistrar {
+  public static <T> ValueMapper<T> withUnit(final String unit, final ValueMapper<T> target) {
+    return new MetadataValueMapper<>("unit", SerializedValue.of(Map.of("value", SerializedValue.of(unit))), target);
+  }
+  public static <T> void discreteResource(final Registrar registrar, final String name, final Resource<T> resource, final ValueMapper<T> valueMapper, final String unit) {
+    registrar.discrete(name, resource, withUnit(unit, valueMapper));
+  }
+  public static void realResource(final Registrar registrar, final String name, final Resource<RealDynamics> resource, final String unit) {
+    registrar.realWithMetadata(name, resource, "unit", unit, new ValueMapper<String>() {
+      @Override
+      public ValueSchema getValueSchema() {
+        return ValueSchema.ofStruct(Map.of("value", ValueSchema.STRING));
+      }
+
+      @Override
+      public Result<String, String> deserializeValue(final SerializedValue serializedValue) {
+        return serializedValue
+            .asMap()
+            .flatMap($ -> $.get("value").asString())
+            .map(Result::<String, String>success)
+            .orElse(Result.failure("Could not deserialize Unit"));
+      }
+
+      @Override
+      public SerializedValue serializeValue(final String value) {
+        return SerializedValue.of(Map.of("value", SerializedValue.of(value)));
+      }
+    });
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/serialization/rulesets/BasicValueMappers.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/serialization/rulesets/BasicValueMappers.java
@@ -37,7 +37,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
-@WithMetadata(name="unit", annotation=gov.nasa.jpl.aerie.contrib.metadata.Unit.class)
 public final class BasicValueMappers {
 
   // Unit is an enum, so `$unit` needs to be defined before `$enum()`

--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -17,6 +17,8 @@ jacocoTestReport {
 }
 
 task e2eTest(type: Test) {
+  dependsOn ":examples:banananation:assemble"
+
   if(file('.env').exists()) {
     file('.env').readLines().each() {
       def (key, value) = it.tokenize('=')

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/MissionModelTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/MissionModelTests.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import javax.json.Json;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -72,9 +73,9 @@ public class MissionModelTests {
     resourceTypes.add(new ResourceType("/flag/conflicted", VALUE_SCHEMA_BOOLEAN));
     resourceTypes.add(new ResourceType(
         "/fruit",
-        new ValueSchemaStruct(Map.of("rate", VALUE_SCHEMA_REAL, "initial", VALUE_SCHEMA_REAL))));
-    resourceTypes.add(new ResourceType("/peel", VALUE_SCHEMA_REAL));
-    resourceTypes.add(new ResourceType("/plant", VALUE_SCHEMA_INT));
+        new ValueSchemaMeta(Map.of("unit", Json.createObjectBuilder(Map.of("value", "bananas")).build()), new ValueSchemaStruct(Map.of("rate", VALUE_SCHEMA_REAL, "initial", VALUE_SCHEMA_REAL)))));
+    resourceTypes.add(new ResourceType("/peel", new ValueSchemaMeta(Map.of("unit", Json.createObjectBuilder(Map.of("value", "kg")).build()), VALUE_SCHEMA_REAL)));
+    resourceTypes.add(new ResourceType("/plant", new ValueSchemaMeta(Map.of("unit", Json.createObjectBuilder(Map.of("value", "count")).build()), VALUE_SCHEMA_INT)));
     resourceTypes.add(new ResourceType("/producer", VALUE_SCHEMA_STRING));
     return resourceTypes;
   }
@@ -91,7 +92,7 @@ public class MissionModelTests {
             "glutenFree", new Parameter(2, VALUE_SCHEMA_BOOLEAN),
             "temperature", new Parameter(0, VALUE_SCHEMA_REAL))));
     activityTypes.add(new ActivityType("BananaNap", Map.of()));
-    activityTypes.add(new ActivityType("BiteBanana", Map.of("biteSize", new Parameter(0, VALUE_SCHEMA_REAL))));
+    activityTypes.add(new ActivityType("BiteBanana", Map.of("biteSize", new Parameter(0, new ValueSchemaMeta(Map.of("unit", Json.createObjectBuilder(Map.of("value", "m")).build(), "banannotation", Json.createObjectBuilder().add("value", Json.createValue("Specifies the size of bite to take")).build()), VALUE_SCHEMA_REAL)))));
     activityTypes.add(new ActivityType("ChangeProducer", Map.of("producer", new Parameter(0, VALUE_SCHEMA_STRING))));
     activityTypes.add(new ActivityType("child", Map.of("counter", new Parameter(0, VALUE_SCHEMA_INT))));
     activityTypes.add(new ActivityType("ControllableDurationActivity", Map.of("duration", new Parameter(0, VALUE_SCHEMA_DURATION))));
@@ -247,8 +248,8 @@ public class MissionModelTests {
             entry("byteArray", new Parameter(19,new ValueSchemaSeries(VALUE_SCHEMA_INT))),
             entry("charArray", new Parameter(23, new ValueSchemaSeries(VALUE_SCHEMA_STRING))),
             entry("doubleMap", new Parameter(43,new ValueSchemaSeries(new ValueSchemaStruct(Map.of(
-                "key", VALUE_SCHEMA_REAL,
-                "value", VALUE_SCHEMA_REAL))))),
+                "key", new ValueSchemaMeta(Map.of("unit", Json.createObjectBuilder(Map.of("value", "s")).build()), VALUE_SCHEMA_REAL),
+                "value", new ValueSchemaMeta(Map.of("unit", Json.createObjectBuilder(Map.of("value", "W")).build()), VALUE_SCHEMA_REAL)))))),
             entry("floatList", new Parameter(35, new ValueSchemaSeries(VALUE_SCHEMA_REAL))),
             entry("longArray", new Parameter(22, new ValueSchemaSeries(VALUE_SCHEMA_INT))),
             entry("obnoxious", new Parameter(57, new ValueSchemaSeries(new ValueSchemaSeries(new ValueSchemaStruct(Map.of(
@@ -265,7 +266,7 @@ public class MissionModelTests {
                 "value", VALUE_SCHEMA_BOOLEAN))))),
             entry("boxedFloat", new Parameter(9, VALUE_SCHEMA_REAL)),
             entry("boxedShort", new Parameter(11, VALUE_SCHEMA_INT)),
-            entry("doubleList", new Parameter(34, new ValueSchemaSeries(VALUE_SCHEMA_REAL))),
+            entry("doubleList", new Parameter(34, new ValueSchemaSeries(new ValueSchemaMeta(Map.of("unit", Json.createObjectBuilder(Map.of("value", "m")).build()), VALUE_SCHEMA_REAL)))),
             entry("floatArray", new Parameter(18, new ValueSchemaSeries(VALUE_SCHEMA_REAL))),
             entry("shortArray", new Parameter(20, new ValueSchemaSeries(VALUE_SCHEMA_INT))),
             entry("stringList", new Parameter(42, new ValueSchemaSeries(VALUE_SCHEMA_STRING))),

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/MissionModelTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/MissionModelTests.java
@@ -90,9 +90,14 @@ public class MissionModelTests {
         Map.of(
             "tbSugar", new Parameter(1, VALUE_SCHEMA_INT),
             "glutenFree", new Parameter(2, VALUE_SCHEMA_BOOLEAN),
-            "temperature", new Parameter(0, VALUE_SCHEMA_REAL))));
+            "temperature", new Parameter(0, VALUE_SCHEMA_REAL)),
+        VALUE_SCHEMA_INT));
     activityTypes.add(new ActivityType("BananaNap", Map.of()));
-    activityTypes.add(new ActivityType("BiteBanana", Map.of("biteSize", new Parameter(0, new ValueSchemaMeta(Map.of("unit", Json.createObjectBuilder(Map.of("value", "m")).build(), "banannotation", Json.createObjectBuilder().add("value", Json.createValue("Specifies the size of bite to take")).build()), VALUE_SCHEMA_REAL)))));
+    activityTypes.add(new ActivityType(
+        "BiteBanana",
+        Map.of("biteSize", new Parameter(0, new ValueSchemaMeta(Map.of("unit", Json.createObjectBuilder(Map.of("value", "m")).build(), "banannotation", Json.createObjectBuilder().add("value", Json.createValue("Specifies the size of bite to take")).build()), VALUE_SCHEMA_REAL))),
+        new ValueSchemaStruct(Map.of("biteSizeWasBig", VALUE_SCHEMA_BOOLEAN, "newFlag", new ValueSchemaVariant(List.of(new Variant("A", "A"), new Variant("B", "B")))))
+        ));
     activityTypes.add(new ActivityType("ChangeProducer", Map.of("producer", new Parameter(0, VALUE_SCHEMA_STRING))));
     activityTypes.add(new ActivityType("child", Map.of("counter", new Parameter(0, VALUE_SCHEMA_INT))));
     activityTypes.add(new ActivityType("ControllableDurationActivity", Map.of("duration", new Parameter(0, VALUE_SCHEMA_DURATION))));
@@ -105,7 +110,12 @@ public class MissionModelTests {
                    new Variant("DSL", "DSL"),
                    new Variant("FiberOptic", "FiberOptic"),
                    new Variant("DietaryFiberOptic", "DietaryFiberOptic")))))));
-    activityTypes.add(new ActivityType("DurationParameterActivity", Map.of("duration", new Parameter(0, VALUE_SCHEMA_DURATION))));
+    activityTypes.add(new ActivityType(
+        "DurationParameterActivity",
+        Map.of("duration", new Parameter(0, VALUE_SCHEMA_DURATION)),
+        new ValueSchemaStruct(Map.of(
+            "duration", VALUE_SCHEMA_DURATION,
+            "durationInSeconds", new ValueSchemaMeta(Map.of("unit", Json.createObjectBuilder(Map.of("value", "s")).build()), VALUE_SCHEMA_REAL)))));
     activityTypes.add(new ActivityType("grandchild", Map.of("counter", new Parameter(0, VALUE_SCHEMA_INT))));
     activityTypes.add(new ActivityType("GrowBanana", Map.of(
         "quantity", new Parameter(0, VALUE_SCHEMA_INT),
@@ -344,6 +354,10 @@ public class MissionModelTests {
         assertTrue(actualParams.containsKey(key));
         assertEquals(expectedParams.get(key), actualParams.get(key));
       }
+
+      final var expectedComputedAttributes = expectedTypes.get(i).computedAttributes();
+      final var actualComputedAttributes = activityTypes.get(i).computedAttributes();
+      assertEquals(expectedComputedAttributes, actualComputedAttributes);
     }
   }
 }

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ActivityType.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ActivityType.java
@@ -5,14 +5,21 @@ import java.util.HashMap;
 import java.util.Map;
 
 
-public record ActivityType(String name, Map<String, Parameter> parameters) {
+public record ActivityType(String name, Map<String, Parameter> parameters, ValueSchema computedAttributes) {
+  /**
+   * Create an ActivityType with an empty computed attributes value schema.
+   */
+  public ActivityType(final String name, final Map<String, Parameter> parameters) {
+    this(name, parameters, new ValueSchema.ValueSchemaStruct(Map.of()));
+  }
+
   public static ActivityType fromJSON(JsonObject json) {
     final var parameters = json.getJsonObject("parameters");
     final var parameterMap = new HashMap<String, Parameter>();
     for (final var parameterName : parameters.keySet()) {
       parameterMap.put(parameterName, Parameter.fromJSON(parameters.getJsonObject(parameterName)));
     }
-    return new ActivityType(json.getString("name"), parameterMap);
+    return new ActivityType(json.getString("name"), parameterMap, ValueSchema.fromJSON(json.getJsonObject("computed_attributes_value_schema")));
   }
 
   public record Parameter(int order, ValueSchema schema) {

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
@@ -174,6 +174,7 @@ public enum GQL {
       activity_type(where: {model_id: {_eq: $missionModelId}}, order_by: {name: asc}) {
         name
         parameters
+        computed_attributes_value_schema
       }
     }"""),
   GET_CONSTRAINT_RUNS("""

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/Configuration.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/Configuration.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.banananation;
 
+import gov.nasa.jpl.aerie.contrib.metadata.Unit;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.AutoValueMapper;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export;
 
@@ -7,7 +8,7 @@ import java.nio.file.Path;
 
 import static gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Template;
 
-public record Configuration(int initialPlantCount, String initialProducer, Path initialDataPath, InitialConditions initialConditions) {
+public record Configuration(@Unit("count") int initialPlantCount, String initialProducer, Path initialDataPath, InitialConditions initialConditions) {
 
   public static final int DEFAULT_PLANT_COUNT = 200;
   public static final String DEFAULT_PRODUCER = "Chiquita";
@@ -33,5 +34,5 @@ public record Configuration(int initialPlantCount, String initialProducer, Path 
   }
 
   @AutoValueMapper.Record
-  public record InitialConditions(double fruit, double peel, Flag flag) {}
+  public record InitialConditions(@Unit("bananas") double fruit, @Unit("kg") double peel, Flag flag) {}
 }

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/CustomValueMappers.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/CustomValueMappers.java
@@ -1,8 +1,0 @@
-package gov.nasa.jpl.aerie.banananation;
-
-import gov.nasa.jpl.aerie.banananation.activities.Banannotation;
-import gov.nasa.jpl.aerie.merlin.framework.annotations.MissionModel;
-
-@MissionModel.WithMetadata(name="banannotation", annotation= Banannotation.class)
-public class CustomValueMappers {
-}

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/CustomValueMappers.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/CustomValueMappers.java
@@ -1,0 +1,8 @@
+package gov.nasa.jpl.aerie.banananation;
+
+import gov.nasa.jpl.aerie.banananation.activities.Banannotation;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.MissionModel;
+
+@MissionModel.WithMetadata(name="banannotation", annotation= Banannotation.class)
+public class CustomValueMappers {
+}

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/Mission.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/Mission.java
@@ -41,7 +41,7 @@ public final class Mission {
     registrar.discrete("/flag/conflicted", this.flag::isConflicted, new BooleanValueMapper());
     discreteResource(registrar, "/peel", this.peel, new DoubleValueMapper(), "kg");
     realResource(registrar, "/fruit", this.fruit, "bananas");
-    registrar.discrete("/plant", this.plant, new IntegerValueMapper());
+    discreteResource(registrar, "/plant", this.plant, new IntegerValueMapper(), "count");
     registrar.discrete("/producer", this.producer, new StringValueMapper());
     registrar.discrete("/data/line_count", this.dataLineCount, new IntegerValueMapper());
     registrar.topic("/producer", this.producer.ref, new StringValueMapper());

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/Mission.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/Mission.java
@@ -17,6 +17,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static gov.nasa.jpl.aerie.contrib.metadata.UnitRegistrar.discreteResource;
+import static gov.nasa.jpl.aerie.contrib.metadata.UnitRegistrar.realResource;
+
 public final class Mission {
   public final Accumulator fruit;
   public final AdditiveRegister peel;
@@ -36,8 +39,8 @@ public final class Mission {
 
     registrar.discrete("/flag", this.flag, new EnumValueMapper<>(Flag.class));
     registrar.discrete("/flag/conflicted", this.flag::isConflicted, new BooleanValueMapper());
-    registrar.discrete("/peel", this.peel, new DoubleValueMapper());
-    registrar.real("/fruit", this.fruit);
+    discreteResource(registrar, "/peel", this.peel, new DoubleValueMapper(), "kg");
+    realResource(registrar, "/fruit", this.fruit, "bananas");
     registrar.discrete("/plant", this.plant, new IntegerValueMapper());
     registrar.discrete("/producer", this.producer, new StringValueMapper());
     registrar.discrete("/data/line_count", this.dataLineCount, new IntegerValueMapper());

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/Banannotation.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/Banannotation.java
@@ -1,0 +1,16 @@
+package gov.nasa.jpl.aerie.banananation.activities;
+
+import gov.nasa.jpl.aerie.merlin.framework.annotations.AutoValueMapper;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE_USE)
+@AutoValueMapper.Annotation
+public @interface Banannotation {
+  String value();
+}

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BiteBananaActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BiteBananaActivity.java
@@ -20,7 +20,10 @@ import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Validation;
 @ActivityType("BiteBanana")
 public final class BiteBananaActivity {
   @Parameter
-  public @Unit("m") double biteSize = 1.0;
+
+  @Banannotation("Specifies the size of bite to take")
+  @Unit("m")
+  public double biteSize = 1.0;
 
   @Validation("bite size must be positive")
   @Validation.Subject("biteSize")

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BiteBananaActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BiteBananaActivity.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.banananation.activities;
 
 import gov.nasa.jpl.aerie.banananation.Flag;
 import gov.nasa.jpl.aerie.banananation.Mission;
+import gov.nasa.jpl.aerie.contrib.metadata.Unit;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.AutoValueMapper;
@@ -19,7 +20,7 @@ import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Validation;
 @ActivityType("BiteBanana")
 public final class BiteBananaActivity {
   @Parameter
-  public double biteSize = 1.0;
+  public @Unit("m") double biteSize = 1.0;
 
   @Validation("bite size must be positive")
   @Validation.Subject("biteSize")

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/DurationParameterActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/DurationParameterActivity.java
@@ -1,12 +1,14 @@
 package gov.nasa.jpl.aerie.banananation.activities;
 
 import gov.nasa.jpl.aerie.banananation.Mission;
+import gov.nasa.jpl.aerie.contrib.metadata.Unit;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.AutoValueMapper;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
 
 /**
  * This activity type intentionally takes a duration as a parameter, but is not a ControllableDuration activity
@@ -17,9 +19,9 @@ public record DurationParameterActivity(Duration duration) {
   @EffectModel
   public ComputedAttributes run(Mission mission) {
     delay(duration);
-    return new ComputedAttributes(duration);
+    return new ComputedAttributes(duration, duration.ratioOver(SECONDS));
   }
 
   @AutoValueMapper.Record
-  public record ComputedAttributes(Duration duration) {}
+  public record ComputedAttributes(Duration duration, @Unit("s") Double durationInSeconds) {}
 }

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/ParameterTestActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/ParameterTestActivity.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.banananation.activities;
 
+import gov.nasa.jpl.aerie.contrib.metadata.Unit;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Parameter;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -57,7 +58,7 @@ public final class ParameterTestActivity {
   @Parameter public boolean[] primBooleanArray;
 
   // List parameters
-  @Parameter public List<Double> doubleList;
+  @Parameter public List<@Unit("m") Double> doubleList;
   @Parameter public List<Float> floatList;
   @Parameter public List<Byte> byteList;
   @Parameter public List<Short> shortList;
@@ -68,7 +69,7 @@ public final class ParameterTestActivity {
   @Parameter public List<String> stringList;
 
   // Map Parameters
-  @Parameter public Map<Double, Double> doubleMap;
+  @Parameter public Map<@Unit("s") Double, @Unit("W") Double> doubleMap;
   @Parameter public Map<Float, Float> floatMap;
   @Parameter public Map<Byte, Byte> byteMap;
   @Parameter public Map<Short, Short> shortMap;

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
@@ -1,7 +1,8 @@
 @MissionModel(model = Mission.class)
 
 @WithMappers(BasicValueMappers.class)
-@WithMappers(CustomValueMappers.class)
+@WithMetadata(name="banannotation", annotation=Banannotation.class)
+@WithMetadata(name="unit", annotation=gov.nasa.jpl.aerie.contrib.metadata.Unit.class)
 
 @WithConfiguration(Configuration.class)
 
@@ -29,6 +30,7 @@ package gov.nasa.jpl.aerie.banananation;
 
 import gov.nasa.jpl.aerie.banananation.activities.BakeBananaBreadActivity;
 import gov.nasa.jpl.aerie.banananation.activities.BananaNapActivity;
+import gov.nasa.jpl.aerie.banananation.activities.Banannotation;
 import gov.nasa.jpl.aerie.banananation.activities.BiteBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ChangeProducerActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ControllableDurationActivity;
@@ -46,5 +48,6 @@ import gov.nasa.jpl.aerie.banananation.activities.ThrowBananaActivity;
 import gov.nasa.jpl.aerie.contrib.serialization.rulesets.BasicValueMappers;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.MissionModel;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.MissionModel.WithActivityType;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.MissionModel.WithMetadata;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.MissionModel.WithConfiguration;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.MissionModel.WithMappers;

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
@@ -1,6 +1,7 @@
 @MissionModel(model = Mission.class)
 
 @WithMappers(BasicValueMappers.class)
+@WithMappers(CustomValueMappers.class)
 
 @WithConfiguration(Configuration.class)
 

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/AutoValueMappers.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/AutoValueMappers.java
@@ -27,6 +27,7 @@ import javax.lang.model.element.Parameterizable;
 import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -307,6 +308,11 @@ public class AutoValueMappers {
    * Turn a given string into a valid Java identifier
    * @param str a string that may or may not be a valid Java identifier
    * @return a string that is a valid Java identifier
+   *
+   * Any illegal characters are replaced by their UTF_8 integer representation as a decimal number surrounded by underscores.
+   * This helps ensure that strings the differ only in illegal characters get unique identifiers. (e.g. "m/s" and "m*s")
+   *
+   * E.g. "<Hello (Worl%d!)" becomes "_60_Hello_32__40_Worl_37_d_33__41_"
    */
   public static String getIdentifier(String str) {
     if (str.length() == 0) throw new IllegalArgumentException("Cannot turn empty string into an identifier");
@@ -314,13 +320,17 @@ public class AutoValueMappers {
     if (Character.isJavaIdentifierStart(str.charAt(0))) {
       identifier.append(str.charAt(0));
     } else {
-      identifier.append("_");
+      identifier.append('_');
+      identifier.append((int) str.charAt(0));
+      identifier.append('_');
     }
     for (int i = 1; i < str.length(); i++) {
       if (Character.isJavaIdentifierPart(str.charAt(i))) {
         identifier.append(str.charAt(i));
       } else {
-        identifier.append("_");
+        identifier.append('_');
+        identifier.append((int) str.charAt(i));
+        identifier.append('_');
       }
     }
     return identifier.toString();

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/AutoValueMappers.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/AutoValueMappers.java
@@ -354,18 +354,15 @@ public class AutoValueMappers {
    * @return enough information to 1) call the record constructor, in order, with the right types, and 2) define a method with the list of required value mappers, and 3) generate a call to that method
    */
   private static ComponentsAndMappers getComponentsAndMappers(final Element element) {
-    final var mapperTypeMirrors = new HashSet<TypeMirror>();
     final var components = new ArrayList<ComponentMapper>();
     final var mappers = new ArrayList<MapperType>();
     for (final var enclosedElement : element.getEnclosedElements()) {
+      final var componentIdentifier = getIdentifier(enclosedElement.getSimpleName().toString());
       if (!(enclosedElement instanceof RecordComponentElement el)) continue;
       final TypeMirror typeMirror = el.getAccessor().getReturnType();
-      final var mapperIdentifier = getIdentifier(typeMirror.toString()) + "ValueMapper";
-      if (!mapperTypeMirrors.contains(typeMirror)) {
-        mapperTypeMirrors.add(typeMirror);
-        mappers.add(new MapperType(mapperIdentifier, TypePattern.from(typeMirror).box()));
-      }
-      final var componentIdentifier = getIdentifier(enclosedElement.getSimpleName().toString());
+      final var typePattern = TypePattern.from(typeMirror).box();
+      final var mapperIdentifier = componentIdentifier + "_ValueMapper";
+      mappers.add(new MapperType(mapperIdentifier, typePattern));
       components.add(new ComponentMapper(componentIdentifier, mapperIdentifier));
     }
     return new ComponentsAndMappers(components, mappers);

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
@@ -96,25 +96,25 @@ public final class MissionModelProcessor implements Processor {
       try {
         final var missionModelRecord$ = missionModelParser.parseMissionModel(packageElement);
 
-        final var concatenatedTypeRules = new ArrayList<>(missionModelRecord$.typeRules);
+        final var concatenatedTypeRules = new ArrayList<>(missionModelRecord$.typeRules());
         for (final var request : autoValueMapperRequests) {
           concatenatedTypeRules.add(AutoValueMappers.typeRule(request, missionModelRecord$.getAutoValueMappersName()));
         }
 
         final var missionModelRecord = new MissionModelRecord(
-            missionModelRecord$.$package,
-            missionModelRecord$.topLevelModel,
-            missionModelRecord$.expectsPlanStart,
-            missionModelRecord$.modelConfigurationType,
+            missionModelRecord$.$package(),
+            missionModelRecord$.topLevelModel(),
+            missionModelRecord$.expectsPlanStart(),
+            missionModelRecord$.modelConfigurationType(),
             concatenatedTypeRules,
-            missionModelRecord$.activityTypes
+            missionModelRecord$.activityTypes()
         );
 
         final var generatedFiles = new ArrayList<>(List.of(
             missionModelGen.generateMerlinPlugin(missionModelRecord),
             missionModelGen.generateSchedulerPlugin(missionModelRecord)));
 
-        missionModelRecord.modelConfigurationType
+        missionModelRecord.modelConfigurationType()
             .flatMap(configType -> missionModelGen.generateMissionModelConfigurationMapper(missionModelRecord, configType))
             .ifPresent(generatedFiles::add);
 
@@ -130,7 +130,7 @@ public final class MissionModelProcessor implements Processor {
             autoValueMapperRequests);
         generatedFiles.add(autoValueMappers);
 
-        for (final var activityRecord : missionModelRecord.activityTypes) {
+        for (final var activityRecord : missionModelRecord.activityTypes()) {
           this.ownedActivityTypes.add(activityRecord.inputType().declaration());
           if (!activityRecord.inputType().mapper().isCustom) {
             missionModelGen.generateActivityMapper(missionModelRecord, activityRecord).ifPresent(generatedFiles::add);

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/Resolver.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/Resolver.java
@@ -65,8 +65,8 @@ public final class Resolver {
   }
 
   public Optional<CodeBlock> applyRules(final TypePattern goal) {
-    if (goal instanceof ClassPattern && ((ClassPattern)goal).name.equals(ClassName.get(Class.class))) {
-      final var pattern = ((ClassPattern)goal).arguments.get(0);
+    if (goal instanceof ClassPattern && ((ClassPattern)goal).name().equals(ClassName.get(Class.class))) {
+      final var pattern = ((ClassPattern)goal).arguments().get(0);
       return Optional.of(
           (pattern.render().equals(pattern.erasure()))
               ? CodeBlock.of("$T.class", pattern.erasure())

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/Resolver.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/Resolver.java
@@ -2,16 +2,28 @@ package gov.nasa.jpl.aerie.merlin.processor;
 
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import com.squareup.javapoet.WildcardTypeName;
 import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
 import gov.nasa.jpl.aerie.merlin.processor.TypePattern.ClassPattern;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.TypeRule;
 
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -56,7 +68,14 @@ public final class Resolver {
   private TypePattern createInitialGoal(final TypeMirror mirror) {
     final List<TypePattern> mapperArguments;
     if (mirror.getKind().isPrimitive()) {
-      mapperArguments = List.of(TypePattern.from(typeUtils.boxedClass((PrimitiveType)mirror).asType()));
+      var typePattern = TypePattern.from(typeUtils.boxedClass((PrimitiveType) mirror).asType());
+      final var annotations = new LinkedList<>(mirror.getAnnotationMirrors());
+      while (!annotations.isEmpty()) {
+        final AnnotationMirror annotation = annotations.removeLast();
+        final var className = ClassName.get((TypeElement) annotation.getAnnotationType().asElement());
+        typePattern = new TypePattern.AnnotationPattern(className, Optional.of(annotation), typePattern);
+      }
+      mapperArguments = List.of(typePattern);
     } else {
       mapperArguments = List.of(TypePattern.from(mirror));
     }
@@ -105,12 +124,25 @@ public final class Resolver {
       if (!typeUtils.isSubtype(patternType, enumType)) return Optional.empty();
     }
 
+    final var annotationValues = new HashMap<ClassName, AnnotationMirror>();
+    for (final var annotation : collectAnnotationParameters(goal)) {
+      final var className = ClassName.get((TypeElement) annotation.getAnnotationType().asElement());
+      annotationValues.put(className, annotation);
+    }
+
     // Satisfy the subgoals of the rule
     final var dependencies = new ArrayList<CodeBlock>(rule.parameters().size());
+    if (rule.label().isPresent()) {
+      dependencies.add(CodeBlock.of("$S", rule.label().get()));
+    }
     for (final var parameter : rule.parameters()) {
-      final var codeBlock = applyRules(parameter.substitute(typeMapping));
-      if (codeBlock.isEmpty()) return Optional.empty();
-      dependencies.add(codeBlock.get());
+      if (parameter instanceof ClassPattern p && annotationValues.containsKey(p.name())) {
+        dependencies.add(CodeBlock.of("$L", generateAnnotationInstance(annotationValues.get(p.name()))));
+      } else {
+        final var codeBlock = applyRules(parameter.substitute(typeMapping));
+        if (codeBlock.isEmpty()) return Optional.empty();
+        dependencies.add(codeBlock.get());
+      }
     }
 
     // Build a codeblock satisfying the goal of this rule
@@ -124,7 +156,72 @@ public final class Resolver {
       }
     }
     builder.add(")");
-
     return Optional.of(builder.build());
+  }
+
+  List<? extends AnnotationMirror> collectAnnotationParameters(TypePattern pattern) {
+    final var result = new ArrayList<AnnotationMirror>();
+    if (pattern instanceof TypePattern.AnnotationPattern p) {
+      result.add(p.payload().get());
+      result.addAll(collectAnnotationParameters(p.target()));
+    } else if (pattern instanceof TypePattern.PrimitivePattern p) {
+      // Do nothing
+    } else if (pattern instanceof TypePattern.ClassPattern p) {
+      for (final var argument : p.arguments()) {
+        result.addAll(collectAnnotationParameters(argument));
+      }
+    } else if (pattern instanceof TypePattern.ArrayPattern p) {
+      result.addAll(collectAnnotationParameters(p.element()));
+    } else if (pattern instanceof TypePattern.TypeVariablePattern p) {
+      // Do nothing
+    } else {
+      throw new Error("unhandled subtype of " + TypePattern.class.getCanonicalName() + ": " + pattern);
+    }
+    return result;
+  }
+
+  private TypeSpec generateAnnotationInstance(final AnnotationMirror annotation) {
+    final var annotationType = annotation.getAnnotationType();
+    final var builder = TypeSpec
+        .anonymousClassBuilder("")
+        .superclass(annotationType)
+        .addMethod(
+            MethodSpec
+                .methodBuilder("annotationType")
+                .addModifiers(Modifier.PUBLIC)
+                .addAnnotation(Override.class)
+                .returns(ParameterizedTypeName.get(
+                    ClassName.get(Class.class),
+                    WildcardTypeName.subtypeOf(TypeName.get(annotationType))))
+                .addStatement(CodeBlock.of("return $T.class", annotationType))
+                .build());
+    for (final var enclosedElement : annotation.getAnnotationType().asElement().getEnclosedElements()) {
+      if (!(enclosedElement instanceof ExecutableElement el)) continue;
+      final String methodName = el.getSimpleName().toString();
+      builder
+          .addMethod(
+              MethodSpec
+                  .methodBuilder(methodName)
+                  .addModifiers(Modifier.PUBLIC)
+                  .addAnnotation(Override.class)
+                  .returns(TypeName.get(el.getReturnType()))
+                  .addStatement(CodeBlock.of("return $L",
+                                             getAnnotationAttribute(annotation, methodName)
+                                                 .orElse(el.getDefaultValue())
+                                                 .toString()))
+                  .build());
+    }
+    return builder.build();
+  }
+
+  private static Optional<AnnotationValue> getAnnotationAttribute(final AnnotationMirror annotationMirror, final String attributeName)
+  {
+    for (final var entry : annotationMirror.getElementValues().entrySet()) {
+      if (Objects.equals(attributeName, entry.getKey().getSimpleName().toString())) {
+        return Optional.of(entry.getValue());
+      }
+    }
+
+    return Optional.empty();
   }
 }

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/Resolver.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/Resolver.java
@@ -132,8 +132,8 @@ public final class Resolver {
 
     // Satisfy the subgoals of the rule
     final var dependencies = new ArrayList<CodeBlock>(rule.parameters().size());
-    if (rule.label().isPresent()) {
-      dependencies.add(CodeBlock.of("$S", rule.label().get()));
+    if (rule.name().isPresent()) {
+      dependencies.add(CodeBlock.of("$S", rule.name().get()));
     }
     for (final var parameter : rule.parameters()) {
       if (parameter instanceof ClassPattern p && annotationValues.containsKey(p.name())) {

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/Resolver.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/Resolver.java
@@ -84,13 +84,13 @@ public final class Resolver {
     // Extract type bindings for the type parameters of the rule
     final Map<String, TypePattern> typeMapping;
     try {
-      typeMapping = rule.head.match(goal);
+      typeMapping = rule.head().match(goal);
     } catch (TypePattern.UnificationException e) {
       return Optional.empty();
     }
 
     // Ensure the match satisfies the rule's type parameter bounds
-    for (final var name : rule.enumBoundedTypeParameters) {
+    for (final var name : rule.enumBoundedTypeParameters()) {
       final var pattern = typeMapping.get(name);
       if (pattern == null) return Optional.empty();
       if (!(pattern instanceof ClassPattern)) return Optional.empty();
@@ -106,8 +106,8 @@ public final class Resolver {
     }
 
     // Satisfy the subgoals of the rule
-    final var dependencies = new ArrayList<CodeBlock>(rule.parameters.size());
-    for (final var parameter : rule.parameters) {
+    final var dependencies = new ArrayList<CodeBlock>(rule.parameters().size());
+    for (final var parameter : rule.parameters()) {
       final var codeBlock = applyRules(parameter.substitute(typeMapping));
       if (codeBlock.isEmpty()) return Optional.empty();
       dependencies.add(codeBlock.get());
@@ -115,7 +115,7 @@ public final class Resolver {
 
     // Build a codeblock satisfying the goal of this rule
     final var builder = CodeBlock.builder();
-    builder.add("$T.$L(", rule.factory, rule.method);
+    builder.add("$T.$L(", rule.factory(), rule.method());
     if (dependencies.size() > 0) {
       final var iter = dependencies.iterator();
       builder.add("\n$>$>$L$<$<", iter.next());

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/TypePattern.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/TypePattern.java
@@ -49,18 +49,62 @@ public sealed interface TypePattern {
     return from(element.asType());
   }
 
+  /**
+   * Given a TypePattern, produce a new TypePattern where all type variables whose names are
+   * in the given map have been replaced with the corresponding type patterns.
+   * @param substitution A map from type variable name to the type pattern with which to replace it
+   * @return a TypePattern with the same structure, but with any matching type variables replaced
+   * E.g. ClassPattern(List, TypeVariablePattern(T)).substitute(Map.of("T", ClassPattern(Double))) will return
+   *   ClassPattern(List, Double)
+   */
   TypePattern substitute(Map<String, TypePattern> substitution);
 
+  /**
+   * Attempt to match this TypePattern against the given other TypePattern. Throw a UnificationException if they cannot be matched
+   * @param other the ground TypePattern to match against this TypePattern
+   * @return an assignment of type variables to TypePatterns, if match is successful
+   * @throws UnificationException if the two patterns do not match
+   */
   Map<String, TypePattern> match(TypePattern other) throws UnificationException;
 
+  /**
+   * Whether this TypePattern contains any type variables. Ground is true if there are no type variables present.
+   * @return false if there is at least one type variable in this TypePattern. true if there are none.
+   */
   boolean isGround();
 
+  /**
+   * Whether this TypePattern has the same structure, same types, and same type variable names as the other pattern
+   * @param other the other TypePattern to compare with
+   * @return true if the two TypePatterns are identical, false otherwise.
+   */
   boolean isSyntacticallyEqualTo(TypePattern other);
 
+  /**
+   * Represent this TypePattern as a javapoet TypeName
+   * @return a javapoet TypeName corresponding to this TypePattern
+   *
+   * E.g. ClassPattern(List, Double).render() --> ClassName(List, Double)
+   */
   TypeName render();
 
+  /**
+   * Represent this TypePattern as a javapoet TypeName without generics
+   * @return a javapoet TypeName corresponding to this TypePattern without generics
+   *
+   * E.g. ClassPattern(List, Double).erasure() --> ClassName(List)
+   */
   TypeName erasure();
 
+  /**
+   * If this TypePattern represents a primitive, return a TypePattern that represents the corresponding Object type.
+   * @return a TypePattern that is not a PrimitiveTypePattern
+   *
+   * E.g. PrimitivePattern(boolean) --> ClassPattern(Boolean)
+   *
+   * There is no need to recurse: if the top level is not a PrimitiveTypePattern,
+   * the entire type pattern is already considered "boxed"
+   */
   TypePattern box();
 
   class UnificationException extends Exception {}

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -146,10 +146,10 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
             .addSuperinterface(
                 ParameterizedTypeName.get(
                     ClassName.get(ModelType.class),
-                    missionModel.modelConfigurationType
+                    missionModel.modelConfigurationType()
                         .map($ -> ClassName.get($.declaration()))
                         .orElse(ClassName.get(Unit.class)),
-                    ClassName.get(missionModel.topLevelModel)))
+                    ClassName.get(missionModel.topLevelModel())))
             .addMethod(
                 MethodSpec
                     .methodBuilder("getDirectiveTypes")
@@ -161,7 +161,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                             ClassName.get(String.class),
                             ParameterizedTypeName.get(
                                 ClassName.get(gov.nasa.jpl.aerie.merlin.framework.ActivityMapper.class),
-                                ClassName.get(missionModel.topLevelModel),
+                                ClassName.get(missionModel.topLevelModel()),
                                 WildcardTypeName.subtypeOf(Object.class),
                                 WildcardTypeName.subtypeOf(Object.class))))
                     .addStatement(
@@ -175,12 +175,12 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                     .addModifiers(Modifier.PUBLIC)
                     .addAnnotation(Override.class)
                     .returns(
-                        missionModel.modelConfigurationType
+                        missionModel.modelConfigurationType()
                             .map(configType -> configType.mapper().name)
                             .orElse(ClassName.get(EmptyInputType.class)))
                     .addStatement(
                         "return new $T()",
-                        missionModel.modelConfigurationType
+                        missionModel.modelConfigurationType()
                             .map(configType -> configType.mapper().name)
                             .orElse(ClassName.get(EmptyInputType.class)))
                 .build())
@@ -194,7 +194,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                         "planStart",
                         Modifier.FINAL)
                     .addParameter(
-                        missionModel.modelConfigurationType
+                        missionModel.modelConfigurationType()
                             .map($ -> ClassName.get($.declaration()))
                             .orElse(ClassName.get(Unit.class)),
                         "configuration",
@@ -203,7 +203,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                         ClassName.get(gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer.class),
                         "builder",
                         Modifier.FINAL)
-                    .returns(ClassName.get(missionModel.topLevelModel))
+                    .returns(ClassName.get(missionModel.topLevelModel()))
                     .addStatement(
                         "$T.registerTopics($L)",
                         missionModel.getTypesName(),
@@ -230,9 +230,9 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
   }
 
   private static CodeBlock generateMissionModelInstantiation(final MissionModelRecord missionModel) {
-    final var modelClassName = ClassName.get(missionModel.topLevelModel);
-    return missionModel.modelConfigurationType
-        .map(configType -> missionModel.expectsPlanStart ?
+    final var modelClassName = ClassName.get(missionModel.topLevelModel());
+    return missionModel.modelConfigurationType()
+        .map(configType -> missionModel.expectsPlanStart() ?
             CodeBlock.of(
                 "new $T($L, $L, $L)",
                 modelClassName,
@@ -244,7 +244,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                 modelClassName,
                 "registrar",
                 "configuration"))
-        .orElseGet(() -> missionModel.expectsPlanStart ?
+        .orElseGet(() -> missionModel.expectsPlanStart() ?
             CodeBlock.of(
                 "new $T($L, $L)",
                 modelClassName,
@@ -279,7 +279,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                     .addStatement("final var result = new $T()", ParameterizedTypeName.get(HashMap.class, String.class, DurationType.class))
                     .addCode(
                         missionModel
-                            .activityTypes
+                            .activityTypes()
                             .stream()
                             .map(
                                 activityTypeRecord ->
@@ -317,7 +317,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
         TypeSpec
             .classBuilder(typeName)
             // The location of the mission model package determines where to put this class.
-            .addOriginatingElement(missionModel.$package)
+            .addOriginatingElement(missionModel.$package())
             // TODO: List found task spec types as dependencies of this generated file.
             .addAnnotation(
                 AnnotationSpec
@@ -328,7 +328,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
             .superclass(gov.nasa.jpl.aerie.merlin.framework.ModelActions.class)
             .addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).build())
             .addMethods(
-                missionModel.activityTypes
+                missionModel.activityTypes()
                     .stream()
                     .flatMap(entry -> Stream
                         .of(
@@ -336,7 +336,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                 .methodBuilder("spawn")
                                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                                 .addParameter(
-                                    ClassName.get(missionModel.topLevelModel),
+                                    ClassName.get(missionModel.topLevelModel()),
                                     "model",
                                     Modifier.FINAL)
                                 .addParameter(
@@ -363,7 +363,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                     "duration",
                                     Modifier.FINAL)
                                 .addParameter(
-                                    ClassName.get(missionModel.topLevelModel),
+                                    ClassName.get(missionModel.topLevelModel()),
                                     "model",
                                     Modifier.FINAL)
                                 .addParameter(
@@ -401,7 +401,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                         .addModifiers(Modifier.FINAL)
                                         .build())
                                 .addParameter(
-                                    ClassName.get(missionModel.topLevelModel),
+                                    ClassName.get(missionModel.topLevelModel()),
                                     "model",
                                     Modifier.FINAL)
                                 .addParameter(
@@ -419,7 +419,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                 .methodBuilder("call")
                                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                                 .addParameter(
-                                    ClassName.get(missionModel.topLevelModel),
+                                    ClassName.get(missionModel.topLevelModel()),
                                     "model",
                                     Modifier.FINAL)
                                 .addParameter(
@@ -461,7 +461,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                     .build())
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addFields(
-                missionModel.activityTypes
+                missionModel.activityTypes()
                     .stream()
                     .map(activityType -> FieldSpec
                         .builder(
@@ -479,7 +479,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                             ClassName.get(String.class),
                             ParameterizedTypeName.get(
                                 ClassName.get(gov.nasa.jpl.aerie.merlin.framework.ActivityMapper.class),
-                                ClassName.get(missionModel.topLevelModel),
+                                ClassName.get(missionModel.topLevelModel()),
                                 WildcardTypeName.subtypeOf(Object.class),
                                 WildcardTypeName.subtypeOf(Object.class))),
                         "directiveTypes",
@@ -487,7 +487,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                     .initializer(
                         "$T.ofEntries($>$>$L$<$<)",
                         ClassName.get(Map.class),
-                        missionModel.activityTypes
+                        missionModel.activityTypes()
                             .stream()
                             .map(activityType -> CodeBlock
                                 .builder()
@@ -521,7 +521,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                     .addParameter(
                         ParameterizedTypeName.get(
                             ClassName.get(ActivityMapper.class),
-                            ClassName.get(missionModel.topLevelModel),
+                            ClassName.get(missionModel.topLevelModel()),
                             TypeVariableName.get("Input"),
                             TypeVariableName.get("Output")),
                         "mapper",
@@ -561,7 +561,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
     return Optional.of(TypeSpec
         .classBuilder(name)
         // The location of the missionModel package determines where to put this class.
-        .addOriginatingElement(missionModel.$package)
+        .addOriginatingElement(missionModel.$package())
         // The fields and methods of the activity determines the overall behavior of this class.
         .addOriginatingElement(inputType.declaration())
         // TODO: Add an originating element for each of the mapper rulesets associated with the mission model.
@@ -628,7 +628,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
     effectModel = activityType.effectModel();
     final var typeMirror = effectModel.flatMap(EffectModelRecord::returnType);
     if (typeMirror.isPresent()) {
-      effectModelReturnMapperBlock = new Resolver(this.typeUtils, this.elementUtils, missionModel.typeRules)
+      effectModelReturnMapperBlock = new Resolver(this.typeUtils, this.elementUtils, missionModel.typeRules())
                   .instantiateNullableMapperFor(typeMirror.get());
       if (effectModelReturnMapperBlock.isEmpty()) {
         this.messager.printMessage(
@@ -642,7 +642,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
       computedAttributesTypeName = TypeName.get(typeMirror.get());
     } else {
       effectModelReturnMapperBlock = new Resolver(
-          this.typeUtils, this.elementUtils, missionModel.typeRules).applyRules(
+          this.typeUtils, this.elementUtils, missionModel.typeRules()).applyRules(
           new TypePattern.ClassPattern(ClassName.get(ValueMapper.class),
                                        List.of(new TypePattern.ClassPattern(ClassName.get(Unit.class), List.of()))));
       computedAttributesTypeName = TypeName.get(Unit.class);
@@ -673,7 +673,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
     final var typeSpec = TypeSpec
         .classBuilder(activityType.inputType().mapper().name)
         // The location of the missionModel package determines where to put this class.
-        .addOriginatingElement(missionModel.$package)
+        .addOriginatingElement(missionModel.$package())
         // The fields and methods of the activity determines the overall behavior of this class.
         .addOriginatingElement(activityType.inputType().declaration())
         // TODO: Add an originating element for each of the mapper rulesets associated with the mission model.
@@ -684,7 +684,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                 .build())
         .addSuperinterface(ParameterizedTypeName.get(
             ClassName.get(ActivityMapper.class),
-            ClassName.get(missionModel.topLevelModel),
+            ClassName.get(missionModel.topLevelModel()),
             ClassName.get(activityType.inputType().declaration()),
             computedAttributesCodeBlocks.typeName().box()))
         .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
@@ -768,7 +768,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                     ClassName.get(TaskFactory.class),
                     activityType.getOutputTypeName()))
                 .addParameter(
-                    ClassName.get(missionModel.topLevelModel),
+                    ClassName.get(missionModel.topLevelModel()),
                     "model",
                     Modifier.FINAL)
                 .addParameter(
@@ -849,7 +849,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
 
   private Optional<Map<String, CodeBlock>> generateParameterMapperBlocks(final MissionModelRecord missionModel, final InputTypeRecord inputType)
   {
-    final var resolver = new Resolver(this.typeUtils, this.elementUtils, missionModel.typeRules);
+    final var resolver = new Resolver(this.typeUtils, this.elementUtils, missionModel.typeRules());
     var failed = false;
     final var mapperBlocks = new HashMap<String, CodeBlock>();
 

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/MissionModelRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/MissionModelRecord.java
@@ -5,32 +5,15 @@ import com.squareup.javapoet.ClassName;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
-public final class MissionModelRecord {
-  public final PackageElement $package;
-  public final TypeElement topLevelModel;
-  public final List<TypeRule> typeRules;
-  public final List<ActivityTypeRecord> activityTypes;
-  public final boolean expectsPlanStart;
-  public final Optional<InputTypeRecord> modelConfigurationType;
-
-  public MissionModelRecord(
-      final PackageElement $package,
-      final TypeElement topLevelModel,
-      final boolean expectsPlanStart,
-      final Optional<InputTypeRecord> modelConfigurationType,
-      final List<TypeRule> typeRules,
-      final List<ActivityTypeRecord> activityTypes)
-  {
-    this.$package = Objects.requireNonNull($package);
-    this.topLevelModel = Objects.requireNonNull(topLevelModel);
-    this.expectsPlanStart = expectsPlanStart;
-    this.modelConfigurationType = Objects.requireNonNull(modelConfigurationType);
-    this.typeRules = Objects.requireNonNull(typeRules);
-    this.activityTypes = Objects.requireNonNull(activityTypes);
-  }
+public record MissionModelRecord(
+    PackageElement $package,
+    TypeElement topLevelModel,
+    boolean expectsPlanStart,
+    Optional<InputTypeRecord> modelConfigurationType,
+    List<TypeRule> typeRules,
+    List<ActivityTypeRecord> activityTypes) {
 
   public ClassName getMerlinPluginName() {
     return ClassName.get(this.$package.getQualifiedName() + ".generated", "GeneratedMerlinPlugin");

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/TypeRule.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/TypeRule.java
@@ -3,28 +3,16 @@ package gov.nasa.jpl.aerie.merlin.processor.metamodel;
 import com.squareup.javapoet.ClassName;
 import gov.nasa.jpl.aerie.merlin.processor.TypePattern;
 
+import javax.lang.model.element.AnnotationMirror;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-public final class TypeRule {
-  public final TypePattern head;
-  public final Set<String> enumBoundedTypeParameters;
-  public final List<TypePattern> parameters;
-  public final ClassName factory;
-  public final String method;
-
-  public TypeRule(
-      final TypePattern head,
-      final Set<String> enumBoundedTypeParameters,
-      final List<TypePattern> parameters,
-      final ClassName factory,
-      final String method
-  ) {
-    this.head = Objects.requireNonNull(head);
-    this.enumBoundedTypeParameters = Objects.requireNonNull(enumBoundedTypeParameters);
-    this.parameters = Objects.requireNonNull(parameters);
-    this.factory = Objects.requireNonNull(factory);
-    this.method = Objects.requireNonNull(method);
-  }
+public record TypeRule(
+    TypePattern head,
+    Set<String> enumBoundedTypeParameters,
+    List<TypePattern> parameters,
+    ClassName factory,
+    String method
+) {
 }

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/TypeRule.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/TypeRule.java
@@ -6,6 +6,7 @@ import gov.nasa.jpl.aerie.merlin.processor.TypePattern;
 import javax.lang.model.element.AnnotationMirror;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 public record TypeRule(
@@ -13,6 +14,26 @@ public record TypeRule(
     Set<String> enumBoundedTypeParameters,
     List<TypePattern> parameters,
     ClassName factory,
-    String method
+    String method,
+    Optional<String> label
 ) {
+  public TypeRule(
+      final TypePattern head,
+      final Set<String> enumBoundedTypeParameters,
+      final List<TypePattern> parameters,
+      final ClassName factory,
+      final String method)
+  {
+    this(head, enumBoundedTypeParameters, parameters, factory, method, Optional.empty());
+  }
+  public TypeRule(
+      final TypePattern head,
+      final Set<String> enumBoundedTypeParameters,
+      final List<TypePattern> parameters,
+      final ClassName factory,
+      final String method,
+      final String name)
+  {
+    this(head, enumBoundedTypeParameters, parameters, factory, method, Optional.of(name));
+  }
 }

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/TypeRule.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/TypeRule.java
@@ -3,9 +3,7 @@ package gov.nasa.jpl.aerie.merlin.processor.metamodel;
 import com.squareup.javapoet.ClassName;
 import gov.nasa.jpl.aerie.merlin.processor.TypePattern;
 
-import javax.lang.model.element.AnnotationMirror;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -15,7 +13,7 @@ public record TypeRule(
     List<TypePattern> parameters,
     ClassName factory,
     String method,
-    Optional<String> label
+    Optional<String> name
 ) {
   public TypeRule(
       final TypePattern head,

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/MetadataValueMapper.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/MetadataValueMapper.java
@@ -1,0 +1,29 @@
+package gov.nasa.jpl.aerie.merlin.framework;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Map;
+
+public record MetadataValueMapper<T>(String label, SerializedValue metadata, ValueMapper<T> target) implements ValueMapper<T> {
+  @Override
+  public ValueSchema getValueSchema() {
+    return ValueSchema.withMeta(label, metadata, target.getValueSchema());
+  }
+
+  @Override
+  public Result<T, String> deserializeValue(final SerializedValue serializedValue) {
+    return target.deserializeValue(serializedValue);
+  }
+
+  @Override
+  public SerializedValue serializeValue(final T value) {
+    return target.serializeValue(value);
+  }
+
+  public static <T, A extends Annotation> ValueMapper<T> annotationValueMapper(String key, ValueMapper<T> TValueMapper, ValueMapper<A> annotationValueMapper, A annotation) {
+    return new MetadataValueMapper<>(key, annotationValueMapper.serializeValue(annotation), TValueMapper);
+  }
+}

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Registrar.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Registrar.java
@@ -10,6 +10,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 public final class Registrar {
   private final Initializer builder;
@@ -27,14 +28,22 @@ public final class Registrar {
   }
 
   public void real(final String name, final Resource<RealDynamics> resource) {
+    real(name, resource, $ -> $);
+  }
+
+  public <T> void realWithMetadata(final String name, final Resource<RealDynamics> resource, final String key, final T metadata, final ValueMapper<T> metadataValueMapper) {
+    real(name, resource, $ -> ValueSchema.withMeta(key, metadataValueMapper.serializeValue(metadata), $));
+  }
+
+  private void real(final String name, final Resource<RealDynamics> resource, UnaryOperator<ValueSchema> schemaModifier) {
     this.builder.resource(
         name,
         makeResource(
             "real",
             resource,
-            ValueSchema.ofStruct(Map.of(
+            schemaModifier.apply(ValueSchema.ofStruct(Map.of(
                 "initial", ValueSchema.REAL,
-                "rate", ValueSchema.REAL)),
+                "rate", ValueSchema.REAL))),
             dynamics -> SerializedValue.of(Map.of(
                 "initial", SerializedValue.of(dynamics.initial),
                 "rate", SerializedValue.of(dynamics.rate)))));

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/AutoValueMapper.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/AutoValueMapper.java
@@ -11,4 +11,8 @@ public @interface AutoValueMapper {
   @Retention(RetentionPolicy.CLASS)
   @Target(ElementType.TYPE)
   @interface Record {}
+
+  @Retention(RetentionPolicy.CLASS)
+  @Target(ElementType.ANNOTATION_TYPE)
+  @interface Annotation {}
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/MissionModel.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/MissionModel.java
@@ -43,4 +43,18 @@ public @interface MissionModel {
   @interface WithMappers {
     Class<?> value();
   }
+
+  @Retention(RetentionPolicy.CLASS)
+  @Target(ElementType.TYPE)
+  @Repeatable(AllMetadata.class)
+  @interface WithMetadata {
+    String name();
+    Class<?> annotation();
+  }
+
+  @Retention(RetentionPolicy.CLASS)
+  @Target(ElementType.TYPE)
+  @interface AllMetadata {
+    WithMetadata[] value();
+  }
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/MissionModel.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/MissionModel.java
@@ -45,7 +45,7 @@ public @interface MissionModel {
   }
 
   @Retention(RetentionPolicy.CLASS)
-  @Target(ElementType.TYPE)
+  @Target(ElementType.PACKAGE)
   @Repeatable(AllMetadata.class)
   @interface WithMetadata {
     String name();
@@ -53,7 +53,7 @@ public @interface MissionModel {
   }
 
   @Retention(RetentionPolicy.CLASS)
-  @Target(ElementType.TYPE)
+  @Target(ElementType.PACKAGE)
   @interface AllMetadata {
     WithMetadata[] value();
   }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/ResponseSerializers.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/ResponseSerializers.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import gov.nasa.jpl.aerie.json.JsonParseResult;
+import gov.nasa.jpl.aerie.merlin.driver.json.ValueSchemaJsonParser;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchSpecificationException;
@@ -196,89 +197,6 @@ public class ResponseSerializers {
   public static JsonValue serializeValueSchema(final ValueSchema schema) {
     if (schema == null) return JsonValue.NULL;
 
-    return schema.match(new ValueSchemaSerializer());
-  }
-
-  private static final class ValueSchemaSerializer implements ValueSchema.Visitor<JsonValue> {
-    @Override
-    public JsonValue onReal() {
-      return Json
-          .createObjectBuilder()
-          .add("type", "real")
-          .build();
-    }
-
-    @Override
-    public JsonValue onInt() {
-      return Json
-          .createObjectBuilder()
-          .add("type", "int")
-          .build();
-    }
-
-    @Override
-    public JsonValue onBoolean() {
-      return Json
-          .createObjectBuilder()
-          .add("type", "boolean")
-          .build();
-    }
-
-    @Override
-    public JsonValue onString() {
-      return Json
-          .createObjectBuilder()
-          .add("type", "string")
-          .build();
-    }
-
-    @Override
-    public JsonValue onDuration() {
-      return Json
-          .createObjectBuilder()
-          .add("type", "duration")
-          .build();
-    }
-
-    @Override
-    public JsonValue onPath() {
-      return Json
-          .createObjectBuilder()
-          .add("type", "path")
-          .build();
-    }
-
-    @Override
-    public JsonValue onSeries(final ValueSchema itemSchema) {
-      return Json
-          .createObjectBuilder()
-          .add("type", "series")
-          .add("items", itemSchema.match(this))
-          .build();
-    }
-
-    @Override
-    public JsonValue onStruct(final Map<String, ValueSchema> parameterSchemas) {
-      return Json
-          .createObjectBuilder()
-          .add("type", "struct")
-          .add("items", serializeMap(x -> x.match(this), parameterSchemas))
-          .build();
-    }
-
-    @Override
-    public JsonValue onVariant(final List<ValueSchema.Variant> variants) {
-      return Json
-          .createObjectBuilder()
-          .add("type", "variant")
-          .add("variants", serializeIterable(
-              v -> Json
-                  .createObjectBuilder()
-                  .add("key", v.key())
-                  .add("label", v.label())
-                  .build(),
-              variants))
-          .build();
-    }
+    return new ValueSchemaJsonParser().unparse(schema);
   }
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/TypescriptCodeGenerationService.java
@@ -303,6 +303,11 @@ return (<T>makeAllDiscreteProfile(args))
                 .map(ValueSchema.Variant::label)
                 .toList());
       }
+
+      @Override
+      public TypescriptType onMeta(final Map<String, SerializedValue> metadata, final ValueSchema target) {
+        return target.match(this);
+      }
     });
   }
 


### PR DESCRIPTION
* **Tickets addressed:** #1034 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This is our second attempt. Our first attempt was #1055.

Short term goal: Allow users to provide unit information for parameters, computed attributes, and resources in their mission model, such that this information can be displayed in the UI and extracted via the API.

Broader goal: Set up a pattern that missions, and Aerie developers, can use to add more kinds of metadata in the future, e.g. Range.

There are two (mostly) independent problems to solve here:
1. How do mission modelers provide unit information, and define other kinds of custom metadata?
2. How is this custom metadata serialized and represented to downstream tools?

The following sections delve into these problems:

### How to define custom metadata
We knew from the outset that we would eventually want to be able to annotate deeply nested aspects of a value schema with metadata. E.g. a rover's pose could be characterized by a compound piece of data:

```yaml
pose:
  position:
    latitude: degrees
    longitude: degrees
    elevation: kilometers
  orientation: quaternion
    q1: unit vector component
    q2: unit vector component
    q3: unit vector component
    q4: scalar
```

We had originally descoped this capability, but then pivoted (i.e. we increased scope) when the path to implementing it became clear.

The two options to select between were Javadoc tags, and annotations. I will describe both approaches, and explain why we have settled on annotations.

#### Surface Syntax

This Javadoc tags approach amounted to parsing javadoc comments as strings, and extracting portions of them based on a set of tags, such as @aerie.unit.

It lended itself quite well to class style parameters, since it could be part of the javadoc comment attached to the parameter itself:

<details>
<summary>Javadoc tags approach</summary>

Example of using javadoc to add unit information to a parameter:

```java
@ActivityType("RunHeater")
public class RunHeater {
  /**
   * @aerie.unit seconds
   */
  @Parameter
  public long duration;

  /**
   * @aerie.unit kWh
   */
  @Parameter
  public int energyConsumptionRate;
}
```

Example of using javadoc to add unit information to a computed attributes record:

```java
  /**
   *
   * @aerie.computedAttribute durationInSeconds
   * @aerie.unit seconds
   * @aerie.computedAttribute energyConsumptionRate
   * @aerie.unit kWh
   */
  @AutoValueMapper.Record
  record ComputedAttributes(
    long durationInSeconds,
    int energyConsumptionRate
  ) {}
```

Example of using `@aerie.resourceName` to assign a unit to all resources that match a regular expression:

```java
/*
 * @aerie.resourceName \/prefix/.*
 * @aerie.unit F resources
 */
```

</details>

A limitation that we discovered of parsing the javadocs is that our implementation would only parse javadocs in a known set of locations. This works fine for parameters and computed attributes, but it breaks down for resources, which in practice are defined in submodels.

The second approach we pursued was to introduce a `@Unit` annotation, which could be attached to the _type_ of a parameter or computed attribute:

<details>
<summary>Annotation approach</summary>

Example of using an annotation to add unit information to a parameter:

```java
@ActivityType("RunHeater")
public class RunHeater {
  @Parameter
  public @Unit("seconds") long duration;

  @Parameter
  public @Unit("kWh") int energyConsumptionRate;
}
```

Example of using an annotation to add unit information to a computed attributes record:

```java
@AutoValueMapper.Record
record ComputedAttributes(
  @Unit("seconds") long durationInSeconds,
  @Unit("kWh") int energyConsumptionRate
) {}
```

</details>

What about resources? Those are defined through a different process from parameters and computed attributes. Resources get registered at runtime, in the mission model constructor, rather than at compile time like the other entities. The approach with javadocs would record a regular expression and do name matching at runtime. The current approach instead expects a mission model to provide the units to the registrar as runtime values. Two convenience methods have been defined:

```java
discreteResource(registrar, "/peel", this.peel, new DoubleValueMapper(), "kg");
realResource(registrar, "/fruit", this.fruit, "bananas");
```

This approach allows us to avoid any custom handling of units in the annotation processor, which means that it will generalize to any future metadata we would like to include. If it turns out that the regular expressions would be a significant quality of life improvement, we can consider that a separate feature.

### How is custom metadata serialized
In Java, there is now a new kind of ValueSchema: a `MetaSchema`, which carries a `Map<String, SerializedValue>`, as well as a nested `ValueSchema`. The interpretation is that all of the metadata in the `MetaSchema` applies to the nested `ValueSchema`.

The `withMeta` method, used to construct a `MetaSchema`, checks to see if the inner value is itself a `MetaSchema`, and if so merges the two, overlaying the outer one on top of the inner one.

When serializing to json, this `Map<String, SerializedValue>` is attached to the nested object, like so:

`MetaSchema(Map.of("unit", "m"),  IntSchema())` becomes

```json
{
  "type": "int",
  "metadata": {
    "unit": "m"
  }
}
```

### Future-proofing
One of the goals of this PR is to lay the groundwork for adding additional metadata to value schemas.

Part of this PR brings annotations into the `Resolver` and `TypePattern` machinery. This allows us to generate value mappers for annotated types.

This PR allows users to define their own annotations, and as long as a value mapper is provided for that annotation, Aerie will be able to serialize it and include it in the value schema.

One generalization that this PR leaves undone is to allow for using value mapper methods to define value mappers for annotated types. The nuance here is that, in this PR, we have users use the `@WithMetadata(Unit.class)` annotation to declare an annotation of interest, and we use that to generate a type rule, rather than the users writing the type rule as the return type from a static method, the way that other value mappers are defined. This is due to a limitation of type use annotations that we may be able to work around in the future.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
The Banananation example model was updated to include some unit information for parameters, computed attributes, and resources.

Things to test manually:
- [x] Do the value schemas look correct in the database?
- [x] Do scheduling and constraint checking still work with banananation? (I.e. do they correctly parse the new value schemas during typescript code generation)

The second bullet may be handled by e2e tests

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
- [ ] Using https://github.com/NASA-AMMOS/aerie-docs/pull/71 as an example, write a new page about metadata.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Incorporate unit information in typescript code generation
- Provide a convenience `@AutoValueMapper.Annotation` to make adding your own metadata annotations less verbose
- Find a workaround that allows type use annotations to be used for value mapper methods
- // int[] repeated(); // TODO add support for arrays in annotations for which we generate value mappers
