### PR TITLE
Fix Parsing Issues with .env in E2E-Tests

### DIFF
--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -17,18 +17,26 @@ jacocoTestReport {
 }
 
 task e2eTest(type: Test) {
+  ext.parseEnvFile = { filePath ->
+    file(filePath).readLines().each() {
+      if (!it.isEmpty() && !it.startsWith("#")) {
+        def (key, value) = it.tokenize('=')
+        if (key.startsWith("export ")) {
+          key = key.split("export ")[1];
+        }
+        if (System.getenv(key) == null) {
+          environment key, value
+        }
+      }
+    }
+  }
+
   dependsOn ":examples:banananation:assemble"
 
   if(file('.env').exists()) {
-    file('.env').readLines().each() {
-      def (key, value) = it.tokenize('=')
-      environment key, value
-    }
+    parseEnvFile('.env')
   } else if(file('../.env').exists()){
-    file('../.env').readLines().each() {
-      def (key, value) = it.tokenize('=')
-      environment key, value
-    }
+    parseEnvFile('../.env')
   }
   environment "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD", 1
   // Run the tests in parallel to improve performance


### PR DESCRIPTION
* **Tickets addressed:** Closes #1224
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

Parsing will now ignore:
- the word "export" before a key
- commented lines
- blank lines

It will also not overwrite any keys in the global environment, should they exist.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Verified by adding the line `println('Placing key ' +key + ' with value '+ value)` in the if statement on L27 (right after `environment key, value`, modifying my `.env` to these formerly problematic states, then running the HealthTests and checking the output from gradle.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

No docs need to be updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
