### PR TITLE
Improve scheduling logs

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Windows.java
@@ -674,4 +674,15 @@ public final class Windows implements Iterable<Segment<Boolean>>, IntervalContai
   public String toString() {
     return segments.toString();
   }
+
+  /**
+   * toString only for the true segments
+   */
+  public String trueSegmentsToString(){
+    final var sb = new StringBuilder();
+    sb.append("[");
+    this.iterateEqualTo(true).forEach(w -> sb.append(w.toString()));
+    sb.append("]");
+    return sb.toString();
+  }
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/conflicts/MissingActivityInstanceConflict.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/conflicts/MissingActivityInstanceConflict.java
@@ -39,7 +39,7 @@ public class MissingActivityInstanceConflict extends MissingActivityConflict {
   @Override
   public String toString() {
     if (this.instance != null) {
-      return "Conflict : missing activity instance " + this.instance;
+      return "Conflict : missing activity instance " + this.instance + ". Produced by goal " + getGoal().getName();
     }
     return "Empty conflict";
   }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/conflicts/MissingActivityTemplateConflict.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/conflicts/MissingActivityTemplateConflict.java
@@ -100,4 +100,17 @@ public class MissingActivityTemplateConflict extends MissingActivityConflict {
   public ActivityExpression getActTemplate() {
     return template;
   }
+
+  @Override
+  public String toString(){
+    return "Conflict: missing activity template [cardinality:"
+           + this.getCardinality()
+           + ", duration: "
+           + (this.getTotalDuration().isPresent() ? this.getTotalDuration() : "N/A")
+           +"] of type: "
+           + getActTemplate().type().getName()
+           + " in temporal context "
+           + getTemporalContext().trueSegmentsToString()
+           + ". Produced by goal " + getGoal().getName();
+  }
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/conflicts/MissingAssociationConflict.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/conflicts/MissingAssociationConflict.java
@@ -29,4 +29,10 @@ public class MissingAssociationConflict extends Conflict {
   public Windows getTemporalContext() {
     return null;
   }
+
+  @Override
+  public String toString(){
+    return "Conflict: missing association between goal and 1 activity of following set: "
+           + this.getActivityInstancesToChooseFrom() + ". Produced by goal " + getGoal().getName();
+  }
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CardinalityGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CardinalityGoal.java
@@ -107,6 +107,9 @@ public class CardinalityGoal extends ActivityTemplateGoal {
       if (occurrenceRange != null) {
         goal.occurrenceRange = occurrenceRange;
       }
+      if(name==null){
+        goal.name = "CardinalityGoal_"+"thereExists_"+this.thereExists.type().getName()+"_(duration:"+((this.durationRange != null) ? this.durationRange: "N/A") +", occurrences:" + ((this.occurrenceRange != null) ? this.occurrenceRange: "N/A") +")";
+      }
       return goal;
     }
   }//Builder

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CoexistenceGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CoexistenceGoal.java
@@ -157,6 +157,10 @@ public class CoexistenceGoal extends ActivityTemplateGoal {
 
       goal.alias = alias;
 
+      if(name==null){
+        goal.name = "CoexistenceGoal_forEach_"+forEach.prettyPrint()+"_thereExists_"+this.thereExists.type().getName();
+      }
+
       return goal;
     }
 

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/RecurrenceGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/RecurrenceGoal.java
@@ -91,6 +91,10 @@ public class RecurrenceGoal extends ActivityTemplateGoal {
       }
       goal.recurrenceInterval = every;
 
+      if(name==null){
+        goal.name = "RecurrenceGoal_one_"+this.thereExists.type().getName()+"_every_["+goal.recurrenceInterval.min+","+goal.recurrenceInterval.max+"]";
+      }
+
       return goal;
     }
 

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -164,6 +164,7 @@ public class SimulationFacade implements AutoCloseable{
   public Map<SchedulingActivityDirective, SchedulingActivityDirectiveId> getAllChildActivities(final Duration endTime)
   throws SimulationException
   {
+    logger.info("Need to compute simulation results until "+ endTime + " for getting child activities");
     var latestSimulationData = this.getLatestDriverSimulationResults();
     //if no initial sim results and no sim has been performed, perform a sim and get the sim results
     if(latestSimulationData.isEmpty()){
@@ -196,6 +197,9 @@ public class SimulationFacade implements AutoCloseable{
       final Collection<SchedulingActivityDirective> activitiesToRemove,
       final Collection<SchedulingActivityDirective> activitiesToAdd) throws SimulationException
   {
+    logger.debug("Removing("+activitiesToRemove.size()+")/Adding("+activitiesToAdd.size()+") activities from simulation");
+    activitiesToRemove.stream().forEach(remove -> logger.debug("Removing act starting at " + remove.startOffset()));
+    activitiesToAdd.stream().forEach(adding -> logger.debug("Adding act starting at " + adding.startOffset()));
     var atLeastOneActualRemoval = false;
     for(final var act: activitiesToRemove){
       if(insertedActivities.containsKey(act)){
@@ -217,10 +221,12 @@ public class SimulationFacade implements AutoCloseable{
       allActivitiesToSimulate.addAll(insertedActivities.keySet());
       insertedActivities.clear();
       planActDirectiveIdToSimulationActivityDirectiveId.clear();
+      logger.info("(Re)creating simulation driver because at least one removal("+atLeastOneActualRemoval+") or insertion in the past ("+earliestActStartTime+")");
       if (driver != null) {
         this.pastSimulationRestarts += driver.getCountSimulationRestarts();
         driver.close();
       }
+      logger.info("Number of simulation restarts so far: " + this.pastSimulationRestarts);
       driver = new ResumableSimulationDriver<>(missionModel, planningHorizon.getAerieHorizonDuration());
     }
     simulateActivities(allActivitiesToSimulate);

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -497,7 +497,7 @@ public class PrioritySolver implements Solver {
     plan.remove(insertedActivities);
     evalForGoal.removeAssociation(associatedActivities);
     evalForGoal.removeAssociation(insertedActivities);
-    evalForGoal.setScore(-(evalForGoal.getNbConflictsDetected().get()));
+    evalForGoal.setScore(-(evalForGoal.getNbConflictsDetected().orElse(1)));
   }
 
   private void satisfyCompositeGoal(CompositeAndGoal goal) {
@@ -510,6 +510,13 @@ public class PrioritySolver implements Solver {
       if (evaluation.forGoal(subgoal).getScore() == 0) {
         logger.info("AND goal " + goal.getName() + ": subgoal " + subgoal.getName() + " has been satisfied, moving on to next subgoal");
         nbGoalSatisfied++;
+      } else {
+        logger.info("AND goal " + goal.getName() + ": subgoal " + subgoal.getName() + " has NOT been satisfied");
+        if(goal.shouldRollbackIfUnsatisfied()){
+          logger.info("AND goal " + goal.getName() + ": stopping goal satisfaction after first failure, remove shouldRollbackIfUnsatisfied(true) on AND goal to maximize satisfaction instead of early termination");
+          break;
+        }
+        logger.info("AND goal " + goal.getName() + ": moving on to next subgoal (trying to maximize satisfaction)");
       }
     }
     final var goalIsSatisfied = (nbGoalSatisfied == goal.getSubgoals().size());

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUnsatisfiableCompositeGoals.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUnsatisfiableCompositeGoals.java
@@ -137,7 +137,7 @@ public class TestUnsatisfiableCompositeGoals {
     Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t1hr, actTypeControllable));
     Assertions.assertTrue(TestUtility.activityStartingAtTime(plan, t2hr, actTypeControllable));
     Assertions.assertEquals(plan.getActivities().size(), 2);
-    assertEquals(4, problem.getSimulationFacade().countSimulationRestarts());
+    assertEquals(2, problem.getSimulationFacade().countSimulationRestarts());
   }
 
   @Test


### PR DESCRIPTION
* **Tickets addressed:** Fixes #969 #868 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
I have been debugging a Clipper case for quite some time now and have added a lot of useful prints to the scheduler. 

The one change that is not a log change is about a short-circuit in the second commit. If we are going to rollback eventually after failing to satisfy an AND goal, stop processing subgoals as soon as possible.

Here is an example of the logs produced for `SchedulingIntegrationTests.testSingleActivityPlanSimpleCoexistenceGoal_AllenFinishesWithin`

```
[Test worker] WARN gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Reinitialization of the scheduling simulation
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Inserting new activities in the plan to check plan validity
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - New activities have been inserted in the plan successfully
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Need to compute simulation results until -2562047788:00:54.775808 for getting child activities
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Starting conflict detection before goal CoexistenceGoal_forEach_
(for-each-activity (filter by ActivityExpression) aliasGrowBanana 
  (during aliasGrowBanana))_thereExists_DurationParameterActivity
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Need to compute simulation results until +96:00:00.000000 (planning horizon end) for computing conflicts
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Removing(0)/Adding(1) activities from simulation
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Adding act starting at +00:05:00.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Has to simulate from +01:05:00.000000 to +96:00:00.000000 to get simulation results
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Simulating until +96:00:00.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Need to compute simulation results until +96:00:00.000000 for getting child activities
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Has to simulate from +01:05:00.000000 to +96:00:00.000000 to get simulation results
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Simulating until +96:00:00.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Found 1 conflicts in conflict detection
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Processing conflict 1
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Conflict: missing activity template [cardinality:1, occurrences: N/A] of type: DurationParameterActivity in temporal context [Interval[+00:00:00.000000, +96:00:00.000000)]. Produced by goal CoexistenceGoal_forEach_
(for-each-activity (filter by ActivityExpression) aliasGrowBanana 
  (during aliasGrowBanana))_thereExists_DurationParameterActivity
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Trying to satisfy template conflict 1 (iteration: 1). Missing cardinality: 1, duration: N/A
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Initial windows from conflict temporal context :[Interval[+00:00:00.000000, +96:00:00.000000)]
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Windows after narrowing by resource constraints :[Interval[+00:00:00.000000, +96:00:00.000000)]
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Need to compute simulation results until +96:00:00.000000 for computing global scheduling conditions
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Windows after narrowing by global scheduling conditions :[Interval[+00:00:00.000000, +96:00:00.000000)]
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Will try to instantiate activity in narrowed windows
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate - Trying to create one activity, will loop through possible windows
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate - Trying in window Interval[+00:00:00.000000, +96:00:00.000000)
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate - Starting rootfinding trying to place activity DurationParameterActivity
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Removing(0)/Adding(1) activities from simulation
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Adding act starting at +00:00:00.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - (Re)creating simulation driver because at least one removal(false) or insertion in the past (+00:00:00.000000)
[Test worker] WARN gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Closing sim
[Test worker] WARN gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Time spent in the last sim 0.001940374s, average per simulation second 4.975317948717948E-7s. Simulated until +01:05:00.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Number of simulation restarts so far: 1
[Test worker] WARN gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Reinitialization of the scheduling simulation
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Removing(1)/Adding(1) activities from simulation
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Removing act starting at +00:00:00.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Adding act starting at +01:00:00.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - (Re)creating simulation driver because at least one removal(true) or insertion in the past (+01:00:00.000000)
[Test worker] WARN gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Closing sim
[Test worker] WARN gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Time spent in the last sim 9.37999E-4s, average per simulation second 2.405125641025641E-7s. Simulated until +01:05:00.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Number of simulation restarts so far: 2
[Test worker] WARN gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Reinitialization of the scheduling simulation
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Removing(1)/Adding(1) activities from simulation
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Removing act starting at +01:00:00.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Adding act starting at +00:07:30.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - (Re)creating simulation driver because at least one removal(true) or insertion in the past (+00:07:30.000000)
[Test worker] WARN gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Closing sim
[Test worker] WARN gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Time spent in the last sim 3.44792E-4s, average per simulation second 5.224121212121212E-8s. Simulated until +01:50:00.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Number of simulation restarts so far: 3
[Test worker] WARN gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Reinitialization of the scheduling simulation
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate - Finished rootfinding: SUCCESS
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate - Rootfinding history
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate - Start:+00:00:00.000000 end:+00:50:00.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate - Start:+01:00:00.000000 end:+01:50:00.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityCreationTemplate - Start:+00:07:30.000000 end:+00:57:30.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Found activity to satisfy missing activity template conflict
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Inserting new activities in the plan to check plan validity
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Removing(0)/Adding(1) activities from simulation
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Adding act starting at +00:07:30.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - New activities have been inserted in the plan successfully
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade - Need to compute simulation results until +01:05:00.000000 for getting child activities
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Not simulating because asked endTime +01:05:00.000000 is before current sim time +01:05:00.000000
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Conflict 1 has been addressed
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver - Finishing goal satisfaction for goal CoexistenceGoal_forEach_
(for-each-activity (filter by ActivityExpression) aliasGrowBanana 
  (during aliasGrowBanana))_thereExists_DurationParameterActivity:SUCCESS. Number of conflicts that could not be addressed: 0
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Has to simulate from +01:05:00.000000 to +96:00:00.000000 to get simulation results
[Test worker] INFO gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Simulating until +96:00:00.000000
[Test worker] WARN gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Closing sim
[Test worker] WARN gov.nasa.jpl.aerie.scheduler.simulation.ResumableSimulationDriver - Time spent in the last sim 5.71626E-4s, average per simulation second 1.4657076923076923E-7s. Simulated until +01:05:00.000000
```

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Logging -> no change in business logic.
short-circuit -> no change to results. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None. 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
More logging I guess. 
I have a commit somewhere to route the name of scheduling goals from the DB to the scheduler so it is the user-defined one that appears in the log. For subgoals, we need to add an builder to the goal to add a name. For now, the names are auto generated. 