### PR TITLE
Add unit-awareness library

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/Dimension.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/Dimension.java
@@ -1,0 +1,175 @@
+package gov.nasa.jpl.aerie.contrib.streamline.unit_aware;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.Collections.reverseOrder;
+import static java.util.Map.Entry.comparingByValue;
+import static java.util.stream.Collectors.joining;
+
+/**
+ * A kind of quantity, which can be measured.
+ * For example, length, time, energy, or data rate.
+ *
+ * <p>
+ * Quantities with the same dimension but different units, like meters and miles,
+ * can be compared, added, and subtracted.
+ * Quantities with different dimensions, like meters and seconds,
+ * cannot be added or subtracted, and are never equal.
+ * </p>
+ *
+ * <p>
+ * Base dimensions are declared using {@link Dimension#createBase}. Base dimensions are definitionally all distinct
+ * from each other, and are distinct from all combinations of other base dimensions.
+ * </p>
+ *
+ * <p>
+ * Dimensions can be composed by multiplication, division, and exponentiation by a constant
+ * to derive new dimensions, and composite units correlate to the composite dimension.
+ * For example, Energy is the dimension defined as Mass * Length^2 / Time^2, and
+ * Newton is a unit of Energy defined as Kilogram * Meter^2 / Second^2.
+ * Internally, all dimensions are a map from base dimensions to their power. For example, Mass is stored (loosely) as
+ * {@code {"Mass": 1}} and Energy is {@code {"Mass": 1, "Length": 2, "Time": -2}}.
+ * </p>
+ */
+public sealed interface Dimension {
+  Dimension SCALAR = new DerivedDimension(Map.of());
+
+  Map<BaseDimension, Rational> basePowers();
+  boolean isBase();
+
+
+  default Dimension multiply(Dimension other) {
+    var resultBasePowers = new HashMap<>(basePowers());
+    for (var dimensionPower : other.basePowers().entrySet()) {
+      var power = dimensionPower.getValue();
+      resultBasePowers.compute(
+          dimensionPower.getKey(),
+          (k, p) -> p == null ? power : power.add(p));
+    }
+    return create(resultBasePowers);
+  }
+
+  default Dimension divide(Dimension other) {
+    var resultBasePowers = new HashMap<>(basePowers());
+    for (var dimensionPower : other.basePowers().entrySet()) {
+      var power = dimensionPower.getValue().negate();
+      resultBasePowers.compute(
+          dimensionPower.getKey(),
+          (k, p) -> p == null ? power : power.add(p));
+    }
+    return create(resultBasePowers);
+  }
+
+  default Dimension power(Rational power) {
+    var resultBasePowers = new HashMap<BaseDimension, Rational>();
+    for (var dimensionPower : basePowers().entrySet()) {
+      resultBasePowers.put(dimensionPower.getKey(), dimensionPower.getValue().multiply(power));
+    }
+    return create(resultBasePowers);
+  }
+
+  private static Dimension create(Map<BaseDimension, Rational> basePowers) {
+    var normalizedBasePowers = new HashMap<BaseDimension, Rational>();
+    for (var entry : basePowers.entrySet()) {
+      if (!entry.getValue().equals(Rational.ZERO)) {
+        normalizedBasePowers.put(entry.getKey(), entry.getValue());
+      }
+    }
+
+    if (normalizedBasePowers.isEmpty()) {
+      return Dimension.SCALAR;
+    } else if (normalizedBasePowers.size() == 1) {
+      final var solePower = normalizedBasePowers.entrySet().stream().findAny().get();
+      if (solePower.getValue().equals(Rational.ONE)) {
+        // This actually *is* the base dimension, so return that instead
+        // Normalizing like this lets us bootstrap using reference equality on base dimensions.
+        return solePower.getKey();
+      }
+    }
+
+    // Otherwise, this is some composite dimension, build it anew.
+    return new DerivedDimension(normalizedBasePowers);
+  }
+
+  static Dimension createBase(String name) {
+    return new BaseDimension(name);
+  }
+
+  final class BaseDimension implements Dimension {
+    public final String name;
+
+    private BaseDimension(final String name) {
+      this.name = name;
+    }
+
+    @Override
+    public Map<BaseDimension, Rational> basePowers() {
+      return Map.of(this, Rational.ONE);
+    }
+
+    @Override
+    public boolean isBase() {
+      return true;
+    }
+
+    // Reference equality is sufficient here. Do *not* override equals/hashCode.
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  final class DerivedDimension implements Dimension {
+    private final Map<BaseDimension, Rational> basePowers;
+
+    private DerivedDimension(final Map<BaseDimension, Rational> basePowers) {
+      this.basePowers = basePowers;
+    }
+
+    @Override
+    public Map<BaseDimension, Rational> basePowers() {
+      return basePowers;
+    }
+
+    @Override
+    public boolean isBase() {
+      return false;
+    }
+
+    // Use semantic equality defined by the base powers map
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      DerivedDimension that = (DerivedDimension) o;
+      return Objects.equals(basePowers, that.basePowers);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(basePowers);
+    }
+
+    @Override
+    public String toString() {
+      return basePowers.entrySet().stream()
+          .sorted(reverseOrder(comparingByValue()))
+          .map(basePower -> formatBasePower(basePower.getKey(), basePower.getValue()))
+          .collect(joining(" "));
+    }
+
+    private static String formatBasePower(BaseDimension d, Rational p) {
+      if (p.equals(Rational.ONE)) {
+        return "[%s]".formatted(d.name);
+      } else if (p.denominator() == 1) {
+        return "[%s]^%s".formatted(d.name, p.numerator());
+      } else {
+        return "[%s]^(%d/%d)".formatted(d.name, p.numerator(), p.denominator());
+      }
+    }
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/Quantities.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/Quantities.java
@@ -1,0 +1,65 @@
+package gov.nasa.jpl.aerie.contrib.streamline.unit_aware;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAware.unitAware;
+
+/**
+ * Utilities for <code>UnitAware&lt;Double&gt;</code>, aka a "Quantity"
+ */
+public final class Quantities {
+  public static UnitAware<Double> quantity(double amount) {
+    return quantity(amount, Unit.SCALAR);
+  }
+
+  public static UnitAware<Double> quantity(double amount, Unit unit) {
+    return unitAware(amount, unit, Quantities::scaling);
+  }
+
+  public static UnitAware<Double> quantity(Duration duration) {
+    return unitAware(duration.ratioOver(Duration.SECOND), StandardUnits.SECOND, Quantities::scaling);
+  }
+
+  public static UnitAware<Double> add(UnitAware<Double> p, UnitAware<Double> q) {
+    return UnitAwareOperations.add(Quantities::scaling, (x, y) -> x + y, p, q);
+  }
+
+  public static UnitAware<Double> subtract(UnitAware<Double> p, UnitAware<Double> q) {
+    return UnitAwareOperations.subtract(Quantities::scaling, (x, y) -> x - y, p, q);
+  }
+
+  public static UnitAware<Double> multiply(UnitAware<Double> p, UnitAware<Double> q) {
+    return UnitAwareOperations.multiply(Quantities::scaling, (x, y) -> x * y, p, q);
+  }
+
+  public static UnitAware<Double> divide(UnitAware<Double> p, UnitAware<Double> q) {
+    return UnitAwareOperations.divide(Quantities::scaling, (x, y) -> x / y, p, q);
+  }
+
+  /**
+   * Absolute value
+   */
+  public static UnitAware<Double> abs(UnitAware<Double> p) {
+    return p.map(Math::abs);
+  }
+
+  public static boolean lessThan(UnitAware<Double> p, UnitAware<Double> q) {
+    return p.value() < q.value(p.unit());
+  }
+
+  public static boolean lessThanOrEquals(UnitAware<Double> p, UnitAware<Double> q) {
+    return p.value() <= q.value(p.unit());
+  }
+
+  public static boolean greaterThan(UnitAware<Double> p, UnitAware<Double> q) {
+    return p.value() > q.value(p.unit());
+  }
+
+  public static boolean greaterThanOrEquals(UnitAware<Double> p, UnitAware<Double> q) {
+    return p.value() >= q.value(p.unit());
+  }
+
+  private static double scaling(double x, double y) {
+    return x * y;
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/Rational.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/Rational.java
@@ -1,0 +1,76 @@
+package gov.nasa.jpl.aerie.contrib.streamline.unit_aware;
+
+import static java.lang.Integer.signum;
+import static org.apache.commons.math3.util.ArithmeticUtils.gcd;
+
+/**
+ * Lightweight exact rational number, used primarily for tracking dimensionality
+ * in the QUDV system.
+ */
+public record Rational(int numerator, int denominator) implements Comparable<Rational> {
+  public static final Rational ZERO = new Rational(0, 1);
+  public static final Rational ONE = new Rational(1, 1);
+
+  public Rational(final int numerator, final int denominator) {
+    if (denominator == 0) {
+      throw new ArithmeticException("Cannot create a Rational with 0 denominator.");
+    }
+
+    // Normalize by dividing by the GCD and forcing the denominator to be positive.
+    final int gcd = gcd(numerator, denominator);
+    final int s = signum(denominator);
+    this.numerator = s * numerator / gcd;
+    this.denominator = s * denominator / gcd;
+  }
+
+  public static Rational rational(final int numerator, final int denominator) {
+    return new Rational(numerator, denominator);
+  }
+
+  public static Rational rational(final int value) {
+    return new Rational(value, 1);
+  }
+
+  public Rational add(Rational other) {
+    return new Rational(
+        numerator * other.denominator + denominator * other.numerator,
+        denominator * other.denominator);
+  }
+
+  public Rational negate() {
+    return new Rational(-numerator, denominator);
+  }
+
+  public Rational subtract(Rational other) {
+    return this.add(other.negate());
+  }
+
+  public Rational multiply(Rational other) {
+    return new Rational(
+        numerator * other.numerator,
+        denominator * other.denominator);
+  }
+
+  /**
+   * Flip numerator and divisor, equivalent to raising to the power -1.
+   */
+  public Rational invert() {
+    return new Rational(denominator, numerator);
+  }
+
+  public Rational divide(Rational other) {
+    return this.multiply(other.invert());
+  }
+
+  @Override
+  public int compareTo(final Rational o) {
+    return Integer.compare(numerator * o.denominator, denominator * o.numerator);
+  }
+
+  /**
+   * Approximate this as a floating-point number.
+   */
+  public double doubleValue() {
+    return ((double) numerator) / denominator;
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/StandardDimensions.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/StandardDimensions.java
@@ -1,0 +1,21 @@
+package gov.nasa.jpl.aerie.contrib.streamline.unit_aware;
+
+/**
+ * Collection of standard dimensions, including all SI base dimensions.
+ */
+public final class StandardDimensions {
+  private StandardDimensions() {}
+
+  // SI base dimensions:
+  public static final Dimension TIME = Dimension.createBase("Time");
+  public static final Dimension LENGTH = Dimension.createBase("Length");
+  public static final Dimension MASS = Dimension.createBase("Mass");
+  public static final Dimension CURRENT = Dimension.createBase("Current");
+  public static final Dimension TEMPERATURE = Dimension.createBase("Temperature");
+  public static final Dimension LUMINOUS_INTENSITY = Dimension.createBase("Luminous Intensity");
+  public static final Dimension AMOUNT = Dimension.createBase("Amount of Substance");
+
+  // Additional base dimensions we've found useful in practice
+  public static final Dimension INFORMATION = Dimension.createBase("Information");
+  public static final Dimension ANGLE = Dimension.createBase("Angle");
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/StandardUnits.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/StandardUnits.java
@@ -1,0 +1,41 @@
+package gov.nasa.jpl.aerie.contrib.streamline.unit_aware;
+
+/**
+ * Collection of standard units, including all SI base units.
+ */
+public final class StandardUnits {
+  private StandardUnits() {}
+
+  // Base units, should correspond 1-1 with base Dimensions
+  public static final Unit SECOND = Unit.createBase("s", "second", StandardDimensions.TIME);
+  public static final Unit METER = Unit.createBase("m", "meter", StandardDimensions.LENGTH);
+  public static final Unit KILOGRAM = Unit.createBase("kg", "kilogram", StandardDimensions.MASS);
+  public static final Unit AMPERE = Unit.createBase("A", "ampere", StandardDimensions.CURRENT);
+  public static final Unit KELVIN = Unit.createBase("K", "Kelvin", StandardDimensions.TEMPERATURE);
+  public static final Unit CANDELA = Unit.createBase("cd", "candela", StandardDimensions.LUMINOUS_INTENSITY);
+  public static final Unit MOLE = Unit.createBase("mol", "mole", StandardDimensions.AMOUNT);
+  public static final Unit BIT = Unit.createBase("b", "bit", StandardDimensions.INFORMATION);
+  public static final Unit RADIAN = Unit.createBase("rad", "radian", StandardDimensions.ANGLE);
+
+  // REVIEW: What derived units should be included here?
+  // Including a few arbitrarily to show a few different styles of derivation
+  public static final Unit MILLISECOND = Unit.derived("ms", "millisecond", 1e-3, SECOND);
+  public static final Unit MINUTE = Unit.derived("min", "minute", 60, SECOND);
+  public static final Unit HOUR = Unit.derived("hr", "hour", 60, MINUTE);
+  public static final Unit KILOMETER = Unit.derived("km", "kilometer", 1000, METER);
+  public static final Unit BYTE = Unit.derived("B", "byte", 8, BIT);
+  public static final Unit NEWTON = Unit.derived("N", "newton", KILOGRAM.multiply(METER).divide(SECOND.power(2)));
+  public static final Unit MEGABIT_PER_SECOND = Unit.derived("Mbps", "megabit per second", 1e6, BIT.divide(SECOND));
+  public static final Unit DEGREE = Unit.derived("deg", "degree", 180 / Math.PI, RADIAN);
+
+  public static final Unit JOULE = Unit.derived("J", "joule", NEWTON.multiply(METER));
+  public static final Unit WATT = Unit.derived("W", "watt", JOULE.divide(SECOND));
+  public static final Unit COULOMB = Unit.derived("C", "coulomb", AMPERE.multiply(SECOND));
+  public static final Unit VOLT = Unit.derived("V", "volt", JOULE.divide(COULOMB));
+
+  /**
+   * Astronomical unit as defined by
+   * <a href="https://www.iau.org/static/resolutions/IAU2012_English.pdf">IAU 2012 Resolution B2</a>.
+   */
+  public static final Unit ASTRONOMICAL_UNIT = Unit.derived("au", "astronomical unit", 149_597_870_700.0, METER);
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/Unit.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/Unit.java
@@ -1,0 +1,106 @@
+package gov.nasa.jpl.aerie.contrib.streamline.unit_aware;
+
+import java.util.Objects;
+
+/**
+ * A unit of measure in the QUDV system.
+ */
+public final class Unit {
+  public static final Unit SCALAR = new Unit(Dimension.SCALAR, 1, "(scalar)", "(scalar)");
+
+  public final Dimension dimension;
+  public final double multiplier;
+  public final String longName;
+  public final String shortName;
+
+  private Unit(final Dimension dimension, final double multiplier) {
+    this(dimension, multiplier, null, null);
+  }
+
+  private Unit(final Dimension dimension, final double multiplier, final String longName, final String shortName) {
+    this.dimension = dimension;
+    this.multiplier = multiplier;
+    this.longName = longName;
+    this.shortName = shortName;
+  }
+
+  public static Unit createBase(final String shortName, final String longName, final Dimension dimension) {
+    // TODO: Track base units, to detect and prevent collisions
+    assert(dimension.isBase());
+    return new Unit(dimension, 1, longName, shortName);
+  }
+
+  /**
+   * Create a "local" unit. Local units denote a locally-relevant concept that doesn't need to be integrated across models into the broader unit system.
+   *
+   * <p>
+   * Local units are given their own unique base dimension with the same name, so are distinct from all other base dimensions.
+   * </p>
+   *
+   * <p>
+   *     For example, to record that instrument A takes 6 observations per hour, we could declare a local unit in the instrument A model for observations and use it to derive "observations / hour", like so:
+   *     <br/>
+   *     <code>
+   *         Unit Observations = Unit.createLocalUnit("observations");<br/>
+   *         UnitAware&lt;Double&gt; observationRate = quantity(6, Observations.divide(HOUR));
+   *     </code>
+   *     <br/>
+   *     If instrument B also declared a local unit called "observations", this would be incommensurate with instrument A's "observations" unit.
+   * </p>
+   */
+  public static Unit createLocalUnit(final String name) {
+    return createBase(name, name, Dimension.createBase(name));
+  }
+
+  // Used for naming compound units
+  public static Unit derived(final String shortName, final String longName, final Unit definingUnit) {
+    return derived(shortName, longName, 1, definingUnit);
+  }
+
+  public static Unit derived(final String shortName, final String longName, final UnitAware<Double> definingQuantity) {
+    return derived(shortName, longName, definingQuantity.value(), definingQuantity.unit());
+  }
+
+  public static Unit derived(final String shortName, final String longName, final double multiplier, final Unit baseUnit) {
+    return new Unit(baseUnit.dimension, baseUnit.multiplier * multiplier, longName, shortName);
+  }
+
+  public Unit multiply(Unit other) {
+    return new Unit(dimension.multiply(other.dimension), multiplier * other.multiplier);
+  }
+
+  public Unit divide(Unit other) {
+    return new Unit(dimension.divide(other.dimension), multiplier / other.multiplier);
+  }
+
+  public Unit power(int power) {
+    return power(Rational.rational(power));
+  }
+
+  public Unit power(Rational power) {
+    return new Unit(dimension.power(power), Math.pow(multiplier, power.doubleValue()));
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Unit unit = (Unit) o;
+    return Double.compare(unit.multiplier, multiplier) == 0 && Objects.equals(dimension, unit.dimension);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(dimension, multiplier);
+  }
+
+  @Override
+  public String toString() {
+     if (longName != null) {
+       return longName;
+     } else {
+       // TODO: Better name derivation, by tracking named base units
+       return "Unit{" + multiplier + " in " + dimension + "}";
+     }
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/UnitAware.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/UnitAware.java
@@ -1,0 +1,97 @@
+package gov.nasa.jpl.aerie.contrib.streamline.unit_aware;
+
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import static java.util.function.Function.identity;
+
+/**
+ * A value of type T with an attached unit.
+ * This can be rescaled to other units measuring the same dimension.
+ */
+public interface UnitAware<T> {
+
+  default T value(Unit desiredUnit) {
+    return in(desiredUnit).value();
+  }
+
+  T value();
+
+  Unit unit();
+
+  UnitAware<T> in(Unit desiredUnit);
+
+  UnitAware<T> map(UnaryOperator<T> unitInvariantFunction);
+
+  /**
+   * General constructor, used primarily by library code.
+   */
+  static <T> UnitAware<T> unitAware(T value, Unit unit, Function<Unit, UnitAware<T>> rescale) {
+
+    return new UnitAware<>() {
+      @Override
+      public T value() {
+        return value;
+      }
+
+      @Override
+      public Unit unit() {
+        return unit;
+      }
+
+      @Override
+      public UnitAware<T> in(Unit desiredUnit) {
+        if (unit == desiredUnit) {
+          // Short-circuit for performance
+          return this;
+        }
+        if (!unit.dimension.equals(desiredUnit.dimension)) {
+          // TODO: Should this be its own kind of exception? A UnitConversionException or DimensionMismatchException?
+          throw new IllegalArgumentException("Cannot convert %s to desired unit %s due to dimension mismatch (%s vs %s)."
+                .formatted(unit, desiredUnit, unit.dimension, desiredUnit.dimension));
+        }
+        return rescale.apply(desiredUnit);
+      }
+
+      @Override
+      public UnitAware<T> map(final UnaryOperator<T> unitInvariantFunction) {
+        return unitAware(unitInvariantFunction.apply(value), unit, rescale);
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (UnitAware<?>) obj;
+        return Objects.equals(value, that.value()) && Objects.equals(unit, that.unit());
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(value, unit);
+      }
+
+      @Override
+      public String toString() {
+        return "UnitAware[" + "value=" + value + ", " + "unit=" + unit + ']';
+      }
+    };
+  }
+
+  /**
+   * Scaling-function constructor, used primarily in code outside this library.
+   */
+  static <T> UnitAware<T> unitAware(T value, Unit unit, BiFunction<T, Double, T> scaling) {
+    return unitAware(
+        value,
+        unit,
+        desiredUnit -> unitAware(scaling.apply(value, unit.multiplier / desiredUnit.multiplier), desiredUnit, scaling));
+  }
+
+  static <T extends Comparable<T>> Comparator<UnitAware<T>> comparator() {
+    return Comparator.comparing(identity(), (p, q) -> p.value().compareTo(q.value(p.unit())));
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/UnitAwareOperations.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/UnitAwareOperations.java
@@ -1,0 +1,59 @@
+package gov.nasa.jpl.aerie.contrib.streamline.unit_aware;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAware.unitAware;
+
+/**
+ * Utilities for working with unit-aware objects correctly.
+ * Primarily includes arithmetic and comparison functions.
+ */
+public final class UnitAwareOperations {
+  private UnitAwareOperations() {}
+
+  public static <A> UnitAware<A> add(BiFunction<A, Double, A> scaling, BiFunction<A, A, A> addition, UnitAware<? extends A> a, UnitAware<? extends A> b) {
+    return unitAware(addition.apply(a.value(), b.value(a.unit())), a.unit(), scaling);
+  }
+
+  public static <A> UnitAware<A> subtract(BiFunction<A, Double, A> scaling, BiFunction<A, A, A> subtraction, UnitAware<? extends A> a, UnitAware<? extends A> b) {
+    return add(scaling, subtraction, a, b);
+  }
+
+  public static <A, B, C> UnitAware<C> multiply(BiFunction<C, Double, C> scaling, BiFunction<A, B, C> multiplication, UnitAware<? extends A> a, UnitAware<? extends B> b) {
+    return unitAware(multiplication.apply(a.value(), b.value()), a.unit().multiply(b.unit()), scaling);
+  }
+
+  public static <A, B, C> UnitAware<C> divide(BiFunction<C, Double, C> scaling, BiFunction<A, B, C> division, UnitAware<? extends A> a, UnitAware<? extends B> b) {
+    return unitAware(division.apply(a.value(), b.value()), a.unit().divide(b.unit()), scaling);
+  }
+
+  public static <A, B> UnitAware<A> integrate(BiFunction<A, Double, A> scaling, BiFunction<A, B, A> integration, UnitAware<? extends A> a, UnitAware<? extends B> b) {
+    final Unit newUnit = a.unit().multiply(StandardUnits.SECOND);
+    return unitAware(integration.apply(a.value(), b.value(newUnit)), newUnit, scaling);
+  }
+
+  public static <A> UnitAware<A> differentiate(BiFunction<A, Double, A> scaling, Function<A, A> differentiation, UnitAware<? extends A> a) {
+    return unitAware(differentiation.apply(a.value()), a.unit().divide(StandardUnits.SECOND), scaling);
+  }
+
+  public static <A extends Comparable<A>> int compare(UnitAware<? extends A> a, UnitAware<? extends A> b) {
+    return a.value().compareTo(b.value(a.unit()));
+  }
+
+  public static <A extends Comparable<A>> boolean lessThan(UnitAware<? extends A> a, UnitAware<? extends A> b) {
+    return compare(a, b) < 0;
+  }
+
+  public static <A extends Comparable<A>> boolean lessThanOrEquals(UnitAware<? extends A> a, UnitAware<? extends A> b) {
+    return compare(a, b) <= 0;
+  }
+
+  public static <A extends Comparable<A>> boolean greaterThan(UnitAware<? extends A> a, UnitAware<? extends A> b) {
+    return compare(a, b) > 0;
+  }
+
+  public static <A extends Comparable<A>> boolean greaterThanOrEquals(UnitAware<? extends A> a, UnitAware<? extends A> b) {
+    return compare(a, b) >= 0;
+  }
+}

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/DimensionTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/unit_aware/DimensionTest.java
@@ -1,0 +1,192 @@
+package gov.nasa.jpl.aerie.contrib.streamline.unit_aware;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.unit_aware.Dimension.SCALAR;
+import static gov.nasa.jpl.aerie.contrib.streamline.unit_aware.Rational.*;
+import static gov.nasa.jpl.aerie.contrib.streamline.unit_aware.StandardDimensions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DimensionTest {
+  @Nested
+  class BaseDimensions {
+    @Test
+    void equal_themselves() {
+      assertEquals(LENGTH, LENGTH);
+    }
+
+    @Test
+    void are_distinct() {
+      assertNotEquals(LENGTH, TIME);
+    }
+
+    @Test
+    void satisfy_is_base_check() {
+      assertTrue(LENGTH.isBase());
+    }
+  }
+
+  @Nested
+  class DimensionProducts {
+    @Test
+    void are_distinct_from_both_factors() {
+      Dimension MASS_LENGTH = MASS.multiply(LENGTH);
+      assertNotEquals(MASS, MASS_LENGTH);
+      assertNotEquals(LENGTH, MASS_LENGTH);
+    }
+
+    @Test
+    void are_equal_to_identically_derived_dimensions() {
+      Dimension MASS_LENGTH_1 = MASS.multiply(LENGTH);
+      Dimension MASS_LENGTH_2 = MASS.multiply(LENGTH);
+      assertEquals(MASS_LENGTH_1, MASS_LENGTH_2);
+    }
+
+    @Test
+    void are_not_equal_to_different_products() {
+      Dimension MASS_LENGTH = MASS.multiply(LENGTH);
+      Dimension MASS_TIME = MASS.multiply(TIME);
+      assertNotEquals(MASS_LENGTH, MASS_TIME);
+    }
+
+    @Test
+    void fail_is_base_check() {
+      Dimension MASS_LENGTH = MASS.multiply(LENGTH);
+      assertFalse(MASS_LENGTH.isBase());
+    }
+
+    @Test
+    void commute() {
+      Dimension MASS_LENGTH = MASS.multiply(LENGTH);
+      Dimension LENGTH_MASS = LENGTH.multiply(MASS);
+      assertEquals(MASS_LENGTH, LENGTH_MASS);
+    }
+
+    @Test
+    void associate() {
+      Dimension MASS_LENGTH_TIME = MASS.multiply(LENGTH).multiply(TIME);
+      Dimension MASS_LENGTH_TIME_2 = MASS.multiply(LENGTH.multiply(TIME));
+      assertEquals(MASS_LENGTH_TIME, MASS_LENGTH_TIME_2);
+    }
+
+    @Test
+    void have_scalar_as_left_identity() {
+      Dimension MASS_2 = SCALAR.multiply(MASS);
+      assertEquals(MASS, MASS_2);
+    }
+
+    @Test
+    void have_scalar_as_right_identity() {
+      Dimension MASS_2 = MASS.multiply(SCALAR);
+      assertEquals(MASS, MASS_2);
+    }
+  }
+
+  @Nested
+  class DimensionQuotients {
+    @Test
+    void are_distinct_from_both_factors() {
+      assertNotEquals(LENGTH, LENGTH.divide(TIME));
+      assertNotEquals(TIME, LENGTH.divide(TIME));
+    }
+
+    @Test
+    void are_equal_to_identically_derived_dimensions() {
+      assertEquals(LENGTH.divide(TIME), LENGTH.divide(TIME));
+    }
+
+    @Test
+    void are_not_equal_to_different_quotients() {
+      assertNotEquals(LENGTH.divide(TIME), MASS.divide(TIME));
+    }
+
+    @Test
+    void fail_is_base_check() {
+      assertFalse(LENGTH.divide(TIME).isBase());
+    }
+
+    @Test
+    void do_not_commute() {
+      assertNotEquals(LENGTH.divide(TIME), TIME.divide(LENGTH));
+    }
+
+    @Test
+    void do_not_have_scalar_as_left_identity() {
+      assertNotEquals(MASS, SCALAR.divide(MASS));
+    }
+
+    @Test
+    void have_scalar_as_right_identity() {
+      assertEquals(MASS, MASS.divide(SCALAR));
+    }
+
+    @Test
+    void invert_dimension_products() {
+      assertEquals(MASS, MASS.multiply(LENGTH).divide(LENGTH));
+    }
+
+    @Test
+    void are_inverted_by_dimension_products() {
+      assertEquals(MASS, MASS.divide(LENGTH).multiply(LENGTH));
+    }
+  }
+
+  @Nested
+  class DimensionPowers {
+    @Test
+    void have_one_as_right_identity() {
+      assertEquals(MASS, MASS.power(ONE));
+    }
+
+    @Test
+    void have_zero_as_right_annihilator() {
+      assertEquals(SCALAR, MASS.power(ZERO));
+    }
+
+    @Test
+    void have_scalar_as_left_annihilator() {
+      assertEquals(SCALAR, SCALAR.power(rational(2)));
+      assertEquals(SCALAR, SCALAR.power(rational(-2)));
+      assertEquals(SCALAR, SCALAR.power(rational(0)));
+    }
+
+    @Test
+    void are_equal_to_repeated_multiplication_for_positive_integer_powers() {
+      assertEquals(MASS.multiply(MASS), MASS.power(rational(2)));
+      assertEquals(MASS.multiply(MASS).multiply(MASS), MASS.power(rational(3)));
+    }
+
+    @Test
+    void are_equal_to_repeated_division_for_negative_integer_powers() {
+      assertEquals(SCALAR.divide(MASS), MASS.power(rational(-1)));
+      assertEquals(SCALAR.divide(MASS).divide(MASS), MASS.power(rational(-2)));
+    }
+
+    @Test
+    void distribute_over_products() {
+      var p = rational(2, 3);
+      assertEquals(MASS.power(p).multiply(LENGTH.power(p)), MASS.multiply(LENGTH).power(p));
+    }
+
+    @Test
+    void distribute_over_quotients() {
+      var p = rational(2, 3);
+      assertEquals(MASS.power(p).divide(LENGTH.power(p)), MASS.divide(LENGTH).power(p));
+    }
+
+    @Test
+    void add_exactly_when_multiplying_common_bases() {
+      var p = rational(2, 3);
+      var q = rational(1, 3);
+      assertEquals(MASS, MASS.power(p).multiply(MASS.power(q)));
+    }
+
+    @Test
+    void subtract_exactly_when_multiplying_common_bases() {
+      var p = rational(4, 3);
+      var q = rational(1, 3);
+      assertEquals(MASS, MASS.power(p).divide(MASS.power(q)));
+    }
+  }
+}


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By file
* **Merge strategy:** Merge (no squash)

## Description
Adds a QUDV (Quantity, Unit, Dimension, and Value) library, generalized over the type of values. This is part of https://github.com/NASA-AMMOS/aerie/pull/1198, which applies units to numbers, dynamics, and resources, and allows adding units to other types.

In this library, base dimensions are declared at runtime, and derived dimensions are constructed by multiplying and taking powers of base dimensions. A dimension is a product of rational powers of base dimensions, and are represented exactly.

Units are a dimension and a scale. To use them properly, we declare a base unit for each base dimension, which implicitly has a scale of "1", and derive all other units from these through multiplication and powers. Derived units are anonymous by default, but can be given names. Since units are a multiplier and a dimension, we can only represent units with "absolute" scales. (So Kelvin is representable, but degrees Fahrenheit isn't.)

Quantities are represented by the `UnitAware<T>` interface, and represent a value of type `T` and a unit, with the ability to do dimensionality checks and rescale the value to convert to a different unit.

## Verification
There's a unit test for the Dimension class, but other classes have only been spot-checked. I'm working on converting the Clipper model, and parts of it use UnitAware types, so that should provide some test cases.

## Documentation
At the moment, only the inline Javadocs document this code, but we want to make wiki page(s) describing this and other parts of https://github.com/NASA-AMMOS/aerie/pull/1198. I'll update this description when that happens.

## Future work
See https://github.com/NASA-AMMOS/aerie/pull/1198
