### PR TITLE
Cancel a Scheduling Run

### DIFF
--- a/deployment/hasura/migrations/AerieScheduler/12_notify_cancel_scheduling/down.sql
+++ b/deployment/hasura/migrations/AerieScheduler/12_notify_cancel_scheduling/down.sql
@@ -1,0 +1,3 @@
+drop trigger notify_scheduling_workers_cancel on scheduling_request;
+drop function notify_scheduling_workers_cancel();
+call migrations.mark_migration_rolled_back('12');

--- a/deployment/hasura/migrations/AerieScheduler/12_notify_cancel_scheduling/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/12_notify_cancel_scheduling/up.sql
@@ -1,0 +1,17 @@
+create function notify_scheduling_workers_cancel()
+returns trigger
+security definer
+language plpgsql as $$
+begin
+  perform pg_notify('scheduling_cancel', '' || new.specification_id);
+  return null;
+end
+$$;
+
+create trigger notify_scheduling_workers_cancel
+after update of canceled on scheduling_request
+for each row
+when ((old.status != 'success' or old.status != 'failed') and new.canceled)
+execute function notify_scheduling_workers_cancel();
+
+call migrations.mark_migration_applied('12');

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/SchedulingTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/SchedulingTests.java
@@ -5,6 +5,7 @@ import gov.nasa.jpl.aerie.e2e.types.ExternalDataset.ProfileInput;
 import gov.nasa.jpl.aerie.e2e.types.ExternalDataset.ProfileInput.ProfileSegmentInput;
 import gov.nasa.jpl.aerie.e2e.types.Plan;
 import gov.nasa.jpl.aerie.e2e.types.ProfileSegment;
+import gov.nasa.jpl.aerie.e2e.types.SchedulingRequest.SchedulingStatus;
 import gov.nasa.jpl.aerie.e2e.types.ValueSchema;
 import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
 import gov.nasa.jpl.aerie.e2e.utils.HasuraRequests;
@@ -710,6 +711,88 @@ public class SchedulingTests {
       assertEquals("BiteBanana", activity.type());
       assertEquals("02:00:00", activity.startOffset());
       assertEquals(Json.createObjectBuilder().add("biteSize", 1).build(), activity.arguments());
+    }
+  }
+
+  @Nested
+  class CancelingScheduling {
+    private int fooId;
+    private int fooPlan;
+    private int fooSchedulingSpecId;
+    private int fooGoalId;
+
+    @BeforeEach
+    void beforeEach() throws IOException, InterruptedException {
+      // Insert the Mission Model
+      // Long Foo plans take long enough to be canceled without risking a race condition like with Banananation
+      try (final var gateway = new GatewayRequests(playwright)) {
+        fooId = hasura.createMissionModel(
+            gateway.uploadFooJar(),
+            "Foo (e2e tests)",
+            "aerie_e2e_tests",
+            "Simulation Tests");
+      }
+      // Insert the Plan
+      fooPlan = hasura.createPlan(
+          fooId,
+          "Foo Plan - Simulation Tests",
+          "720:00:00",
+          planStartTimestamp);
+
+      // Insert Scheduling Spec
+      fooSchedulingSpecId = hasura.insertSchedulingSpecification(
+          fooPlan,
+          hasura.getPlanRevision(fooPlan),
+          planStartTimestamp,
+          "2023-01-31T00:00:00+00:00",
+          JsonValue.EMPTY_JSON_OBJECT,
+          false);
+
+      // Add Goal
+      fooGoalId = hasura.insertSchedulingGoal(
+          "Foo Recurrence Test Goal",
+          fooId,
+          """
+          export default function recurrenceGoalExample() {
+            return Goal.ActivityRecurrenceGoal({
+              activityTemplate: ActivityTemplates.bar(),
+              interval: Temporal.Duration.from({ hours: 2 }),
+            });
+          }""");
+      hasura.createSchedulingSpecGoal(fooGoalId, fooSchedulingSpecId, 0);
+    }
+
+    @AfterEach
+    void afterEach() throws IOException {
+      // Remove Goal
+      hasura.deleteSchedulingGoal(fooGoalId);
+
+      // Remove Model and Plan
+      hasura.deletePlan(fooPlan);
+      hasura.deleteMissionModel(fooId);
+    }
+
+    /**
+     * Cancelling a scheduling run causes the "Reason" field to report that the run was canceled
+     */
+    @Test
+    void cancelingSchedulingUpdatesRequestReason() throws IOException {
+      final var results = hasura.cancelingScheduling(fooSchedulingSpecId);
+      // Assert that the run was incomplete
+      assertEquals(SchedulingStatus.incomplete, results.status());
+
+      // Assert reason
+      assertTrue(results.reason().isPresent());
+      final var reason = results.reason().get();
+      assertEquals("SCHEDULING_CANCELED", reason.type());
+      assertEquals("Scheduling run was canceled", reason.message());
+      assertEquals("", reason.trace());
+
+      // Assert the data in the reason
+      final var reasonData = reason.data();
+      assertEquals(2, reasonData.size());
+      assertTrue(reasonData.containsKey("location"));
+      assertEquals("Scheduling was interrupted while "+ reasonData.getString("location"), reasonData.getString("message"));
     }
   }
 }

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/SimulationTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/SimulationTests.java
@@ -89,8 +89,6 @@ public class SimulationTests {
     assertDoesNotThrow(() -> hasura.awaitSimulation(planId));
   }
 
