### PR TITLE
Add PUBLIC_AERIE_FILE_STORE_PREFIX environment variable

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -142,6 +142,7 @@ services:
     depends_on: ["postgres"]
     environment:
       ORIGIN: http://localhost
+      PUBLIC_AERIE_FILE_STORE_PREFIX: "/usr/src/app/merlin_file_store/"
       PUBLIC_LOGIN_PAGE: "enabled"
       PUBLIC_GATEWAY_CLIENT_URL: http://localhost:9000
       PUBLIC_GATEWAY_SERVER_URL: http://aerie_gateway:9000

--- a/deployment/kubernetes/aerie-ui-deployment.yaml
+++ b/deployment/kubernetes/aerie-ui-deployment.yaml
@@ -17,6 +17,8 @@ spec:
         - env:
             - name: ORIGIN
               value: http://127.0.0.1
+            - name: PUBLIC_AERIE_FILE_STORE_PREFIX
+              value: /usr/src/app/merlin_file_store/
             - name: PUBLIC_GATEWAY_CLIENT_URL
               value: http://localhost:9000
             - name: PUBLIC_GATEWAY_SERVER_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
     depends_on: ["postgres"]
     environment:
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
+      PUBLIC_AERIE_FILE_STORE_PREFIX: "/usr/src/app/merlin_file_store/"
       PUBLIC_LOGIN_PAGE: "enabled"
       ORIGIN: http://localhost
       PUBLIC_GATEWAY_CLIENT_URL: http://localhost:9000

--- a/e2e-tests/docker-compose-many-workers.yml
+++ b/e2e-tests/docker-compose-many-workers.yml
@@ -103,6 +103,7 @@ services:
     depends_on: ["postgres"]
     environment:
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
+      PUBLIC_AERIE_FILE_STORE_PREFIX: "/usr/src/app/merlin_file_store/"
       PUBLIC_LOGIN_PAGE: "enabled"
       ORIGIN: http://localhost
       PUBLIC_GATEWAY_CLIENT_URL: http://localhost:9000

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -106,6 +106,7 @@ services:
     environment:
       NODE_TLS_REJECT_UNAUTHORIZED: '0'
       ORIGIN: http://localhost
+      PUBLIC_AERIE_FILE_STORE_PREFIX: "/usr/src/app/merlin_file_store/"
       PUBLIC_GATEWAY_CLIENT_URL: http://localhost:9000
       PUBLIC_GATEWAY_SERVER_URL: http://aerie_gateway:9000
       PUBLIC_HASURA_CLIENT_URL: http://localhost:8080/v1/graphql


### PR DESCRIPTION
* **Tickets addressed:** Related to NASA-AMMOS/aerie-ui#1054
* **Review:** By file  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
As of NASA-AMMOS/aerie-ui#1054, the aerie UI uses the `PUBLIC_AERIE_FILE_STORE_PREFIX` to set the names of files uploaded to the simulation configuration.

This PR defines `PUBLIC_AERIE_FILE_STORE_PREFIX` for every docker-compose and kubernetes file I could find in the aerie repo.

I searched for occurrences of `PUBLIC_GATEWAY_CLIENT_URL` to identify files that needed changing. I did not change `docker-compose-proxy.yml`, since that seemed to only have the environment variables pertaining to URLs.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I did not verify these changes - any suggestions for how to do that are welcome.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
UI environment variables are documented in the Aerie UI repo. NASA-AMMOS/aerie-ui#1054 updates that documentation.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- None yet