### PR TITLE
add HTTPS-enabled reverse proxy deployment example

### DIFF
--- a/deployment/.env
+++ b/deployment/.env
@@ -11,3 +11,7 @@ HASURA_GRAPHQL_JWT_SECRET=
 
 POSTGRES_USER=
 POSTGRES_PASSWORD=
+
+# Optionally define the host Aerie will run on, if you need HTTPS / TLS
+# See the deployment/proxy folder for more info
+# AERIE_HOST=

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     restart: always
     volumes:
       - aerie_file_store:/app/files
+    networks:
+      - aerie_net
   aerie_merlin:
     container_name: aerie_merlin
     depends_on: ["postgres"]
@@ -42,6 +44,8 @@ services:
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store
+    networks:
+      - aerie_net
   aerie_merlin_worker_1:
     container_name: aerie_merlin_worker
     depends_on: ["postgres"]
@@ -63,6 +67,8 @@ services:
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store:ro
+    networks:
+      - aerie_net
   aerie_scheduler:
     container_name: aerie_scheduler
     depends_on: ["aerie_merlin", "postgres"]
@@ -83,6 +89,8 @@ services:
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store
+    networks:
+      - aerie_net
   aerie_scheduler_worker_1:
     container_name: aerie_scheduler_worker_1
     depends_on: ["postgres"]
@@ -105,6 +113,8 @@ services:
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store:ro
+    networks:
+      - aerie_net
   aerie_sequencing:
     container_name: aerie_sequencing
     depends_on: ["postgres"]
@@ -125,6 +135,8 @@ services:
     restart: always
     volumes:
       - aerie_file_store:/usr/src/app/sequencing_file_store
+    networks:
+      - aerie_net
   aerie_ui:
     container_name: aerie_ui
     depends_on: ["postgres"]
@@ -139,6 +151,8 @@ services:
     image: "${REPOSITORY_DOCKER_URL}/aerie-ui:${DOCKER_TAG}"
     ports: ["80:80"]
     restart: always
+    networks:
+      - aerie_net
   hasura:
     container_name: hasura
     depends_on: ["postgres"]
@@ -163,6 +177,8 @@ services:
     restart: always
     volumes:
       - ./hasura/metadata:/hasura-metadata
+    networks:
+      - aerie_net
   postgres:
     container_name: postgres
     environment:
@@ -177,8 +193,13 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./postgres-init-db:/docker-entrypoint-initdb.d
+    networks:
+      - aerie_net
 
 volumes:
   aerie_file_store:
   mission_file_store:
   postgres_data:
+
+networks:
+  aerie_net:

--- a/deployment/proxy/Dockerfile
+++ b/deployment/proxy/Dockerfile
@@ -1,0 +1,7 @@
+from docker.io/nginx:alpine3.18
+
+# inject AERIE_HOST into nginx.conf
+copy ./nginx.conf.template /etc/nginx/templates/default.conf.template
+
+copy ./cert.pem /cert.pem
+copy ./key.pem /key.pem

--- a/deployment/proxy/docker-compose-proxy.yml
+++ b/deployment/proxy/docker-compose-proxy.yml
@@ -1,0 +1,44 @@
+services:
+  aerie_proxy:
+    container_name: aerie_proxy
+    depends_on:
+     - "aerie_ui"
+     - "hasura"
+     - "aerie_gateway"
+    build:
+      context: proxy
+    ports:
+     - "80:80"
+     - "443:443"
+     - "8080:8080"
+     - "9000:9000"
+    environment:
+        NGINX_ENVSUBST_TEMPLATE_SUFFIX: ".template"
+        AERIE_HOST: ${AERIE_HOST}
+    networks:
+      - aerie_net
+  aerie_gateway:
+    ports: !reset []
+    environment:
+      GQL_API_URL: http://hasura:8080/v1/graphql
+  aerie_merlin:
+    ports: !reset []
+  aerie_merlin_worker_1:
+    ports: !reset []
+  aerie_scheduler:
+    ports: !reset []
+  aerie_scheduler_worker_1:
+    ports: !reset []
+  aerie_sequencing:
+    ports: !reset []
+  aerie_ui:
+    ports: !reset []
+    environment:
+      ORIGIN: https://${AERIE_HOST}
+      PUBLIC_GATEWAY_CLIENT_URL: https://${AERIE_HOST}:9000
+      PUBLIC_HASURA_CLIENT_URL: https://${AERIE_HOST}:8080/v1/graphql
+      PUBLIC_HASURA_WEB_SOCKET_URL: wss://${AERIE_HOST}:8080/v1/graphql
+  hasura:
+    ports: !reset []
+  postgres:
+    ports: !reset []

