### PR TITLE
Use skip-list multi-map to speed up job queue

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/JobSchedule.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/JobSchedule.java
@@ -1,15 +1,13 @@
 package gov.nasa.jpl.aerie.merlin.driver.engine;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 public final class JobSchedule<JobRef, TimeRef extends SchedulingInstant> {
   /** The scheduled time for each upcoming job. */
@@ -17,43 +15,45 @@ public final class JobSchedule<JobRef, TimeRef extends SchedulingInstant> {
 
   /** A time-ordered queue of all tasks whose resumption time is concretely known. */
   @DerivedFrom("scheduledJobs")
-  private final PriorityQueue<Pair<TimeRef, JobRef>> queue = new PriorityQueue<>(Comparator.comparing(Pair::getLeft));
+  private final ConcurrentSkipListMap<TimeRef, Set<JobRef>> queue = new ConcurrentSkipListMap<>();
 
   public void schedule(final JobRef job, final TimeRef time) {
     final var oldTime = this.scheduledJobs.put(job, time);
 
-    if (oldTime != null) this.queue.remove(Pair.of(oldTime, job));
-    this.queue.add(Pair.of(time, job));
+    if (oldTime != null) removeJobFromQueue(oldTime, job);
+
+    this.queue.compute(time, (t, jobsAtNewTime) -> {
+      if (jobsAtNewTime == null) jobsAtNewTime = new HashSet<>();
+      jobsAtNewTime.add(job);
+      return jobsAtNewTime;
+    });
   }
 
   public void unschedule(final JobRef job) {
     final var oldTime = this.scheduledJobs.remove(job);
+    if (oldTime != null) removeJobFromQueue(oldTime, job);
+  }
 
-    if (oldTime != null) this.queue.remove(Pair.of(oldTime, job));
+  private void removeJobFromQueue(TimeRef time, JobRef job) {
+    var jobsAtOldTime = this.queue.get(time);
+    jobsAtOldTime.remove(job);
+    if (jobsAtOldTime.isEmpty()) {
+      this.queue.remove(time);
+    }
   }
 
   public Batch<JobRef> extractNextJobs(final Duration maximumTime) {
     if (this.queue.isEmpty()) return new Batch<>(maximumTime, Collections.emptySet());
 
-    final var time = this.queue.peek().getKey();
+    final var time = this.queue.firstKey();
     if (time.project().longerThan(maximumTime)) {
       return new Batch<>(maximumTime, Collections.emptySet());
     }
 
     // Ready all tasks at the soonest task time.
-    final var readyJobs = new HashSet<JobRef>();
-    while (true) {
-      final var entry = this.queue.peek();
-      if (entry == null) break;
-      if (entry.getLeft().compareTo(time) > 0) break;
-
-      this.scheduledJobs.remove(entry.getRight());
-      this.queue.remove();
-
-      readyJobs.add(entry.getRight());
-    }
-
-    return new Batch<>(time.project(), readyJobs);
+    final var entry = this.queue.pollFirstEntry();
+    entry.getValue().forEach(this.scheduledJobs::remove);
+    return new Batch<>(entry.getKey().project(), entry.getValue());
   }
 
   public void clear() {

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/JobSchedule.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/JobSchedule.java
@@ -22,11 +22,7 @@ public final class JobSchedule<JobRef, TimeRef extends SchedulingInstant> {
 
     if (oldTime != null) removeJobFromQueue(oldTime, job);
 
-    this.queue.compute(time, (t, jobsAtNewTime) -> {
-      if (jobsAtNewTime == null) jobsAtNewTime = new HashSet<>();
-      jobsAtNewTime.add(job);
-      return jobsAtNewTime;
-    });
+    this.queue.computeIfAbsent(time, $ -> new HashSet<>()).add(job);
   }
 
   public void unschedule(final JobRef job) {


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Changes the data structure for job queue from a priority queue to a skip-list-based multimap. During some profiling for the Clipper model, we found that removing condition jobs from the queue in order to reprioritize them was taking significant time. To mitigate this, we use a skip-list based map to order batches, and store a set for each batch. In practice, this reduced runtime for a 1-year plan with the Clipper model from ~60 seconds to ~20 seconds.

## Verification
Both the clipper model and a toy model were run with this changes while recording the number of jobs run and the number of resource samples taken. These numbers were verified not to change because of this change.

## Documentation
N/A - purely an internal refactor

## Future work
N/A - standalone change
