### PR TITLE
Track when Merge Requests were last updated

### DIFF
--- a/deployment/hasura/migrations/AerieMerlin/36_metadata_updated_at/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/36_metadata_updated_at/down.sql
@@ -1,0 +1,5 @@
+drop trigger set_timestamp on merge_request;
+drop function merge_request_set_updated_at();
+alter table merge_request drop column updated_at;
+
+call migrations.mark_migration_rolled_back('36');

--- a/deployment/hasura/migrations/AerieMerlin/36_metadata_updated_at/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/36_metadata_updated_at/up.sql
@@ -1,0 +1,17 @@
+alter table merge_request add column updated_at timestamptz not null default now();
+
+create function merge_request_set_updated_at()
+returns trigger
+security definer
+language plpgsql as $$begin
+  new.updated_at = now();
+  return new;
+end$$;
+
+create trigger set_timestamp
+  before update or insert on merge_request
+  for each row
+execute function merge_request_set_updated_at();
+
+call migrations.mark_migration_applied('36');
+

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -38,3 +38,4 @@ call migrations.mark_migration_applied('32');
 call migrations.mark_migration_applied('33');
 call migrations.mark_migration_applied('34');
 call migrations.mark_migration_applied('35');
+call migrations.mark_migration_applied('36');


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

The column `updated_at` was added to the merge requests table. Because merge requests are solely updated via DB code, this always reflect the time at which the status of a merge request last changed. This will be useful if there are concerns with what changes committing a merge applied, as entries in the `activity_directive_changelog` can be correlated with a commit merge action via this `updated_at` timestamp.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