--- a/deployment/proxy/nginx.conf.template
+++ b/deployment/proxy/nginx.conf.template
@@ -1,0 +1,51 @@
+# increase max body size for model uploads
+client_max_body_size 100M;
+
+# redirect HTTP to HTTPS (80 -> 443)
+server {
+    listen 80;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+# terminate TLS and proxy pass UI
+server {
+    listen              443 ssl;
+    server_name         ${AERIE_HOST};
+    ssl_certificate     /cert.pem;
+    ssl_certificate_key /key.pem;
+    ssl_protocols       TLSv1.3;
+
+    location / {
+        proxy_pass http://aerie_ui;
+    }
+}
+
+# terminate TLS and proxy pass hasura
+server {
+    listen              8080 ssl;
+    server_name         ${AERIE_HOST};
+    ssl_certificate     /cert.pem;
+    ssl_certificate_key /key.pem;
+    ssl_protocols       TLSv1.3;
+
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+
+    location / {
+        proxy_pass http://hasura:8080;
+    }
+}
+
+# terminate TLS and proxy pass gateway
+server {
+    listen              9000 ssl;
+    server_name         ${AERIE_HOST};
+    ssl_certificate     /cert.pem;
+    ssl_certificate_key /key.pem;
+    ssl_protocols       TLSv1.3;
+
+    location / {
+        proxy_pass http://aerie_gateway:9000;
+    }
+}


### PR DESCRIPTION
* **Tickets addressed:** Closes #1167 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
**TL;DR**: New optional container in compose stack listens for HTTPS requests and forwards them as HTTP requests to internal containers. This enables encryption of traffic between clients and Aerie and reduces the number of exposed ports of an Aerie deployment.

Currently, the deployment we provide to customers is fairly barebones, and simply spins up the Aerie components with all ports exposed, and lets users hit `localhost:80` for the UI. This deployment is useful for local development purposes and quick testing, but a production Aerie deployment would likely want to encrypt traffic between the browser and Aerie components, using HTTPS, and be deployed under a specific domain name (e.g. `aerie-dev.jpl.nasa.gov`)

This PR adds a new optional component `aerie_proxy` to the docker compose stack, which runs an [`nginx`](https://nginx.org/en/) instance (a popular open-souce HTTP webserver and reverse proxy) in a "reverse proxy" configuration. This new container will listen on the provided domain for just the essential ports of an Aerie deployment (`443` for the UI, `8080` for Hasura, and `9000` for the gateway), create a TLS tunnel with connecting clients using the provided TLS certificates, which on the communicate with the client on these ports using TLS with the provided certificates, and then terminate TLS and proxy the traffic to internal containers within the network namespace provided by docker.

For clarification, this component doesn't really offer much utility when deploying locally for development, and is mostly useful as an example pattern for end-users to deploy Aerie with HTTPS.

An example client <-> server interaction with this new reverse proxy is as follows:

```mermaid
sequenceDiagram
    participant browser
    participant nginx
    participant hasura
    browser->>nginx: TLS handshake init (ClientHello)
    nginx->>browser: TLS handshake complete
    browser->>nginx: HTTPS request for aerie.test:8080/v1/graphql with JSON payload
    Note over nginx: Nginx strips TLS
    nginx->>hasura: Forward HTTP request to hasura:8080/v1/graphql
    hasura->>nginx: Query result HTTP response (JSON body)
    nginx->>browser: Query result HTTPS response (JSON body)
```

## Verification
The following manual steps were done to verify this new component works correctly:
- Generate self-signed TLS cert for testing:
  - `openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365`
  - Move certs to `proxy` folder
- Edit `deployment/.env` to add new `AERIE_HOST` entry as `aerie.test`
- Edit `/etc/hosts` to add `127.0.0.1 aerie.test` as a fake DNS entry
- Run docker compose up with both the deployment yaml and the new proxy overlay
  -  `docker compose -f docker-compose.yml -f proxy/docker-compose-proxy.yml up -d --build`
- Visit `https://aerie.test` and confirm regular Aerie functionality.

## Documentation
Need to type up docs under the advanced deployment section of `aerie-docs`.

## Future work
Possibly continue this effort of creating patterns for common deployment needs (database backups, 3rd party identity providers, etc)