-
-
   @Nested
   class TemporalSubsetSimulation {
     private int firstHalfActivityId;
@@ -259,7 +257,7 @@ public class SimulationTests {
       // Long Foo plans take long enough to be canceled without risking a race condition like with Banananation
       try (final var gateway = new GatewayRequests(playwright)) {
         fooId = hasura.createMissionModel(
-            gateway.uploadJarFile("../examples/foo-missionmodel/build/libs/foo-missionmodel.jar"),
+            gateway.uploadFooJar(),
             "Foo (e2e tests)",
             "aerie_e2e_tests",
             "Simulation Tests");

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/SchedulingRequest.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/SchedulingRequest.java
@@ -1,0 +1,43 @@
+package gov.nasa.jpl.aerie.e2e.types;
+
+import javax.json.JsonObject;
+import java.util.Optional;
+
+public record SchedulingRequest(
+    int analysisId,
+    int specificationId,
+    int specificationRevision,
+    SchedulingStatus status,
+    boolean canceled,
+    Optional<SchedulingReason> reason
+) {
+  public enum SchedulingStatus { pending, incomplete, failed, success }
+
+  public record SchedulingReason(
+      String type,
+      String message,
+      String trace,
+      JsonObject data
+  )
+  {
+    public static SchedulingReason fromJSON(JsonObject json) {
+      return new SchedulingReason(
+          json.getString("type"),
+          json.getString("message"),
+          json.getString("trace"),
+          json.getJsonObject("data")
+      );
+    }
+  }
+
+  public static SchedulingRequest fromJSON(JsonObject json) {
+    return new SchedulingRequest(
+        json.getInt("analysis_id"),
+        json.getInt("specification_id"),
+        json.getInt("specification_revision"),
+        SchedulingStatus.valueOf(json.getString("status")),
+        json.getBoolean("canceled"),
+        json.isNull("reason") ? Optional.empty() : Optional.of(SchedulingReason.fromJSON(json.getJsonObject("reason")))
+    );
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
@@ -25,6 +25,19 @@ public enum GQL {
         simulation_template_id
       }
     }"""),
+  CANCEL_SCHEDULING("""
+    mutation cancelScheduling($analysis_id: Int!) {
+      update_scheduling_request(where: {analysis_id: {_eq: $analysis_id}}, _set: {canceled: true}) {
+        returning {
+          analysis_id
+          specification_id
+          specification_revision
+          canceled
+          reason
+          status
+        }
+      }
+    }"""),
   CANCEL_SIMULATION("""
     mutation cancelSimulation($id: Int!) {
       update_simulation_dataset_by_pk(pk_columns: {id: $id}, _set: {canceled: true}) {
@@ -352,6 +365,17 @@ public enum GQL {
           filePath
           content
         }
+      }
+    }"""),
+  GET_SCHEDULING_REQUEST("""
+    query GetSchedulingRequest($specificationId: Int!, $specificationRev: Int!) {
+      scheduling_request_by_pk(specification_id: $specificationId, specification_revision: $specificationRev) {
+        specification_id
+        specification_revision
+        analysis_id
+        canceled
+        reason
+        status
       }
     }"""),
   GET_SIMULATION_DATASET("""

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GatewayRequests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GatewayRequests.java
@@ -35,6 +35,13 @@ public class GatewayRequests implements AutoCloseable {
   }
 
   /**
+   * Uploads the Foo JAR
+   */
+  public int uploadFooJar() throws IOException {
+    return uploadJarFile("../examples/foo-missionmodel/build/libs/foo-missionmodel.jar");
+  }
+
+  /**
    * Uploads the JAR found at searchPath
    * @param jarPath is relative to the e2e-tests directory.
    */

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/EquationSolvingAlgorithms.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/EquationSolvingAlgorithms.java
@@ -38,11 +38,12 @@ public class EquationSolvingAlgorithms {
                                                        InfiniteDerivativeException,
                                                        DivergenceException,
                                                        ExceededMaxIterationException,
-                                                       NoSolutionException;
+                                                       NoSolutionException,
+                                                       SchedulingInterruptedException;
   }
 
   public interface Function<T, Metadata> {
-    T valueAt(T x, History<T, Metadata> history) throws DiscontinuityException;
+    T valueAt(T x, History<T, Metadata> history) throws DiscontinuityException, SchedulingInterruptedException;
   }
 
   public interface History<T, Metadata>{
@@ -124,7 +125,7 @@ public class EquationSolvingAlgorithms {
         final Duration max,
         final History<Duration, Metadata> history,
         final int maxIteration)
-    throws ExceededMaxIterationException
+    throws ExceededMaxIterationException, SchedulingInterruptedException
     {
       var cur = init;
       int i = 0;
@@ -174,11 +175,12 @@ public class EquationSolvingAlgorithms {
         final Duration xHigh,
         final int maxNbIterations)
     throws ZeroDerivativeException, NoSolutionException, ExceededMaxIterationException, DivergenceException,
-           InfiniteDerivativeException
+           InfiniteDerivativeException, SchedulingInterruptedException
     {
       final var ff = new EquationSolvingAlgorithms.Function<Duration, Metadata>(){
         @Override
-        public Duration valueAt(final Duration x, final History<Duration, Metadata> history) throws EquationSolvingAlgorithms.DiscontinuityException
+        public Duration valueAt(final Duration x, final History<Duration, Metadata> history)
+        throws EquationSolvingAlgorithms.DiscontinuityException, SchedulingInterruptedException
         {
           return f.valueAt(x, history).minus(y);
         }
@@ -210,7 +212,8 @@ public class EquationSolvingAlgorithms {
         final Duration xLow,
         final Duration xHigh,
         final int maxNbIterations)
-    throws ZeroDerivativeException, InfiniteDerivativeException, ExceededMaxIterationException
+    throws ZeroDerivativeException, InfiniteDerivativeException, ExceededMaxIterationException,
+           SchedulingInterruptedException
     {
       final var xLow_long = xLow.in(Duration.MICROSECONDS);
       final var xHigh_long = xHigh.in(Duration.MICROSECONDS);

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/SchedulingInterruptedException.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/SchedulingInterruptedException.java
@@ -1,0 +1,15 @@
+package gov.nasa.jpl.aerie.scheduler;
+
+public class SchedulingInterruptedException extends InterruptedException {
+  public final String location;
+
+  /**
+   * Create a SchedulingInterruptedException that is aware of the part of the
+   * scheduling process in which it was created
+   * @param location Where in scheduling this Exception was thrown
+   */
+  public SchedulingInterruptedException(String location) {
+    super("Scheduling was interrupted while "+ location);
+    this.location = location;
+  }
+}

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
@@ -18,6 +18,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
 import gov.nasa.jpl.aerie.scheduler.NotNull;
+import gov.nasa.jpl.aerie.scheduler.SchedulingInterruptedException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,7 +138,7 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
     this.engine.close();
   }
 
-  private void simulateUntil(Duration endTime){
+  private void simulateUntil(Duration endTime) throws SchedulingInterruptedException{
     long before = System.nanoTime();
     logger.info("Simulating until "+endTime);
     assert(endTime.noShorterThan(curTime));
@@ -146,6 +147,7 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
       }
       // Increment real time, if necessary.
       while(!batch.offsetFromStart().longerThan(endTime) && !endTime.isEqualTo(Duration.MAX_VALUE)) {
+        if(canceledListener.get()) throw new SchedulingInterruptedException("simulating");
         //by default, curTime is negative to signal we have not started simulation yet. We set it to 0 when we start.
         final var delta = batch.offsetFromStart().minus(curTime.isNegative() ? Duration.ZERO : curTime);
         curTime = batch.offsetFromStart();
@@ -169,7 +171,13 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
    * @param anchoredToStart toggle for if the activity is anchored to the start or end of its anchor
    * @param activityId the activity id for the activity to simulate
    */
-  public void simulateActivity(final Duration startOffset, final SerializedActivity activity, final ActivityDirectiveId anchorId, final boolean anchoredToStart, final ActivityDirectiveId activityId) {
+  public void simulateActivity(
+      final Duration startOffset,
+      final SerializedActivity activity,
+      final ActivityDirectiveId anchorId,
+      final boolean anchoredToStart,
+      final ActivityDirectiveId activityId
+  ) throws SchedulingInterruptedException {
     simulateActivity(new ActivityDirective(startOffset, activity, anchorId, anchoredToStart), activityId);
   }
 
@@ -179,11 +187,12 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
    * @param activityId the ActivityDirectiveId for the activity to simulate
    */
   public void simulateActivity(ActivityDirective activityToSimulate, ActivityDirectiveId activityId)
-  {
+  throws SchedulingInterruptedException {
     simulateActivities(Map.of(activityId, activityToSimulate));
   }
 
-  public void simulateActivities(@NotNull Map<ActivityDirectiveId, ActivityDirective> activitiesToSimulate) {
+  public void simulateActivities(@NotNull Map<ActivityDirectiveId, ActivityDirective> activitiesToSimulate)
+  throws SchedulingInterruptedException {
     if(activitiesToSimulate.isEmpty()) return;
 
     activitiesInserted.putAll(activitiesToSimulate);
@@ -207,7 +216,7 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
    * @param startTimestamp the timestamp for the start of the planning horizon. Used as epoch for computing SimulationResults.
    * @return the simulation results
    */
-  public SimulationResults getSimulationResults(Instant startTimestamp){
+  public SimulationResults getSimulationResults(Instant startTimestamp) throws SchedulingInterruptedException {
     return getSimulationResultsUpTo(startTimestamp, curTime);
   }
 
@@ -222,7 +231,8 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
    * @param endTime the end timepoint. The simulation results will be computed up to this point.
    * @return the simulation results
    */
-  public SimulationResults getSimulationResultsUpTo(Instant startTimestamp, Duration endTime){
+  public SimulationResults getSimulationResultsUpTo(Instant startTimestamp, Duration endTime)
+  throws SchedulingInterruptedException {
     //if previous results cover a bigger period, we return do not regenerate
     if(endTime.longerThan(curTime)){
       logger.info("Simulating from " + curTime + " to " + endTime + " to get simulation results");
@@ -232,6 +242,7 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
     }
     final var before = System.nanoTime();
     if(lastSimResults == null || endTime.longerThan(lastSimResultsEnd) || startTimestamp.compareTo(lastSimResults.startTime) != 0) {
+      if(canceledListener.get()) throw new SchedulingInterruptedException("computing simulation results");
       lastSimResults = SimulationEngine.computeResults(
           engine,
           startTimestamp,
@@ -248,7 +259,7 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
   }
 
   private void simulateSchedule(final Map<ActivityDirectiveId, ActivityDirective> schedule)
-  {
+  throws SchedulingInterruptedException {
     final var before = System.nanoTime();
     if (schedule.isEmpty()) {
       throw new IllegalArgumentException("simulateSchedule() called with empty schedule, use simulateUntil() instead");
@@ -281,6 +292,8 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
 
     //once all tasks are finished, we need to wait for events triggered at the same time
     while (!allTaskFinished || delta.isZero()) {
+      if(canceledListener.get()) throw new SchedulingInterruptedException("simulating");
+
       curTime = batch.offsetFromStart();
       timeline.add(delta);
       // TODO: Advance a dense time counter so that future tasks are strictly ordered relative to these,

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
@@ -28,8 +28,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public class ResumableSimulationDriver<Model> implements AutoCloseable {
+  private final Supplier<Boolean> canceledListener;
 
   public long durationSinceRestart = 0;
 
@@ -61,11 +63,16 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
   //effectively counting the number of calls to initSimulation()
   private int countSimulationRestarts;
 
-  public ResumableSimulationDriver(MissionModel<Model> missionModel, Duration planDuration){
+  public ResumableSimulationDriver(
+      MissionModel<Model> missionModel,
+      Duration planDuration,
+      Supplier<Boolean> canceledListener
+  ){
     this.missionModel = missionModel;
     plannedDirectiveToTask = new HashMap<>();
     this.planDuration = planDuration;
     countSimulationRestarts = 0;
+    this.canceledListener = canceledListener;
     initSimulation();
   }
 

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * A facade for simulating plans and processing simulation results.
@@ -31,6 +32,7 @@ import java.util.Optional;
 public class SimulationFacade implements AutoCloseable{
 
   private static final Logger logger = LoggerFactory.getLogger(SimulationFacade.class);
+  private final Supplier<Boolean> canceledListener;
 
   private final MissionModel<?> missionModel;
   private final SchedulerModel schedulerModel;
@@ -102,12 +104,17 @@ public class SimulationFacade implements AutoCloseable{
     return Optional.of(lastSimulationData.driverResults());
   }
 
-  public SimulationFacade(final PlanningHorizon planningHorizon,
-                          final MissionModel<?> missionModel,
-                          final SchedulerModel schedulerModel) {
+  public Supplier<Boolean> getCanceledListener() {return canceledListener;}
+
+  public SimulationFacade(
+      final PlanningHorizon planningHorizon,
+      final MissionModel<?> missionModel,
+      final SchedulerModel schedulerModel,
+      Supplier<Boolean> canceledListener
+  ) {
     this.missionModel = missionModel;
     this.planningHorizon = planningHorizon;
-    this.driver = new ResumableSimulationDriver<>(missionModel, planningHorizon.getAerieHorizonDuration());
+    this.driver = new ResumableSimulationDriver<>(missionModel, planningHorizon.getAerieHorizonDuration(), canceledListener);
     this.itSimActivityId = 0;
     this.insertedActivities = new HashMap<>();
     this.activityTypes = new HashMap<>();
@@ -115,6 +122,7 @@ public class SimulationFacade implements AutoCloseable{
     this.initialPlan = new ArrayList<>();
     this.initialSimulationResults = Optional.empty();
     this.schedulerModel = schedulerModel;
+    this.canceledListener = canceledListener;
   }
 
   @Override

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/Solver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/Solver.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.scheduler.solver;
 
+import gov.nasa.jpl.aerie.scheduler.SchedulingInterruptedException;
 import gov.nasa.jpl.aerie.scheduler.model.Plan;
 
 import java.util.Optional;
@@ -44,6 +45,6 @@ public interface Solver {
    *     previously specified planning problem, or empty if the solver
    *     cannot provide any more solutions right now
    */
-  Optional<Plan> getNextSolution();
+  Optional<Plan> getNextSolution() throws SchedulingInterruptedException;
 
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/FixedDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/FixedDurationTest.java
@@ -29,11 +29,11 @@ public class FixedDurationTest {
   void setUp(){
     planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochDays(3));
     MissionModel<?> bananaMissionModel = SimulationUtility.getBananaMissionModel();
-    problem = new Problem(bananaMissionModel, planningHorizon, new SimulationFacade(planningHorizon, bananaMissionModel, SimulationUtility.getBananaSchedulerModel()), SimulationUtility.getBananaSchedulerModel());
+    problem = new Problem(bananaMissionModel, planningHorizon, new SimulationFacade(planningHorizon, bananaMissionModel, SimulationUtility.getBananaSchedulerModel(), ()-> false), SimulationUtility.getBananaSchedulerModel());
   }
 
   @Test
-  public void testFieldAnnotation(){
+  public void testFieldAnnotation() throws SchedulingInterruptedException {
 
     final var fixedDurationActivityTemplate = new ActivityExpression.Builder()
         .ofType(problem.getActivityType("BananaNap"))
@@ -63,7 +63,7 @@ public class FixedDurationTest {
 
 
   @Test
-  public void testMethodAnnotation(){
+  public void testMethodAnnotation() throws SchedulingInterruptedException {
 
     final var fixedDurationActivityTemplate = new ActivityExpression.Builder()
         .ofType(problem.getActivityType("RipenBanana"))

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/LongDurationPlanTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/LongDurationPlanTest.java
@@ -8,7 +8,6 @@ import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
 import gov.nasa.jpl.aerie.scheduler.model.PlanInMemory;
 import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
 import gov.nasa.jpl.aerie.scheduler.model.Problem;
-import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
 import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +49,7 @@ public class LongDurationPlanTest {
   }
 
   @Test
-  public void getNextSolution_initialPlanInOutput() {
+  public void getNextSolution_initialPlanInOutput() throws SchedulingInterruptedException {
     final var problem = makeTestMissionAB();
     final var expectedPlan = makePlanA012(problem);
     problem.setInitialPlan(makePlanA012(problem));
@@ -64,7 +63,7 @@ public class LongDurationPlanTest {
   }
 
   @Test
-  public void getNextSolution_proceduralGoalCreatesActivities() {
+  public void getNextSolution_proceduralGoalCreatesActivities() throws SchedulingInterruptedException {
     final var problem = makeTestMissionAB();
     final var expectedPlan = makePlanA012(problem);
     final var goal = new ProceduralCreationGoal.Builder()

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/ParametricDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/ParametricDurationTest.java
@@ -31,11 +31,11 @@ public class ParametricDurationTest {
   void setUp(){
     planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochDays(3));
     MissionModel<?> bananaMissionModel = SimulationUtility.getBananaMissionModel();
-    problem = new Problem(bananaMissionModel, planningHorizon, new SimulationFacade(planningHorizon, bananaMissionModel, SimulationUtility.getBananaSchedulerModel()), SimulationUtility.getBananaSchedulerModel());
+    problem = new Problem(bananaMissionModel, planningHorizon, new SimulationFacade(planningHorizon, bananaMissionModel, SimulationUtility.getBananaSchedulerModel(), ()-> false), SimulationUtility.getBananaSchedulerModel());
   }
 
   @Test
-  public void testStartConstraint() {
+  public void testStartConstraint() throws SchedulingInterruptedException {
 
     final var parameterizedDurationActivityTemplate = new ActivityExpression.Builder()
         .ofType(problem.getActivityType("DownloadBanana"))
@@ -65,7 +65,7 @@ public class ParametricDurationTest {
   }
 
   @Test
-  public void testEndConstraint() {
+  public void testEndConstraint() throws SchedulingInterruptedException {
 
     final var parameterizedDurationActivityTemplate = new ActivityExpression.Builder()
         .ofType(problem.getActivityType("DownloadBanana"))

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/RootfindingTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/RootfindingTest.java
@@ -19,7 +19,7 @@ public class RootfindingTest {
   void testHighlyDiscontinuous()
   throws EquationSolvingAlgorithms.ZeroDerivativeException, EquationSolvingAlgorithms.NoSolutionException,
          EquationSolvingAlgorithms.ExceededMaxIterationException, EquationSolvingAlgorithms.DivergenceException,
-         EquationSolvingAlgorithms.InfiniteDerivativeException
+         EquationSolvingAlgorithms.InfiniteDerivativeException, SchedulingInterruptedException
   {
     final var durationFunctionDiscontinuousAtEverySecond =
         new EquationSolvingAlgorithms.Function<Duration, PrioritySolver.ActivityMetadata>() {
@@ -60,7 +60,7 @@ public class RootfindingTest {
   public void testSimpleDiscontinuous()
   throws EquationSolvingAlgorithms.ZeroDerivativeException, EquationSolvingAlgorithms.NoSolutionException,
          EquationSolvingAlgorithms.ExceededMaxIterationException, EquationSolvingAlgorithms.DivergenceException,
-         EquationSolvingAlgorithms.InfiniteDerivativeException
+         EquationSolvingAlgorithms.InfiniteDerivativeException, SchedulingInterruptedException
   {
     final var alg = new EquationSolvingAlgorithms.SecantDurationAlgorithm<PrioritySolver.ActivityMetadata>();
 
@@ -101,7 +101,7 @@ public class RootfindingTest {
   public void squareZeros()
   throws EquationSolvingAlgorithms.ZeroDerivativeException,
          EquationSolvingAlgorithms.ExceededMaxIterationException,
-         EquationSolvingAlgorithms.InfiniteDerivativeException
+         EquationSolvingAlgorithms.InfiniteDerivativeException, SchedulingInterruptedException
   {
     final var alg = new EquationSolvingAlgorithms.SecantDurationAlgorithm<PrioritySolver.ActivityMetadata>();
     //f(x) = x^2
@@ -136,7 +136,7 @@ public class RootfindingTest {
   public void floorZeros()
   throws EquationSolvingAlgorithms.ZeroDerivativeException,
          EquationSolvingAlgorithms.ExceededMaxIterationException,
-         EquationSolvingAlgorithms.InfiniteDerivativeException
+         EquationSolvingAlgorithms.InfiniteDerivativeException, SchedulingInterruptedException
   {
     final var alg = new EquationSolvingAlgorithms.SecantDurationAlgorithm<PrioritySolver.ActivityMetadata>();
     final var floorFunc =

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationFacadeTest.java
@@ -83,7 +83,7 @@ public class SimulationFacadeTest {
   public void setUp() {
     missionModel = SimulationUtility.getBananaMissionModel();
     final var schedulerModel = SimulationUtility.getBananaSchedulerModel();
-    facade = new SimulationFacade(horizon, missionModel, schedulerModel);
+    facade = new SimulationFacade(horizon, missionModel, schedulerModel, ()-> false);
     problem = new Problem(missionModel, horizon, facade, schedulerModel);
   }
 
@@ -125,7 +125,7 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void associationToExistingSatisfyingActivity(){
+  public void associationToExistingSatisfyingActivity() throws SchedulingInterruptedException {
     final var plan = makeEmptyPlan();
     final var actTypePeel = problem.getActivityType("PeelBanana");
     final var actTypeBite = problem.getActivityType("BiteBanana");
@@ -166,7 +166,9 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void getValueAtTimeDoubleOnSimplePlanMidpoint() throws SimulationFacade.SimulationException {
+  public void getValueAtTimeDoubleOnSimplePlanMidpoint()
+  throws SimulationFacade.SimulationException, SchedulingInterruptedException
+  {
     facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
     final var stateQuery = new StateQueryParam(getFruitRes().name, new TimeExpressionConstant(t1_5));
@@ -175,7 +177,9 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void getValueAtTimeDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
+  public void getValueAtTimeDoubleOnSimplePlan()
+  throws SimulationFacade.SimulationException, SchedulingInterruptedException
+  {
     facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
     final var stateQuery = new StateQueryParam(getFruitRes().name, new TimeExpressionConstant(t2));
@@ -185,7 +189,9 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void whenValueAboveDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
+  public void whenValueAboveDoubleOnSimplePlan()
+  throws SimulationFacade.SimulationException, SchedulingInterruptedException
+  {
     facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
     var actual = new GreaterThan(getFruitRes(), new RealValue(2.9)).evaluate(facade.getLatestConstraintSimulationResults().get());
@@ -197,7 +203,9 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void whenValueBelowDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
+  public void whenValueBelowDoubleOnSimplePlan()
+  throws SimulationFacade.SimulationException, SchedulingInterruptedException
+  {
     facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
     var actual = new LessThan(getFruitRes(), new RealValue(3.0)).evaluate(facade.getLatestConstraintSimulationResults().get());
@@ -209,7 +217,9 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void whenValueBetweenDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
+  public void whenValueBetweenDoubleOnSimplePlan()
+  throws SimulationFacade.SimulationException, SchedulingInterruptedException
+  {
     facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
     var actual = new And(new GreaterThanOrEqual(getFruitRes(), new RealValue(3.0)), new LessThanOrEqual(getFruitRes(), new RealValue(3.99))).evaluate(facade.getLatestConstraintSimulationResults().get());
@@ -222,7 +232,9 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void whenValueEqualDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
+  public void whenValueEqualDoubleOnSimplePlan()
+  throws SimulationFacade.SimulationException, SchedulingInterruptedException
+  {
     facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
     var actual = new Equal<>(getFruitRes(), new RealValue(3.0)).evaluate(facade.getLatestConstraintSimulationResults().get());
@@ -235,7 +247,9 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void whenValueNotEqualDoubleOnSimplePlan() throws SimulationFacade.SimulationException {
+  public void whenValueNotEqualDoubleOnSimplePlan()
+  throws SimulationFacade.SimulationException, SchedulingInterruptedException
+  {
     facade.insertActivitiesIntoSimulation(makeTestPlanP0B1().getActivities());
     facade.computeSimulationResultsUntil(tEnd);
     var actual = new NotEqual<>(getFruitRes(), new RealValue(3.0)).evaluate(facade.getLatestConstraintSimulationResults().get());
@@ -248,7 +262,7 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void testCoexistenceGoalWithResourceConstraint() {
+  public void testCoexistenceGoalWithResourceConstraint() throws SchedulingInterruptedException {
     problem.setInitialPlan(makeTestPlanP0B1());
 
     /**
@@ -288,7 +302,7 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void testProceduralGoalWithResourceConstraint() {
+  public void testProceduralGoalWithResourceConstraint() throws SchedulingInterruptedException {
     problem.setInitialPlan(makeTestPlanP0B1());
 
     final var constraint = new And(
@@ -330,7 +344,7 @@ public class SimulationFacadeTest {
   }
 
   @Test
-  public void testActivityTypeWithResourceConstraint() {
+  public void testActivityTypeWithResourceConstraint() throws SchedulingInterruptedException {
     problem.setInitialPlan(makeTestPlanP0B1());
 
     final var constraint = new And(

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationUtility.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/SimulationUtility.java
@@ -41,7 +41,8 @@ public final class SimulationUtility {
         new SimulationFacade(
             planningHorizon,
             fooMissionModel,
-            fooSchedulerModel),
+            fooSchedulerModel,
+            ()->false),
         fooSchedulerModel);
   }
 
@@ -54,7 +55,8 @@ public final class SimulationUtility {
         new SimulationFacade(
             planningHorizon,
             fooMissionModel,
-            fooSchedulerModel),
+            fooSchedulerModel,
+            ()->false),
         fooSchedulerModel);
   }
 

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
@@ -46,7 +46,6 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static gov.nasa.jpl.aerie.scheduler.SimulationUtility.buildProblemFromFoo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -59,7 +58,7 @@ public class TestApplyWhen {
 
   ////////////////////////////////////////////RECURRENCE////////////////////////////////////////////
   @Test
-  public void testRecurrenceCutoff1() {
+  public void testRecurrenceCutoff1() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
     final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
@@ -92,7 +91,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testRecurrenceCutoff2() {
+  public void testRecurrenceCutoff2() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
     final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
@@ -125,7 +124,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testRecurrenceShorterWindow() {
+  public void testRecurrenceShorterWindow() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
     final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
@@ -158,7 +157,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testRecurrenceLongerWindow() {
+  public void testRecurrenceLongerWindow() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
     final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
@@ -191,7 +190,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testRecurrenceBabyWindow() {
+  public void testRecurrenceBabyWindow() throws SchedulingInterruptedException {
     /*
     The plan horizon ranges from [0,20).
     The recurrent activities can be placed inside the following window: [1,2). That is, there is exactly 1 unit of time where an activity can be placed
@@ -237,7 +236,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testRecurrenceWindows() {
+  public void testRecurrenceWindows() throws SchedulingInterruptedException {
     // RECURRENCE WINDOW: [++---++---++---++---]
     // GOAL WINDOW:       [++++++----+++++++---]
     // RESULT:            [++--------++--------]
@@ -280,7 +279,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testRecurrenceWindowsCutoffMidInterval() {
+  public void testRecurrenceWindowsCutoffMidInterval() throws SchedulingInterruptedException {
     // RECURRENCE WINDOW: [++---++---++---++---]
     // GOAL WINDOW:       [++++------+++-------]
     // RESULT:            [++--------++--------]
@@ -323,7 +322,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testRecurrenceWindowsGlobalCheck() {
+  public void testRecurrenceWindowsGlobalCheck() throws SchedulingInterruptedException {
     //                     123456789012345678901
     // RECURRENCE WINDOW: [++-++-++-++-++-++-++-] (if global)
     // GOAL WINDOW:       [+++++--++++++++-++++-] (if interval is same length as recurrence interval, fails)
@@ -368,7 +367,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testRecurrenceWindowsCutoffMidActivity() {
+  public void testRecurrenceWindowsCutoffMidActivity() throws SchedulingInterruptedException {
     //                     12345678901234567890
     // RECURRENCE WINDOW: [++---++---++---++---]
     // GOAL WINDOW:       [+-----+++-+++-------]
@@ -413,7 +412,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testRecurrenceCutoffUncontrollable() {
+  public void testRecurrenceCutoffUncontrollable() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(21));
     final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("BasicActivity");
@@ -448,7 +447,7 @@ public class TestApplyWhen {
   ////////////////////////////////////////////CARDINALITY////////////////////////////////////////////
 
   @Test
-  public void testCardinality() {
+  public void testCardinality() throws SchedulingInterruptedException {
     Interval period = Interval.betweenClosedOpen(Duration.of(0, Duration.SECONDS), Duration.of(5, Duration.SECONDS));
 
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
@@ -487,7 +486,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testCardinalityWindows() {
+  public void testCardinalityWindows() throws SchedulingInterruptedException {
     // DURATION:    [++]
     // GOAL WINDOW: [++++------++++------]
     // RESULT:      [++++------++++------]
@@ -534,7 +533,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testCardinalityWindowsCutoffMidActivity() {
+  public void testCardinalityWindowsCutoffMidActivity() throws SchedulingInterruptedException {
     // DURATION:    [++]
     // GOAL WINDOW: [+-----++--+++-------]
     // RESULT:      [------++--++--------]
@@ -582,7 +581,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testCardinalityUncontrollable() { //ruled unpredictable for now
+  public void testCardinalityUncontrollable() throws SchedulingInterruptedException { //ruled unpredictable for now
     /*
       Expect 5 to get scheduled just in a row, as basicactivity's duration should allow that.
      */
@@ -629,7 +628,7 @@ public class TestApplyWhen {
   ////////////////////////////////////////////COEXISTENCE////////////////////////////////////////////
 
   @Test
-  public void testCoexistenceWindowCutoff() {
+  public void testCoexistenceWindowCutoff() throws SchedulingInterruptedException {
 
     Interval period = Interval.betweenClosedOpen(Duration.of(0, Duration.SECONDS), Duration.of(12, Duration.SECONDS));
 
@@ -678,7 +677,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testCoexistenceJustFits() {
+  public void testCoexistenceJustFits() throws SchedulingInterruptedException {
 
     Interval period = Interval.betweenClosedOpen(Duration.of(0, Duration.SECONDS), Duration.of(13, Duration.SECONDS));//13, so it just fits in
 
@@ -731,7 +730,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testCoexistenceUncontrollableCutoff() { //ruled unpredictable for now
+  public void testCoexistenceUncontrollableCutoff() throws SchedulingInterruptedException { //ruled unpredictable for now
     /*
                      123456789012345678901234
        GOAL WINDOW: [+++++++++++++-- ---------]
@@ -793,7 +792,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testCoexistenceWindows() {
+  public void testCoexistenceWindows() throws SchedulingInterruptedException {
     // COEXISTENCE LATCH POINTS:
     //    (seek to add Duration 2 activities to each of these)
     //               1234567890123456789012
@@ -858,7 +857,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testCoexistenceWindowsCutoffMidActivity() {
+  public void testCoexistenceWindowsCutoffMidActivity() throws SchedulingInterruptedException {
     // COEXISTENCE LATCH POINTS:
     //    (seek to add Duration [++] activities to each of these)
     //               1234567890123456789012345678
@@ -932,7 +931,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testCoexistenceWindowsBisect() { //bad, should fail completely. worth investigating.
+  public void testCoexistenceWindowsBisect() throws SchedulingInterruptedException { //bad, should fail completely. worth investigating.
     /*
        COEXISTENCE LATCH POINTS:
        (seek to add Duration [++] activities to each of these, wherever an activity happens/theres a interval)
@@ -999,7 +998,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testCoexistenceWindowsBisect2() { //corrected. Bisection does work successfully.
+  public void testCoexistenceWindowsBisect2() throws SchedulingInterruptedException { //corrected. Bisection does work successfully.
     /*
        COEXISTENCE LATCH POINTS:
           (seek to add Duration [++] activities to each of these, wherever an activity happens/theres a interval)
@@ -1065,7 +1064,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testCoexistenceUncontrollableJustFits() {
+  public void testCoexistenceUncontrollableJustFits() throws SchedulingInterruptedException {
 
     Interval period = Interval.betweenClosedOpen(Duration.of(0, Duration.SECONDS), Duration.of(13, Duration.SECONDS));
 
@@ -1118,7 +1117,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void testCoexistenceExternalResource() {
+  public void testCoexistenceExternalResource() throws SchedulingInterruptedException {
     Interval period = Interval.betweenClosedOpen(Duration.of(0, Duration.SECONDS), Duration.of(25, Duration.SECONDS));
 
     final var fooMissionModel = SimulationUtility.getFooMissionModel();
@@ -1130,7 +1129,8 @@ public class TestApplyWhen {
         new SimulationFacade(
             planningHorizon,
             fooMissionModel,
-            fooSchedulerMissionModel),
+            fooSchedulerMissionModel,
+            () -> false),
         fooSchedulerMissionModel);
 
     final var r3Value = Map.of("amountInMicroseconds", SerializedValue.of(6));
@@ -1184,7 +1184,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void changingForAllTimeIn() {
+  public void changingForAllTimeIn() throws SchedulingInterruptedException {
 
     //basic setup
     PlanningHorizon hor = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(20));
@@ -1258,7 +1258,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void changingForAllTimeInCutoff() {
+  public void changingForAllTimeInCutoff() throws SchedulingInterruptedException {
 
     //basic setup
     PlanningHorizon hor = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(18));
@@ -1333,7 +1333,7 @@ public class TestApplyWhen {
   }
 
   @Test
-  public void changingForAllTimeInAlternativeCutoff() {
+  public void changingForAllTimeInAlternativeCutoff() throws SchedulingInterruptedException {
 
     //basic setup
     PlanningHorizon hor = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(20));

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestCardinalityGoal.java
@@ -16,12 +16,11 @@ import java.util.List;
 
 import static gov.nasa.jpl.aerie.scheduler.SimulationUtility.buildProblemFromFoo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestCardinalityGoal {
 
   @Test
-  public void testone() {
+  public void testone() throws SchedulingInterruptedException {
     Interval period = Interval.betweenClosedOpen(Duration.of(0, Duration.SECONDS), Duration.of(20, Duration.SECONDS));
 
     final var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(25));
@@ -45,7 +44,7 @@ public class TestCardinalityGoal {
 
     final var solver = new PrioritySolver(problem);
     var plan = solver.getNextSolution();
-    assertTrue(plan.get().getActivitiesByTime().size() == 6);
+    assertEquals(6, plan.get().getActivitiesByTime().size());
     assertEquals(plan.get().getActivitiesByTime().stream()
                      .map(SchedulingActivityDirective::duration)
                      .reduce(Duration.ZERO, Duration::plus), Duration.of(12, Duration.SECOND));

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoal.java
@@ -7,8 +7,6 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
 import gov.nasa.jpl.aerie.scheduler.goals.RecurrenceGoal;
 import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
-import gov.nasa.jpl.aerie.scheduler.model.Problem;
-import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
 import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class TestRecurrenceGoal {
 
   @Test
-  public void testRecurrence() {
+  public void testRecurrence() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
     final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoalExtended.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestRecurrenceGoalExtended.java
@@ -22,7 +22,7 @@ public class TestRecurrenceGoalExtended {
    * This test checks that a number activities are placed in the plan. VV
    */
   @Test
-  public void testRecurrence() {
+  public void testRecurrence() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
     final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
@@ -54,7 +54,7 @@ public class TestRecurrenceGoalExtended {
    * This test checks that only one activity is placed as the second one would exceed the goal window and the plan horizon. VV
    */
   @Test
-  public void testRecurrenceSecondGoalOutOfWindowAndPlanHorizon() {
+  public void testRecurrenceSecondGoalOutOfWindowAndPlanHorizon() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
     final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
@@ -83,7 +83,7 @@ public class TestRecurrenceGoalExtended {
    * This test checks that in case the repeat interval is larger than the window where the goal can be placed, the scheduler still manages to place one activity. VV
    */
   @Test
-  public void testRecurrenceRepeatIntervalLargerThanGoalWindow() {
+  public void testRecurrenceRepeatIntervalLargerThanGoalWindow() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
     final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
@@ -112,7 +112,7 @@ public class TestRecurrenceGoalExtended {
    * This test checks that in case the window where the goal can be placed is larger than the plan horizon, then the window is updated to the plan horizon size. xx
    */
   @Test
-  public void testGoalWindowLargerThanPlanHorizon() {
+  public void testGoalWindowLargerThanPlanHorizon() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(5),TestUtility.timeFromEpochSeconds(15));
     final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
@@ -148,7 +148,7 @@ public class TestRecurrenceGoalExtended {
    * This test checks that in case the goal duration is larger than goal window, no activity is added to the plan. VV
    */
   @Test
-  public void testGoalDurationLargerGoalWindow() {
+  public void testGoalDurationLargerGoalWindow() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
     final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
@@ -178,7 +178,7 @@ public class TestRecurrenceGoalExtended {
    * This test checks that in case the goal repeat cycle is shorter than the goal duration, then no activity is added to the plan. VV
    */
   @Test
-  public void testGoalDurationLargerRepeatInterval() {
+  public void testGoalDurationLargerRepeatInterval() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
     final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");
@@ -208,7 +208,7 @@ public class TestRecurrenceGoalExtended {
    * This test checks the behaviour when activity is added to a non-empty plan. How is distance preserved? What happens if activity already existing is deleted?
    */
   @Test
-  public void testAddActivityNonEmptyPlan() {
+  public void testAddActivityNonEmptyPlan() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0),TestUtility.timeFromEpochSeconds(20));
     final var problem = buildProblemFromFoo(planningHorizon);
     final var activityType = problem.getActivityType("ControllableDurationActivity");

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUnsatisfiableCompositeGoals.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestUnsatisfiableCompositeGoals.java
@@ -17,7 +17,6 @@ import gov.nasa.jpl.aerie.scheduler.model.PlanInMemory;
 import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
 import gov.nasa.jpl.aerie.scheduler.model.Problem;
 import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
-import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
 import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -72,7 +71,7 @@ public class TestUnsatisfiableCompositeGoals {
   }
 
   @Test
-  public void testAndWithoutBackTrack(){
+  public void testAndWithoutBackTrack() throws SchedulingInterruptedException {
     final var problem = makeTestMissionAB();
     problem.setInitialPlan(makePlanA12(problem));
     final var actTypeControllable = problem.getActivityType("ControllableDurationActivity");
@@ -107,7 +106,7 @@ public class TestUnsatisfiableCompositeGoals {
   }
 
   @Test
-  public void testAndWithBackTrack(){
+  public void testAndWithBackTrack() throws SchedulingInterruptedException {
     final var problem = makeTestMissionAB();
     problem.setInitialPlan(makePlanA12(problem));
     final var actTypeControllable = problem.getActivityType("ControllableDurationActivity");
@@ -140,7 +139,7 @@ public class TestUnsatisfiableCompositeGoals {
   }
 
   @Test
-  public void testOrWithoutBacktrack(){
+  public void testOrWithoutBacktrack() throws SchedulingInterruptedException {
     final var problem = makeTestMissionAB();
     problem.setInitialPlan(makePlanA12(problem));
     final var actTypeControllable = problem.getActivityType("ControllableDurationActivity");
@@ -180,7 +179,7 @@ public class TestUnsatisfiableCompositeGoals {
   }
 
   @Test
-  public void testOrWithBacktrack(){
+  public void testOrWithBacktrack() throws SchedulingInterruptedException {
     final var problem = makeTestMissionAB();
     problem.setInitialPlan(makePlanA12(problem));
     final var actTypeControllable = problem.getActivityType("ControllableDurationActivity");
@@ -215,7 +214,7 @@ public class TestUnsatisfiableCompositeGoals {
   }
 
   @Test
-  public void testCardinalityBacktrack() {
+  public void testCardinalityBacktrack() throws SchedulingInterruptedException {
     var planningHorizon = new PlanningHorizon(TestUtility.timeFromEpochSeconds(0), TestUtility.timeFromEpochSeconds(20));
 
     final var problem = buildProblemFromFoo(planningHorizon);

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/UncontrollableDurationTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/UncontrollableDurationTest.java
@@ -1,10 +1,8 @@
 package gov.nasa.jpl.aerie.scheduler;
 
-import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.constraints.tree.SpansFromWindows;
 import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
-import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
@@ -18,7 +16,6 @@ import gov.nasa.jpl.aerie.scheduler.model.Plan;
 import gov.nasa.jpl.aerie.scheduler.model.PlanInMemory;
 import gov.nasa.jpl.aerie.scheduler.model.PlanningHorizon;
 import gov.nasa.jpl.aerie.scheduler.model.Problem;
-import gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacade;
 import gov.nasa.jpl.aerie.scheduler.solver.PrioritySolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,7 +44,7 @@ public class UncontrollableDurationTest {
     return new PlanInMemory();
   }
   @Test
-  public void testNonLinear(){
+  public void testNonLinear() throws SchedulingInterruptedException {
 
     //duration should be 300 seconds trapezoidal
     final var solarPanelActivityTrapezoidal = new ActivityExpression.Builder()
@@ -100,7 +97,7 @@ public class UncontrollableDurationTest {
   }
 
   @Test
-  public void testTimeDependent(){
+  public void testTimeDependent() throws SchedulingInterruptedException {
 
     final var solarPanelActivityTrapezoidal = new ActivityExpression.Builder()
         .ofType(problem.getActivityType("SolarPanelNonLinearTimeDependent"))
@@ -153,7 +150,7 @@ public class UncontrollableDurationTest {
   }
 
   @Test
-  public void testBug(){
+  public void testBug() throws SchedulingInterruptedException {
     final var controllableDurationActivity = SchedulingActivityDirective.of(problem.getActivityType("ControllableDurationActivity"),
                                                                    Duration.of(1, Duration.MICROSECONDS),
                                                                    Duration.of(3, Duration.MICROSECONDS), null, true);
@@ -191,7 +188,7 @@ public class UncontrollableDurationTest {
   }
 
   @Test
-  public void testScheduleExceptionThrowingTask(){
+  public void testScheduleExceptionThrowingTask() throws SchedulingInterruptedException {
     final var zeroDurationUncontrollableActivity = new ActivityExpression.Builder()
         .ofType(problem.getActivityType("LateRiser"))
         .withTimingPrecision(Duration.of(1, Duration.MICROSECONDS))

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/AnchorSchedulerTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/AnchorSchedulerTest.java
@@ -22,6 +22,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+import gov.nasa.jpl.aerie.scheduler.SchedulingInterruptedException;
 import org.apache.commons.lang3.tuple.Triple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -49,7 +50,7 @@ public class AnchorSchedulerTest {
 
   @BeforeEach
   void beforeEach() {
-    driver = new ResumableSimulationDriver<>(AnchorTestModel, tenDays);
+    driver = new ResumableSimulationDriver<>(AnchorTestModel, tenDays, () -> false);
   }
 
   @Nested
@@ -118,7 +119,7 @@ public class AnchorSchedulerTest {
 
     @Test
     @DisplayName("Activities depending on no activities simulate at the correct time")
-    public void activitiesAnchoredToPlan() {
+    public void activitiesAnchoredToPlan() throws SchedulingInterruptedException {
       final var minusOneMinute = Duration.of(-60, Duration.SECONDS);
       final var resolveToPlanStartAnchors = new HashMap<ActivityDirectiveId, ActivityDirective>(415);
       final Map<SimulatedActivityId, SimulatedActivity> simulatedActivities = new HashMap<>(415);
@@ -227,7 +228,7 @@ public class AnchorSchedulerTest {
 
     @Test
     @DisplayName("Activities depending on another activities simulate at the correct time")
-    public void activitiesAnchoredToOtherActivities() {
+    public void activitiesAnchoredToOtherActivities() throws SchedulingInterruptedException {
       final var allEndTimeAnchors = new HashMap<ActivityDirectiveId, ActivityDirective>(400);
       final var endTimeAnchorEveryFifth = new HashMap<ActivityDirectiveId, ActivityDirective>(400);
       final Map<SimulatedActivityId, SimulatedActivity> simulatedActivities = new HashMap<>(800);
@@ -340,7 +341,7 @@ public class AnchorSchedulerTest {
 
     @Test
     @DisplayName("Decomposition and anchors do not interfere with each other")
-    public void decomposingActivitiesAndAnchors(){
+    public void decomposingActivitiesAndAnchors() throws SchedulingInterruptedException{
       // Given positions Left, Center, Right in an anchor chain, where each position can either contain a Non-Decomposition (ND) activity or a Decomposition (D) activity,
       // and the connection between Center and Left and Right and Center can be either Start (<-s-) or End (<-e-),
       // and two NDs cannot be adjacent to each other, there are 20 permutations.
@@ -583,7 +584,7 @@ public class AnchorSchedulerTest {
 
     @Test
     @DisplayName("Activities arranged in a wide anchor tree simulate at the correct time")
-    public void naryTreeAnchorChain() {
+    public void naryTreeAnchorChain() throws SchedulingInterruptedException{
       // Full and complete 5-ary tree,  6 levels deep
       // Number of activity directives = 5^0 + 5^1 + 5^2 + 5^3 + 5^4 + 5^5 = 3906
 

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -14,3 +14,4 @@ call migrations.mark_migration_applied('8');
 call migrations.mark_migration_applied('9');
 call migrations.mark_migration_applied('10');
 call migrations.mark_migration_applied('11');
+call migrations.mark_migration_applied('12');

--- a/scheduler-server/sql/scheduler/tables/scheduling_request.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_request.sql
@@ -86,3 +86,19 @@ create trigger cancel_pending_scheduling_rqs
   before insert on scheduling_request
   for each row
   execute function cancel_pending_scheduling_rqs();
+
+create function notify_scheduling_workers_cancel()
+returns trigger
+security definer
+language plpgsql as $$
+begin
+  perform pg_notify('scheduling_cancel', '' || new.specification_id);
+  return null;
+end
+$$;
+
+create trigger notify_scheduling_workers_cancel
+after update of canceled on scheduling_request
+for each row
+when ((old.status != 'success' or old.status != 'failed') and new.canceled)
+execute function notify_scheduling_workers_cancel();

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/ResultsProtocol.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/ResultsProtocol.java
@@ -2,6 +2,8 @@ package gov.nasa.jpl.aerie.scheduler.server;
 
 import java.util.Optional;
 import java.util.function.Consumer;
+
+import gov.nasa.jpl.aerie.scheduler.SchedulingInterruptedException;
 import gov.nasa.jpl.aerie.scheduler.server.models.DatasetId;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleFailure;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleResults;
@@ -77,23 +79,17 @@ public final class ResultsProtocol {
    * producer for a scheduling result
    */
   public interface WriterRole {
-
-    /**
-     * flag to check to see if all interest in the result has been cancelled
-     *
-     * the producer should still call failWith() after it notices a cancellation
-     *
-     * @return true iff a cancel has been invoked on the corresponding reader
-     */
-    //TODO: determine if this also kills the actual run itself (ie should plan possibly mutate after a cancel?)
-    boolean isCanceled();
-
     /**
      * mark the scheduling run as fully complete and attach the given results
      *
      * @param results the summary results of the scheduling run, including satisfaction metrics etc
      */
     void succeedWith(ScheduleResults results, Optional<DatasetId> datasetId);
+
+    /**
+     * Mark that the scheduler has acknowledged the cancellation
+     */
+    void reportCanceled(final SchedulingInterruptedException e);
 
     /**
      * mark the scheduling run as having failed with the given reason

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulerAgent.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/SchedulerAgent.java
@@ -2,6 +2,8 @@ package gov.nasa.jpl.aerie.scheduler.server.services;
 
 import gov.nasa.jpl.aerie.scheduler.server.ResultsProtocol;
 
+import java.util.function.Supplier;
+
 /**
  * agent that can handle posed scheduling requests
  */
@@ -18,6 +20,9 @@ public interface SchedulerAgent {
    * @param request details of scheduling request, including target plan version
    * @param writer object representing the request for scheduling results, including space to store results
    */
-  void schedule(ScheduleRequest request, ResultsProtocol.WriterRole writer) throws InterruptedException;
-
+  void schedule(
+      ScheduleRequest request,
+      ResultsProtocol.WriterRole writer,
+      Supplier<Boolean> canceledListener
+  ) throws InterruptedException;
 }

--- a/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/ListenSchedulerCapability.java
+++ b/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/ListenSchedulerCapability.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.scheduler.worker;
 
+import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
 import gov.nasa.jpl.aerie.scheduler.server.remotes.postgres.DatabaseException;
 import gov.nasa.jpl.aerie.scheduler.worker.postgres.ListenSchedulingRequestStatusAction;
 import gov.nasa.jpl.aerie.scheduler.worker.postgres.PostgresSchedulingRequestNotificationPayload;
@@ -28,7 +29,7 @@ public class ListenSchedulerCapability {
     this.notificationQueue = notificationQueue;
   }
 
-  public Thread registerListener() {
+  public Thread registerListener(SchedulingCanceledListener canceledListener) {
     final var listenerThread = new Thread(() -> {
       try (final var connection = this.dataSource.getConnection()) {
         try (final var listenSimulationStatusAction = new ListenSchedulingRequestStatusAction(connection)) {
@@ -45,18 +46,24 @@ public class ListenSchedulerCapability {
               final var processId = notification.getPID();
               final var channelName = notification.getName();
               final var payload = notification.getParameter();
+
               logger.info("Received PSQL Notification: {}, {}, {}", processId, channelName, payload);
-              try (final var reader = Json.createReader(new StringReader(payload))) {
-                final var jsonValue = reader.readValue();
-                final var notificationPayload = postgresSchedulingRequestNotificationP
-                    .parse(jsonValue)
-                    .getSuccessOrThrow();
-                try {
-                  this.notificationQueue.put(notificationPayload);
-                } catch (InterruptedException e) {
-                  // This thread will be interrupted when the worker's main loop exits, so it should exit gracefully:
-                  logger.info("Listener has been interrupted");
-                  return;
+
+              if (channelName.equals("scheduling_cancel")) {
+                  canceledListener.receiveSignal(new SpecificationId(Long.parseLong(payload)));
+              } else {
+                try (final var reader = Json.createReader(new StringReader(payload))) {
+                  final var jsonValue = reader.readValue();
+                  final var notificationPayload = postgresSchedulingRequestNotificationP
+                      .parse(jsonValue)
+                      .getSuccessOrThrow();
+                  try {
+                    this.notificationQueue.put(notificationPayload);
+                  } catch (InterruptedException e) {
+                    // This thread will be interrupted when the worker's main loop exits, so it should exit gracefully:
+                    logger.info("Listener has been interrupted");
+                    return;
+                  }
                 }
               }
             }

--- a/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/SchedulerWorkerAppDriver.java
+++ b/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/SchedulerWorkerAppDriver.java
@@ -85,19 +85,28 @@ public final class SchedulerWorkerAppDriver {
         final var specificationRevision = notification.specificationRevision();
         final var specificationId = new SpecificationId(notification.specificationId());
 
+        // Register as early as possible to avoid potentially missing a canceled signal
+        canceledListener.register(specificationId);
+
         final Optional<ResultsProtocol.OwnerRole> owner = stores.results().claim(specificationId);
-        if (owner.isEmpty()) continue;
+        if (owner.isEmpty()) {
+          canceledListener.unregister();
+          continue;
+        }
 
         final var revisionData = new SpecificationRevisionData(specificationRevision);
         final ResultsProtocol.WriterRole writer = owner.get();
         try {
-          scheduleAgent.schedule(new ScheduleRequest(specificationId, revisionData), writer);
+          scheduleAgent.schedule(new ScheduleRequest(specificationId, revisionData), writer, canceledListener);
         } catch (final Throwable ex) {
           ex.printStackTrace(System.err);
           writer.failWith(b -> b
               .type("UNEXPECTED_SCHEDULER_EXCEPTION")
               .message("Something went wrong while scheduling")
               .trace(ex));
+        }
+        finally {
+          canceledListener.unregister();
         }
       }
     } finally {

--- a/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/SchedulerWorkerAppDriver.java
+++ b/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/SchedulerWorkerAppDriver.java
@@ -73,7 +73,8 @@ public final class SchedulerWorkerAppDriver {
 
     final var notificationQueue = new LinkedBlockingQueue<PostgresSchedulingRequestNotificationPayload>();
     final var listenAction = new ListenSchedulerCapability(hikariDataSource, notificationQueue);
-    final var listenThread = listenAction.registerListener();
+    final var canceledListener = new SchedulingCanceledListener();
+    final var listenThread = listenAction.registerListener(canceledListener);
 
     try(final var app = Javalin.create().start(8080)) {
       app.get("/health", ctx -> ctx.status(200));

--- a/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/SchedulingCanceledListener.java
+++ b/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/SchedulingCanceledListener.java
@@ -1,0 +1,55 @@
+package gov.nasa.jpl.aerie.scheduler.worker;
+
+import gov.nasa.jpl.aerie.scheduler.server.models.SpecificationId;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class SchedulingCanceledListener implements Supplier<Boolean> {
+  private Optional<SpecificationId> registeredSchedulingRun;
+  private boolean canceled;
+
+  public SchedulingCanceledListener() {
+    registeredSchedulingRun = Optional.empty();
+    canceled = false;
+  }
+
+  /**
+   * Receive a canceled signal.
+   * All signals that are not for this object's registered scheduling run will be ignored.
+   * @param payload The payload of the signal
+   */
+  public void receiveSignal(SpecificationId payload){
+    if (registeredSchedulingRun.isEmpty() || !registeredSchedulingRun.get().equals(payload)) return;
+    canceled = true;
+  }
+
+  /**
+   * Register the listener to a specific scheduling run
+   * @param id the specification id of the scheduling run
+   */
+  public void register(SpecificationId id) {
+    registeredSchedulingRun = Optional.of(id);
+    canceled = false;
+  }
+
+  /**
+   * Unregister the listener
+   */
+  public void unregister(){
+    registeredSchedulingRun = Optional.empty();
+    canceled = false;
+  }
+
+  /**
+   * @return if the current registered scheduling run has been canceled
+   */
+  public boolean isCanceled() {
+    return registeredSchedulingRun.isPresent() && canceled;
+  }
+
+  @Override
+  public Boolean get() {
+    return isCanceled();
+  }
+}

--- a/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/postgres/ListenSchedulingRequestStatusAction.java
+++ b/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/postgres/ListenSchedulingRequestStatusAction.java
@@ -7,7 +7,8 @@ import org.intellij.lang.annotations.Language;
 
 /*package local*/ public class ListenSchedulingRequestStatusAction implements AutoCloseable{
   private static final @Language("SQL") String sql = """
-    LISTEN "scheduling_request_notification"
+    LISTEN "scheduling_request_notification";
+    LISTEN "scheduling_cancel";
   """;
 
   private final PreparedStatement statement;

--- a/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/services/SynchronousSchedulerAgent.java
+++ b/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/services/SynchronousSchedulerAgent.java
@@ -301,8 +301,7 @@ public record SynchronousSchedulerAgent(
 
   private Optional<DatasetId> storeSimulationResults(PlanningHorizon planningHorizon, SimulationFacade simulationFacade, PlanMetadata planMetadata,
                                                      final Map<SchedulingActivityDirective, ActivityDirectiveId> schedDirectiveToMerlinId)
-  throws MerlinServiceException, IOException
-  {
+      throws MerlinServiceException, IOException, SchedulingInterruptedException {
     if(!simulationFacade.areInitialSimulationResultsStale()) return Optional.empty();
     //finish simulation until end of horizon before posting results
     try {

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/MockResultsProtocolWriter.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/MockResultsProtocolWriter.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.scheduler.worker.services;
 import java.util.ArrayList;
 import java.util.Optional;
 
+import gov.nasa.jpl.aerie.scheduler.SchedulingInterruptedException;
 import gov.nasa.jpl.aerie.scheduler.server.ResultsProtocol;
 import gov.nasa.jpl.aerie.scheduler.server.models.DatasetId;
 import gov.nasa.jpl.aerie.scheduler.server.services.ScheduleFailure;
@@ -17,18 +18,18 @@ class MockResultsProtocolWriter implements ResultsProtocol.WriterRole {
 
   sealed interface Result {
     record Success(ScheduleResults results, Optional<DatasetId> datasetId) implements Result {}
-
     record Failure(ScheduleFailure reason) implements Result {}
-  }
-
-  @Override
-  public boolean isCanceled() {
-    return false;
+    record Canceled(ScheduleFailure message) implements Result {}
   }
 
   @Override
   public void succeedWith(final ScheduleResults results, final Optional<DatasetId> datasetId) {
     this.results.add(new Result.Success(results, datasetId));
+  }
+
+  @Override
+  public void reportCanceled(final SchedulingInterruptedException e) {
+    this.results.add(new Result.Canceled(new ScheduleFailure.Builder().build()));
   }
 
   @Override

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
@@ -2003,9 +2003,7 @@ public class SchedulingIntegrationTests {
     mockMerlinService.setMissionModel(getMissionModelInfo(desc));
     mockMerlinService.setInitialPlan(plannedActivities);
     mockMerlinService.setPlanningHorizon(planningHorizon);
-    if(externalProfiles.isPresent()) {
-      mockMerlinService.setExternalDataset(externalProfiles.get());
-    }
+    externalProfiles.ifPresent(mockMerlinService::setExternalDataset);
     final var planId = new PlanId(1L);
     final var goalsByPriority = new ArrayList<GoalRecord>();
 
@@ -2030,7 +2028,7 @@ public class SchedulingIntegrationTests {
         schedulingDSLCompiler);
     // Scheduling Goals -> Scheduling Specification
     final var writer = new MockResultsProtocolWriter();
-    agent.schedule(new ScheduleRequest(new SpecificationId(1L), $ -> RevisionData.MatchResult.success()), writer);
+    agent.schedule(new ScheduleRequest(new SpecificationId(1L), $ -> RevisionData.MatchResult.success()), writer, () -> false);
     assertEquals(1, writer.results.size());
     final var result = writer.results.get(0);
     if (result instanceof MockResultsProtocolWriter.Result.Failure e) {


### PR DESCRIPTION
* **Tickets addressed:** Closes #1241 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Allows for a scheduling run to be canceled.

Scheduling will check if it has been canceled:
  - before computing simulation results
  - before processing a batch in simulation
  - before initializing the plan
  - at the top of `satisfyGoal`
  - at the top of `removeAndInsertActivitiesFromSimulation`
If it has been canceled, it will throw a `SchedulingInterruptedException`, which will bubble up until it hits the `SynchronousSchedulerAgent`, which will catch the exception and report the scheduling run as canceled.

Unlike with simulation, partial results are not returned.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
- Unit tests have been updated with the new `schedule` syntax. All of them have been set to uncancelable.
- A new e2e test was added to check that canceling works and updates the `reason` column.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs need to be updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
UI needs to be updated to allow for canceling an in-progress Scheduling Run
