### PR TITLE
Implement Spans.contains eDSL method

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Interval.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/time/Interval.java
@@ -252,11 +252,7 @@ public final class Interval implements Comparable<Interval>{
   }
 
   public int compareEndToStart(Interval other) {
-    final var timeComparison = this.end.compareTo(other.start);
-    if (timeComparison != 0) return timeComparison;
-    else if (this.endInclusivity != other.startInclusivity) return 0;
-    else if (this.endInclusivity == Inclusive) return 1;
-    else return -1;
+    return compareEndToStart(this, other);
   }
 
   public boolean contains(Duration d){
@@ -321,20 +317,30 @@ public final class Interval implements Comparable<Interval>{
   }
 
   public static int compareStartToEnd(final Interval x, final Interval y) {
-    // First, order by absolute time.
-    if (!x.start.isEqualTo(y.end)) {
-      return x.start.compareTo(y.end);
-    }
-
-    // Second, order by inclusivity
-    if (!y.includesEnd()) return 1;
-    if (!x.includesStart()) return 1;
-
-    return 0;
+    return -compareEndToStart(y, x);
   }
 
+  /**
+   * Compares the end of x to the start of y.
+   *
+   * Returns -1 if x ends before y starts.
+   * Returns 1 if x ends after (see below) y starts.
+   * Returns 0 if x exactly meets (see below) y with no overlap
+   *
+   * To clarify, `compareEndToStart([a, b), [b, c)) == 0`,
+   * but `compareEndToStart([a, b], [b, c]) == 1`. This might be unintuitive,
+   * but I've found this to be much more useful in practice than `-1` and `0`, respectively.
+   * This is because as long as x starts before y, we get a few properties:
+   * - -1 indicates a gap between x and y
+   * - 1 indicates overlap between x and y
+   * - 0 indicates no gap and no overlap
+   */
   public static int compareEndToStart(final Interval x, final Interval y) {
-    return -compareStartToEnd(y, x);
+    final var timeComparison = x.end.compareTo(y.start);
+    if (timeComparison != 0) return timeComparison;
+    else if (x.endInclusivity != y.startInclusivity) return 0;
+    else if (x.endInclusivity == Inclusive) return 1;
+    else return -1;
   }
 
   public static boolean meets(final Interval x, final Interval y) {

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansConnectTo.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansConnectTo.java
@@ -25,21 +25,21 @@ public record SpansConnectTo(Expression<Spans> from, Expression<Spans> to) imple
         toIndex++;
       }
       final Duration endTime;
-      final Interval.Inclusivity endInlusivity;
+      final Interval.Inclusivity endInclusivity;
       if (toIndex == sortedTo.size()) {
         endTime = bounds.end;
-        endInlusivity = bounds.endInclusivity;
+        endInclusivity = bounds.endInclusivity;
       }
       else {
         endTime = sortedTo.get(toIndex).interval().start;
-        endInlusivity = Interval.Inclusivity.Inclusive;
+        endInclusivity = Interval.Inclusivity.Inclusive;
       }
       result.add(
           Interval.between(
               startTime,
               Interval.Inclusivity.Inclusive,
               endTime,
-              endInlusivity
+              endInclusivity
           ),
           span.value()
       );

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansContains.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansContains.java
@@ -37,7 +37,7 @@ public record SpansContains(Expression<Spans> parents, Expression<Spans> childre
     final var children = this.children.evaluate(results, bounds, environment);
     var falseIntervals = new ArrayList<Interval>();
 
-
+    // Check for count requirements if they exist
     if (this.requirement.minCount.isPresent() || this.requirement.maxCount.isPresent()) {
       final var sortedParents = StreamSupport.stream(parents.spliterator(), true).sorted((l, r) -> l
           .interval()
@@ -70,6 +70,8 @@ public record SpansContains(Expression<Spans> parents, Expression<Spans> childre
         }
       }
     }
+
+    // Check for duration requirements if they exist.
     if (this.requirement.minDur().isPresent() || this.requirement.maxDur.isPresent()) {
       final var accumulatedDuration = children.accumulatedDuration(Duration.MICROSECOND);
       final Optional<Long> minDur;

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansContains.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansContains.java
@@ -66,8 +66,8 @@ public record SpansContains(Expression<Spans> parents, Expression<Spans> childre
         var lookaheadChildIndex = childIndex;
         while (lookaheadChildIndex < childrenLength) {
           final var childInterval = sortedChildren.get(lookaheadChildIndex).interval();
-          if (!parentInterval.contains(childInterval)) break;
-          instanceCount.getAndIncrement();
+          if (parentInterval.contains(childInterval)) instanceCount.getAndIncrement();
+          else if (parentInterval.compareEndToStart(childInterval) < 1) break;
           lookaheadChildIndex++;
         }
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansContains.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/SpansContains.java
@@ -1,0 +1,119 @@
+package gov.nasa.jpl.aerie.constraints.tree;
+
+import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
+import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.constraints.time.Spans;
+import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.StreamSupport;
+
+
+public record SpansContains(Expression<Spans> parents, Expression<Spans> children, Requirement requirement) implements Expression<Windows> {
+  public record Requirement(
+      Optional<Integer> minCount,
+      Optional<Integer> maxCount,
+      Optional<Expression<Duration>> minDur,
+      Optional<Expression<Duration>> maxDur
+  ) {
+    public static SpansContains.Requirement newDefault() {
+      return new Requirement(
+          Optional.of(1),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty()
+      );
+    }
+  }
+
+  @Override
+  public Windows evaluate(final SimulationResults results, final Interval bounds, final EvaluationEnvironment environment) {
+    final var parents = this.parents.evaluate(results, bounds, environment);
+    final var children = this.children.evaluate(results, bounds, environment);
+    var falseIntervals = new ArrayList<Interval>();
+
+
+    if (this.requirement.minCount.isPresent() || this.requirement.maxCount.isPresent()) {
+      final var sortedParents = StreamSupport.stream(parents.spliterator(), true).sorted((l, r) -> l
+          .interval()
+          .compareStarts(r.interval())).toList();
+      final var sortedChildren = StreamSupport.stream(children.spliterator(), true).sorted((l, r) -> l
+          .interval()
+          .compareStarts(r.interval())).toList();
+      var childIndex = 0;
+
+      for (final var parent: sortedParents) {
+        final var parentInterval = parent.interval();
+        var childInterval = sortedChildren.get(childIndex).interval();
+        while (childInterval.compareStarts(parentInterval) == -1) {
+          childIndex++;
+          childInterval = sortedChildren.get(childIndex).interval();
+        }
+
+        var instanceCount = new AtomicInteger(0);
+        var transientChildIndex = childIndex;
+        while (parentInterval.contains(childInterval)) {
+          instanceCount.getAndIncrement();
+          transientChildIndex++;
+          childInterval = sortedChildren.get(transientChildIndex).interval();
+        }
+
+        if (this.requirement.minCount.map(c -> instanceCount.get() < c).orElse(false)) {
+          falseIntervals.add(parentInterval);
+        } else if (this.requirement.maxCount.map(c -> instanceCount.get() > c).orElse(false)) {
+          falseIntervals.add(parentInterval);
+        }
+      }
+    }
+    if (this.requirement.minDur().isPresent() || this.requirement.maxDur.isPresent()) {
+      final var accumulatedDuration = children.accumulatedDuration(Duration.MICROSECOND);
+      final Optional<Long> minDur;
+      final Optional<Long> maxDur;
+      if (this.requirement.minDur().isPresent()) {
+        minDur = Optional.of(this.requirement.minDur().get().evaluate(results, bounds, environment).dividedBy(Duration.MICROSECOND));
+      } else {
+        minDur = Optional.empty();
+      }
+      if (this.requirement.maxDur().isPresent()) {
+        maxDur = Optional.of(this.requirement.maxDur().get().evaluate(results, bounds, environment).dividedBy(Duration.MICROSECOND));
+      } else {
+        maxDur = Optional.empty();
+      }
+      for (final var parent: parents) {
+        final var parentInterval = parent.interval();
+        final var startAcc = accumulatedDuration.valueAt(parentInterval.start).get().asReal().get();
+        final var endAcc = accumulatedDuration.valueAt(parentInterval.end).get().asReal().get();
+
+        if (minDur.isPresent() && endAcc - startAcc < minDur.get()) {
+          falseIntervals.add(parentInterval);
+        } else if (maxDur.isPresent() && endAcc - startAcc > maxDur.get()) {
+          falseIntervals.add(parentInterval);
+        }
+      }
+    }
+
+    return (new Windows(bounds, true)).set(falseIntervals, false);
+  }
+
+  @Override
+  public void extractResources(final Set<String> names) {
+    this.parents.extractResources(names);
+    this.children.extractResources(names);
+  }
+
+  @Override
+  public String prettyPrint(final String prefix) {
+    return String.format(
+        "\n%s(spans-contains require %s of %s in %s)",
+        prefix,
+        this.requirement.toString(),
+        this.children.prettyPrint(),
+        this.parents.prettyPrint()
+    );
+  }
+}

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -1570,10 +1570,10 @@ public class ASTTests {
     );
 
     final var parents = new Spans(
-        interval(0, 3, SECONDS), // has no children inside it
-        interval(6, 9, SECONDS), // has one child of duration 3
-        interval(12, 15, SECONDS), // has two children, total duration 2
-        interval(16, 19, SECONDS) // has one partially-contained child, intersection duration 3
+        interval(0, 3, SECONDS),
+        interval(6, 9, SECONDS),
+        interval(12, 15, SECONDS),
+        interval(16, 19, SECONDS)
     );
 
     final var children = new Spans(
@@ -1593,6 +1593,44 @@ public class ASTTests {
         .set(interval(6, 9, SECONDS), false)
         .set(interval(12, 15, SECONDS), false)
         .set(interval(16, 19, SECONDS), false);
+    assertIterableEquals(count1Expected, count1Result);
+  }
+
+  @Test
+  void testSpansContainsLookahead() {
+    final var simResults = new SimulationResults(
+        Instant.EPOCH, Interval.between(0, 20, SECONDS),
+        List.of(),
+        Map.of(),
+        Map.of()
+    );
+
+    final var parents = new Spans(
+        interval(0, 3, SECONDS),
+        interval(5, 9, SECONDS),
+        interval(5, 9, SECONDS),
+        interval(11, 13, SECONDS),
+        interval(11, 13, SECONDS)
+    );
+
+    final var children = new Spans(
+        interval(3, 4, SECONDS),
+        interval(6, 7, SECONDS),
+        interval(7, 8, SECONDS)
+    );
+
+    // require min count 1
+    final var count1Result =
+        (new SpansContains(Supplier.of(parents), Supplier.of(children), new SpansContains.Requirement(
+            Optional.of(2),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()
+        )))
+            .evaluate(simResults);
+    final var count1Expected = new Windows(interval(0, 20, SECONDS), true)
+        .set(interval(0, 3, SECONDS), false)
+        .set(interval(11, 13, SECONDS), false);
     assertIterableEquals(count1Expected, count1Result);
   }
 

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -1474,6 +1474,7 @@ public class ASTTests {
         interval(16, 20, SECONDS)
     );
 
+    // require min count 1
     final var count1Result =
         (new SpansContains(Supplier.of(parents), Supplier.of(children), new SpansContains.Requirement(
             Optional.of(1),
@@ -1487,6 +1488,7 @@ public class ASTTests {
         .set(interval(16, 19, SECONDS), false);
     assertIterableEquals(count1Expected, count1Result);
 
+    // require min count 2
     final var count2Result =
         (new SpansContains(Supplier.of(parents), Supplier.of(children), new SpansContains.Requirement(
             Optional.of(2),
@@ -1501,6 +1503,7 @@ public class ASTTests {
         .set(interval(16, 19, SECONDS), false);
     assertIterableEquals(count2Expected, count2Result);
 
+    // require max count 1
     final var count3Result =
         (new SpansContains(Supplier.of(parents), Supplier.of(children), new SpansContains.Requirement(
             Optional.empty(),
@@ -1513,6 +1516,7 @@ public class ASTTests {
         .set(interval(12, 15, SECONDS), false);
     assertIterableEquals(count3Expected, count3Result);
 
+    // require min duration 3s
     final var duration1Result =
         (new SpansContains(Supplier.of(parents), Supplier.of(children), new SpansContains.Requirement(
             Optional.empty(),
@@ -1526,6 +1530,7 @@ public class ASTTests {
         .set(interval(12, 15, SECONDS), false);
     assertIterableEquals(duration1Expected, duration1Result);
 
+    // require max duration 2.5s
     final var duration2Result =
         (new SpansContains(Supplier.of(parents), Supplier.of(children), new SpansContains.Requirement(
             Optional.empty(),
@@ -1539,6 +1544,7 @@ public class ASTTests {
         .set(interval(16, 19, SECONDS), false);
     assertIterableEquals(duration2Expected, duration2Result);
 
+    // require min count 1 and max duration 2s
     final var combinedResult =
         (new SpansContains(Supplier.of(parents), Supplier.of(children), new SpansContains.Requirement(
             Optional.of(1),

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-ast.ts
@@ -30,6 +30,7 @@ export enum NodeKind {
   SpansExpressionConnectTo = 'SpansExpressionConnectTo',
   SpansExpressionInterval = 'SpansExpressionInterval',
   SpansSelectWhenTrue = 'SpansSelectWhenTrue',
+  SpansExpressionContains = 'SpansExpressionContains',
   ExpressionEqual = 'ExpressionEqual',
   ExpressionNotEqual = 'ExpressionNotEqual',
   RealProfileLessThan = 'RealProfileLessThan',
@@ -115,7 +116,8 @@ export type WindowsExpression =
   | IntervalsExpressionStarts
   | IntervalsExpressionEnds
   | AssignGapsExpression<WindowsExpression>
-    | WindowsExpressionKeepTrueSegment;
+  | WindowsExpressionKeepTrueSegment
+  | SpansExpressionContains;
 
 
 export type SpansExpression =
@@ -166,6 +168,22 @@ export interface WindowsExpressionKeepTrueSegment {
   kind: NodeKind.WindowsExpressionKeepTrueSegment;
   expression: WindowsExpression;
   index: number;
+}
+
+export interface SpansExpressionContains {
+  kind: NodeKind.SpansExpressionContains;
+  parents: SpansExpression;
+  children: SpansExpression;
+  requirement: {
+    count: {
+      min?: number,
+      max?: number
+    },
+    duration: {
+      min?: Duration,
+      max?: Duration
+    }
+  };
 }
 
 export interface IntervalsExpressionShiftEdges {

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -612,7 +612,7 @@ export class Spans {
    * Both `min` and `max` can be provided at the same time (e.g. `{count: {min: 1, max: 3}}`.
    *
    * There is no option to require an exact duration, because the implementation uses floating point comparison.
-   * If you need an exact duration, you can approximate it by using a small around around the desired value.
+   * If you need an exact duration, you can approximate it by using a small range around the desired value.
    *
    * @param children child spans to check the existence of.
    * @param requirement what to check for in each parent span.
@@ -1540,7 +1540,7 @@ declare global {
      * Both `min` and `max` can be provided at the same time (e.g. `{count: {min: 1, max: 3}}`.
      *
      * There is no option to require an exact duration, because the implementation uses floating point comparison.
-     * If you need an exact duration, you can approximate it by using a small around around the desired value.
+     * If you need an exact duration, you can approximate it by using a small range around the desired value.
      *
      * @param children child spans to check the existence of.
      * @param requirement what to check for in each parent span.

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -588,6 +588,61 @@ export class Spans {
       windowsExpression: windows.__astNode
     });
   }
+
+  /**
+   * Creates a windows object that is false when one of these Spans does not contain a child span, and true otherwise.
+   * The parents are the callee and the children are the argument, i.e. `parents.contains(children)`.
+   * The default requirement of one child per parent can be modified.
+   *
+   * More concretely, for the expression `A.contains(B)`, the result is:
+   * - `true` inside any A spans if (by default) they contain at least one B span
+   *   - for counting spans, "contain" means that the entire B span is inside the A span.
+   * - `true` (vacuously) outside the union of all A spans
+   * - `false` inside any A spans that do not contain a B span
+   *
+   * The requirement for one child span can be optionally changed by providing the second argument:
+   * - `{count: n}` requires *exactly* `n` children per parent.
+   * - `{count: {min: n}}` requires at least `n` children per parent.
+   * - `{count: {max: n}}` requires at most `n` children per parent
+   * - `{duration: {min: d}}` requires a total duration of children of at least `d`
+   * - `{duration: {max: d}}` requires a total duration of children of at most `d`
+   *
+   * Both `count` and `duration` can be provided at the same time
+   * (e.g. `{count: 2, duration: {min: Temporal.Duration.from({hours: 1})}}`).
+   * Both `min` and `max` can be provided at the same time (e.g. `{count: {min: 1, max: 3}}`.
+   *
+   * There is no option to require an exact duration, because the implementation uses floating point comparison.
+   * If you need an exact duration, you can approximate it by using a small around around the desired value.
+   *
+   * @param children child spans to check the existence of.
+   * @param requirement what to check for in each parent span.
+   */
+  public contains(children: Spans, requirement?: SpansContainsRequirement): Windows {
+    if (requirement === undefined) requirement = {count: {min: 1}};
+    if (requirement.count === undefined) requirement.count = {};
+    else if (typeof requirement.count === 'number') requirement.count = {
+      min: requirement.count,
+      max: requirement.count
+    };
+    if (requirement.duration === undefined) requirement.duration = {};
+    return new Windows({
+      kind: AST.NodeKind.SpansExpressionContains,
+      parents: this.__astNode,
+      children: children.__astNode,
+      requirement: requirement as {count: {min?: number, max?: number}, duration: {min?: AST.Duration, max?: AST.Duration}}
+    });
+  }
+}
+
+export type SpansContainsRequirement = {
+  count?: number | {
+    min?: number,
+    max?: number
+  },
+  duration?: AST.Duration | {
+    min?: AST.Duration,
+    max?: AST.Duration
+  }
 }
 
 /**
@@ -1196,7 +1251,7 @@ declare global {
     ExcessHull = 'ExcessHull',
     DeficitSpans = 'DeficitSpans',
     DeficitHull = 'DeficitHull'
-}
+  }
 
   /** A boolean profile; a function from time to truth values. */
   export class Windows {
@@ -1461,6 +1516,47 @@ declare global {
      * @param windows
      */
     public selectWhenTrue(windows: Windows): Spans;
+
+    /**
+     * Creates a windows object that is false when one of these Spans does not contain a child span, and true otherwise.
+     * The parents are the callee and the children are the argument, i.e. `parents.contains(children)`.
+     * The default requirement of one child per parent can be modified.
+     *
+     * More concretely, for the expression `A.contains(B)`, the result is:
+     * - `true` inside any A spans if (by default) they contain at least one B span
+     *   - for counting spans, "contain" means that the entire B span is inside the A span.
+     * - `true` (vacuously) outside the union of all A spans
+     * - `false` inside any A spans that do not contain a B span
+     *
+     * The requirement for one child span can be optionally changed by providing the second argument:
+     * - `{count: n}` requires *exactly* `n` children per parent.
+     * - `{count: {min: n}}` requires at least `n` children per parent.
+     * - `{count: {max: n}}` requires at most `n` children per parent
+     * - `{duration: {min: d}}` requires a total duration of children of at least `d`
+     * - `{duration: {max: d}}` requires a total duration of children of at most `d`
+     *
+     * Both `count` and `duration` can be provided at the same time
+     * (e.g. `{count: 2, duration: {min: Temporal.Duration.from({hours: 1})}}`).
+     * Both `min` and `max` can be provided at the same time (e.g. `{count: {min: 1, max: 3}}`.
+     *
+     * There is no option to require an exact duration, because the implementation uses floating point comparison.
+     * If you need an exact duration, you can approximate it by using a small around around the desired value.
+     *
+     * @param children child spans to check the existence of.
+     * @param requirement what to check for in each parent span.
+     */
+    public contains(children: Spans, requirement?: SpansContainsRequirement): Windows;
+  }
+
+  export type SpansContainsRequirement = {
+    count?: number | {
+      min?: number,
+      max?: number
+    },
+    duration?: {
+      min?: AST.Duration,
+      max?: AST.Duration
+    }
   }
 
   /**


### PR DESCRIPTION
* **Tickets addressed:** closes #1113
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This adds the coexistence-goal equivalent to the constraints edsl. It is meant to serve similar purposes, but is not a meant to be an exact replica of the judgement phase of coexistence goal.

I'm just going to copy-paste the doc-comment I wrote for the method, as a description of what it does:
```ts
/**
 * Creates a windows object that is false when one of these Spans does not contain a child span, and true otherwise.
 * The parents are the callee and the children are the argument, i.e. `parents.contains(children)`.
 * The default requirement of one child per parent can be modified.
 *
 * More concretely, for the expression `A.contains(B)`, the result is:
 * - `true` inside any A spans if (by default) they contain at least one B span
 *   - for counting spans, "contain" means that the entire B span is inside the A span.
 * - `true` (vacuously) outside the union of all A spans
 * - `false` inside any A spans that do not contain a B span
 *
 * The requirement for one child span can be optionally changed by providing the second argument:
 * - `{count: n}` requires *exactly* `n` children per parent.
 * - `{count: {min: n}}` requires at least `n` children per parent.
 * - `{count: {max: n}}` requires at most `n` children per parent
 * - `{duration: {min: d}}` requires a total duration of children of at least `d`
 * - `{duration: {max: d}}` requires a total duration of children of at most `d`
 *
 * Both `count` and `duration` can be provided at the same time
 * (e.g. `{count: 2, duration: {min: Temporal.Duration.from({hours: 1})}}`).
 * Both `min` and `max` can be provided at the same time (e.g. `{count: {min: 1, max: 3}}`.
 *
 * There is no option to require an exact duration, because the implementation uses floating point comparison.
 * If you need an exact duration, you can approximate it by using a small range around the desired value.
 *
 * @param children child spans to check the existence of.
 * @param requirement what to check for in each parent span.
 */
public contains(children: Spans, requirement?: SpansContainsRequirement): Windows;
```

## Verification
I've added the usual AST node and eDSL compilation tests

## Documentation
The methods are documented. This enables a new pattern of constraint, which deserves an addition to the constraints docs; but I've been procrastinating on that because procedural constraints / scheduling is going to require a massive rework of the documentation and it would be a waste of effort.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
