### PR TITLE
Automatically calculate and cache directive validations

### DIFF
--- a/deployment/Environment.md
+++ b/deployment/Environment.md
@@ -16,17 +16,19 @@ See the [environment variables document](https://github.com/NASA-AMMOS/aerie-gat
 
 ## Aerie Merlin
 
-| Name                 | Description                                                                                                                 | Type     | Default                         |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------- |
-| `JAVA_OPTS`          | Configuration for Merlin's logging level and output file                                                                    | `string` | log level: warn. output: stderr |
-| `MERLIN_PORT`        | Port number for the Merlin server                                                                                           | `number` | 27183                           |
-| `MERLIN_LOCAL_STORE` | Local storage for Merlin in the container                                                                                   | `string` | /usr/src/app/merlin_file_store  |
-| `MERLIN_DB_SERVER`   | The DB instance that Merlin will connect with                                                                               | `string` |                                 |
-| `MERLIN_DB_PORT`     | The DB instance port number that Merlin will connect with                                                                   | `number` | 5432                            |
-| `MERLIN_DB_USER`     | Username of the DB instance                                                                                                 | `string` |                                 |
-| `MERLIN_DB_PASSWORD` | Password of the DB instance                                                                                                 | `string` |                                 |
-| `MERLIN_DB`          | The DB for Merlin.                                                                                                          | `string` | aerie_merlin                    |
-| `UNTRUE_PLAN_START`  | Temporary solution to provide plan start time to models, should be set to a time that models will not fail to initialize on | `string` |                                 |
+| Name                                  | Description                                                                                                                 | Type     | Default                         |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------- |
+| `JAVA_OPTS`                           | Configuration for Merlin's logging level and output file                                                                    | `string` | log level: warn. output: stderr |
+| `MERLIN_PORT`                         | Port number for the Merlin server                                                                                           | `number` | 27183                           |
+| `MERLIN_LOCAL_STORE`                  | Local storage for Merlin in the container                                                                                   | `string` | /usr/src/app/merlin_file_store  |
+| `MERLIN_DB_SERVER`                    | The DB instance that Merlin will connect with                                                                               | `string` |                                 |
+| `MERLIN_DB_PORT`                      | The DB instance port number that Merlin will connect with                                                                   | `number` | 5432                            |
+| `MERLIN_DB_USER`                      | Username of the DB instance                                                                                                 | `string` |                                 |
+| `MERLIN_DB_PASSWORD`                  | Password of the DB instance                                                                                                 | `string` |                                 |
+| `MERLIN_DB`                           | The DB for Merlin.                                                                                                          | `string` | aerie_merlin                    |
+| `UNTRUE_PLAN_START`                   | Temporary solution to provide plan start time to models, should be set to a time that models will not fail to initialize on | `string` |                                 |
+| `ENABLE_CONTINUOUS_VALIDATION_THREAD` | Flag to enable a worker thread that continously computes and caches activity directive validation results                   | `boolean`| true                            |
+| `VALIDATION_THREAD_POLLING_PERIOD`    | Number of milliseconds the above worker thread should wait before querying the database for new, unvalidated directives     | `string` | 500                             |
 
 ## Aerie Merlin Worker
 

--- a/deployment/hasura/migrations/AerieMerlin/32_automatic_activity_validations/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/32_automatic_activity_validations/down.sql
@@ -1,0 +1,21 @@
+drop trigger validation_entry_on_insert on activity_directive;
+
+drop function activity_directive_validation_entry;
+
+create or replace function activity_directive_set_arguments_updated_at()
+  returns trigger
+  security definer
+  language plpgsql as $$begin
+    call plan_locked_exception(new.plan_id);
+    new.last_modified_arguments_at = now();
+  return new;
+end$$;
+
+alter table activity_directive_validations
+  drop column last_modified_arguments_at,
+  add column last_modified_at timestamptz not null default now();
+
+comment on column activity_directive_validations.last_modified_at is e''
+  'The time at which these argument validations were last modified.';
+
+call migrations.mark_migration_rolled_back('32');

--- a/deployment/hasura/migrations/AerieMerlin/32_automatic_activity_validations/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/32_automatic_activity_validations/down.sql
@@ -13,6 +13,7 @@ end$$;
 
 alter table activity_directive_validations
   drop column last_modified_arguments_at,
+  drop column status,
   add column last_modified_at timestamptz not null default now();
 
 comment on column activity_directive_validations.last_modified_at is e''

--- a/deployment/hasura/migrations/AerieMerlin/32_automatic_activity_validations/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/32_automatic_activity_validations/up.sql
@@ -1,0 +1,42 @@
+alter table activity_directive_validations
+  drop column last_modified_at,
+  add column last_modified_arguments_at timestamptz not null;
+
+comment on column activity_directive_validations.last_modified_arguments_at is e''
+  'The time at which these argument validations were last modified.';
+
+-- reuse exising  insert empty validations row on argument update
+create or replace function activity_directive_set_arguments_updated_at()
+  returns trigger
+  security definer
+  language plpgsql as
+$$ begin
+  call plan_locked_exception(new.plan_id);
+  new.last_modified_arguments_at = now();
+
+  -- clear old validations
+  update activity_directive_validations
+    set last_modified_arguments_at = new.last_modified_arguments_at,
+        validations = '{}'
+    where (directive_id, plan_id) = (new.id, new.plan_id);
+
+  return new;
+end $$;
+
+create function activity_directive_validation_entry()
+  returns trigger
+  security definer
+  language plpgsql as
+$$ begin
+  insert into activity_directive_validations
+    (directive_id, plan_id, last_modified_arguments_at)
+    values (new.id, new.plan_id, new.last_modified_arguments_at);
+  return new;
+end $$;
+
+create trigger validation_entry_on_insert
+  after insert on activity_directive
+  for each row
+execute function activity_directive_validation_entry();
+
+call migrations.mark_migration_applied('32');

--- a/deployment/hasura/migrations/AerieMerlin/32_automatic_activity_validations/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/32_automatic_activity_validations/up.sql
@@ -1,5 +1,6 @@
 alter table activity_directive_validations
   drop column last_modified_at,
+  add column status text not null default 'pending',
   add column last_modified_arguments_at timestamptz not null;
 
 comment on column activity_directive_validations.last_modified_arguments_at is e''
@@ -14,10 +15,10 @@ $$ begin
   call plan_locked_exception(new.plan_id);
   new.last_modified_arguments_at = now();
 
-  -- clear old validations
+  -- request new validation
   update activity_directive_validations
     set last_modified_arguments_at = new.last_modified_arguments_at,
-        validations = '{}'
+        status = 'pending'
     where (directive_id, plan_id) = (new.id, new.plan_id);
 
   return new;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
       UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
+      ENABLE_CONTINUOUS_VALIDATION_THREAD: true
     image: aerie_merlin
     ports: ["27183:27183", "5005:5005"]
     restart: always

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -46,6 +46,7 @@ services:
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
       UNTRUE_PLAN_START: '2000-01-01T11:58:55.816Z'
+      ENABLE_CONTINUOUS_VALIDATION_THREAD: true
     image: aerie_merlin
     ports: ['27183:27183', '5005:5005']
     restart: always

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/AutomaticValidationTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/AutomaticValidationTests.java
@@ -1,0 +1,113 @@
+package gov.nasa.jpl.aerie.e2e;
+
+import com.microsoft.playwright.Playwright;
+import gov.nasa.jpl.aerie.e2e.types.ActivityValidation;
+import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
+import gov.nasa.jpl.aerie.e2e.utils.HasuraRequests;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import javax.json.Json;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AutomaticValidationTests {
+  // Requests
+  private Playwright playwright;
+  private HasuraRequests hasura;
+
+  // Per-Test Data
+  private int modelId;
+  private int planId;
+
+  @BeforeAll
+  void beforeAll() {
+    // Setup Requests
+    playwright = Playwright.create();
+    hasura = new HasuraRequests(playwright);
+  }
+
+  @AfterAll
+  void afterAll() {
+    // Cleanup Requests
+    hasura.close();
+    playwright.close();
+  }
+
+  @BeforeEach
+  void beforeEach() throws IOException, InterruptedException {
+    // Insert the Mission Model
+    try (final var gateway = new GatewayRequests(playwright)) {
+      modelId = hasura.createMissionModel(
+          gateway.uploadJarFile(),
+          "Banananation (e2e tests)",
+          "aerie_e2e_tests",
+          "Automatic Validation Tests");
+    }
+    // Insert the Plan
+    planId = hasura.createPlan(
+        modelId,
+        "Test Plan - Automatic Validation Tests",
+        "1212h",
+        "2021-01-01T00:00:00Z");
+  }
+
+  @AfterEach
+  void afterEach() throws IOException {
+    // Remove Model, Plan, and Constraint
+    hasura.deletePlan(planId);
+    hasura.deleteMissionModel(modelId);
+  }
+
+  @Test
+  void validationSuccess() throws IOException, InterruptedException {
+    final var activityId = hasura.insertActivity(
+        planId,
+        "BiteBanana",
+        "1h",
+        Json.createObjectBuilder().add("biteSize", 1).build());
+    Thread.sleep(1000); // TODO consider a while loop here
+    final var activityValidations = hasura.getActivityValidations(planId);
+    final ActivityValidation activityValidation = activityValidations.get((long) activityId);
+    assertEquals(new ActivityValidation.Success(), activityValidation);
+  }
+
+  @Test
+  void exceptionDuringValidationHandled() throws IOException, InterruptedException {
+    final var exceptionActivityId = hasura.insertActivity(
+        planId,
+        "ExceptionActivity",
+        "1h",
+        Json.createObjectBuilder().add("throwException", true).build());
+
+    // sleep to make sure exception activity is picked up
+    Thread.sleep(1000); // TODO consider a while loop here
+
+    final var biteActivityId = hasura.insertActivity(
+        planId,
+        "BiteBanana",
+        "1h",
+        Json.createObjectBuilder().add("biteSize", 1).build());
+
+    Thread.sleep(1000); // TODO consider a while loop here
+
+    final var activityValidations = hasura.getActivityValidations(planId);
+
+    final ActivityValidation exceptionValidations = activityValidations.get((long) exceptionActivityId);
+    final ActivityValidation biteValidations = activityValidations.get((long) biteActivityId);
+
+    // then make sure the exception was caught and serialized, and didn't crash the worker thread
+    assertEquals(new ActivityValidation.ValidationFailure(List.of(
+        new ActivityValidation.ValidationNotice(List.of("throwException"), "Throwing runtime exception during validation"))),
+                 exceptionValidations);
+    // if the above is true, bite banana will have its validation still
+    assertEquals(new ActivityValidation.Success(), biteValidations);
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/MissionModelTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/MissionModelTests.java
@@ -116,6 +116,7 @@ public class MissionModelTests {
         new ValueSchemaStruct(Map.of(
             "duration", VALUE_SCHEMA_DURATION,
             "durationInSeconds", new ValueSchemaMeta(Map.of("unit", Json.createObjectBuilder(Map.of("value", "s")).build()), VALUE_SCHEMA_REAL)))));
+    activityTypes.add(new ActivityType("ExceptionActivity", Map.of("throwException", new Parameter(0, VALUE_SCHEMA_BOOLEAN))));
     activityTypes.add(new ActivityType("grandchild", Map.of("counter", new Parameter(0, VALUE_SCHEMA_INT))));
     activityTypes.add(new ActivityType("GrowBanana", Map.of(
         "quantity", new Parameter(0, VALUE_SCHEMA_INT),

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/SchedulingTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/SchedulingTests.java
@@ -324,7 +324,7 @@ public class SchedulingTests {
     assertEquals("05:00:00", plantSegments.get(2).startOffset()); // GB2 end
 
     final var topics = hasura.getTopicsEvents(datasetId);
-    assertEquals(39, topics.size());
+    assertEquals(41, topics.size());
     // Assert that the keys to be inspected are included
     assertTrue(topics.containsKey("ActivityType.Input.GrowBanana"));
     assertTrue(topics.containsKey("ActivityType.Output.GrowBanana"));

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ActivityValidation.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ActivityValidation.java
@@ -1,0 +1,54 @@
+package gov.nasa.jpl.aerie.e2e.types;
+
+import javax.json.JsonObject;
+import javax.json.JsonString;
+import javax.json.JsonValue;
+import java.util.List;
+
+public sealed interface ActivityValidation {
+  record Pending() implements ActivityValidation {}
+  record Success() implements ActivityValidation {}
+  record InstantiationFailure(List<String> extraneousArguments, List<String> missingArguments, List<?> unconstructableArguments) implements ActivityValidation {}
+  record ValidationFailure(List<ValidationNotice> notices) implements ActivityValidation {}
+  record NoSuchActivityTypeFailure(String message, String activityType) implements ActivityValidation {}
+
+  record ValidationNotice(List<String> subjects, String message) { }
+  record UnconstructableArgument(String name, String failure) { }
+
+  static ActivityValidation fromJSON(JsonObject obj) {
+    final var status = obj.getString("status");
+    if (!status.equals("complete")) {
+      return new Pending();
+    }
+    final var validations = obj.getJsonObject("validations");
+    if (validations.getBoolean("success")) {
+      return new Success();
+    }
+    final String type = validations.getString("type");
+    final JsonObject errors = validations.getJsonObject("errors");
+    return switch (type) {
+      case "INSTANTIATION_ERRORS" -> new InstantiationFailure(
+          getStringArray(errors, "extraneousArguments"),
+          getStringArray(errors, "missingArguments"),
+          errors
+              .asJsonObject()
+              .getJsonArray("unconstructableArguments")
+              .getValuesAs(
+                  $ -> new UnconstructableArgument(
+                      $.asJsonObject().getString("name"),
+                      $.asJsonObject().getString("failure"))));
+      case "VALIDATION_NOTICES" -> new ValidationFailure(
+          errors.getJsonArray("validationNotices")
+                .getValuesAs(
+                    $ -> new ValidationNotice(
+                        getStringArray($, "subjects"),
+                        $.asJsonObject().getString("message"))));
+      case "NO_SUCH_ACTIVITY_TYPE" -> new NoSuchActivityTypeFailure(errors.getJsonObject("noSuchActivityError").getString("message"), errors.getJsonObject("noSuchActivityError").getString("activity_type"));
+      default -> throw new RuntimeException("Unhandled error type: " + type);
+    };
+  }
+
+  static List<String> getStringArray(JsonValue object, String key) {
+    return object.asJsonObject().getJsonArray(key).getValuesAs(subj -> ((JsonString) subj).getString());
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
@@ -210,6 +210,16 @@ public enum GQL {
         success
       }
     }"""),
+  GET_ACTIVITY_VALIDATIONS("""
+    query GetActivityValidations($planId: Int!) {
+      activity_directive_validations(where: {plan_id: {_eq: $planId}}) {
+        status
+        validations
+        plan_id
+        last_modified_arguments_at
+        directive_id
+      }
+    }"""),
   GET_EFFECTIVE_MODEL_ARGUMENTS("""
     query GetEffectiveModelArguments($modelId: ID!, $modelArgs: ModelArguments!) {
       getModelEffectiveArguments(missionModelId: $modelId, modelArguments: $modelArgs) {

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/HasuraRequests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/HasuraRequests.java
@@ -9,6 +9,7 @@ import gov.nasa.jpl.aerie.e2e.types.*;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.json.Json;
+import javax.json.JsonArray;
 import javax.json.JsonValue;
 import javax.json.JsonObject;
 import java.io.IOException;
@@ -222,6 +223,22 @@ public class HasuraRequests implements AutoCloseable {
         .getJsonArray("getActivityEffectiveArgumentsBulk")
         .getValuesAs(EffectiveActivityArguments::fromJSON);
   }
+
+  public Map<Long, ActivityValidation> getActivityValidations(final int planId) throws IOException {
+    final var variables = Json.createObjectBuilder()
+                              .add("planId", planId)
+                              .build();
+    final JsonArray response = makeRequest(GQL.GET_ACTIVITY_VALIDATIONS, variables)
+        .getJsonArray("activity_directive_validations");
+    final var res = new HashMap<Long, ActivityValidation>();
+    for (final var object : response) {
+      res.put(
+          (long) object.asJsonObject().getInt("directive_id"),
+          ActivityValidation.fromJSON(object.asJsonObject()));
+    }
+    return res;
+  }
+
   //endregion
 
   //region Simulation

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/ExceptionActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/ExceptionActivity.java
@@ -1,0 +1,29 @@
+package gov.nasa.jpl.aerie.banananation.activities;
+
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Parameter;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Validation;
+
+/**
+ * Conditionally throws a runtime exception at both validation time and runtime
+ */
+@ActivityType("ExceptionActivity")
+public final class ExceptionActivity {
+  @Parameter
+  public boolean throwException = false;
+
+  @Validation("Throws an exception if set")
+  @Validation.Subject("throwException")
+  public boolean conditionallyThrowException() {
+    if (this.throwException) {
+      throw new RuntimeException("Throwing runtime exception during validation");
+    }
+    return true;
+  }
+
+  public void run() {
+    if (this.throwException) {
+      throw new RuntimeException("Throwing runtime exception during runtime");
+    }
+  }
+}

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
@@ -25,6 +25,7 @@
 @WithActivityType(DurationParameterActivity.class)
 @WithActivityType(ControllableDurationActivity.class)
 @WithActivityType(RipenBananaActivity.class)
+@WithActivityType(ExceptionActivity.class)
 
 package gov.nasa.jpl.aerie.banananation;
 
@@ -38,6 +39,7 @@ import gov.nasa.jpl.aerie.banananation.activities.DecomposingActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DecomposingSpawnActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DownloadBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.DurationParameterActivity;
+import gov.nasa.jpl.aerie.banananation.activities.ExceptionActivity;
 import gov.nasa.jpl.aerie.banananation.activities.GrowBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.LineCountBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.ParameterTestActivity;

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MapperMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MapperMethodMaker.java
@@ -159,6 +159,7 @@ public abstract sealed class MapperMethodMaker permits
 
                     return CodeBlock
                         .builder()
+                        .beginControlFlow("try")
                         .addStatement(
                             "if (!$L.$L()) notices.add(new $T($T.of($L), $S))",
                             "input",
@@ -166,7 +167,10 @@ public abstract sealed class MapperMethodMaker permits
                             ValidationNotice.class,
                             List.class,
                             subjects,
-                            validation.failureMessage());
+                            validation.failureMessage())
+                        .nextControlFlow("catch ($T ex)", Throwable.class)
+                        .addStatement("notices.add(new $T($T.of($L), ex.getMessage()))", ValidationNotice.class, List.class, subjects)
+                        .endControlFlow();
                 })
                 .reduce(CodeBlock.builder(), (x, y) -> x.add(y.build()))
                 .build())

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -34,3 +34,4 @@ call migrations.mark_migration_applied('28');
 call migrations.mark_migration_applied('29');
 call migrations.mark_migration_applied('30');
 call migrations.mark_migration_applied('31');
+call migrations.mark_migration_applied('32');

--- a/merlin-server/sql/merlin/tables/activity_directive.sql
+++ b/merlin-server/sql/merlin/tables/activity_directive.sql
@@ -191,10 +191,10 @@ $$ begin
   call plan_locked_exception(new.plan_id);
   new.last_modified_arguments_at = now();
 
-  -- clear old validations
+  -- request new validation
   update activity_directive_validations
     set last_modified_arguments_at = new.last_modified_arguments_at,
-        validations = '{}'
+        status = 'pending'
     where (directive_id, plan_id) = (new.id, new.plan_id);
 
   return new;

--- a/merlin-server/sql/merlin/tables/activity_directive_validations.sql
+++ b/merlin-server/sql/merlin/tables/activity_directive_validations.sql
@@ -2,6 +2,7 @@ create table activity_directive_validations (
   directive_id integer not null,
   plan_id integer not null,
   last_modified_arguments_at timestamptz not null,
+  status text not null default 'pending',
   validations jsonb default '{}'::jsonb,
 
   constraint activity_directive_validations_natural_key

--- a/merlin-server/sql/merlin/tables/activity_directive_validations.sql
+++ b/merlin-server/sql/merlin/tables/activity_directive_validations.sql
@@ -1,8 +1,7 @@
 create table activity_directive_validations (
   directive_id integer not null,
   plan_id integer not null,
-
-  last_modified_at timestamptz not null default now(),
+  last_modified_arguments_at timestamptz not null,
   validations jsonb default '{}'::jsonb,
 
   constraint activity_directive_validations_natural_key
@@ -21,7 +20,7 @@ comment on column activity_directive_validations.directive_id is e''
   'The activity directive these validations are extracted from.';
 comment on column activity_directive_validations.plan_id is ''
   'The plan associated with the activity directive these validations are extracted from.';
-comment on column activity_directive_validations.last_modified_at is e''
+comment on column activity_directive_validations.last_modified_arguments_at is e''
   'The time at which these argument validations were last modified.';
 comment on column activity_directive_validations.validations is e''
   'The argument validations extracted from an activity directive.';

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/config/AppConfiguration.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/config/AppConfiguration.java
@@ -12,7 +12,9 @@ public record AppConfiguration (
     Store store,
     Instant untruePlanStart,
     URI hasuraGraphqlURI,
-    String hasuraGraphQlAdminSecret
+    String hasuraGraphQlAdminSecret,
+    boolean enableContinuousValidationThread,
+    int validationThreadPollingPeriod
 ) {
   public AppConfiguration {
     Objects.requireNonNull(merlinFileStore);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -172,6 +172,7 @@ public final class ResponseSerializers {
     } else if (response instanceof BulkArgumentValidationResponse.Validation v) {
       return Json.createObjectBuilder()
                  .add("success", JsonValue.FALSE)
+                 .add("type", "VALIDATION_NOTICES")
                  .add("errors", Json.createObjectBuilder()
                      .add("validationNotices", serializeIterable(ResponseSerializers::serializeValidationNotice, v.notices()))
                      .build())
@@ -179,12 +180,15 @@ public final class ResponseSerializers {
     } else if (response instanceof BulkArgumentValidationResponse.NoSuchActivityError e) {
       return Json.createObjectBuilder()
                  .add("success", JsonValue.FALSE)
+                 .add("type", "NO_SUCH_ACTIVITY_TYPE")
                  .add("errors", Json.createObjectBuilder()
                      .add("noSuchActivityError", serializeNoSuchActivityTypeException(e.ex()))
                      .build())
                  .build();
     } else if (response instanceof BulkArgumentValidationResponse.InstantiationError f) {
-      return serializeInstantiationException(f.ex());
+      return Json.createObjectBuilder(serializeInstantiationException(f.ex()).asJsonObject())
+          .add("type", "INSTANTIATION_ERRORS")
+          .build();
     }
 
     // This should never happen, but we don't have exhaustive pattern matching

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityDirectiveForValidation.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityDirectiveForValidation.java
@@ -6,6 +6,5 @@ public record ActivityDirectiveForValidation
 (
     ActivityDirectiveId id,
     PlanId planId,
-    Timestamp argumentsModifiedTime,
     SerializedActivity activity
 ) { }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityDirectiveForValidation.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ActivityDirectiveForValidation.java
@@ -2,9 +2,12 @@ package gov.nasa.jpl.aerie.merlin.server.models;
 
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
 
+import java.sql.Timestamp;
+
 public record ActivityDirectiveForValidation
 (
     ActivityDirectiveId id,
     PlanId planId,
+    Timestamp argumentsModifiedTime,
     SerializedActivity activity
 ) { }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelId.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/MissionModelId.java
@@ -1,0 +1,8 @@
+package gov.nasa.jpl.aerie.merlin.server.models;
+
+public record MissionModelId(long id) {
+  @Override
+  public String toString() {
+    return String.valueOf(this.id());
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/MissionModelRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/MissionModelRepository.java
@@ -1,14 +1,14 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes;
 
 import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.Parameter;
-import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Resource;
-import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveId;
+import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveForValidation;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
+import gov.nasa.jpl.aerie.merlin.server.models.MissionModelId;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelJar;
-import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
-import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
+import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService.BulkArgumentValidationResponse;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 import java.util.Map;
@@ -23,8 +23,9 @@ public interface MissionModelRepository {
     // Mutations
     void updateModelParameters(String missionModelId, final List<Parameter> modelParameters) throws NoSuchMissionModelException;
     void updateActivityTypes(String missionModelId, final Map<String, ActivityType> activityTypes) throws NoSuchMissionModelException;
-    void updateActivityDirectiveValidations(final ActivityDirectiveId directiveId, final PlanId planId, final Timestamp argumentsModifiedTime, final List<ValidationNotice> notices);
     void updateResourceTypes(String missionModelId, final Map<String, Resource<?>> resourceTypes) throws NoSuchMissionModelException;
+    Map<MissionModelId, List<ActivityDirectiveForValidation>> getUnvalidatedDirectives();
+    void updateDirectiveValidations(List<Pair<ActivityDirectiveForValidation, BulkArgumentValidationResponse>> updates);
 
     final class NoSuchMissionModelException extends Exception {}
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetUnvalidatedDirectivesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetUnvalidatedDirectivesAction.java
@@ -1,0 +1,64 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
+import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveForValidation;
+import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveId;
+import gov.nasa.jpl.aerie.merlin.server.models.MissionModelId;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.activityArgumentsP;
+import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.getJsonColumn;
+
+public class GetUnvalidatedDirectivesAction implements AutoCloseable {
+  private static final String sql = """
+      select ad.id, ad.plan_id, ad.type, ad.arguments, p.model_id
+        from activity_directive ad
+        join activity_directive_validations adv
+          on ad.id = adv.directive_id and ad.plan_id = adv.plan_id
+        join plan p
+          on ad.plan_id = p.id
+        where adv.validations = '{}';
+        """;
+
+  private final PreparedStatement statement;
+
+  public GetUnvalidatedDirectivesAction(Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public Map<MissionModelId, List<ActivityDirectiveForValidation>> get() throws SQLException {
+    final var results = this.statement.executeQuery();
+    final var map = new HashMap<MissionModelId, List<ActivityDirectiveForValidation>>();
+
+    while (results.next()) {
+      final var modelId = new MissionModelId(results.getInt("model_id"));
+      final var directiveId = results.getInt("id");
+      final var planId = results.getInt("plan_id");
+      final var type = results.getString("type");
+      final var arguments = getJsonColumn(results, "arguments", activityArgumentsP)
+          .getSuccessOrThrow($ -> new Error("Corrupt activity arguments cannot be parsed: " + $.reason()));
+
+      map.computeIfAbsent(modelId, $ -> new ArrayList<>())
+         .add(new ActivityDirectiveForValidation(
+             new ActivityDirectiveId(directiveId),
+             new PlanId(planId),
+             new SerializedActivity(type, arguments)
+         ));
+    }
+
+    return map;
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetUnvalidatedDirectivesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetUnvalidatedDirectivesAction.java
@@ -25,7 +25,7 @@ public class GetUnvalidatedDirectivesAction implements AutoCloseable {
           on ad.id = adv.directive_id and ad.plan_id = adv.plan_id
         join plan p
           on ad.plan_id = p.id
-        where adv.validations = '{}';
+        where adv.status = 'pending';
         """;
 
   private final PreparedStatement statement;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PreparedStatements.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PreparedStatements.java
@@ -2,11 +2,11 @@ package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.driver.SimulationFailure;
 import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.Parameter;
-import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.ValidationNotice;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.server.http.MerlinParsers;
 import gov.nasa.jpl.aerie.merlin.server.http.ResponseSerializers;
 import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
+import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService;
 import org.intellij.lang.annotations.Language;
 
 import javax.json.Json;
@@ -83,9 +83,12 @@ public final class PreparedStatements {
     statement.setString(parameter, ResponseSerializers.serializeStringList(requiredParameters).toString());
   }
 
-  public static void setValidationNotices(final PreparedStatement statement, final int parameter, final List<ValidationNotice> notices)
-  throws SQLException {
-    statement.setString(parameter, ResponseSerializers.serializeValidationNotices(notices).toString());
+  public static void setValidationResponse(
+      final PreparedStatement statement,
+      final int parameter,
+      final MissionModelService.BulkArgumentValidationResponse response
+  ) throws SQLException {
+    statement.setString(parameter, ResponseSerializers.serializeBulkArgumentValidationResponse(response).toString());
   }
 
   public static void setFailureReason(final PreparedStatement statement, final int parameter, final SimulationFailure reason)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateActivityDirectiveValidationsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateActivityDirectiveValidationsAction.java
@@ -1,8 +1,9 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
-import gov.nasa.jpl.aerie.merlin.protocol.model.InputType.ValidationNotice;
-import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
+import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveForValidation;
+import org.apache.commons.lang3.tuple.Pair;
 import org.intellij.lang.annotations.Language;
+import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService.BulkArgumentValidationResponse;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -11,14 +12,9 @@ import java.util.List;
 
 /*package-local*/ final class UpdateActivityDirectiveValidationsAction implements AutoCloseable {
   private static final @Language("SQL") String sql = """
-    insert into activity_directive_validations
-        as validation (directive_id, plan_id, last_modified_at, validations)
-    values (?, ?, ?::timestamptz, ?::json)
-    on conflict (directive_id, plan_id) do update
-        set
-            last_modified_at = excluded.last_modified_at,
-            validations = excluded.validations
-        where validation.last_modified_at < excluded.last_modified_at
+    update activity_directive_validations
+    set validations = ?::jsonb
+    where (directive_id, plan_id) = (?, ?)
   """;
 
   private final PreparedStatement statement;
@@ -27,15 +23,18 @@ import java.util.List;
     this.statement = connection.prepareStatement(sql);
   }
 
-  public void apply(final long directiveId, final long planId, final Timestamp argumentsModifiedTime, final List<ValidationNotice> notices)
-  throws SQLException, FailedUpdateException
-  {
-    this.statement.setLong(1, directiveId);
-    this.statement.setLong(2, planId);
-    PreparedStatements.setTimestamp(this.statement, 3, argumentsModifiedTime);
-    PreparedStatements.setValidationNotices(this.statement, 4, notices);
+  public void apply(List<Pair<ActivityDirectiveForValidation, BulkArgumentValidationResponse>> updates)
+  throws SQLException, FailedUpdateException {
+    for (final var update : updates) {
+      final var directive = update.getLeft();
+      final var validation = update.getRight();
 
-    statement.executeUpdate();
+      PreparedStatements.setValidationResponse(this.statement, 1, validation);
+      this.statement.setLong(2, directive.id().id());
+      this.statement.setLong(3, directive.planId().id());
+      statement.addBatch();
+    }
+    statement.executeBatch();
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateActivityDirectiveValidationsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateActivityDirectiveValidationsAction.java
@@ -16,7 +16,7 @@ import java.util.List;
     update activity_directive_validations
     set validations = ?::jsonb,
         status = 'complete'
-    where (directive_id, plan_id) = (?, ?)
+    where (directive_id, plan_id, last_modified_arguments_at) = (?, ?, ?)
   """;
 
   private final PreparedStatement statement;
@@ -35,6 +35,7 @@ import java.util.List;
         PreparedStatements.setValidationResponse(statement, 1, validation);
         statement.setLong(2, directive.id().id());
         statement.setLong(3, directive.planId().id());
+        statement.setTimestamp(4, directive.argumentsModifiedTime());
 
         statement.addBatch();
       }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateActivityDirectiveValidationsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateActivityDirectiveValidationsAction.java
@@ -13,7 +13,8 @@ import java.util.List;
 /*package-local*/ final class UpdateActivityDirectiveValidationsAction implements AutoCloseable {
   private static final @Language("SQL") String sql = """
     update activity_directive_validations
-    set validations = ?::jsonb
+    set validations = ?::jsonb,
+        status = 'complete'
     where (directive_id, plan_id) = (?, ?)
   """;
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -10,8 +10,6 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
-import gov.nasa.jpl.aerie.merlin.server.ResultsProtocol;
-import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveForValidation;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityType;
 import gov.nasa.jpl.aerie.merlin.server.models.Constraint;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelJar;
@@ -71,8 +69,6 @@ public interface MissionModelService {
 
   void refreshModelParameters(String missionModelId) throws NoSuchMissionModelException;
   void refreshActivityTypes(String missionModelId) throws NoSuchMissionModelException;
-  void refreshActivityValidations(String missionModelId, ActivityDirectiveForValidation directive)
-  throws NoSuchMissionModelException, InstantiationException;
   void refreshResourceTypes(String missionModelId) throws NoSuchMissionModelException;
 
   sealed interface ActivityInstantiationFailure {
@@ -106,5 +102,12 @@ public interface MissionModelService {
     record Success(SerializedActivity activity) implements  BulkEffectiveArgumentResponse { }
     record TypeFailure(NoSuchActivityTypeException ex) implements  BulkEffectiveArgumentResponse { }
     record InstantiationFailure(InstantiationException ex) implements  BulkEffectiveArgumentResponse { }
+  }
+
+  sealed interface BulkArgumentValidationResponse {
+    record Success() implements BulkArgumentValidationResponse { }
+    record Validation(List<ValidationNotice> notices) implements BulkArgumentValidationResponse { }
+    record NoSuchActivityError(NoSuchActivityTypeException ex) implements BulkArgumentValidationResponse { }
+    record InstantiationError(InstantiationException ex) implements BulkArgumentValidationResponse { }
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ValidationWorker.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ValidationWorker.java
@@ -53,7 +53,9 @@ public record ValidationWorker(LocalMissionModelService missionModelService, int
       } catch (NoSuchMissionModelException ex) {
         logger.error("Validation request failed due to no such mission model: {}", ex.toString());
       } catch (InterruptedException ex) {
-        throw new RuntimeException("Failed to sleep in validation thread", ex);
+        return;
+      } catch (Throwable t) {
+        logger.error("Recovering from unexpected error encountered in validation thread: ", t);
       }
     }
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ValidationWorker.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ValidationWorker.java
@@ -1,0 +1,60 @@
+package gov.nasa.jpl.aerie.merlin.server.services;
+
+import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveForValidation;
+import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService.NoSuchMissionModelException;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.stream.IntStream;
+import java.util.List;
+
+public record ValidationWorker(LocalMissionModelService missionModelService, int pollingPeriod) {
+
+  private static final Logger logger = LoggerFactory.getLogger(ValidationWorker.class);
+
+  public void workerLoop() {
+    logger.info("validation worker starting...");
+    while (!Thread.interrupted()) {
+      try {
+        Thread.sleep(pollingPeriod);
+
+        final var validationRequests = missionModelService.getUnvalidatedDirectives();
+        if (!validationRequests.isEmpty()) {
+          logger.debug(
+              "queried {} directives that need validations, across {} models",
+              validationRequests.size(),
+              validationRequests.keySet().size());
+        }
+
+        for (final var entry : validationRequests.entrySet()) {
+          final var beginTime = System.nanoTime();
+          final var modelId = entry.getKey();
+          logger.debug("processing batch for mission model: {}", modelId.toString());
+          final var unvalidatedDirectives = entry.getValue();
+          final var responses = missionModelService.validateActivityArgumentsBulk(modelId, unvalidatedDirectives);
+
+          // zip lists together
+          final List<Pair<ActivityDirectiveForValidation, MissionModelService.BulkArgumentValidationResponse>>
+              zippedList = IntStream
+                .range(0, Math.min(unvalidatedDirectives.size(), responses.size()))
+                .mapToObj(i -> Pair.of(
+                    unvalidatedDirectives.get(i),
+                    responses.get(i)))
+                .toList();
+
+          // write validations out to DB
+          missionModelService.updateDirectiveValidations(zippedList);
+          final var endTime = System.nanoTime();
+          final var duration = (endTime - beginTime) / 1_000_000.0;
+          logger.debug("processed model batch of size {} in {} ms", unvalidatedDirectives.size(), duration);
+        }
+
+      } catch (NoSuchMissionModelException ex) {
+        logger.error("Validation request failed due to no such mission model: {}", ex.toString());
+      } catch (InterruptedException ex) {
+        throw new RuntimeException("Failed to sleep in validation thread", ex);
+      }
+    }
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ValidationWorker.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ValidationWorker.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveForValidation;
 import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService.NoSuchMissionModelException;
+import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService.BulkArgumentValidationResponse;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +20,7 @@ public record ValidationWorker(LocalMissionModelService missionModelService, int
       try {
         Thread.sleep(pollingPeriod);
 
+        // get unvalidated directives, batched by mission model id
         final var validationRequests = missionModelService.getUnvalidatedDirectives();
         if (!validationRequests.isEmpty()) {
           logger.debug(
@@ -27,24 +29,22 @@ public record ValidationWorker(LocalMissionModelService missionModelService, int
               validationRequests.keySet().size());
         }
 
+        // spin up each mission model once and process all corresponding directive validations
         for (final var entry : validationRequests.entrySet()) {
           final var beginTime = System.nanoTime();
+
           final var modelId = entry.getKey();
           logger.debug("processing batch for mission model: {}", modelId.toString());
+
           final var unvalidatedDirectives = entry.getValue();
           final var responses = missionModelService.validateActivityArgumentsBulk(modelId, unvalidatedDirectives);
 
-          // zip lists together
-          final List<Pair<ActivityDirectiveForValidation, MissionModelService.BulkArgumentValidationResponse>>
-              zippedList = IntStream
-                .range(0, Math.min(unvalidatedDirectives.size(), responses.size()))
-                .mapToObj(i -> Pair.of(
-                    unvalidatedDirectives.get(i),
-                    responses.get(i)))
-                .toList();
+          // zip together directives and validations, since DB action needs to insert validations for a given directive
+          final List<Pair<ActivityDirectiveForValidation, BulkArgumentValidationResponse>> zippedList = zip(unvalidatedDirectives, responses);
 
           // write validations out to DB
           missionModelService.updateDirectiveValidations(zippedList);
+
           final var endTime = System.nanoTime();
           final var duration = (endTime - beginTime) / 1_000_000.0;
           logger.debug("processed model batch of size {} in {} ms", unvalidatedDirectives.size(), duration);
@@ -53,10 +53,18 @@ public record ValidationWorker(LocalMissionModelService missionModelService, int
       } catch (NoSuchMissionModelException ex) {
         logger.error("Validation request failed due to no such mission model: {}", ex.toString());
       } catch (InterruptedException ex) {
+        // we were interrupted, so exit gracefully
         return;
       } catch (Throwable t) {
+        // catch all to keep validation thread from dying, which would require a merlin-server restart
         logger.error("Recovering from unexpected error encountered in validation thread: ", t);
       }
     }
+  }
+
+  private static <L, R> List<Pair<L, R>> zip(List<L> left, List<R> right) {
+    return IntStream.range(0, Math.min(left.size(), right.size()))
+                    .mapToObj(i -> Pair.of(left.get(i), right.get(i)))
+                    .toList();
   }
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -214,8 +214,5 @@ public final class StubMissionModelService implements MissionModelService {
   public void refreshActivityTypes(final String missionModelId) throws NoSuchMissionModelException {}
 
   @Override
-  public void refreshActivityValidations(final String missionModelId, final ActivityDirectiveForValidation directive) {}
-
-  @Override
   public void refreshResourceTypes(final String missionModelId) throws NoSuchMissionModelException {}
 }


### PR DESCRIPTION
* **Tickets addressed:** closes https://github.com/NASA-AMMOS/aerie/issues/1195 closes #502 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Implements automatic activity directive validation (plus caching of results in DB). This PR adds a new worker thread to `merlin-server` which queries `activity_directive_validations` for any directive that doesn't yet have its `validations` field populated.

The `activity_directive_validations` table is populated by database triggers on `activity_directive` insert / update, that will clear out existing validations for a given activity directive, causing the validation thread to pick up that work, and write fresh validation results.

For performance, the validation thread will poll for new validation requests every 500ms (configurable by env var), batch by mission model, thereby only loading each mission model once per poll. The database action that writes validation results back is also capable of batching writes.

The UI is now able to subscribe as follows to get validations for all activities in the currently selected plan, which it can use to populate the [validation error console](https://github.com/NASA-AMMOS/aerie-ui/issues/281)

```graphql
subscription directiveValidations {
  activity_directive_validations(
    where: {status: {_eq: "complete"}, 
    _and: {plan_id: {_eq: 1}}}
  ) {
    validations
    directive_id
  }
}

```

The `validations` JSON will have variable fields depending on what errors were encountered during validation. The JSON could be parsed roughly as follows:
```javascript
if (!validations.success) {
  // there are errors, need to dig deeper
  const { type, errors } = validations;
 
  // these top-level cases are mutually exclusive
  switch (type) {
    case: "NO_SUCH_ACTIVITY_TYPE":
      const { noSuchActivityType } = errors;
      // add to UI error list
      ...
      break;
    case: "VALIDATION_NOTICES":
      const { validationNotices } = errors;
      // add to UI error list
      ...
      break;
    case: "INSTANTIATION_ERRORS":
      // we have instantiation errors, which have sub error
      // types that are all simultaneously possible
      // (need to check size of all three remaining lists)
      const { missingArguments,
              extraneousArguments,
              unconstructableArguments } = errors;
      // add each list to UI error list
      ...
      break;
  }
}
```

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
So far most of the testing has been performance based, utilizing load tests to ensure performance is sufficient. Manual testing so far has shown promising results, with a single request taking ~20ms:
```
[Thread-0] INFO gov.nasa.jpl.aerie.merlin.server.services.ValidationWorker - processing batch for mission model: 1
[Thread-0] INFO gov.nasa.jpl.aerie.merlin.server.services.ValidationWorker - processed model batch of size 1 in 17.452291 ms
```

... and batches of ~1000 requests taking ~60ms (once this validation code has moved up a few compilation tiers in the JVM JIT)
```
[Thread-0] INFO gov.nasa.jpl.aerie.merlin.server.services.ValidationWorker - processing batch for mission model: 1
[Thread-0] INFO gov.nasa.jpl.aerie.merlin.server.services.ValidationWorker - processed model batch of size 445 in 22.684292 ms
[Thread-0] INFO gov.nasa.jpl.aerie.merlin.server.services.ValidationWorker - processing batch for mission model: 2
[Thread-0] INFO gov.nasa.jpl.aerie.merlin.server.services.ValidationWorker - processed model batch of size 416 in 36.900708 ms
```

torture test of 10000 inserts on a single mission model is still quite quick
```
[Thread-0] INFO gov.nasa.jpl.aerie.merlin.server.services.ValidationWorker - processing batch for mission model: 2
[Thread-0] INFO gov.nasa.jpl.aerie.merlin.server.services.ValidationWorker - processed model batch of size 10000 in 134.382375 ms
```

Correctness tests can be added if desired.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
API docs need to be created, as querying this validation table might be useful to some API consumers.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Unblocks https://github.com/NASA-AMMOS/aerie-ui/issues/936.
Long term, it might make sense to spin this validation work off into it's own container, e.g. `merlin-validator` that can be independently scaled from `merlin-server`.