### PR TITLE
Handle task scheduling in ResumableSimulationDriver

### DIFF
--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -1028,7 +1028,7 @@ public class PrioritySolver implements Solver {
             if(computedDuration.isPresent()) {
               history.add(new EquationSolvingAlgorithms.FunctionCoordinate<>(start, start.plus(computedDuration.get())), new ActivityMetadata(actToSim));
             } else{
-              logger.debug("No simulation error but activity duration could not be found in simulation, likely caused by unfinished activity.");
+              logger.debug("No simulation error but activity duration could not be found in simulation, likely caused by unfinished activity or activity outside plan bounds.");
               history.add(new EquationSolvingAlgorithms.FunctionCoordinate<>(start,  null), new ActivityMetadata(actToSim));
             }
           } catch (SimulationFacade.SimulationException e) {

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/AnchorSchedulerTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/AnchorSchedulerTest.java
@@ -340,6 +340,21 @@ public class AnchorSchedulerTest {
     }
 
     @Test
+    @DisplayName("Reference to anchored activities are correctly maintained by the driver")
+    public void activitiesAnchoredToOtherActivitiesSimple() throws SchedulingInterruptedException {
+      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective>(2);
+      activitiesToSimulate.put(
+          new ActivityDirectiveId(0),
+          new ActivityDirective(oneMinute, serializedDelayDirective, null, true));
+      activitiesToSimulate.put(
+          new ActivityDirectiveId(1),
+          new ActivityDirective(oneMinute, serializedDelayDirective, new ActivityDirectiveId(0), false));
+      driver.simulateActivities(activitiesToSimulate);
+      final var durationOfAnchoredActivity = driver.getActivityDuration(new ActivityDirectiveId(1));
+      assertTrue(durationOfAnchoredActivity.isPresent());
+    }
+
+    @Test
     @DisplayName("Decomposition and anchors do not interfere with each other")
     public void decomposingActivitiesAndAnchors() throws SchedulingInterruptedException{
       // Given positions Left, Center, Right in an anchor chain, where each position can either contain a Non-Decomposition (ND) activity or a Decomposition (D) activity,

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
@@ -2695,15 +2695,14 @@ public class SchedulingIntegrationTests {
             new ActivityDirectiveId(2L),
             new ActivityDirective(
                 tenMinutes,
-                "GrowBanana",
+                "PickBanana",
                 Map.of(
-                    "quantity", SerializedValue.of(1),
-                    "growingDuration", SerializedValue.of(activityDuration.in(Duration.MICROSECONDS))),
+                    "quantity", SerializedValue.of(1)),
                 new ActivityDirectiveId(1L),
                 true)),
         List.of(new SchedulingGoal(new GoalId(0L), """
           export default () => Goal.CoexistenceGoal({
-            forEach: ActivityExpression.ofType(ActivityTypes.GrowBanana),
+            forEach: ActivityExpression.ofType(ActivityTypes.PickBanana),
             activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
             startsAt: TimingConstraint.singleton(WindowProperty.START).plus(Temporal.Duration.from({ minutes : 5}))
           })
@@ -2724,20 +2723,20 @@ public class SchedulingIntegrationTests {
 
     final var planByActivityType = partitionByActivityType(results.updatedPlan());
     final var peelBananas = planByActivityType.get("PeelBanana");
-    final var growBananas = planByActivityType.get("GrowBanana");
+    final var pickBananas = planByActivityType.get("PickBanana");
     final var durationParamActivities = planByActivityType.get("DurationParameterActivity");
 
     assertEquals(1, peelBananas.size());
-    assertEquals(1, growBananas.size());
+    assertEquals(1, pickBananas.size());
     assertEquals(1, durationParamActivities.size());
     final var peelBanana = peelBananas.iterator().next();
-    final var growBanana = growBananas.iterator().next();
+    final var pickBanana = pickBananas.iterator().next();
     final var durationParamActivity = durationParamActivities.iterator().next();
 
     assertEquals(Duration.ZERO, durationParamActivity.startOffset());
 
-    assertEquals(tenMinutes, growBanana.startOffset());
-    assertEquals(SerializedValue.of(1), growBanana.serializedActivity().getArguments().get("quantity"));
+    assertEquals(tenMinutes, pickBanana.startOffset());
+    assertEquals(SerializedValue.of(1), pickBanana.serializedActivity().getArguments().get("quantity"));
 
     assertEquals(Duration.of(15, Duration.MINUTES), peelBanana.startOffset());
     assertEquals(SerializedValue.of("fromStem"), peelBanana.serializedActivity().getArguments().get("peelDirection"));


### PR DESCRIPTION
* **Tickets addressed:** Fixes #1256 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Here is an example of how the issue has manifested: 
- The scheduler has to simulate a plan with activities A and B with B anchored to A. 
- After simulation, the scheduler tries to query the duration of task B, it fails
- Indeed, the resumable simulation driver does not have a direct reference to task B because of how anchored activities were managed, that is, by creating an anonymous task that would include the A, a delay, then B. The driver would remember the id of this anonymous task but not the id of task B precisely. The id of a task is given when the task is scheduled and in this case, the simulation engine would schedule task A and B, not the driver. 

The solution consists in replacing this anonymous task creation with a mechanism that lets the driver schedule dependent tasks as soon as their dependent is finishing. Handling task creation allows to maintaining references to task ids and solve the above issue. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
A simple test that was not passing before has been added.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A