### PR TITLE
Added a new ValidationResult type that can be used to return more spe…

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/ValidationResult.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/ValidationResult.java
@@ -1,0 +1,5 @@
+package gov.nasa.jpl.aerie.contrib.models;
+
+import java.util.Optional;
+
+public record ValidationResult(boolean success, String subject, Optional<String> message) {}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/ValidationResult.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/ValidationResult.java
@@ -2,4 +2,4 @@ package gov.nasa.jpl.aerie.contrib.models;
 
 import java.util.Optional;
 
-public record ValidationResult(boolean success, String subject, Optional<String> message) {}
+public record ValidationResult(boolean success, String subject, String message) {}

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -191,7 +191,7 @@ type MerlinSimulationResponse {
 }
 
 type ValidationResponse {
-  errors: [ValidationNotice!]
+  errors: ValidationNotice!
   success: Boolean!
 }
 

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -191,7 +191,7 @@ type MerlinSimulationResponse {
 }
 
 type ValidationResponse {
-  errors: [ValidationNotice]!
+  errors: [ValidationNotice!]
   success: Boolean!
 }
 

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -191,7 +191,7 @@ type MerlinSimulationResponse {
 }
 
 type ValidationResponse {
-  errors: ValidationNotice!
+  errors: [ValidationNotice]!
   success: Boolean!
 }
 

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BakeBananaBreadActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BakeBananaBreadActivity.java
@@ -15,12 +15,12 @@ public record BakeBananaBreadActivity(double temperature, int tbSugar, boolean g
   @Validation
   public ValidationResult validateTemperatures() {
     if (this.temperature < 0) {
-      return new ValidationResult(false, "temperature", Optional.of("Temperature must be positive"));
+      return new ValidationResult(false, "temperature", "Temperature must be positive");
     }
 
     return new ValidationResult(!glutenFree || temperature >= 100,
       "glutenFree",
-      Optional.of("Gluten-free bread must be baked at a temperature >= 100"));
+      "Gluten-free bread must be baked at a temperature >= 100");
   }
 
   @EffectModel

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BakeBananaBreadActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BakeBananaBreadActivity.java
@@ -1,24 +1,26 @@
 package gov.nasa.jpl.aerie.banananation.activities;
 
 import gov.nasa.jpl.aerie.banananation.Mission;
+import gov.nasa.jpl.aerie.contrib.models.ValidationResult;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Validation;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.WithDefaults;
 
