### PR TITLE
Simplify extension_roles

### DIFF
--- a/deployment/hasura/metadata/databases/AerieUI/tables/public_extension_roles.yaml
+++ b/deployment/hasura/metadata/databases/AerieUI/tables/public_extension_roles.yaml
@@ -29,7 +29,7 @@ insert_permissions:
 update_permissions:
   - role: aerie_admin
     permission:
-      columns: [extension_id, role]
+      columns: [role]
       filter: {}
 delete_permissions:
   - role: aerie_admin

--- a/deployment/hasura/migrations/AerieUI/2_extensions/up.sql
+++ b/deployment/hasura/migrations/AerieUI/2_extensions/up.sql
@@ -35,16 +35,11 @@ create trigger extensions_set_timestamp
 execute function extensions_set_updated_at();
 
 create table extension_roles (
-  id integer generated always as identity,
-  extension_id  integer not null,
+  extension_id integer not null references extensions(id)
+    on update cascade
+    on delete cascade,
   role text not null,
-
-  constraint extension_roles_primary_key primary key (id),
-  constraint extension_roles_to_extension
-    foreign key (extension_id)
-      references "extensions"
-      on update cascade
-      on delete cascade
+  primary key(extension_id, role)
 );
 
 comment on table extension_roles is e''

--- a/deployment/postgres-init-db/sql/ui/tables/extension_roles.sql
+++ b/deployment/postgres-init-db/sql/ui/tables/extension_roles.sql
@@ -1,14 +1,9 @@
 create table extension_roles (
-  id integer generated always as identity,
-  extension_id  integer not null,
+  extension_id  integer not null references extensions(id)
+    on update cascade
+    on delete cascade,
   role text not null,
-
-  constraint extension_roles_primary_key primary key (id),
-  constraint extension_roles_to_extension
-    foreign key (extension_id)
-      references "extensions"
-      on update cascade
-      on delete cascade
+  primary key (extension_id, role)
 );
 
 comment on table extension_roles is e''


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Simplifies the `extension_roles` table by removing the `id` PK and turning the `extension_id` and `role` column into the PK. This not only makes it consistent with our other association tables, it will avoid potential bugs caused by duplicate rows.

It also restricts the update permissions on this table. As an association table, this table should have no update permissions, however because `role` is a text field that's unable to have an FK against the `user_roles` table, we should permit this column to be edited in order to resolve typos/role name changes.

[There is a sister PR to accommodate the breaking change in the UI](https://github.com/NASA-AMMOS/aerie-ui/pull/941).

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Validated in Hasura.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

The Extensions docs need to be slightly tweaked (the ones in `Planning` provide the table's entire schema, and the `API` docs are returning the `id` column)

## Future work
<!-- What next steps can we anticipate from here, if any? -->
