### PR TITLE
Fix serialization/deserialization issue for controllable durations

### DIFF
--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/SchedulingTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/SchedulingTests.java
@@ -20,6 +20,7 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonValue;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
@@ -671,21 +672,28 @@ public class SchedulingTests {
                                              .toList();
       assertEquals(1, findFile.size());
 
-      final var resources = """
-          export type Resource = {
-            "/peel": number,
-            "/my_boolean": boolean,
-            "/fruit": {initial: number, rate: number, },
-            "/data/line_count": number,
-            "/flag/conflicted": boolean,
-            "/plant": number,
-            "/flag": ( | "A" | "B"),
-            "/producer": string,
-          };
-          """;
-      for(final var resourcesLine: resources.split("\n")){
-        assertTrue(findFile.get(0).content().contains(resourcesLine));
-      }
+      // Create a list of the exported resource types, one entry per new line
+      final List<String> resourceTypes = Arrays.stream(findFile.get(0)
+                                       .content()
+                                       .split("export type Resource = \\{\\n")[1]
+                                       .split("\\n};")[0] // isolate to export type Resource block
+                                       .split("\\n"))
+                                       .map(String::strip) // remove whitespace
+                                       .toList();
+
+      final var expectedResources = List.of(
+          "\"/data/line_count\": number,",
+          "\"/flag\": ( | \"A\" | \"B\"),",
+          "\"/flag/conflicted\": boolean,",
+          "\"/fruit\": {initial: number, rate: number, },",
+          "\"/my_boolean\": boolean,",
+          "\"/peel\": number,",
+          "\"/plant\": number,",
+          "\"/producer\": string,"
+      );
+
+      assertEquals(expectedResources.size(), resourceTypes.size());
+      assertTrue(resourceTypes.containsAll(expectedResources));
     }
 
     /**

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/SchedulingTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/SchedulingTests.java
@@ -683,7 +683,9 @@ public class SchedulingTests {
             "/producer": string,
           };
           """;
-      assertTrue(findFile.get(0).content().contains(resources));
+      for(final var resourcesLine: resources.split("\n")){
+        assertTrue(findFile.get(0).content().contains(resourcesLine));
+      }
     }
 
     /**

--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/mappers/FooValueMappers.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/mappers/FooValueMappers.java
@@ -2,10 +2,15 @@ package gov.nasa.jpl.aerie.foomissionmodel.mappers;
 
 import gov.nasa.jpl.aerie.contrib.serialization.mappers.Vector3DValueMapper;
 import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 public class FooValueMappers {
   public static ValueMapper<Vector3D> vector3d(final ValueMapper<Double> elementMapper) {
     return new Vector3DValueMapper(elementMapper);
+  }
+
+  public static ValueMapper<Duration> duration(){
+    return new SmartestDurationValueMapper();
   }
 }

--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/mappers/SmartestDurationValueMapper.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/mappers/SmartestDurationValueMapper.java
@@ -1,0 +1,35 @@
+package gov.nasa.jpl.aerie.foomissionmodel.mappers;
+
+import gov.nasa.jpl.aerie.merlin.framework.Result;
+import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+
+import java.util.Map;
+
+public class SmartestDurationValueMapper implements ValueMapper<Duration> {
+
+  final static String FIELD_NAME = "amountInMicroseconds";
+
+  @Override
+  public ValueSchema getValueSchema() {
+    return ValueSchema.ofStruct(
+        Map.of(FIELD_NAME, ValueSchema.INT)
+    );
+  }
+
+  @Override
+  public Result<Duration, String> deserializeValue(final SerializedValue serializedValue) {
+    final var asMap = serializedValue.asMap();
+    if(asMap.isEmpty() || !asMap.get().containsKey(FIELD_NAME)){
+      return Result.failure("failed to deserialize duration as map or a required field is not present");
+    }
+    return Result.success(Duration.of(asMap.get().get(FIELD_NAME).asInt().get(), Duration.MICROSECONDS));
+  }
+
+  @Override
+  public SerializedValue serializeValue(final Duration value) {
+    return SerializedValue.of(Map.of(FIELD_NAME, SerializedValue.of(value.in(Duration.MICROSECONDS))));
+  }
+}

--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/package-info.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/package-info.java
@@ -2,8 +2,8 @@
 
 @WithConfiguration(Configuration.class)
 
-@WithMappers(BasicValueMappers.class)
 @WithMappers(FooValueMappers.class)
+@WithMappers(BasicValueMappers.class)
 
 @WithActivityType(BasicActivity.class)
 @WithActivityType(FooActivity.class)

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/SchedulerModel.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/SchedulerModel.java
@@ -1,9 +1,13 @@
 package gov.nasa.jpl.aerie.merlin.protocol.model;
 
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.util.Map;
 
 public interface SchedulerModel {
   Map<String, DurationType> getDurationTypes();
+  SerializedValue serializeDuration(final Duration duration);
+  Duration deserializeDuration(final SerializedValue serializedValue);
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/Problem.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/Problem.java
@@ -100,6 +100,8 @@ public class Problem {
     return planningHorizon;
   }
 
+  public SchedulerModel getSchedulerModel() { return schedulerModel; }
+
   /**
    * adds a new global constraint to the mission model
    *

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -1048,9 +1048,7 @@ public class PrioritySolver implements Solver {
       //handle variable duration parameter here
       final Duration setActivityDuration;
       if (instantiatedArguments.containsKey(durationParameterName)) {
-        final var argumentDuration = Duration.of(
-            instantiatedArguments.get(durationParameterName).asInt().get(),
-            Duration.MICROSECOND);
+        final var argumentDuration = problem.getSchedulerModel().deserializeDuration(instantiatedArguments.get(durationParameterName));
         if (solved.duration().contains(argumentDuration)) {
           setActivityDuration = argumentDuration;
         } else {

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/FixedDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/FixedDurationTest.java
@@ -29,7 +29,7 @@ public class FixedDurationTest {
   void setUp(){
     planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochDays(3));
     MissionModel<?> bananaMissionModel = SimulationUtility.getBananaMissionModel();
-    problem = new Problem(bananaMissionModel, planningHorizon, new SimulationFacade(planningHorizon, bananaMissionModel), SimulationUtility.getBananaSchedulerModel());
+    problem = new Problem(bananaMissionModel, planningHorizon, new SimulationFacade(planningHorizon, bananaMissionModel, SimulationUtility.getBananaSchedulerModel()), SimulationUtility.getBananaSchedulerModel());
   }
 
   @Test

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/LongDurationPlanTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/LongDurationPlanTest.java
@@ -26,8 +26,7 @@ public class LongDurationPlanTest {
 
   //test mission with two primitive activity types
   private static Problem makeTestMissionAB() {
-    final var banananationMissionModel = SimulationUtility.getBananaMissionModel();
-    return new Problem(banananationMissionModel, h, new SimulationFacade(h, banananationMissionModel), SimulationUtility.getBananaSchedulerModel());
+    return SimulationUtility.buildProblemFromBanana(h);
   }
 
   private final static PlanningHorizon h = new PlanningHorizon(TimeUtility.fromDOY("2025-001T01:01:01.001"), TimeUtility.fromDOY("2030-005T01:01:01.001"));

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/ParametricDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/ParametricDurationTest.java
@@ -31,7 +31,7 @@ public class ParametricDurationTest {
   void setUp(){
     planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochDays(3));
     MissionModel<?> bananaMissionModel = SimulationUtility.getBananaMissionModel();
-    problem = new Problem(bananaMissionModel, planningHorizon, new SimulationFacade(planningHorizon, bananaMissionModel), SimulationUtility.getBananaSchedulerModel());
+    problem = new Problem(bananaMissionModel, planningHorizon, new SimulationFacade(planningHorizon, bananaMissionModel, SimulationUtility.getBananaSchedulerModel()), SimulationUtility.getBananaSchedulerModel());
   }
 
   @Test

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/PrioritySolverTest.java
@@ -31,12 +31,13 @@ import static org.junit.jupiter.api.Assertions.*;
 public class PrioritySolverTest {
   private static PrioritySolver makeEmptyProblemSolver() {
     MissionModel<?> bananaMissionModel = SimulationUtility.getBananaMissionModel();
+    final var schedulerModel = SimulationUtility.getBananaSchedulerModel();
     return new PrioritySolver(
             new Problem(
                     bananaMissionModel,
                     h,
-                    new SimulationFacade(h, bananaMissionModel),
-                    SimulationUtility.getBananaSchedulerModel()));
+                    new SimulationFacade(h, bananaMissionModel, schedulerModel),
+                    schedulerModel));
   }
 
   private static PrioritySolver makeProblemSolver(Problem problem) {
@@ -75,7 +76,8 @@ public class PrioritySolverTest {
   //test mission with two primitive activity types
   private static Problem makeTestMissionAB() {
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    return new Problem(fooMissionModel, h, new SimulationFacade(h, fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var fooSchedulerModel = SimulationUtility.getFooSchedulerModel();
+    return new Problem(fooMissionModel, h, new SimulationFacade(h, fooMissionModel, fooSchedulerModel), fooSchedulerModel);
   }
 
   private final static PlanningHorizon h = new PlanningHorizon(TimeUtility.fromDOY("2025-001T01:01:01.001"), TimeUtility.fromDOY("2025-005T01:01:01.001"));
@@ -241,7 +243,10 @@ public class PrioritySolverTest {
   {
     final var problem = makeTestMissionAB();
 
-    final var adHocFacade = new SimulationFacade(problem.getPlanningHorizon(), problem.getMissionModel());
+    final var adHocFacade = new SimulationFacade(
+        problem.getPlanningHorizon(),
+        problem.getMissionModel(),
+        problem.getSchedulerModel());
     adHocFacade.insertActivitiesIntoSimulation(makePlanA012(problem).getActivities());
     adHocFacade.computeSimulationResultsUntil(problem.getPlanningHorizon().getEndAerie());
     final var simResults = adHocFacade.getLatestDriverSimulationResults().get();
@@ -276,9 +281,15 @@ public class PrioritySolverTest {
     var planningHorizon = h;
 
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
+    final var fooSchedulerModel = SimulationUtility.getFooSchedulerModel();
+    Problem problem = new Problem(
+        fooMissionModel,
         planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+        new SimulationFacade(
+            planningHorizon,
+            fooMissionModel,
+            fooSchedulerModel),
+        SimulationUtility.getFooSchedulerModel());
     final var activityType = problem.getActivityType("ControllableDurationActivity");
 
     //act at t=1hr and at t=2hrs

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
@@ -83,7 +83,7 @@ public class SimulationFacadeTest {
   public void setUp() {
     missionModel = SimulationUtility.getBananaMissionModel();
     final var schedulerModel = SimulationUtility.getBananaSchedulerModel();
-    facade = new SimulationFacade(horizon, missionModel);
+    facade = new SimulationFacade(horizon, missionModel, schedulerModel);
     problem = new Problem(missionModel, horizon, facade, schedulerModel);
   }
 

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationUtility.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationUtility.java
@@ -6,6 +6,9 @@ import gov.nasa.jpl.aerie.merlin.driver.DirectiveTypeRegistry;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
 import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
+import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
+import gov.nasa.jpl.aerie.scheduler.model.Problem;
+import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
 
 import java.nio.file.Path;
 import java.time.Instant;
@@ -27,6 +30,32 @@ public final class SimulationUtility {
     final var builder = new MissionModelBuilder();
     final var model = factory.instantiate(Instant.EPOCH, config, builder);
     return builder.build(model, registry);
+  }
+
+  public static Problem buildProblemFromFoo(final PlanningHorizon planningHorizon){
+    final var fooMissionModel = SimulationUtility.getFooMissionModel();
+    final var fooSchedulerModel = SimulationUtility.getFooSchedulerModel();
+    return new Problem(
+        fooMissionModel,
+        planningHorizon,
+        new SimulationFacade(
+            planningHorizon,
+            fooMissionModel,
+            fooSchedulerModel),
+        fooSchedulerModel);
+  }
+
+  public static Problem buildProblemFromBanana(final PlanningHorizon planningHorizon){
+    final var fooMissionModel = SimulationUtility.getBananaMissionModel();
+    final var fooSchedulerModel = SimulationUtility.getBananaSchedulerModel();
+    return new Problem(
+        fooMissionModel,
+        planningHorizon,
+        new SimulationFacade(
+            planningHorizon,
+            fooMissionModel,
+            fooSchedulerModel),
+        fooSchedulerModel);
   }
 
   public static SchedulerModel getFooSchedulerModel(){

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
@@ -60,10 +60,7 @@ public class TestApplyWhen {
   @Test
   public void testRecurrenceCutoff1() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")
@@ -96,10 +93,7 @@ public class TestApplyWhen {
   @Test
   public void testRecurrenceCutoff2() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")
@@ -132,10 +126,7 @@ public class TestApplyWhen {
   @Test
   public void testRecurrenceShorterWindow() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")
@@ -168,10 +159,7 @@ public class TestApplyWhen {
   @Test
   public void testRecurrenceLongerWindow() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")
@@ -217,10 +205,7 @@ public class TestApplyWhen {
     RESULT: [+-------------------]
     */
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")
@@ -257,10 +242,7 @@ public class TestApplyWhen {
     // RESULT:            [++--------++--------]
 
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
 
     final var goalWindow = new Windows(false).set(Arrays.asList(
@@ -303,10 +285,7 @@ public class TestApplyWhen {
     // RESULT:            [++--------++--------]
 
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
 
     final var goalWindow = new Windows(false).set(Arrays.asList(
@@ -350,10 +329,7 @@ public class TestApplyWhen {
     // RESULT:            [++-----++-++----~~---] (if not global)
 
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
 
     final var goalWindow = new Windows(false).set(List.of(
@@ -398,10 +374,7 @@ public class TestApplyWhen {
     // RESULT:            [----------++--------]
 
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
 
     final var goalWindow = new Windows(false).set(List.of(
@@ -441,10 +414,7 @@ public class TestApplyWhen {
   @Test
   public void testRecurrenceCutoffUncontrollable() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(21));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("BasicActivity");
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")
@@ -482,9 +452,7 @@ public class TestApplyWhen {
 
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(25));
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
 
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     TestUtility.createAutoMutexGlobalSchedulingCondition(activityType).forEach(problem::add);
@@ -525,10 +493,7 @@ public class TestApplyWhen {
 
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
 
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
 
     final var goalWindow = new Windows(false).set(List.of(
@@ -575,10 +540,7 @@ public class TestApplyWhen {
 
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
 
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
 
     final var goalWindow = new Windows(false).set(List.of(
@@ -627,9 +589,7 @@ public class TestApplyWhen {
 
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(25));
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
 
 
     final var activityType = problem.getActivityType("BasicActivity");
@@ -674,9 +634,7 @@ public class TestApplyWhen {
 
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(25));
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
 
     //have some activity already present
     //  create a PlanInMemory, add ActivityInstances
@@ -729,9 +687,7 @@ public class TestApplyWhen {
 
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(25));
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
 
     //have some activity already present
     //  create a PlanInMemory, add ActivityInstances
@@ -791,9 +747,7 @@ public class TestApplyWhen {
 
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(25));
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
 
     //have some activity already present
     //  create a PlanInMemory, add ActivityInstances
@@ -848,9 +802,7 @@ public class TestApplyWhen {
 
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(25));
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
 
     //have some activity already present
     //  create a PlanInMemory, add ActivityInstances
@@ -915,9 +867,7 @@ public class TestApplyWhen {
 
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(28)); //this boundary is inclusive.
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
 
     //have some activity already present
     //  create a PlanInMemory, add ActivityInstances
@@ -994,9 +944,7 @@ public class TestApplyWhen {
 
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(12));
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
 
     //have some activity already present
     //  create a PlanInMemory, add ActivityInstances
@@ -1062,9 +1010,7 @@ public class TestApplyWhen {
 
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(16));
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
 
     //have some activity already present
     //  create a PlanInMemory, add ActivityInstances
@@ -1128,9 +1074,7 @@ public class TestApplyWhen {
 
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(25));
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
 
     //have some activity already present
     //  create a PlanInMemory, add ActivityInstances
@@ -1237,10 +1181,7 @@ public class TestApplyWhen {
 
     //basic setup
     PlanningHorizon hor = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, hor, new SimulationFacade(
-        hor,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(hor);
 
     final var activityTypeIndependent = problem.getActivityType("BasicFooActivity");
     logger.debug("BasicFooActivity: " + activityTypeIndependent.toString());
@@ -1314,10 +1255,7 @@ public class TestApplyWhen {
 
     //basic setup
     PlanningHorizon hor = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(18));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, hor, new SimulationFacade(
-        hor,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(hor);
 
     final var activityTypeIndependent = problem.getActivityType("BasicFooActivity");
     logger.debug("BasicFooActivity: " + activityTypeIndependent.toString());
@@ -1392,10 +1330,7 @@ public class TestApplyWhen {
 
     //basic setup
     PlanningHorizon hor = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, hor, new SimulationFacade(
-        hor,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(hor);
 
     final var activityTypeIndependent = problem.getActivityType("BasicFooActivity");
     logger.debug("BasicFooActivity: " + activityTypeIndependent.toString());

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
@@ -7,17 +7,15 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
 import gov.nasa.jpl.aerie.scheduler.goals.CardinalityGoal;
 import gov.nasa.jpl.aerie.scheduler.goals.ChildCustody;
-import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
 import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
-import gov.nasa.jpl.aerie.scheduler.model.Problem;
-import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
+import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
 import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static gov.nasa.jpl.aerie.scheduler.SimulationUtility.buildProblemFromFoo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestCardinalityGoal {
@@ -26,11 +24,9 @@ public class TestCardinalityGoal {
   public void testone() {
     Interval period = Interval.betweenClosedOpen(Duration.of(0, Duration.SECONDS), Duration.of(20, Duration.SECONDS));
 
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
     final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(25));
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
+
 
     CardinalityGoal goal = new CardinalityGoal.Builder()
         .duration(Interval.between(Duration.of(12, Duration.SECONDS), Duration.of(15, Duration.SECONDS)))

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static gov.nasa.jpl.aerie.scheduler.SimulationUtility.buildProblemFromFoo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -23,10 +24,7 @@ public class TestRecurrenceGoal {
   @Test
   public void testRecurrence() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")
@@ -55,13 +53,7 @@ public class TestRecurrenceGoal {
   @Test
   public void testRecurrenceNegative() {
     final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel,
-                                  planningHorizon,
-                                  new SimulationFacade(planningHorizon,
-                                                       fooMissionModel),
-                                  SimulationUtility.getFooSchedulerModel());
-
+    final var problem = buildProblemFromFoo(planningHorizon);
     try {
       final var activityType = problem.getActivityType("ControllableDurationActivity");
       final var goal = new RecurrenceGoal.Builder()

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoalExtended.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoalExtended.java
@@ -7,15 +7,13 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
 import gov.nasa.jpl.aerie.scheduler.goals.RecurrenceGoal;
 import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
-import gov.nasa.jpl.aerie.scheduler.model.Problem;
-import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
 import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static gov.nasa.jpl.aerie.scheduler.SimulationUtility.buildProblemFromFoo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestRecurrenceGoalExtended {
@@ -26,10 +24,7 @@ public class TestRecurrenceGoalExtended {
   @Test
   public void testRecurrence() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")
@@ -61,10 +56,7 @@ public class TestRecurrenceGoalExtended {
   @Test
   public void testRecurrenceSecondGoalOutOfWindowAndPlanHorizon() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")
@@ -93,10 +85,7 @@ public class TestRecurrenceGoalExtended {
   @Test
   public void testRecurrenceRepeatIntervalLargerThanGoalWindow() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")
@@ -125,10 +114,7 @@ public class TestRecurrenceGoalExtended {
   @Test
   public void testGoalWindowLargerThanPlanHorizon() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(5),TestUtility.timeFromEpochSeconds(15));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     final var goalWindow = new Windows(false).set(List.of(
         Interval.between(Duration.of(1, Duration.SECONDS), Duration.of(5, Duration.SECONDS)),
@@ -164,10 +150,7 @@ public class TestRecurrenceGoalExtended {
   @Test
   public void testGoalDurationLargerGoalWindow() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")
@@ -197,10 +180,7 @@ public class TestRecurrenceGoalExtended {
   @Test
   public void testGoalDurationLargerRepeatInterval() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")
@@ -230,10 +210,7 @@ public class TestRecurrenceGoalExtended {
   @Test
   public void testAddActivityNonEmptyPlan() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
     RecurrenceGoal goal = new RecurrenceGoal.Builder()
         .named("Test recurrence goal")
@@ -251,8 +228,7 @@ public class TestRecurrenceGoalExtended {
     var plan = solver.getNextSolution().orElseThrow();
 
     // Create a new problem with previous plan and add new goal interleaved two time units wrt original goal
-    Problem problem2 = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon, fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem2 = buildProblemFromFoo(planningHorizon);
     problem2.setInitialPlan(plan);
     RecurrenceGoal goal2 = new RecurrenceGoal.Builder()
         .named("Test recurrence goal 2")

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUnsatisfiableCompositeGoals.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUnsatisfiableCompositeGoals.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static gov.nasa.jpl.aerie.scheduler.SimulationUtility.buildProblemFromFoo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestUnsatisfiableCompositeGoals {
@@ -41,8 +42,7 @@ public class TestUnsatisfiableCompositeGoals {
 
   //test mission with two primitive activity types
   private static Problem makeTestMissionAB() {
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    return new Problem(fooMissionModel, h, new SimulationFacade(h, fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    return SimulationUtility.buildProblemFromFoo(h);
   }
 
   private static PlanInMemory makePlanA12(Problem problem) {
@@ -218,10 +218,7 @@ public class TestUnsatisfiableCompositeGoals {
   public void testCardinalityBacktrack() {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(20));
 
-    final var fooMissionModel = SimulationUtility.getFooMissionModel();
-    Problem problem = new Problem(fooMissionModel, planningHorizon, new SimulationFacade(
-        planningHorizon,
-        fooMissionModel), SimulationUtility.getFooSchedulerModel());
+    final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
 
     final var goalWindow = new Windows(false).set(List.of(

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/UncontrollableDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/UncontrollableDurationTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static gov.nasa.jpl.aerie.scheduler.SimulationUtility.buildProblemFromFoo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,8 +38,7 @@ public class UncontrollableDurationTest {
   @BeforeEach
   void setUp(){
     planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(3000));
-    MissionModel<?> aerieLanderMissionModel = SimulationUtility.getFooMissionModel();
-    problem = new Problem(aerieLanderMissionModel, planningHorizon, new SimulationFacade(planningHorizon, aerieLanderMissionModel), SimulationUtility.getFooSchedulerModel());
+    problem = buildProblemFromFoo(planningHorizon);
     plan = makeEmptyPlan();
   }
 

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationTest.java
@@ -4,7 +4,6 @@ import gov.nasa.jpl.aerie.merlin.driver.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.driver.engine.SimulationEngine;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
-import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.scheduler.SimulationUtility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.ThreadPoolExecutor;
 
-import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECOND;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -80,9 +78,10 @@ public class ResumableSimulationTest {
 
   @Test
   public void testStopsAtEndOfPlanningHorizon(){
+    final var fooSchedulerModel = SimulationUtility.getFooSchedulerModel();
     final var activity = new TestSimulatedActivity(
         Duration.of(0, SECONDS),
-        new SerializedActivity("ControllableDurationActivity", Map.of("duration", SerializedValue.of(tenHours.in(MICROSECOND)))),
+        new SerializedActivity("ControllableDurationActivity", Map.of("duration", fooSchedulerModel.serializeDuration(tenHours))),
         new ActivityDirectiveId(1));
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
     resumableSimulationDriver = new ResumableSimulationDriver<>(fooMissionModel, fiveHours);

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/MerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/MerlinService.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.scheduler.server.services;
 
 import gov.nasa.jpl.aerie.merlin.driver.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.scheduler.model.Plan;
@@ -124,7 +125,8 @@ public interface MerlinService {
     Pair<PlanId, Map<SchedulingActivityDirective, ActivityDirectiveId>> createNewPlanWithActivityDirectives(
         final PlanMetadata planMetadata,
         final Plan plan,
-        final Map<SchedulingActivityDirective, GoalId> activityToGoalId
+        final Map<SchedulingActivityDirective, GoalId> activityToGoalId,
+        final SchedulerModel schedulerModel
     )
     throws IOException, NoSuchPlanException, MerlinServiceException;
 
@@ -158,7 +160,8 @@ public interface MerlinService {
         Map<SchedulingActivityDirectiveId, ActivityDirectiveId> idsFromInitialPlan,
         MerlinPlan initialPlan,
         Plan plan,
-        Map<SchedulingActivityDirective, GoalId> activityToGoalId
+        Map<SchedulingActivityDirective, GoalId> activityToGoalId,
+        SchedulerModel schedulerModel
     )
     throws IOException, NoSuchPlanException, MerlinServiceException, NoSuchActivityInstanceException;
 
@@ -188,7 +191,8 @@ public interface MerlinService {
     Map<SchedulingActivityDirective, ActivityDirectiveId> createAllPlanActivityDirectives(
         final PlanId planId,
         final Plan plan,
-        final Map<SchedulingActivityDirective, GoalId> activityToGoalId
+        final Map<SchedulingActivityDirective, GoalId> activityToGoalId,
+        final SchedulerModel schedulerModel
     )
     throws IOException, NoSuchPlanException, MerlinServiceException;
 


### PR DESCRIPTION
* **Tickets addressed:** Fixes #1220 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
First commit: give access to mission model value mapper serialization/deserialization via the `SchedulerModel`.

Second commit is about fixing all the times that durations were assumed to be in a specific schema (long number of microseconds). 

Third commit: I added a (very smart) custom value mapper for durations to the foo mission model (as a test) and had to update 2 or 3 tests to use model serialization to build activities. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Foo has now a custom duration value mapper so all the tests using foo are testing the new pipeline

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None. 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None.