### PR TITLE
[Aerie-1117]  Return compilation errors with constraints

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/ConstraintCompilationException.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/ConstraintCompilationException.java
@@ -1,7 +1,0 @@
-package gov.nasa.jpl.aerie.constraints;
-
-public class ConstraintCompilationException extends RuntimeException {
-  public ConstraintCompilationException(final String message) {
-    super(message);
-  }
-}

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -105,7 +105,7 @@ type Query {
 }
 
 type Query {
-  constraintViolations(planId: Int!, simulationDatasetId: Int): [ConstraintResult!]!
+  constraintViolations(planId: Int!, simulationDatasetId: Int): [ConstraintResponse!]!
 }
 
 type Query {
@@ -276,6 +276,12 @@ type CodeLocation {
 
 type ResourceSamplesResponse {
   resourceSamples: ResourceSamples!
+}
+
+type ConstraintResponse {
+  success: String!
+  errors: [UserCodeError!]!
+  results: [ConstraintResult!]!
 }
 
 type ConstraintResult {

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/ConstraintsTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/ConstraintsTests.java
@@ -1,6 +1,8 @@
 package gov.nasa.jpl.aerie.e2e;
 
 import com.microsoft.playwright.Playwright;
+import gov.nasa.jpl.aerie.e2e.types.ConstraintError;
+import gov.nasa.jpl.aerie.e2e.types.ConstraintResult;
 import gov.nasa.jpl.aerie.e2e.types.ExternalDataset.ProfileInput;
 import gov.nasa.jpl.aerie.e2e.types.ExternalDataset.ProfileInput.ProfileSegmentInput;
 import gov.nasa.jpl.aerie.e2e.types.ValueSchema;
@@ -100,11 +102,13 @@ public class ConstraintsTests {
   @Test
   void constraintsSucceedOneViolation() throws IOException {
     hasura.awaitSimulation(planId);
-    final var constraintsResults = hasura.checkConstraints(planId);
-    assertEquals(1, constraintsResults.size());
+    final var constraintsResponses = hasura.checkConstraints(planId);
+    assertEquals(1, constraintsResponses.size());
 
     // Check the Result
-    final var constraintResult = constraintsResults.get(0);
+    final var constraintResponse = constraintsResponses.get(0);
+    assertEquals(true,constraintResponse.success());
+    final ConstraintResult constraintResult = constraintResponse.result();
     assertEquals(constraintId, constraintResult.constraintId());
     assertEquals(constraintName, constraintResult.constraintName());
 
@@ -155,7 +159,9 @@ public class ConstraintsTests {
 
     // Check results
     assertTrue(cachedRun.results().isPresent());
-    assertEquals(constraintRuns.get(0), cachedRun.results().get());
+    final var constraintResponse = constraintRuns.get(0);
+    assertEquals(true,constraintResponse.success());
+    assertEquals(constraintResponse.result(), cachedRun.results().get());
   }
 
   @Test
@@ -217,11 +223,13 @@ public class ConstraintsTests {
         "0h",
         Json.createObjectBuilder().add("duration", thirtyFiveDays).build());
     hasura.awaitSimulation(planId);
-    final var constraintResults = hasura.checkConstraints(planId);
-    assertEquals(1, constraintResults.size());
+    final var constraintsResponses = hasura.checkConstraints(planId);
+    assertEquals(1, constraintsResponses.size());
 
     // Check the Result
-    final var constraintResult = constraintResults.get(0);
+    final var constraintResponse = constraintsResponses.get(0);
+    assertEquals(true,constraintResponse.success());
+    final var constraintResult = constraintResponse.result();
     assertEquals(constraintId, constraintResult.constraintId());
     assertEquals(constraintName, constraintResult.constraintName());
 
@@ -253,11 +261,14 @@ public class ConstraintsTests {
     assertEquals(0, newConstraintResults.size());
 
     // Expect one violation on the old simulation
-    final var oldConstraintResults = hasura.checkConstraints(planId, oldSimDatasetId);
-    assertEquals(1, oldConstraintResults.size());
+    final var oldConstraintsResponses = hasura.checkConstraints(planId, oldSimDatasetId);
+    assertEquals(1, oldConstraintsResponses.size());
 
     // Check the Result
-    final var constraintResult = oldConstraintResults.get(0);
+    final var oldConstraintResponse = oldConstraintsResponses.get(0);
+    assertEquals(true,oldConstraintResponse.success());
+    final var constraintResult = oldConstraintResponse.result();
+
     assertEquals(constraintId, constraintResult.constraintId());
     assertEquals(constraintName, constraintResult.constraintName());
 
@@ -338,12 +349,15 @@ public class ConstraintsTests {
       // Constraint Results w/o SimDatasetId
       final var noDatasetResults = hasura.checkConstraints(planId);
       assertEquals(1, noDatasetResults.size());
-      final var ndRecord = noDatasetResults.get(0);
+      assertEquals(true,  noDatasetResults.get(0).success());
+
+      final var ndRecord = noDatasetResults.get(0).result();
 
       // Constraint Results w/ SimDatasetId
       final var withDatasetResults = hasura.checkConstraints(planId, simDatasetId);
       assertEquals(1, withDatasetResults.size());
-      final var wdRecord = withDatasetResults.get(0);
+      assertEquals(true,  withDatasetResults.get(0).success());
+      final var wdRecord = withDatasetResults.get(0).result();
 
       // The results should be the same
       assertEquals(ndRecord, wdRecord);
@@ -390,9 +404,12 @@ public class ConstraintsTests {
       hasura.deleteActivity(planId, activityId);
       hasura.awaitSimulation(planId);
       // Check constraints against the old simID (the one with the external dataset)
-      final var constraintRuns = hasura.checkConstraints(planId, simDatasetId);
-      assertEquals(1, constraintRuns.size());
-      final var record = constraintRuns.get(0);
+      final var constraintResponses = hasura.checkConstraints(planId, simDatasetId);
+      assertEquals(1, constraintResponses.size());
+
+      final var constraintResponse = constraintResponses.get(0);
+      assertEquals(true,constraintResponse.success());
+      final var record = constraintResponse.result();
 
       // Check the Result
       assertEquals(constraintName, record.constraintName());
@@ -437,14 +454,13 @@ public class ConstraintsTests {
       final int newSimDatasetId = hasura.awaitSimulation(planId).simDatasetId();
       // This test causes the endpoint to throw an exception when it fails to compile the constraint,
       // as it cannot find the external dataset resource in the set of known resource types.
-      // "input mismatch exception" is the return msg for this error
-      final var exception = assertThrows(RuntimeException.class, () -> hasura.checkConstraints(planId, newSimDatasetId));
-      final var message = exception.getMessage().split("\"message\":\"")[1].split("\"}]")[0];
-      // Hasura strips the cause message ("Constraint compilation failed -- Error[errors=[UserCodeError[ $ERROR ]]]")
-      // from the error it returns
-      if (!message.equals("constraint compilation exception")) {
-        throw exception;
-      }
+      final var constraintResponses = hasura.checkConstraints(planId);
+      assertEquals(1,constraintResponses.size());
+      final var constraintRepsonse = constraintResponses.get(0);
+      assertEquals(false,constraintRepsonse.success());
+      assertEquals(1,constraintRepsonse.errors().size());
+      final ConstraintError error = constraintRepsonse.errors().get(0);
+      assertEquals("Constraint 'fruit_equal_peel': TypeError: TS2345 Argument of type '\"/my_boolean\"' is not assignable to parameter of type 'ResourceName'.",error.message());
     }
 
     @Test
@@ -456,12 +472,14 @@ public class ConstraintsTests {
 
       // The constraint run is expected to fail with the following message because the constraint
       // DSL isn't being generated for datasets that are outdated.
-      final var exception = assertThrows(RuntimeException.class, () -> hasura.checkConstraints(planId));
-      final var message = exception.getMessage().split("\"message\":\"")[1].split("\"}]")[0];
+      final var constraintResponses = hasura.checkConstraints(planId);
+      assertEquals(1,constraintResponses.size());
+      final var constraintRepsonse = constraintResponses.get(0);
+      assertEquals(false,constraintRepsonse.success());
+      assertEquals(1,constraintRepsonse.errors().size());
+      final ConstraintError error = constraintRepsonse.errors().get(0);
+      assertEquals("Constraint 'fruit_equal_peel': TypeError: TS2345 Argument of type '\"/my_boolean\"' is not assignable to parameter of type 'ResourceName'.",error.message());
 
-      if (!message.equals("constraint compilation exception")) {
-        throw exception;
-      }
     }
   }
 }

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/CachedConstraintRun.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/CachedConstraintRun.java
@@ -8,7 +8,7 @@ public record CachedConstraintRun(
       int simDatasetId,
       String constraintDefinition,
       boolean definitionOutdated,
-      Optional<ConstraintRecord> results
+      Optional<ConstraintResult> results
   ) {
   public static CachedConstraintRun fromJSON(JsonObject json) {
     return new CachedConstraintRun(
@@ -18,7 +18,7 @@ public record CachedConstraintRun(
         json.getBoolean("definition_outdated"),
         json.getJsonObject("results").isEmpty() ?
             Optional.empty() :
-            Optional.of(ConstraintRecord.fromJSON(json.getJsonObject("results")))
+            Optional.of(ConstraintResult.fromJSON(json.getJsonObject("results")))
     );
   }
 }

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ConstraintError.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ConstraintError.java
@@ -1,0 +1,15 @@
+package gov.nasa.jpl.aerie.e2e.types;
+
+import javax.json.JsonObject;
+
+public record ConstraintError(String message, String stack, Location location ){
+  record Location(int column, int line){
+    public static Location fromJSON(JsonObject json){
+      return new Location(json.getJsonNumber("column").intValue(), json.getJsonNumber("line").intValue());
+    }
+  };
+
+  public static ConstraintError fromJSON(JsonObject json){
+    return new ConstraintError(json.getString("message"),json.getString("stack"),Location.fromJSON(json.getJsonObject("location")));
+  }
+};

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ConstraintRecord.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ConstraintRecord.java
@@ -6,41 +6,15 @@ import javax.json.JsonString;
 import java.util.List;
 
 public record ConstraintRecord(
-      int constraintId,
-      String constraintName,
-      String type,
-      List<String> resourceIds,
-      List<ConstraintViolation> violations,
-      List<Interval> gaps
+    boolean success,
+    ConstraintResult result,
+    List<ConstraintError> errors
+
   ) {
-  public record ConstraintViolation(List<Integer> activityInstanceIds, List<Interval> windows) {
-    public static ConstraintViolation fromJSON(JsonObject json) {
-      return new ConstraintViolation(
-          json.getJsonArray("activityInstanceIds")
-              .getValuesAs(JsonNumber::intValue),
-          json.getJsonArray("windows")
-              .getValuesAs(Interval::fromJSON));
-    }
-  }
-
-  public record Interval(long start, long end) {
-    public static Interval fromJSON(JsonObject json) {
-      return new Interval(json.getJsonNumber("start").longValue(), json.getJsonNumber("end").longValue());
-    }
-  }
-
-  public static ConstraintRecord fromJSON(JsonObject json) {
-    final var resourceIds = json.getJsonArray("resourceIds").getValuesAs(JsonString::getString);
-    final var gaps = json.getJsonArray("gaps").getValuesAs(Interval::fromJSON);
-    final var violations = json.getJsonArray("violations").getValuesAs(ConstraintViolation::fromJSON);
-
+  public static ConstraintRecord fromJSON(JsonObject json){
     return new ConstraintRecord(
-        json.getInt("constraintId"),
-        json.getString("constraintName"),
-        json.getString("type"),
-        resourceIds,
-        violations,
-        gaps
-    );
+        json.getBoolean("success"),
+        json.getJsonObject("results").isEmpty() ? null : ConstraintResult.fromJSON(json.getJsonObject("results")),
+        json.getJsonArray("errors").getValuesAs(ConstraintError::fromJSON));
   }
 }

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ConstraintResult.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ConstraintResult.java
@@ -1,0 +1,45 @@
+package gov.nasa.jpl.aerie.e2e.types;
+
+import javax.json.JsonNumber;
+import javax.json.JsonObject;
+import javax.json.JsonString;
+import java.util.List;
+
+public record ConstraintResult(int constraintId,
+                        String constraintName,
+                        String type,
+                        List<String> resourceIds,
+                        List<ConstraintResult.ConstraintViolation> violations,
+                        List<ConstraintResult.Interval> gaps){
+  public record ConstraintViolation(List<Integer> activityInstanceIds, List<Interval> windows) {
+
+    public static ConstraintViolation fromJSON(JsonObject json) {
+      return new ConstraintViolation(
+          json.getJsonArray("activityInstanceIds")
+              .getValuesAs(JsonNumber::intValue),
+          json.getJsonArray("windows")
+              .getValuesAs(Interval::fromJSON));
+    }
+  }
+
+  public record Interval(long start, long end) {
+    public static Interval fromJSON(JsonObject json) {
+      return new Interval(json.getJsonNumber("start").longValue(), json.getJsonNumber("end").longValue());
+    }
+  }
+
+  public static ConstraintResult fromJSON(JsonObject json) {
+    final var resourceIds = json.getJsonArray("resourceIds").getValuesAs(JsonString::getString);
+    final var gaps = json.getJsonArray("gaps").getValuesAs(Interval::fromJSON);
+    final var violations = json.getJsonArray("violations").getValuesAs(ConstraintViolation::fromJSON);
+
+    return new ConstraintResult(
+        json.getInt("constraintId"),
+        json.getString("constraintName"),
+        json.getString("type"),
+        resourceIds,
+        violations,
+        gaps
+    );
+  }
+};

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
@@ -28,20 +28,31 @@ public enum GQL {
   CHECK_CONSTRAINTS("""
     query checkConstraints($planId: Int!, $simulationDatasetId: Int) {
       constraintViolations(planId: $planId, simulationDatasetId: $simulationDatasetId) {
-        constraintId
-        constraintName
-        type
-        resourceIds
-        violations {
-          activityInstanceIds
-          windows {
-            start
+        success
+        results {
+          constraintId
+          constraintName
+          resourceIds
+          type
+          gaps {
             end
+            start
+          }
+          violations {
+            activityInstanceIds
+            windows {
+              end
+              start
+            }
           }
         }
-        gaps {
-          start
-          end
+        errors {
+          message
+          stack
+          location {
+            column
+            line
+          }
         }
       }
     }"""),

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/ConstraintCompilationException.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/exceptions/ConstraintCompilationException.java
@@ -1,0 +1,21 @@
+package gov.nasa.jpl.aerie.merlin.server.exceptions;
+
+import gov.nasa.jpl.aerie.merlin.server.services.ConstraintsDSLCompilationService;
+
+public class ConstraintCompilationException extends  Exception {
+  String constraintName;
+  ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Error error;
+    public ConstraintCompilationException(String constraintName, ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Error error) {
+      super("Constraint "+constraintName+" compilation failed:\n"+error.toString());
+      this.constraintName = constraintName;
+      this.error = error;
+    }
+
+  public String getConstraintName() {
+    return constraintName;
+  }
+
+  public ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Error getErrors() {
+    return error;
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -1,10 +1,10 @@
 package gov.nasa.jpl.aerie.merlin.server.http;
 
-import gov.nasa.jpl.aerie.constraints.ConstraintCompilationException;
 import gov.nasa.jpl.aerie.constraints.InputMismatchException;
 import gov.nasa.jpl.aerie.json.JsonParser;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.ConstraintCompilationException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.SimulationDatasetMismatchException;
@@ -240,6 +240,8 @@ public final class MerlinBindings implements Plugin {
       final var constraintViolations = this.constraintAction.getViolations(planId, simulationDatasetId);
 
       ctx.result(ResponseSerializers.serializeConstraintResults(constraintViolations).toString());
+    } catch (ConstraintCompilationException ex) {
+      ctx.result((ResponseSerializers.serializeConstraintCompileException(ex)).toString());
     } catch (final InvalidJsonException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     } catch (final InvalidEntityException ex) {
@@ -252,8 +254,6 @@ public final class MerlinBindings implements Plugin {
       ctx.status(404).result(ExceptionSerializers.serializeNoSuchPlanException(ex).toString());
     } catch (final InputMismatchException ex) {
       ctx.status(404).result(ResponseSerializers.serializeInputMismatchException(ex).toString());
-    } catch (final ConstraintCompilationException ex) {
-      ctx.status(404).result(ResponseSerializers.serializeConstraintCompilationException(ex).toString());
     } catch (SimulationDatasetMismatchException ex) {
       ctx.status(404).result(ResponseSerializers.serializeSimulationDatasetMismatchException(ex).toString());
     } catch (final PermissionsServiceException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintAction.java
@@ -1,6 +1,5 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
-import gov.nasa.jpl.aerie.constraints.ConstraintCompilationException;
 import gov.nasa.jpl.aerie.constraints.InputMismatchException;
 import gov.nasa.jpl.aerie.constraints.model.ActivityInstance;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
@@ -10,7 +9,9 @@ import gov.nasa.jpl.aerie.constraints.model.ConstraintResult;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.tree.Expression;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.server.exceptions.ConstraintCompilationException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.SimulationDatasetMismatchException;
+import gov.nasa.jpl.aerie.merlin.server.models.ConstraintsCompilationError;
 import gov.nasa.jpl.aerie.merlin.server.models.SimulationDatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.SimulationResultsHandle;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
@@ -49,7 +50,7 @@ public class ConstraintAction {
   }
 
   public List<ConstraintResult> getViolations(final PlanId planId, final Optional<SimulationDatasetId> simulationDatasetId)
-      throws NoSuchPlanException, MissionModelService.NoSuchMissionModelException, SimulationDatasetMismatchException {
+      throws NoSuchPlanException, MissionModelService.NoSuchMissionModelException, SimulationDatasetMismatchException , ConstraintCompilationException{
     final var plan = this.planService.getPlanForValidation(planId);
     final Optional<SimulationResultsHandle> resultsHandle$;
     final SimulationDatasetId simDatasetId;
@@ -155,6 +156,7 @@ public class ConstraintAction {
         final var constraint = entry.getValue();
         final Expression<ConstraintResult> expression;
 
+        // TODO: cache these results, @JoelCourtney is this in reference to caching the output of the DSL compilation?
         final var constraintCompilationResult = constraintsDSLCompilationService.compileConstraintsDSL(
             plan.missionModelId,
             Optional.of(planId),
@@ -165,9 +167,15 @@ public class ConstraintAction {
         if (constraintCompilationResult instanceof ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Success success) {
           expression = success.constraintExpression();
         } else if (constraintCompilationResult instanceof ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Error error) {
-          throw new ConstraintCompilationException("Constraint compilation failed: " + error);
+          throw new ConstraintCompilationException(constraint.name(),error);
         } else {
-          throw new ConstraintCompilationException("Unhandled variant of ConstraintsDSLCompilationResult: " + constraintCompilationResult);
+          throw new ConstraintCompilationException(constraint.name(),new ConstraintsDSLCompilationService.ConstraintsDSLCompilationResult.Error(new ArrayList<>(){{
+            add(new ConstraintsCompilationError.UserCodeError(
+                "Unhandled variant of ConstraintsDSLCompilationResult: " + constraintCompilationResult,
+                "",
+                new ConstraintsCompilationError.CodeLocation(0, 0),
+                ""));
+          }}));
         }
 
         final var names = new HashSet<String>();


### PR DESCRIPTION
* **Tickets addressed:** Closes #1117
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Currently, if a constraint compilation error occurs, the server swallows it, making it difficult for users to develop constraints in Aerie. This is because users cannot see why the constraint is not running or where the error is located.

This PR changes this behavior by capturing compilation errors and sending them back to the UI, which will display them in the UI console. This will allow users to quickly identify and fix compilation errors, improving their constraint development experience.

Additionally, this PR updates the Hasura action to support sending back errors or results per constraint. This will be used in a future PR to stop the Merlin server from short-circuiting and not running the full list of constraints.

We will also need to merge in the UI PR which allows the frontend to support this modified Hasura call
https://github.com/NASA-AMMOS/aerie-ui/pull/967

## Verification
Updated e2e test 

## Documentation
None

## Future work
https://github.com/NASA-AMMOS/aerie/issues/1194