+import java.util.Optional;
+
 @ActivityType("BakeBananaBread")
 public record BakeBananaBreadActivity(double temperature, int tbSugar, boolean glutenFree) {
 
-  @Validation("Temperature must be positive")
-  @Validation.Subject("temperature")
-  public boolean validateTemperature() {
-    return this.temperature() > 0;
-  }
+  @Validation
+  public ValidationResult validateTemperatures() {
+    if (this.temperature < 0) {
+      return new ValidationResult(false, "temperature", Optional.of("Temperature must be positive"));
+    }
 
-  @Validation("Gluten-free bread must be baked at a temperature >= 100")
-  @Validation.Subject({"glutenFree", "temperature"})
-  public boolean validateGlutenFreeTemperature() {
-    return !glutenFree || temperature >= 100;
+    return new ValidationResult(!glutenFree || temperature >= 100,
+      "glutenFree",
+      Optional.of("Gluten-free bread must be baked at a temperature >= 100"));
   }
 
   @EffectModel

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BakeBananaBreadActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BakeBananaBreadActivity.java
@@ -7,8 +7,6 @@ import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Validation;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.WithDefaults;
 
-import java.util.Optional;
-
 @ActivityType("BakeBananaBread")
 public record BakeBananaBreadActivity(double temperature, int tbSugar, boolean glutenFree) {
 

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BiteBananaActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BiteBananaActivity.java
@@ -30,7 +30,7 @@ public final class BiteBananaActivity {
 
   @Validation
   public ValidationResult validateBiteSize() {
-    return new ValidationResult(this.biteSize > 0, "biteSize", Optional.of("bite size must be positive"));
+    return new ValidationResult(this.biteSize > 0, "biteSize", "bite size must be positive");
   }
 
   @EffectModel

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BiteBananaActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BiteBananaActivity.java
@@ -10,8 +10,6 @@ import gov.nasa.jpl.aerie.merlin.framework.annotations.AutoValueMapper;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Parameter;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Validation;
 
-import java.util.Optional;
-
 /**
  * Bite a banana.
  *

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BiteBananaActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BiteBananaActivity.java
@@ -3,11 +3,14 @@ package gov.nasa.jpl.aerie.banananation.activities;
 import gov.nasa.jpl.aerie.banananation.Flag;
 import gov.nasa.jpl.aerie.banananation.Mission;
 import gov.nasa.jpl.aerie.contrib.metadata.Unit;
+import gov.nasa.jpl.aerie.contrib.models.ValidationResult;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.AutoValueMapper;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Parameter;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Validation;
+
+import java.util.Optional;
 
 /**
  * Bite a banana.
@@ -25,10 +28,9 @@ public final class BiteBananaActivity {
   @Unit("m")
   public double biteSize = 1.0;
 
-  @Validation("bite size must be positive")
-  @Validation.Subject("biteSize")
-  public boolean validateBiteSize() {
-    return this.biteSize > 0;
+  @Validation
+  public ValidationResult validateBiteSize() {
+    return new ValidationResult(this.biteSize > 0, "biteSize", Optional.of("bite size must be positive"));
   }
 
   @EffectModel

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
@@ -502,6 +502,10 @@ import java.util.stream.Collectors;
     for (final var element : exportTypeElement.getEnclosedElements()) {
       if (element.getAnnotation(Export.Validation.class) == null) continue;
 
+      // Is there a way to tie this to the actual class rather than the string?
+      boolean isSimpleValidation = !(element.getKind() == ElementKind.METHOD &&
+          ((ExecutableElement) element).getReturnType().toString().equals("gov.nasa.jpl.aerie.contrib.models.ValidationResult"));
+
       final var name = element.getSimpleName().toString();
       final var message = element.getAnnotation(Export.Validation.class).value();
       final var subjects = element.getAnnotation(Export.Validation.Subject.class) == null ?
@@ -519,7 +523,7 @@ import java.util.stream.Collectors;
                 .formatted(name, missingSubjects$.get()), exportTypeElement);
       }
 
-      validations.add(new ParameterValidationRecord(name, subjects, message));
+      validations.add(new ParameterValidationRecord(name, subjects, message, isSimpleValidation));
     }
 
     return validations;

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.processor;
 
 import com.squareup.javapoet.ClassName;
+import gov.nasa.jpl.aerie.contrib.models.ValidationResult;
 import gov.nasa.jpl.aerie.merlin.framework.MetadataValueMapper;
 import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
@@ -502,9 +503,8 @@ import java.util.stream.Collectors;
     for (final var element : exportTypeElement.getEnclosedElements()) {
       if (element.getAnnotation(Export.Validation.class) == null) continue;
 
-      // Is there a way to tie this to the actual class rather than the string?
       boolean isSimpleValidation = !(element.getKind() == ElementKind.METHOD &&
-          ((ExecutableElement) element).getReturnType().toString().equals("gov.nasa.jpl.aerie.contrib.models.ValidationResult"));
+          ((ExecutableElement) element).getReturnType().toString().equals(ValidationResult.class.getTypeName()));
 
       final var name = element.getSimpleName().toString();
       final var message = element.getAnnotation(Export.Validation.class).value();

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MapperMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MapperMethodMaker.java
@@ -182,7 +182,7 @@ public abstract sealed class MapperMethodMaker permits
                     }
 
                     codeBlock.addStatement(
-                      "if (!$L.$L().$L()) notices.add(new $T($T.of($L.$L().$L()), $L.$L().$L().orElse(null)))",
+                      "if (!$L.$L().$L()) notices.add(new $T($T.of($L.$L().$L()), $L.$L().$L()))",
                       "input",
                       validation.methodName(),
                       "success",

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MapperMethodMaker.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MapperMethodMaker.java
@@ -12,8 +12,10 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.UnconstructableArgumentException;
 
 import javax.lang.model.element.Modifier;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -151,26 +153,58 @@ public abstract sealed class MapperMethodMaker permits
             inputType.validations()
                 .stream()
                 .map(validation -> {
-                    final var subjects = Arrays.stream(validation.subjects())
-                        .map(subject -> CodeBlock.builder().add("$S", subject))
-                        .reduce((x, y) -> x.add(", ").add(y.build()))
-                        .orElse(CodeBlock.builder())
-                        .build();
+                    CodeBlock.Builder codeBlock = CodeBlock.builder().beginControlFlow("try");
 
-                    return CodeBlock
-                        .builder()
-                        .beginControlFlow("try")
-                        .addStatement(
-                            "if (!$L.$L()) notices.add(new $T($T.of($L), $S))",
-                            "input",
-                            validation.methodName(),
-                            ValidationNotice.class,
-                            List.class,
-                            subjects,
-                            validation.failureMessage())
-                        .nextControlFlow("catch ($T ex)", Throwable.class)
-                        .addStatement("notices.add(new $T($T.of($L), ex.getMessage()))", ValidationNotice.class, List.class, subjects)
-                        .endControlFlow();
+                    if (validation.isSimpleValidation()) {
+                        final var subjects = Arrays.stream(validation.subjects())
+                          .map(subject -> CodeBlock.builder().add("$S", subject))
+                          .reduce((x, y) -> x.add(", ").add(y.build()))
+                          .orElse(CodeBlock.builder())
+                          .build();
+
+                        codeBlock.addStatement(
+                          "if (!$L.$L()) notices.add(new $T($T.of($L), $S))",
+                          "input",
+                          validation.methodName(),
+                          ValidationNotice.class,
+                          List.class,
+                          subjects,
+                          validation.failureMessage());
+
+                        return codeBlock
+                          .nextControlFlow("catch ($T ex)", Throwable.class)
+                          .addStatement(
+                              "notices.add(new $T($T.of($L), ex.getMessage()))",
+                              ValidationNotice.class,
+                              List.class,
+                              subjects)
+                          .endControlFlow();
+                    }
+
+                    codeBlock.addStatement(
+                      "if (!$L.$L().$L()) notices.add(new $T($T.of($L.$L().$L()), $L.$L().$L().orElse(null)))",
+                      "input",
+                      validation.methodName(),
+                      "success",
+                      ValidationNotice.class,
+                      List.class,
+                      "input",
+                      validation.methodName(),
+                      "subject",
+                      "input",
+                      validation.methodName(),
+                      "message");
+
+                    return codeBlock
+                      .nextControlFlow("catch ($T ex)", Throwable.class)
+                      .addStatement(
+                          "notices.add(new $T($T.of($L.$L().$L()), ex.getMessage()))",
+                          ValidationNotice.class,
+                          List.class,
+                          "input",
+                          validation.methodName(),
+                          "subject")
+                      .endControlFlow();
                 })
                 .reduce(CodeBlock.builder(), (x, y) -> x.add(y.build()))
                 .build())

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ParameterValidationRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ParameterValidationRecord.java
@@ -1,3 +1,3 @@
 package gov.nasa.jpl.aerie.merlin.processor.metamodel;
 
-public record ParameterValidationRecord(String methodName, String[] subjects, String failureMessage) { }
+public record ParameterValidationRecord(String methodName, String[] subjects, String failureMessage, boolean isSimpleValidation) { }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/Export.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/Export.java
@@ -31,7 +31,7 @@ public @interface Export {
   @Retention(RetentionPolicy.CLASS)
   @Target(ElementType.METHOD)
   @interface Validation {
-    String value();
+    String value() default "";
 
     @Retention(RetentionPolicy.CLASS)
     @Target(ElementType.METHOD)


### PR DESCRIPTION
…cific validation notices

* **Tickets addressed:** #941.
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
I added a new `ValidationResult` class that can return more specific validation failures.

## Verification
Re-ran tests and manually tested against existing Bananation activities that use the new `ValidationResult` return type.

## Documentation
https://github.com/NASA-AMMOS/aerie-docs/pull/112

## Future work
Not sure, I'm hoping these changes capture what we wanted as part of #941.
