### PR TITLE
Add description to `create_snapshot`

### DIFF
--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -33,3 +33,4 @@ call migrations.mark_migration_applied('27');
 call migrations.mark_migration_applied('28');
 call migrations.mark_migration_applied('29');
 call migrations.mark_migration_applied('30');
+call migrations.mark_migration_applied('31');

--- a/merlin-server/sql/merlin/functions/hasura/snapshot_functions.sql
+++ b/merlin-server/sql/merlin/functions/hasura/snapshot_functions.sql
@@ -1,5 +1,6 @@
 create table hasura_functions.create_snapshot_return_value(snapshot_id integer);
-create function hasura_functions.create_snapshot(_plan_id integer, _snapshot_name text, hasura_session json)
+-- Description must be the last parameter since it has a default value
+create function hasura_functions.create_snapshot(_plan_id integer, _snapshot_name text, hasura_session json, _description text default null)
   returns hasura_functions.create_snapshot_return_value
   volatile
   language plpgsql as $$
@@ -18,7 +19,7 @@ begin
     raise exception 'Snapshot name cannot be null.';
   end if;
 
-  select create_snapshot(_plan_id, _snapshot_name, _snapshotter) into _snapshot_id;
+  select create_snapshot(_plan_id, _snapshot_name, _description, _snapshotter) into _snapshot_id;
   return row(_snapshot_id)::hasura_functions.create_snapshot_return_value;
 end;
 $$;


### PR DESCRIPTION
* **Tickets addressed:** Closes #1160
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Adds an optional `description` field to `hasura_function.create_snapshot()` and `public.create_snapshot`.
This is **not** a breaking change, as the Hasura Function still allows for `description` to not be provided and no other code called `public.create_snapshot(integer, text, text)`

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
No tests need to be updated, as the DB tests are using the Hasura Function to create snapshots with names and user information.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs need to be updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
