### PR TITLE
Fix "UpdateSimulationExtentAction"

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateSimulationExtentAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateSimulationExtentAction.java
@@ -10,7 +10,9 @@ import java.sql.SQLException;
 /*package-local*/ final class UpdateSimulationExtentAction implements AutoCloseable {
   private final @Language("SQL") String sql = """
         insert into simulation_extent (simulation_dataset_id, extent)
-        values (?, ?::interval)
+        select id, ?::interval
+          from simulation_dataset
+          where dataset_id = ?
         on conflict (simulation_dataset_id)
         do update
           set extent = ?::interval;
@@ -22,15 +24,15 @@ import java.sql.SQLException;
     this.statement = connection.prepareStatement(sql);
   }
 
-  public void apply(final long simulationDatasetId, final Duration extent)
+  public void apply(final long datasetId, final Duration extent)
   throws SQLException, NoSuchSimulationDatasetException
   {
-    this.statement.setLong(1, simulationDatasetId);
-    PreparedStatements.setDuration(this.statement, 2, extent);
+    this.statement.setLong(2, datasetId);
+    PreparedStatements.setDuration(this.statement, 1, extent);
     PreparedStatements.setDuration(this.statement, 3, extent);
 
     final var count = this.statement.executeUpdate();
-    if (count < 1) throw new NoSuchSimulationDatasetException(simulationDatasetId);
+    if (count < 1) throw new NoSuchSimulationDatasetException(datasetId);
     if (count > 1) throw new Error("More than one row affected by dataset update by primary key. Is the database corrupted?");
   }
 


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The input to this function is a `datasetId`, not a `simDatasetId`. The SQL statement has been adjusted to use this dataset id to lookup the simulation dataset id.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Manual verification:
- Create a plan. 
- Create an external dataset for the plan.
- Simulate the plan.

If you check the Postgres logs, you should see `ERROR:  insert or update on table "simulation_extent" violates foreign key constraint "simulation_dataset_exists"` on develop and not on this branch.

(This desynchronization occurs naturally during constraints and scheduling e2e tests involving external datasets.)
