### PR TITLE
Add streamline resource framework core

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2.java
@@ -1,0 +1,133 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ErrorCatchingMonad;
+import gov.nasa.jpl.aerie.merlin.framework.CellRef;
+import gov.nasa.jpl.aerie.merlin.protocol.model.CellType;
+import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.util.List;
+import java.util.function.BinaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.ErrorCatching.failure;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.expiring;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.Labelled.labelled;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.ZERO;
+
+public final class CellRefV2 {
+  private CellRefV2() {}
+
+  /**
+   * Allocate a new resource with an explicitly given effect type and effect trait.
+   */
+  public static <D extends Dynamics<?, D>, E extends DynamicsEffect<D>> CellRef<Labelled<E>, Cell<D>> allocate(ErrorCatching<Expiring<D>> initialDynamics, EffectTrait<Labelled<E>> effectTrait) {
+    return CellRef.allocate(new Cell<>(initialDynamics), new CellType<>() {
+      @Override
+      public EffectTrait<Labelled<E>> getEffectType() {
+        return effectTrait;
+      }
+
+      @Override
+      public Cell<D> duplicate(Cell<D> cell) {
+        return new Cell<>(cell.initialDynamics, cell.dynamics, cell.elapsedTime);
+      }
+
+      @Override
+      public void apply(Cell<D> cell, Labelled<E> effect) {
+        cell.initialDynamics = effect.data().apply(cell.dynamics).match(
+            ErrorCatching::success,
+            error -> failure(new RuntimeException(
+                "Applying '%s' failed.".formatted(effect.name()), error)));
+        cell.dynamics = cell.initialDynamics;
+        cell.elapsedTime = ZERO;
+      }
+
+      @Override
+      public void step(Cell<D> cell, Duration duration) {
+        // Avoid accumulated round-off error in imperfect stepping
+        // by always stepping up from the initial dynamics
+        cell.elapsedTime = cell.elapsedTime.plus(duration);
+        cell.dynamics = ErrorCatchingMonad.map(cell.initialDynamics, d ->
+            expiring(d.data().step(cell.elapsedTime), d.expiry().minus(cell.elapsedTime)));
+      }
+    });
+  }
+
+  public static <D extends Dynamics<?, D>> EffectTrait<Labelled<DynamicsEffect<D>>> noncommutingEffects() {
+    return resolvingConcurrencyBy((left, right) -> x -> {
+          throw new UnsupportedOperationException(
+              "Concurrent effects are not supported on this resource.");
+        });
+  }
+
+  public static <D extends Dynamics<?, D>> EffectTrait<Labelled<DynamicsEffect<D>>> commutingEffects() {
+    return resolvingConcurrencyBy((left, right) -> x -> right.apply(left.apply(x)));
+  }
+
+  public static <D extends Dynamics<?, D>> EffectTrait<Labelled<DynamicsEffect<D>>> autoEffects() {
+    return resolvingConcurrencyBy((left, right) -> x -> {
+      final var lrx = left.apply(right.apply(x));
+      final var rlx = right.apply(left.apply(x));
+      if (lrx.equals(rlx)) {
+        return lrx;
+      } else {
+        throw new UnsupportedOperationException(
+            "Detected non-commuting concurrent effects!");
+      }
+    });
+  }
+
+  public static <D extends Dynamics<?, D>> EffectTrait<Labelled<DynamicsEffect<D>>> resolvingConcurrencyBy(BinaryOperator<DynamicsEffect<D>> combineConcurrent) {
+    return new EffectTrait<>() {
+      @Override
+      public Labelled<DynamicsEffect<D>> empty() {
+        return labelled("No-op", x -> x);
+      }
+
+      @Override
+      public Labelled<DynamicsEffect<D>> sequentially(final Labelled<DynamicsEffect<D>> prefix, final Labelled<DynamicsEffect<D>> suffix) {
+        return new Labelled<>(
+            x -> suffix.data().apply(prefix.data().apply(x)),
+            "(%s) then (%s)".formatted(prefix.name(), suffix.name()));
+      }
+
+      @Override
+      public Labelled<DynamicsEffect<D>> concurrently(final Labelled<DynamicsEffect<D>> left, final Labelled<DynamicsEffect<D>> right) {
+        try {
+          final DynamicsEffect<D> combined = combineConcurrent.apply(left.data(), right.data());
+          return new Labelled<>(
+              x -> {
+                try {
+                  return combined.apply(x);
+                } catch (Exception e) {
+                  return failure(e);
+                }
+              },
+              "(%s) and (%s)".formatted(left.name(), right.name()));
+        } catch (Throwable e) {
+          return new Labelled<>(
+              $ -> failure(e),
+              "Failed to combine concurrent effects: (%s) and (%s)".formatted(left.name(), right.name()));
+        }
+      }
+    };
+  }
+
+  public static class Cell<D> {
+    public ErrorCatching<Expiring<D>> initialDynamics;
+    public ErrorCatching<Expiring<D>> dynamics;
+    public Duration elapsedTime;
+
+    public Cell(ErrorCatching<Expiring<D>> dynamics) {
+      this(dynamics, dynamics, ZERO);
+    }
+
+    public Cell(ErrorCatching<Expiring<D>> initialDynamics, ErrorCatching<Expiring<D>> dynamics, Duration elapsedTime) {
+      this.initialDynamics = initialDynamics;
+      this.dynamics = dynamics;
+      this.elapsedTime = elapsedTime;
+    }
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellResource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellResource.java
@@ -1,0 +1,131 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.monads.DynamicsMonad;
+import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ErrorCatchingMonad;
+import gov.nasa.jpl.aerie.contrib.streamline.debugging.Context;
+import gov.nasa.jpl.aerie.merlin.framework.CellRef;
+import gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.Cell;
+import gov.nasa.jpl.aerie.merlin.framework.Scoped;
+import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.allocate;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.autoEffects;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.Labelled.labelled;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.DynamicsMonad.unit;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Unit.UNIT;
+import static java.util.stream.Collectors.joining;
+
+/**
+ * Resource which is backed directly by a cell.
+ * Effects can be applied to this resource.
+ * Effect names are augmented with this resource's name(s).
+ */
+public interface CellResource<D extends Dynamics<?, D>> extends Resource<D> {
+  void emit(Labelled<DynamicsEffect<D>> effect);
+  default void emit(String effectName, DynamicsEffect<D> effect) {
+    emit(labelled(effectName, effect));
+  }
+  default void emit(DynamicsEffect<D> effect) {
+    emit("anonymous effect", effect);
+  }
+
+  static <D extends Dynamics<?, D>> CellResource<D> cellResource(D initial) {
+    return cellResource(unit(initial));
+  }
+
+  static <D extends Dynamics<?, D>> CellResource<D> cellResource(D initial, EffectTrait<Labelled<DynamicsEffect<D>>> effectTrait) {
+    return cellResource(unit(initial), effectTrait);
+  }
+
+  static <D extends Dynamics<?, D>> CellResource<D> cellResource(ErrorCatching<Expiring<D>> initial) {
+    return cellResource(initial, autoEffects());
+  }
+
+  static <D extends Dynamics<?, D>> CellResource<D> cellResource(ErrorCatching<Expiring<D>> initial, EffectTrait<Labelled<DynamicsEffect<D>>> effectTrait) {
+    return new CellResource<>() {
+      // Use autoEffects for a generic CellResource, on the theory that most resources
+      // have relatively few effects, and even fewer concurrent effects, so this is performant enough.
+      // If that doesn't hold, a more specialized solution can be constructed directly.
+      private final CellRef<Labelled<DynamicsEffect<D>>, Cell<D>> cell = allocate(initial, effectTrait);
+      private final List<String> names = new LinkedList<>();
+
+      @Override
+      public void emit(final Labelled<DynamicsEffect<D>> effect) {
+        cell.emit(labelled(augmentEffectName(effect.name()), effect.data()));
+      }
+
+      @Override
+      public ErrorCatching<Expiring<D>> getDynamics() {
+        return cell.get().dynamics;
+      }
+
+      @Override
+      public void registerName(final String name) {
+        names.add(name);
+      }
+
+      private String augmentEffectName(String effectName) {
+        var resourceName = switch (names.size()) {
+          case 0 -> "anonymous resource";
+          case 1 -> names.get(0);
+          default -> names.get(0) + " (aka. %s)".formatted(String.join(", ", names.subList(1, names.size())));
+        };
+        return effectName + " on " + resourceName + Context.get().stream().map(c -> " during " + c).collect(joining());
+      }
+    };
+  }
+
+  static <D extends Dynamics<?, D>> CellResource<D> staticallyCreated(Supplier<CellResource<D>> constructor) {
+    return new CellResource<>() {
+      private CellResource<D> delegate = constructor.get();
+
+      @Override
+      public void emit(final Labelled<DynamicsEffect<D>> effect) {
+        actOnCell(() -> delegate.emit(effect));
+      }
+
+      @Override
+      public ErrorCatching<Expiring<D>> getDynamics() {
+        // Keep the field access using () -> ... form, don't simplify to delegate::getDynamics
+        // Simplifying will access delegate before calling actOnCell, failing if we need to re-allocate delegate.
+        return actOnCell(() -> delegate.getDynamics());
+      }
+
+      @Override
+      public void registerName(final String name) {
+        delegate.registerName(name);
+      }
+
+      private void actOnCell(Runnable action) {
+        actOnCell(() -> {
+          action.run();
+          return UNIT;
+        });
+      }
+
+      private <R> R actOnCell(Supplier<R> action) {
+        try {
+          return action.get();
+        } catch (Scoped.EmptyDynamicCellException | IllegalArgumentException e) {
+          // If we're running unit tests, several simulations can happen without reloading the Resources class.
+          // In that case, we'll have discarded the clock resource we were using, and get the above exception.
+          // REVIEW: Is there a cleaner way to make sure this resource gets (re-)initialized?
+          delegate = constructor.get();
+          return action.get();
+        }
+      }
+    };
+  }
+
+  static <D extends Dynamics<?, D>> void set(CellResource<D> resource, D newDynamics) {
+    resource.emit("Set " + newDynamics, DynamicsMonad.effect(x -> newDynamics));
+  }
+
+  static <D extends Dynamics<?, D>> void set(CellResource<D> resource, Expiring<D> newDynamics) {
+    resource.emit("Set " + newDynamics, ErrorCatchingMonad.<Expiring<D>, Expiring<D>>lift($ -> newDynamics)::apply);
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Dynamics.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Dynamics.java
@@ -1,0 +1,9 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+public interface Dynamics<V, D extends Dynamics<V, D>> {
+    V extract();
+
+    D step(Duration t);
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/DynamicsEffect.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/DynamicsEffect.java
@@ -1,0 +1,5 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core;
+
+public interface DynamicsEffect<D extends Dynamics<?, D>> {
+    ErrorCatching<Expiring<D>> apply(ErrorCatching<Expiring<D>> dynamics);
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/ErrorCatching.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/ErrorCatching.java
@@ -1,0 +1,43 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ErrorCatchingMonad;
+
+import java.util.function.Function;
+
+public sealed interface ErrorCatching<T> {
+  <R> R match(Function<T, R> onSuccess, Function<Throwable, R> onError);
+
+  static <T> ErrorCatching<T> success(T result) {
+    return new Success<>(result);
+  }
+
+  static <T> ErrorCatching<T> failure(Throwable exception) {
+    return new Failure<>(exception);
+  }
+
+  default <R> ErrorCatching<R> map(Function<T, R> f) {
+    return ErrorCatchingMonad.map(this, f);
+  }
+
+  default T getOrThrow() {
+    return match(
+        Function.identity(),
+        e -> {
+          throw new RuntimeException(e);
+        });
+  }
+
+  record Success<T>(T result) implements ErrorCatching<T> {
+    @Override
+    public <R> R match(final Function<T, R> onSuccess, final Function<Throwable, R> onError) {
+      return onSuccess.apply(result);
+    }
+  }
+
+  record Failure<T>(Throwable exception) implements ErrorCatching<T> {
+    @Override
+    public <R> R match(final Function<T, R> onSuccess, final Function<Throwable, R> onError) {
+      return onError.apply(exception);
+    }
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Expiring.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Expiring.java
@@ -1,0 +1,19 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiry.NEVER;
+
+public record Expiring<D>(D data, Expiry expiry) {
+  public static <D> Expiring<D> expiring(D data, Expiry expiry) {
+    return new Expiring<>(data, expiry);
+  }
+
+  public static <D> Expiring<D> neverExpiring(D data) {
+    return expiring(data, NEVER);
+  }
+
+  public static <D> Expiring<D> expiring(D data, Duration expiry) {
+    return expiring(data, Expiry.at(expiry));
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Expiry.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Expiry.java
@@ -1,0 +1,68 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public record Expiry(Optional<Duration> value) {
+  public static Expiry NEVER = expiry(Optional.empty());
+
+  public static Expiry at(Duration t) {
+    return expiry(Optional.of(t));
+  }
+
+  public static Expiry expiry(Optional<Duration> value) {
+    return new Expiry(value);
+  }
+
+  public Expiry or(Expiry other) {
+    return expiry(
+        Stream.concat(value().stream(), other.value().stream()).reduce(Duration::min));
+  }
+
+  public Expiry minus(Duration t) {
+    return expiry(value().map(v -> v.minus(t)));
+  }
+
+  public boolean isNever() {
+    return value().isEmpty();
+  }
+
+  public int compareTo(Expiry other) {
+    if (this.isNever()) {
+      if (other.isNever()) {
+        return 0;
+      } else {
+        return 1;
+      }
+    } else {
+      if (other.isNever()) {
+        return -1;
+      } else {
+        return this.value().get().compareTo(other.value().get());
+      }
+    }
+  }
+
+  public boolean shorterThan(Expiry other) {
+    return this.compareTo(other) < 0;
+  }
+
+  public boolean noShorterThan(Expiry other) {
+    return this.compareTo(other) >= 0;
+  }
+
+  public boolean longerThan(Expiry other) {
+    return this.compareTo(other) > 0;
+  }
+
+  public boolean noLongerThan(Expiry other) {
+    return this.compareTo(other) <= 0;
+  }
+
+  @Override
+  public String toString() {
+    return value.map(Duration::toString).orElse("NEVER");
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Labelled.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Labelled.java
@@ -1,0 +1,25 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core;
+
+import java.util.Objects;
+
+/**
+ * Attaches name and context to a datum.
+ */
+public record Labelled<V>(V data, String name) {
+  public static <V> Labelled<V> labelled(String name, V data) {
+    return new Labelled<>(data, name);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Labelled<?> labelled = (Labelled<?>) o;
+    return Objects.equals(data, labelled.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data);
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Reactions.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Reactions.java
@@ -1,0 +1,55 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core;
+
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
+import gov.nasa.jpl.aerie.merlin.framework.Condition;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.dynamicsChange;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.when;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.replaying;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.spawn;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.waitUntil;
+
+public final class Reactions {
+  private Reactions() {}
+
+  public static void whenever(Resource<Discrete<Boolean>> conditionResource, Runnable action) {
+    whenever(when(conditionResource), action);
+  }
+
+  public static void whenever(Condition condition, Runnable action) {
+    whenever(() -> condition, action);
+  }
+
+  public static void whenever(Supplier<Condition> trigger, Runnable action) {
+    final Condition condition = trigger.get();
+    // Use replaying tasks to avoid threading overhead.
+    spawn(replaying(() -> {
+      waitUntil(condition);
+      action.run();
+      // Trampoline off this task to avoid replaying.
+      whenever(trigger, action);
+    }));
+  }
+
+  // Special case for dynamicsChange condition, since it's non-obvious that this needs to be run in lambda form
+  public static <D extends Dynamics<?, D>> void wheneverDynamicsChange(Resource<D> resource, Consumer<ErrorCatching<Expiring<D>>> reaction) {
+    whenever(() -> dynamicsChange(resource), () -> reaction.accept(resource.getDynamics()));
+  }
+
+  public static void every(Duration period, Runnable action) {
+    every(() -> period, action);
+  }
+
+  public static void every(Supplier<Duration> periodSupplier, Runnable action) {
+    spawn(replaying(() -> {
+      delay(periodSupplier.get());
+      action.run();
+      every(periodSupplier, action);
+    }));
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Resource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Resource.java
@@ -1,0 +1,8 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core;
+
+public interface Resource<D> {
+  ErrorCatching<Expiring<D>> getDynamics();
+
+  // By default, resources don't track their names
+  default void registerName(String name) {}
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Resources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Resources.java
@@ -1,0 +1,96 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core;
+
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock;
+import gov.nasa.jpl.aerie.merlin.framework.Condition;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.util.List;
+import java.util.Optional;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.CellResource.cellResource;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.CellResource.staticallyCreated;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock.clock;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.ZERO;
+
+/**
+ * Utility methods for {@link Resource}s.
+ */
+public final class Resources {
+  private Resources() {}
+
+  /**
+   * Ensure that Resources are initialized.
+   *
+   * <p>
+   *   This method needs to be called during simulation initialization.
+   *   This method is idempotent; calling it multiple times is the same as calling it once.
+   * </p>
+   */
+  public static void init() {
+    currentTime();
+  }
+
+  private static final Resource<Clock> CLOCK = staticallyCreated(() -> cellResource(clock(ZERO)));
+  public static Duration currentTime() {
+    return currentValue(CLOCK);
+  }
+
+  public static <D> D currentData(Resource<D> resource) {
+    return resource.getDynamics().getOrThrow().data();
+  }
+
+  public static <D> D currentData(Resource<D> resource, D dynamicsIfError) {
+    return resource.getDynamics().match(Expiring::data, error -> dynamicsIfError);
+  }
+
+  public static <V, D extends Dynamics<V, D>> V currentValue(Resource<D> resource) {
+    return currentData(resource).extract();
+  }
+
+  public static <V, D extends Dynamics<V, D>> V currentValue(Resource<D> resource, V valueIfError) {
+    return resource.getDynamics().match(result -> result.data().extract(), error -> valueIfError);
+  }
+
+  public static <D extends Dynamics<?, D>> Condition dynamicsChange(Resource<D> resource) {
+    final var startingDynamics = resource.getDynamics();
+    final Duration startTime = currentTime();
+    return (positive, atEarliest, atLatest) -> {
+      var currentDynamics = resource.getDynamics();
+      boolean haveChanged = startingDynamics.match(
+          start -> currentDynamics.match(
+              current -> !current.data().equals(start.data().step(currentTime().minus(startTime))),
+              ignored -> true),
+          startException -> currentDynamics.match(
+              ignored -> true,
+              // Use semantic comparison for exceptions, since derivation can generate the exception each invocation.
+              currentException -> !equivalentExceptions(startException, currentException)));
+
+      return positive == haveChanged
+          ? Optional.of(atEarliest)
+          : positive
+            ? currentDynamics.match(
+                expiring -> expiring.expiry().value().filter(atLatest::noShorterThan),
+                exception -> Optional.empty())
+            : Optional.empty();
+    };
+  }
+
+  // TODO: Should this be moved somewhere else?
+  /**
+   * Tests if two exceptions are equivalent from the point of view of resource values.
+   * Two exceptions are equivalent if they have the same type and message.
+   */
+  public static boolean equivalentExceptions(Throwable startException, Throwable currentException) {
+    return startException.getClass().equals(currentException.getClass())
+           && startException.getMessage().equals(currentException.getMessage());
+  }
+
+  public static <D extends Dynamics<?, D>> Condition dynamicsChange(List<Resource<D>> resources) {
+    assert resources.size() > 0;
+    var result = dynamicsChange(resources.get(0));
+    for (Resource<D> r : resources) {
+      result = result.or(dynamicsChange(r));
+    }
+    return result;
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/DynamicsMonad.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/DynamicsMonad.java
@@ -1,0 +1,45 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core.monads;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
+import gov.nasa.jpl.aerie.contrib.streamline.core.DynamicsEffect;
+import gov.nasa.jpl.aerie.contrib.streamline.core.ErrorCatching;
+import gov.nasa.jpl.aerie.contrib.streamline.core.Expiring;
+
+import java.util.function.Function;
+
+public final class DynamicsMonad {
+  private DynamicsMonad() {}
+
+  public static <A> ErrorCatching<Expiring<A>> unit(A a) {
+    return ExpiringMonadTransformer.unit(ErrorCatchingMonad::unit, a);
+  }
+
+  public static <A, B> ErrorCatching<Expiring<B>> bind(ErrorCatching<Expiring<A>> a, Function<A, ErrorCatching<Expiring<B>>> f) {
+    return ExpiringMonadTransformer.<A, ErrorCatching<Expiring<A>>, B, ErrorCatching<Expiring<B>>>bind(
+        ErrorCatchingMonad::unit,
+        ErrorCatchingMonad::bind,
+        ErrorCatchingMonad::bind,
+        a,
+        f);
+  }
+
+  // Convenient methods defined in terms of bind and unit:
+
+  public static <A, B> ErrorCatching<Expiring<B>> map(ErrorCatching<Expiring<A>> a, Function<A, B> f) {
+    return bind(a, f.andThen(DynamicsMonad::unit));
+  }
+
+  public static <A, B> Function<ErrorCatching<Expiring<A>>, ErrorCatching<Expiring<B>>> lift(Function<A, B> f) {
+    return a -> map(a, f);
+  }
+
+  // Not fully monadic since we intentionally ignore expiry information, but useful nonetheless.
+
+  public static <A extends Dynamics<?, A>> DynamicsEffect<A> effect(Function<A, A> f) {
+    return bindEffect(f.andThen(DynamicsMonad::unit));
+  }
+
+  public static <A extends Dynamics<?, A>> DynamicsEffect<A> bindEffect(Function<A, ErrorCatching<Expiring<A>>> f) {
+    return ea -> ErrorCatchingMonad.bind(ea, a -> f.apply(a.data()));
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ErrorCatchingMonad.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ErrorCatchingMonad.java
@@ -1,0 +1,31 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core.monads;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.ErrorCatching;
+
+import java.util.function.Function;
+
+public final class ErrorCatchingMonad {
+  private ErrorCatchingMonad() {}
+
+  public static <A> ErrorCatching<A> unit(A a) {
+    return ErrorCatchingMonadTransformer.unit(IdentityMonad::unit, a);
+  }
+
+  public static <A, B> ErrorCatching<B> bind(ErrorCatching<A> a, Function<A, ErrorCatching<B>> f) {
+    return ErrorCatchingMonadTransformer.<A, ErrorCatching<A>, B, ErrorCatching<B>>bind(
+        IdentityMonad::unit,
+        IdentityMonad::bind,
+        a,
+        f);
+  }
+
+  // Convenient methods defined in terms of bind and unit:
+
+  public static <A, B> ErrorCatching<B> map(ErrorCatching<A> a, Function<A, B> f) {
+    return bind(a, f.andThen(ErrorCatchingMonad::unit));
+  }
+
+  public static <A, B> Function<ErrorCatching<A>, ErrorCatching<B>> lift(Function<A, B> f) {
+    return a -> map(a, f);
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ErrorCatchingMonadTransformer.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ErrorCatchingMonadTransformer.java
@@ -1,0 +1,41 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core.monads;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.ErrorCatching;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.ErrorCatching.*;
+
+/**
+ * Monad transformer for {@link ErrorCatching}, M A -> M {@link ErrorCatching}&lt;A&gt;
+ *
+ * <p>
+ *   Bind for this operation does two jobs:
+ *   First, if a computation fails by throwing an exception, that exception is caught so as not to crash the simulation.
+ *   Second, if a prior computation failed, the exception is passed through and further computations are skipped.
+ * </p>
+ */
+public final class ErrorCatchingMonadTransformer {
+  private ErrorCatchingMonadTransformer() {}
+
+  public static <A, MEA> MEA unit(Function<ErrorCatching<A>, MEA> mUnit, A a) {
+    return mUnit.apply(success(a));
+  }
+
+  public static <A, MEA, B, MEB> MEB bind(
+      Function<ErrorCatching<B>, MEB> mUnit,
+      BiFunction<MEA, Function<ErrorCatching<A>, MEB>, MEB> mBind,
+      MEA mea,
+      Function<A, MEB> f) {
+    return mBind.apply(mea, eb -> eb.match(
+        a -> {
+          try {
+            return f.apply(a);
+          } catch (Throwable e) {
+            return mUnit.apply(failure(e));
+          }
+        },
+        e -> mUnit.apply(failure(e))));
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ErrorCatchingToResourceMonad.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ErrorCatchingToResourceMonad.java
@@ -1,0 +1,21 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core.monads;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.ErrorCatching;
+import gov.nasa.jpl.aerie.contrib.streamline.core.Expiring;
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
+
+import java.util.function.Function;
+
+public final class ErrorCatchingToResourceMonad {
+  private ErrorCatchingToResourceMonad() {}
+
+  public static <A> Resource<A> unit(ErrorCatching<Expiring<A>> a) {
+    return () -> a;
+  }
+
+  public static <A, B> Resource<B> bind(
+      Resource<A> a,
+      Function<ErrorCatching<Expiring<A>>, Resource<B>> f) {
+    return () -> f.apply(a.getDynamics()).getDynamics();
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ExpiringMonad.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ExpiringMonad.java
@@ -1,0 +1,37 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core.monads;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Expiring;
+
+import java.util.function.Function;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.expiring;
+
+/**
+ * The {@link Expiring} monad, which demands derived values expire no later than their sources.
+ */
+public final class ExpiringMonad {
+  private ExpiringMonad() {}
+
+  public static <A> Expiring<A> unit(A data) {
+    return ExpiringMonadTransformer.unit(IdentityMonad::unit, data);
+  }
+
+  public static <A, B> Expiring<B> bind(Expiring<A> a, Function<A, Expiring<B>> f) {
+    return ExpiringMonadTransformer.<A, Expiring<A>, B, Expiring<B>>bind(
+        IdentityMonad::unit,
+        IdentityMonad::bind,
+        IdentityMonad::bind,
+        a,
+        f);
+  }
+
+  // Convenient methods defined in terms of bind and unit:
+
+  public static <A, B> Expiring<B> map(Expiring<A> a, Function<A, B> f) {
+    return bind(a, f.andThen(ExpiringMonad::unit));
+  }
+
+  public static <A, B> Function<Expiring<A>, Expiring<B>> lift(Function<A, B> f) {
+    return a -> map(a, f);
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ExpiringMonadTransformer.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ExpiringMonadTransformer.java
@@ -1,0 +1,35 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core.monads;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Expiring;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.*;
+
+/**
+ * Monad transformer for {@link Expiring}, M A -> M {@link Expiring}&lt;A&gt;
+ *
+ * <p>
+ *   Bind for this monad ensures that results expire no later than the values they're derived from.
+ * </p>
+ */
+public final class ExpiringMonadTransformer {
+  private ExpiringMonadTransformer() {}
+
+  public static <A, MEA> MEA unit(Function<Expiring<A>, MEA> mUnit, A a) {
+    return mUnit.apply(neverExpiring(a));
+  }
+
+  public static <A, MEA, B, MEB> MEB bind(
+      Function<Expiring<B>, MEB> mUnit,
+      BiFunction<MEA, Function<Expiring<A>, MEB>, MEB> mBind1,
+      BiFunction<MEB, Function<Expiring<B>, MEB>, MEB> mBind2,
+      MEA mea,
+      Function<A, MEB> f) {
+    // TODO: for performance, this could take mMap instead of mUnit and mBind2
+    return mBind1.apply(mea, ea ->
+        mBind2.apply(f.apply(ea.data()), eb ->
+            mUnit.apply(expiring(eb.data(), ea.expiry().or(eb.expiry())))));
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ExpiringToResourceMonad.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ExpiringToResourceMonad.java
@@ -1,0 +1,28 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core.monads;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Expiring;
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
+
+import java.util.function.Function;
+
+public final class ExpiringToResourceMonad {
+  private ExpiringToResourceMonad() {}
+
+  public static <A> Resource<A> unit(Expiring<A> a) {
+    return ErrorCatchingMonadTransformer.unit(ErrorCatchingToResourceMonad::unit, a);
+  }
+
+  public static <A, B> Resource<B> bind(Resource<A> a, Function<Expiring<A>, Resource<B>> f) {
+    return ErrorCatchingMonadTransformer.<Expiring<A>, Resource<A>, Expiring<B>, Resource<B>>bind(
+        ErrorCatchingToResourceMonad::unit,
+        ErrorCatchingToResourceMonad::bind,
+        a,
+        f);
+  }
+
+  // Convenient methods defined in terms of bind and unit:
+
+  public static <A, B> Resource<B> map(Resource<A> a, Function<Expiring<A>, Expiring<B>> f) {
+    return bind(a, f.andThen(ExpiringToResourceMonad::unit));
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/IdentityMonad.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/IdentityMonad.java
@@ -1,0 +1,18 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core.monads;
+
+import java.util.function.Function;
+
+/**
+ * The trivial monad A -> A
+ */
+public final class IdentityMonad {
+  private IdentityMonad() {}
+
+  public static <A> A unit(A a) {
+                                return a;
+                                         }
+
+  public static <A, B> B bind(A a, Function<A, B> f) {
+                                                     return f.apply(a);
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ResourceMonad.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/monads/ResourceMonad.java
@@ -1,0 +1,59 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core.monads;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
+import org.apache.commons.lang3.function.TriFunction;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Monad A -> Resource&lt;A&gt;.
+ * This is the primary monad for model authors,
+ * handling both expiry and "stitching together" of derived resources.
+ */
+public final class ResourceMonad {
+  private ResourceMonad() {}
+
+  public static <A> Resource<A> unit(A a) {
+    return ExpiringMonadTransformer.unit(ExpiringToResourceMonad::unit, a);
+  }
+
+  public static <A, B> Resource<B> bind(Resource<A> a, Function<A, Resource<B>> f) {
+    return ExpiringMonadTransformer.<A, Resource<A>, B, Resource<B>>bind(
+        ExpiringToResourceMonad::unit,
+        ExpiringToResourceMonad::bind,
+        ExpiringToResourceMonad::bind,
+        a,
+        f);
+  }
+
+  // Convenient methods defined in terms of bind and unit:
+
+  public static <A, B> Resource<B> map(Resource<A> a, Function<A, B> f) {
+    return bind(a, f.andThen(ResourceMonad::unit));
+  }
+
+  public static <A, B, C> Resource<C> map(Resource<A> a, Resource<B> b, BiFunction<A, B, C> f) {
+    return bind(a, a$ -> map(b, b$ -> f.apply(a$, b$)));
+  }
+
+  public static <A, B, C, D> Resource<D> map(Resource<A> a, Resource<B> b, Resource<C> c, TriFunction<A, B, C, D> f) {
+    return bind(a, a$ -> map(b, c, (b$, c$) -> f.apply(a$, b$, c$)));
+  }
+
+  public static <A, B, C> Resource<C> bind(Resource<A> a, Resource<B> b, BiFunction<A, B, Resource<C>> f) {
+    return bind(a, a$ -> bind(b, b$ -> f.apply(a$, b$)));
+  }
+
+  public static <A, B, C, D> Resource<D> bind(Resource<A> a, Resource<B> b, Resource<C> c, TriFunction<A, B, C, Resource<D>> f) {
+    return bind(a, a$ -> bind(b, c, (b$, c$) -> f.apply(a$, b$, c$)));
+  }
+
+  public static <A, B> Function<Resource<A>, Resource<B>> lift(Function<A, B> f) {
+    return a -> map(a, f);
+  }
+
+  public static <A, B, C> BiFunction<Resource<A>, Resource<B>, Resource<C>> lift(BiFunction<A, B, C> f) {
+    return (a, b) -> map(a, b, f);
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Context.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Context.java
@@ -1,0 +1,147 @@
+package gov.nasa.jpl.aerie.contrib.streamline.debugging;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Unit.UNIT;
+
+/**
+ * Thread-local scope-bound description of the current context.
+ */
+public final class Context {
+  private Context() {}
+
+  private static final ThreadLocal<Deque<String>> contexts = ThreadLocal.withInitial(ArrayDeque::new);
+
+  /**
+   * @see Context#inContext(String, Supplier)
+   */
+  public static void inContext(String contextName, Runnable action) {
+    inContext(contextName, asSupplier(action));
+  }
+
+  /**
+   * Run action in a globally-visible context.
+   * Contexts stack, and contexts are removed when control leaves action for any reason.
+   */
+  public static <R> R inContext(String contextName, Supplier<R> action) {
+    // Using a thread-local context stack maintains isolation for threaded tasks.
+    try {
+      contexts.get().push(contextName);
+      return action.get();
+      // TODO: Should we add a catch clause here that would add context to the error?
+    } finally {
+      // Doing the tear-down in a finally block maintains isolation for replaying tasks.
+      contexts.get().pop();
+    }
+  }
+
+  /**
+   * @see Context#inContext(List, Supplier)
+   */
+  public static void inContext(List<String> contextStack, Runnable action) {
+    inContext(contextStack, asSupplier(action));
+  }
+
+  /**
+   * Run action in a context stack like that returned by {@link Context#get}.
+   *
+   * <p>
+   *   This can be used to "copy" a context into another task, e.g.
+   *   <pre>
+   *     var context = Context.get();
+   *     spawn(() -> inContext(context, () -> { ... });
+   *   </pre>
+   * </p>
+   *
+   * @see Context#contextualized
+   */
+  public static <R> R inContext(List<String> contextStack, Supplier<R> action) {
+    if (contextStack.isEmpty()) {
+      return action.get();
+    } else {
+      int n = contextStack.size() - 1;
+      return inContext(contextStack.get(n), () ->
+          inContext(contextStack.subList(0, n), action));
+    }
+  }
+
+  /**
+   * @see Context#contextualized(Supplier)
+   */
+  public static Runnable contextualized(Runnable action) {
+    return contextualized(asSupplier(action))::get;
+  }
+
+  /**
+   * Adds the current context into action.
+   *
+   * <p>
+   *   This can be used to contextualize sub-tasks with their parents context:
+   *   <pre>
+   *     inContext("parent", () -> {
+   *       // Capture parent context while calling spawn:
+   *       spawn(contextualized(() -> {
+   *         // Runs child task in context "parent"
+   *       }));
+   *     });
+   *   </pre>
+   * </p>
+   *
+   * @see Context#contextualized(String, Runnable)
+   * @see Context#inContext(List, Runnable)
+   * @see Context#inContext(String, Runnable)
+   */
+  public static <R> Supplier<R> contextualized(Supplier<R> action) {
+    final var context = get();
+    return () -> inContext(context, action);
+  }
+
+  /**
+   * @see Context#contextualized(String, Supplier)
+   */
+  public static Runnable contextualized(String childContext, Runnable action) {
+    return contextualized(childContext, asSupplier(action))::get;
+  }
+
+  /**
+   * Adds the current context into action, as well as an additional child context.
+   *
+   * <p>
+   *   This can be used to contextualize sub-tasks with their parents context:
+   *   <pre>
+   *     inContext("parent", () -> {
+   *       // Capture parent context while calling spawn:
+   *       spawn(contextualized("child", () -> {
+   *         // Runs child task in context ("child", "parent")
+   *       }));
+   *     });
+   *   </pre>
+   * </p>
+   *
+   * @see Context#contextualized(Runnable)
+   * @see Context#inContext(List, Runnable)
+   * @see Context#inContext(String, Runnable)
+   */
+  public static <R> Supplier<R> contextualized(String childContext, Supplier<R> action) {
+    return contextualized(() -> inContext(childContext, action));
+  }
+
+  /**
+   * Returns the list of contexts, from innermost context out.
+   */
+  public static List<String> get() {
+    return contexts.get().stream().toList();
+  }
+
+  private static Supplier<Unit> asSupplier(Runnable action) {
+    return () -> {
+      action.run();
+      return UNIT;
+    };
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/Clock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/Clock.java
@@ -1,0 +1,15 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+public record Clock(Duration extract) implements Dynamics<Duration, Clock> {
+  @Override
+  public Clock step(Duration t) {
+    return clock(extract().plus(t));
+  }
+
+  public static Clock clock(Duration startingTime) {
+    return new Clock(startingTime);
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/Discrete.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/Discrete.java
@@ -1,0 +1,15 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+public record Discrete<V>(V extract) implements Dynamics<V, Discrete<V>> {
+  @Override
+  public Discrete<V> step(Duration t) {
+    return this;
+  }
+
+  public static <V> Discrete<V> discrete(V value) {
+    return new Discrete<>(value);
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteResources.java
@@ -1,0 +1,20 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
+import gov.nasa.jpl.aerie.merlin.framework.Condition;
+
+import java.util.Optional;
+
+public final class DiscreteResources {
+  private DiscreteResources() {}
+
+  /**
+   * Returns a condition that's satisfied whenever this resource is true.
+   */
+  public static Condition when(Resource<Discrete<Boolean>> resource) {
+    return (positive, atEarliest, atLatest) ->
+        resource.getDynamics().match(
+            dynamics -> Optional.of(atEarliest).filter($ -> dynamics.data().extract() == positive),
+            error -> Optional.empty());
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/monads/DiscreteDynamicsMonad.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/monads/DiscreteDynamicsMonad.java
@@ -1,0 +1,37 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.DynamicsEffect;
+import gov.nasa.jpl.aerie.contrib.streamline.core.ErrorCatching;
+import gov.nasa.jpl.aerie.contrib.streamline.core.Expiring;
+import gov.nasa.jpl.aerie.contrib.streamline.core.monads.DynamicsMonad;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
+
+import java.util.function.Function;
+
+public final class DiscreteDynamicsMonad {
+  private DiscreteDynamicsMonad() {}
+
+  public static <A> ErrorCatching<Expiring<Discrete<A>>> unit(A a) {
+    return DiscreteMonadTransformer.unit(DynamicsMonad::unit, a);
+  }
+
+  public static <A, B> ErrorCatching<Expiring<Discrete<B>>> bind(ErrorCatching<Expiring<Discrete<A>>> a, Function<A, ErrorCatching<Expiring<Discrete<B>>>> f) {
+    return DiscreteMonadTransformer.bind(DynamicsMonad::bind, a, f);
+  }
+
+  // Convenient methods defined in terms of bind and unit:
+
+  public static <A, B> ErrorCatching<Expiring<Discrete<B>>> map(ErrorCatching<Expiring<Discrete<A>>> a, Function<A, B> f) {
+    return bind(a, f.andThen(DiscreteDynamicsMonad::unit));
+  }
+
+  public static <A, B> Function<ErrorCatching<Expiring<Discrete<A>>>, ErrorCatching<Expiring<Discrete<B>>>> lift(Function<A, B> f) {
+    return a -> map(a, f);
+  }
+
+  // Not monadic, strictly speaking, but useful nonetheless.
+
+  public static <A> DynamicsEffect<Discrete<A>> effect(Function<A, A> f) {
+      return DynamicsMonad.effect(DiscreteMonad.lift(f));
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/monads/DiscreteExpiringMonad.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/monads/DiscreteExpiringMonad.java
@@ -1,0 +1,25 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Expiring;
+import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ExpiringMonad;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
+
+import java.util.function.Function;
+
+public final class DiscreteExpiringMonad {
+  private DiscreteExpiringMonad() {}
+
+  public static <A> Expiring<Discrete<A>> unit(A a) {
+    return DiscreteMonadTransformer.unit(ExpiringMonad::unit, a);
+  }
+
+  public static <A, B> Expiring<Discrete<B>> bind(Expiring<Discrete<A>> a, Function<A, Expiring<Discrete<B>>> f) {
+    return DiscreteMonadTransformer.bind(ExpiringMonad::bind, a, f);
+  }
+
+  // Convenient methods defined in terms of bind and unit:
+
+  public static <A, B> Expiring<Discrete<B>> map(Expiring<Discrete<A>> a, Function<A, B> f) {
+    return bind(a, f.andThen(DiscreteExpiringMonad::unit));
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/monads/DiscreteMonad.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/monads/DiscreteMonad.java
@@ -1,0 +1,31 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.monads.IdentityMonad;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
+
+import java.util.function.Function;
+
+/**
+ * {@link Discrete} monad
+ */
+public final class DiscreteMonad {
+  private DiscreteMonad() {}
+
+  public static <A> Discrete<A> unit(A a) {
+    return DiscreteMonadTransformer.unit(IdentityMonad::unit, a);
+  }
+
+  public static <A, B> Discrete<B> bind(Discrete<A> a, Function<A, Discrete<B>> f) {
+    return DiscreteMonadTransformer.bind(IdentityMonad::bind, a, f);
+  }
+
+  // Convenient methods defined in terms of bind and unit:
+
+  public static <A, B> Discrete<B> map(Discrete<A> a, Function<A, B> f) {
+    return bind(a, f.andThen(DiscreteMonad::unit));
+  }
+
+  public static <A, B> Function<Discrete<A>, Discrete<B>> lift(Function<A, B> f) {
+    return a -> map(a, f);
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/monads/DiscreteMonadTransformer.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/monads/DiscreteMonadTransformer.java
@@ -1,0 +1,25 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads;
+
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Monad transformer for {@link Discrete}, M A -> M ({@link Discrete}&lt;A&gt;)
+ */
+public final class DiscreteMonadTransformer {
+  private DiscreteMonadTransformer() {}
+
+  public static <A, MDA> MDA unit(Function<Discrete<A>, MDA> mUnit, A a) {
+    return mUnit.apply(Discrete.discrete(a));
+  }
+
+  public static <A, MDA, MDB> MDB bind(BiFunction<MDA, Function<Discrete<A>, MDB>, MDB> mBind, MDA m, Function<A, MDB> f) {
+    return mBind.apply(m, d -> f.apply(d.extract()));
+  }
+
+  public static <A, MA, MDA> MDA lift(BiFunction<MA, Function<A, Discrete<A>>, MDA> mBind, MA m) {
+    return mBind.apply(m, Discrete::discrete);
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/monads/DiscreteResourceMonad.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/monads/DiscreteResourceMonad.java
@@ -1,0 +1,48 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
+import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.unit_aware.UnitAware;
+import org.apache.commons.lang3.function.TriFunction;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public final class DiscreteResourceMonad {
+  private DiscreteResourceMonad() {}
+
+  public static <A> Resource<Discrete<A>> unit(A a) {
+    return DiscreteMonadTransformer.unit(ResourceMonad::unit, a);
+  }
+
+  public static <A, B> Resource<Discrete<B>> bind(Resource<Discrete<A>> a, Function<A, Resource<Discrete<B>>> f) {
+    return DiscreteMonadTransformer.bind(ResourceMonad::bind, a, f);
+  }
+
+  // Convenient methods defined in terms of bind and unit:
+
+  public static <A, B> Resource<Discrete<B>> map(Resource<Discrete<A>> a, Function<A, B> f) {
+    return bind(a, f.andThen(DiscreteResourceMonad::unit));
+  }
+
+  // Map functions with higher arities are defined for discrete resources,
+  // because deriving discrete values with many sources is fairly common.
+
+  public static <A, B, C> Resource<Discrete<C>> map(Resource<Discrete<A>> a, Resource<Discrete<B>> b, BiFunction<A, B, C> f) {
+    return bind(a, a$ -> map(b, b$ -> f.apply(a$, b$)));
+  }
+
+  public static <A, B, C, D> Resource<Discrete<D>> map(Resource<Discrete<A>> a, Resource<Discrete<B>> b, Resource<Discrete<C>> c, TriFunction<A, B, C, D> f) {
+    return bind(a, a$ -> map(b, c, (b$, c$) -> f.apply(a$, b$, c$)));
+  }
+
+  public static <A, B> Function<Resource<Discrete<A>>, Resource<Discrete<B>>> lift(Function<A, B> f) {
+    return a -> map(a, f);
+  }
+
+  public static <A, B, C> BiFunction<Resource<Discrete<A>>, Resource<Discrete<B>>, Resource<Discrete<C>>> lift(BiFunction<A, B, C> f) {
+    return (a, b) -> map(a, b, f);
+  }
+}


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By file
* **Merge strategy:** Merge (no squash)

## Description
Core classes from https://github.com/NASA-AMMOS/aerie/pull/1198. This includes the classes in the `core` module, and a minimal set of other classes. In particular, this includes the clock and discrete dynamics types, but no effects or resource derivation functions.

## Verification
The code in this PR was used, as part of https://github.com/NASA-AMMOS/aerie/pull/1198, in both a toy model and for part of the Clipper model. We verified the results were both correct and performant.

## Documentation
See https://github.com/NASA-AMMOS/aerie/pull/1198

## Future work
See https://github.com/NASA-AMMOS/aerie/pull/1198
