### PR TITLE
Feature  activity type value mappers

### DIFF
--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/RussianNestingBanana.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/RussianNestingBanana.java
@@ -1,0 +1,72 @@
+package gov.nasa.jpl.aerie.banananation.activities;
+
+import gov.nasa.jpl.aerie.banananation.Mission;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.AutoValueMapper;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.Export;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.util.List;
+import java.util.Optional;
+
+import static gov.nasa.jpl.aerie.banananation.generated.ActivityActions.call;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
+
+/**
+ * RussianNestingBanana nests activity types as parameters inside an activity
+ *
+ * This activity tests the use of activity types as parameters and within compound type parameters. There are a few use cases:
+ * 1. Basic activity type parameter which is passed through and called without parent level modeling
+ * 2. List of activity types which are just iterated through and called
+ * 3. Using a parent level parameter to override information in the call to a child from an activity type parameter
+ *
+ * @subsystem fruit
+ * @contact John Doe
+ */
+@ActivityType("RussianNestingBanana")
+public final class RussianNestingBanana {
+
+  /** Record encapsulating an activity type **/
+  @AutoValueMapper.Record
+  public record pickBananaWithId(
+      int id,
+      PickBananaActivity pickBananaActivity
+  ) {}
+
+  /** Record type parameter encapsulating an activity type **/
+  @Export.Parameter
+  public pickBananaWithId pickBananaActivityRecord;
+
+  /** Parent level override parameter, in this case to override call to peel banana
+   * found in the pickBannaActivityRecord parameter **/
+  @Export.Parameter
+  public int pickBananaQuantityOverride = 0;
+
+  /** List of activity type parameter example **/
+  @Export.Parameter
+  public List<BiteBananaActivity> biteBananaActivity;
+
+  /** Vanilla activity type parameter **/
+  @Export.Parameter
+  public PeelBananaActivity peelBananaActivity;
+
+
+  @ActivityType.EffectModel
+  public void run(final Mission mission) {
+    // if the pickBananaQuantityOverride is preset use that integer instead of the pickBananaActivityRecord
+    if(pickBananaQuantityOverride != 0) {
+      PickBananaActivity pickBananaActivity = pickBananaActivityRecord.pickBananaActivity;
+      pickBananaActivity.quantity = pickBananaQuantityOverride;
+      call(mission, pickBananaActivity);
+    } else { // else use the record type parameter supplied
+      call(mission, pickBananaActivityRecord.pickBananaActivity());
+    }
+    // call a bite banana for each element in the list of biteBanana activities
+    for (final var bite : biteBananaActivity) {
+      call(mission, bite);
+      delay(Duration.of(30, Duration.MINUTE));
+    }
+    // call peel banana activity
+    call(mission, peelBananaActivity);
+  }
+}

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/package-info.java
@@ -26,7 +26,7 @@
 @WithActivityType(ControllableDurationActivity.class)
 @WithActivityType(RipenBananaActivity.class)
 @WithActivityType(ExceptionActivity.class)
-
+@WithActivityType(RussianNestingBanana.class)
 package gov.nasa.jpl.aerie.banananation;
 
 import gov.nasa.jpl.aerie.banananation.activities.BakeBananaBreadActivity;
@@ -46,6 +46,7 @@ import gov.nasa.jpl.aerie.banananation.activities.ParameterTestActivity;
 import gov.nasa.jpl.aerie.banananation.activities.PeelBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.PickBananaActivity;
 import gov.nasa.jpl.aerie.banananation.activities.RipenBananaActivity;
+import gov.nasa.jpl.aerie.banananation.activities.RussianNestingBanana;
 import gov.nasa.jpl.aerie.banananation.activities.ThrowBananaActivity;
 import gov.nasa.jpl.aerie.contrib.serialization.rulesets.BasicValueMappers;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.MissionModel;

--- a/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/activities/RussianNestingActivityTest.java
+++ b/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/activities/RussianNestingActivityTest.java
@@ -1,0 +1,65 @@
+package gov.nasa.jpl.aerie.banananation.activities;
+
+import gov.nasa.jpl.aerie.banananation.Configuration;
+import gov.nasa.jpl.aerie.banananation.Mission;
+import gov.nasa.jpl.aerie.banananation.SimulationUtility;
+import gov.nasa.jpl.aerie.banananation.generated.GeneratedModelType;
+import gov.nasa.jpl.aerie.banananation.generated.activities.ParameterTestActivityMapper;
+import gov.nasa.jpl.aerie.banananation.generated.activities.RussianNestingBananaMapper;
+import gov.nasa.jpl.aerie.contrib.serialization.mappers.DurationValueMapper;
+import gov.nasa.jpl.aerie.merlin.driver.DirectiveTypeRegistry;
+import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
+import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
+import gov.nasa.jpl.aerie.merlin.framework.Registrar;
+import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static gov.nasa.jpl.aerie.banananation.generated.ActivityActions.call;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MILLISECONDS;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.duration;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MerlinExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class RussianNestingActivityTest {
+  private final RussianNestingBananaMapper mapper;
+
+  public RussianNestingActivityTest() {
+    this.mapper = new RussianNestingBananaMapper();
+  }
+
+  @Test
+  public void testDefaultSimulationDoesNotThrow() {
+    final var schedule = SimulationUtility.buildSchedule(
+        Pair.of(
+            duration(1100, MILLISECONDS),
+            new SerializedActivity("RussianNestingBanana",
+                                   Map.of("pickBananaActivityRecord",
+                                          SerializedValue.of(Map.of("id", SerializedValue.of(2),
+                                                                    "pickBananaActivity", SerializedValue.of(Map.of("quantity", SerializedValue.of(10)))))
+                                   , "pickBananaQuantityOverride", SerializedValue.of(0),
+                                          "biteBananaActivity", SerializedValue.of(List.of()),
+                                          "peelBananaActivity", SerializedValue.of(Map.of("peelDirection", SerializedValue.of("fromStem")))))));
+
+    final var simulationDuration = duration(5, SECONDS);
+
+    final var simulationResults = SimulationUtility.simulate(schedule, simulationDuration);
+
+    System.out.println(simulationResults.discreteProfiles);
+    System.out.println(simulationResults.realProfiles);
+  }
+
+}

--- a/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/activities/RussianNestingActivityTest.java
+++ b/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/activities/RussianNestingActivityTest.java
@@ -1,36 +1,22 @@
 package gov.nasa.jpl.aerie.banananation.activities;
 
-import gov.nasa.jpl.aerie.banananation.Configuration;
-import gov.nasa.jpl.aerie.banananation.Mission;
 import gov.nasa.jpl.aerie.banananation.SimulationUtility;
-import gov.nasa.jpl.aerie.banananation.generated.GeneratedModelType;
-import gov.nasa.jpl.aerie.banananation.generated.activities.ParameterTestActivityMapper;
 import gov.nasa.jpl.aerie.banananation.generated.activities.RussianNestingBananaMapper;
-import gov.nasa.jpl.aerie.contrib.serialization.mappers.DurationValueMapper;
-import gov.nasa.jpl.aerie.merlin.driver.DirectiveTypeRegistry;
-import gov.nasa.jpl.aerie.merlin.driver.MissionModelBuilder;
 import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
-import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
-import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.nio.file.Path;
-import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static gov.nasa.jpl.aerie.banananation.generated.ActivityActions.call;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MILLISECONDS;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MINUTE;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.duration;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MerlinExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -48,18 +34,48 @@ public class RussianNestingActivityTest {
             duration(1100, MILLISECONDS),
             new SerializedActivity("RussianNestingBanana",
                                    Map.of("pickBananaActivityRecord",
-                                          SerializedValue.of(Map.of("id", SerializedValue.of(2),
-                                                                    "pickBananaActivity", SerializedValue.of(Map.of("quantity", SerializedValue.of(10)))))
-                                   , "pickBananaQuantityOverride", SerializedValue.of(0),
-                                          "biteBananaActivity", SerializedValue.of(List.of()),
-                                          "peelBananaActivity", SerializedValue.of(Map.of("peelDirection", SerializedValue.of("fromStem")))))));
+                                          SerializedValue.of(Map.of("id",
+                                                                    SerializedValue.of(2),
+                                                                    "pickBananaActivity",
+                                                                    SerializedValue.of(Map.of("quantity",
+                                                                                              SerializedValue.of(10))))),
+                                          "pickBananaQuantityOverride", SerializedValue.of(3),
+                                          "biteBananaActivity", SerializedValue.of(List.of(SerializedValue.of(Map.of("biteSize",
+                                                                                                                     SerializedValue.of(7.0))),
+                                                                                           SerializedValue.of(Map.of("biteSize",
+                                                                                                                     SerializedValue.of(1.0))))),
+                                          "peelBananaActivity", SerializedValue.of(Map.of("peelDirection",
+                                                                                          SerializedValue.of("fromStem")))))));
 
     final var simulationDuration = duration(5, SECONDS);
 
-    final var simulationResults = SimulationUtility.simulate(schedule, simulationDuration);
+    var simulationResults = SimulationUtility.simulate(schedule, simulationDuration);
+    
+    // verify results
+    // 1. Plant count decreased by 3 (200 -> 197) from the pickBananaActivity call using pickBananaQuantityOverride
+    var finalPlantCount = simulationResults.discreteProfiles.get("/plant").getValue().get(simulationResults.discreteProfiles.get("/plant").getValue().size()-1).dynamics().asInt().orElseThrow();
+    assert(finalPlantCount == 197);
 
-    System.out.println(simulationResults.discreteProfiles);
-    System.out.println(simulationResults.realProfiles);
+    // 2. Verify first bite banana activity ran, decrementing "/fruit" by 7 (from 4 to -3) in total and setting flag to flag B
+    var finalFruitCount = simulationResults.realProfiles.get("/fruit").getValue().get(simulationResults.realProfiles.get("/fruit").getValue().size()-1).dynamics().initial;
+    var finalFlagState = simulationResults.discreteProfiles.get("/flag").getValue().get(simulationResults.discreteProfiles.get("/flag").getValue().size()-1).dynamics().asString().orElseThrow();
+
+    assert(finalFruitCount == 4.0 - 7.0);
+    assert(finalFlagState == "B");
+
+    // 3. Verify second bite banana activity ran, decrementing "/fruit" by 1 (from -3 to -4) in total and setting flag to flag A
+    simulationResults = SimulationUtility.simulate(schedule, duration(35, MINUTE));
+    finalFruitCount = simulationResults.realProfiles.get("/fruit").getValue().get(simulationResults.realProfiles.get("/fruit").getValue().size()-1).dynamics().initial;
+    finalFlagState = simulationResults.discreteProfiles.get("/flag").getValue().get(simulationResults.discreteProfiles.get("/flag").getValue().size()-1).dynamics().asString().orElseThrow();
+    assert(finalFruitCount == 4.0 - 8.0);
+    assert(finalFlagState == "A");
+
+    simulationResults = SimulationUtility.simulate(schedule, duration(65, MINUTE));
+    // 4. Verify peel banana activity ran educing frruit by 1.0 and peel by 1.0 to -5.0 and 3.0 respectively
+    finalFruitCount = simulationResults.realProfiles.get("/fruit").getValue().get(simulationResults.realProfiles.get("/fruit").getValue().size()-1).dynamics().initial;
+    var finalPeelState = simulationResults.discreteProfiles.get("/peel").getValue().get(simulationResults.discreteProfiles.get("/peel").getValue().size()-1).dynamics().asReal().orElseThrow();
+    assert(finalFruitCount == 4.0 - 9.0);
+    assert(finalPeelState == 3.0);
   }
 
 }

--- a/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/activities/RussianNestingActivityTest.java
+++ b/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/activities/RussianNestingActivityTest.java
@@ -50,7 +50,7 @@ public class RussianNestingActivityTest {
     final var simulationDuration = duration(5, SECONDS);
 
     var simulationResults = SimulationUtility.simulate(schedule, simulationDuration);
-    
+
     // verify results
     // 1. Plant count decreased by 3 (200 -> 197) from the pickBananaActivity call using pickBananaQuantityOverride
     var finalPlantCount = simulationResults.discreteProfiles.get("/plant").getValue().get(simulationResults.discreteProfiles.get("/plant").getValue().size()-1).dynamics().asInt().orElseThrow();

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/AutoValueMappers.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/AutoValueMappers.java
@@ -13,6 +13,7 @@ import com.squareup.javapoet.TypeVariableName;
 import gov.nasa.jpl.aerie.contrib.serialization.mappers.RecordValueMapper;
 import gov.nasa.jpl.aerie.merlin.framework.Result;
 import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.AutoValueMapper;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.MissionModelRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.TypeRule;
@@ -59,6 +60,24 @@ public class AutoValueMappers {
             .toList(),
         generatedClassName,
         ClassName.get((TypeElement) autoValueMapperElement).canonicalName().replace(".", "_"));
+  }
+
+  static TypeRule activityTypeRule(final Element activityTypeElement, final ClassName generatedClassName) throws InvalidMissionModelException {
+    if (!(activityTypeElement.getKind().equals(ElementKind.CLASS) || activityTypeElement.getKind().equals(ElementKind.RECORD))) { //todo: check if activities are constrained to class and record
+      throw new InvalidMissionModelException(
+          "@%s is only allowed on classes and records".formatted(
+              ActivityType.class.getSimpleName()),
+          activityTypeElement);
+    }
+
+    return new TypeRule(
+        new TypePattern.ClassPattern(
+            ClassName.get(ValueMapper.class),
+            List.of(TypePattern.from(activityTypeElement.asType()))),
+        Set.of(),
+        List.of(),
+        generatedClassName,
+        ClassName.get((TypeElement) activityTypeElement).canonicalName().replace("activities", "generated_activitiesValueMappers").replace(".", "_") + "ValueMapper");
   }
 
   static TypeRule annotationTypeRule(final Element autoValueMapperElement, final ClassName generatedClassName) throws InvalidMissionModelException {

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
@@ -9,10 +9,11 @@ import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.MissionModel;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityTypeRecord;
+import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityValueMapperRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.InputTypeRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.EffectModelRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ExportDefaultsStyle;
-import gov.nasa.jpl.aerie.merlin.processor.metamodel.MapperRecord;
+import gov.nasa.jpl.aerie.merlin.processor.metamodel.ActivityMapperRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.MissionModelRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ParameterRecord;
 import gov.nasa.jpl.aerie.merlin.processor.metamodel.ParameterValidationRecord;
@@ -183,9 +184,10 @@ import java.util.stream.Collectors;
     final var name = declaration.getSimpleName().toString();
     final var parameters = getExportParameters(declaration);
     final var validations = this.getExportValidations(declaration, parameters);
-    final var mapper = getExportMapper(missionModelElement, declaration);
+    final var activityMapper = getExportActivityMapper(missionModelElement, declaration);
+    final var valueMapper = getExportValueMapper(missionModelElement, declaration);
     final var defaultsStyle = getExportDefaultsStyle(declaration);
-    return Optional.of(new InputTypeRecord(name, declaration, parameters, validations, mapper, defaultsStyle));
+    return Optional.of(new InputTypeRecord(name, declaration, parameters, validations, activityMapper, valueMapper, defaultsStyle));
   }
 
   private List<TypeElement> getMissionModelMapperClasses(final PackageElement missionModelElement)
@@ -381,7 +383,8 @@ import java.util.stream.Collectors;
   {
     final var fullyQualifiedClassName = activityTypeElement.getQualifiedName();
     final var name = this.getActivityTypeName(activityTypeElement);
-    final var mapper = this.getExportMapper(missionModelElement, activityTypeElement);
+    final var activityMapper = getExportActivityMapper(missionModelElement, activityTypeElement);
+    final var valueMapper = getExportValueMapper(missionModelElement, activityTypeElement);
     final var parameters = this.getExportParameters(activityTypeElement);
     final var validations = this.getExportValidations(activityTypeElement, parameters);
     final var effectModel = this.getActivityEffectModel(activityTypeElement);
@@ -405,7 +408,7 @@ import java.util.stream.Collectors;
     return new ActivityTypeRecord(
         fullyQualifiedClassName.toString(),
         name,
-        new InputTypeRecord(name, activityTypeElement, parameters, validations, mapper, defaultsStyle),
+        new InputTypeRecord(name, activityTypeElement, parameters, validations, activityMapper, valueMapper, defaultsStyle),
         effectModel);
   }
 
@@ -471,12 +474,12 @@ import java.util.stream.Collectors;
     return (String) nameAttribute.getValue();
   }
 
-  private MapperRecord getExportMapper(final PackageElement missionModelElement, final TypeElement exportTypeElement)
+  private ActivityMapperRecord getExportActivityMapper(final PackageElement missionModelElement, final TypeElement exportTypeElement)
   throws InvalidMissionModelException
   {
     final var annotationMirror = this.getAnnotationMirrorByType(exportTypeElement, ActivityType.WithMapper.class);
     if (annotationMirror.isEmpty()) {
-      return MapperRecord.generatedFor(
+      return ActivityMapperRecord.generatedFor(
           ClassName.get(exportTypeElement),
           missionModelElement);
     }
@@ -488,7 +491,27 @@ import java.util.stream.Collectors;
             annotationMirror.get()))
         .getValue();
 
-    return MapperRecord.custom(
+    return ActivityMapperRecord.custom(
+        ClassName.get((TypeElement) mapperType.asElement()));
+  }
+  private ActivityValueMapperRecord getExportValueMapper(final PackageElement missionModelElement, final TypeElement exportTypeElement)
+  throws InvalidMissionModelException
+  {
+    final var annotationMirror = this.getAnnotationMirrorByType(exportTypeElement, ActivityType.WithMapper.class);
+    if (annotationMirror.isEmpty()) {
+      return ActivityValueMapperRecord.generatedFor(
+          ClassName.get(exportTypeElement),
+          missionModelElement);
+    }
+
+    final var mapperType = (DeclaredType) getAnnotationAttribute(annotationMirror.get(), "value")
+        .orElseThrow(() -> new InvalidMissionModelException(
+            "Unable to get value attribute of annotation",
+            exportTypeElement,
+            annotationMirror.get()))
+        .getValue();
+
+    return ActivityValueMapperRecord.custom(
         ClassName.get((TypeElement) mapperType.asElement()));
   }
 

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ActivityMapperRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ActivityMapperRecord.java
@@ -1,0 +1,39 @@
+package gov.nasa.jpl.aerie.merlin.processor.metamodel;
+
+import com.squareup.javapoet.ClassName;
+
+import javax.lang.model.element.PackageElement;
+import java.util.Objects;
+
+public final class ActivityMapperRecord {
+  public final ClassName name;
+  public final boolean isCustom;
+
+  public ActivityMapperRecord(final ClassName name, final boolean isCustom) {
+    this.name = Objects.requireNonNull(name);
+    this.isCustom = isCustom;
+  }
+
+  public static ActivityMapperRecord custom(final ClassName name) {
+    return new ActivityMapperRecord(name, true);
+  }
+
+  public static ActivityMapperRecord
+  generatedFor(final ClassName activityTypeName, final PackageElement missionModelElement) {
+    final var missionModelPackage = missionModelElement.getQualifiedName().toString();
+    final var activityPackage = activityTypeName.packageName();
+
+    final String generatedSuffix;
+    if ((activityPackage + ".").startsWith(missionModelPackage + ".")) {
+      generatedSuffix = activityPackage.substring(missionModelPackage.length());
+    } else {
+      generatedSuffix = activityPackage;
+    }
+
+    final var mapperName = ClassName.get(
+        missionModelPackage + ".generated" + generatedSuffix,
+        activityTypeName.simpleName() + "Mapper");
+
+    return new ActivityMapperRecord(mapperName, false);
+  }
+}

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ActivityValueMapperRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/ActivityValueMapperRecord.java
@@ -1,0 +1,39 @@
+package gov.nasa.jpl.aerie.merlin.processor.metamodel;
+
+import com.squareup.javapoet.ClassName;
+
+import javax.lang.model.element.PackageElement;
+import java.util.Objects;
+
+public final class ActivityValueMapperRecord {
+  public final ClassName name;
+  public final boolean isCustom;
+
+  public ActivityValueMapperRecord(final ClassName name, final boolean isCustom) {
+    this.name = Objects.requireNonNull(name);
+    this.isCustom = isCustom;
+  }
+
+  public static ActivityValueMapperRecord custom(final ClassName name) {
+    return new ActivityValueMapperRecord(name, true);
+  }
+
+  public static ActivityValueMapperRecord
+  generatedFor(final ClassName activityTypeName, final PackageElement missionModelElement) {
+    final var missionModelPackage = missionModelElement.getQualifiedName().toString();
+    final var activityPackage = activityTypeName.packageName() + "ValueMappers";
+
+    final String generatedSuffix;
+    if ((activityPackage + ".").startsWith(missionModelPackage + ".")) {
+      generatedSuffix = activityPackage.substring(missionModelPackage.length());
+    } else {
+      generatedSuffix = activityPackage;
+    }
+
+    final var mapperName = ClassName.get(
+        missionModelPackage + ".generated" + generatedSuffix,
+        activityTypeName.simpleName() + "ValueMapper");
+
+    return new ActivityValueMapperRecord(mapperName, false);
+  }
+}

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/InputTypeRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/InputTypeRecord.java
@@ -8,6 +8,7 @@ public record InputTypeRecord(
     TypeElement declaration,
     List<ParameterRecord> parameters,
     List<ParameterValidationRecord> validations,
-    MapperRecord mapper,
+    ActivityMapperRecord activityMapper,
+    ActivityValueMapperRecord valueMapper,
     ExportDefaultsStyle defaultsStyle
 ) {}

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/MissionModelRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/MissionModelRecord.java
@@ -35,6 +35,10 @@ public record MissionModelRecord(
     return ClassName.get(this.$package.getQualifiedName() + ".generated", "ActivityActions");
   }
 
+  public ClassName getActivityValueMappers() {
+    return ClassName.get(this.$package.getQualifiedName() + ".generated", "ActivityValueMappers");
+  }
+
   public ClassName getTypesName() {
     return ClassName.get(this.$package.getQualifiedName() + ".generated", "ActivityTypes");
   }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ActivityValueMapper.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ActivityValueMapper.java
@@ -1,0 +1,40 @@
+package gov.nasa.jpl.aerie.merlin.framework;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
+
+import java.util.Map;
+
+public record ActivityValueMapper<T>(ActivityMapper<?, T, ?> activityMapper, String ActivityName) implements ValueMapper<T> {
+  @Override
+  public ValueSchema getValueSchema() {
+    return ValueSchema.withMeta("activity",
+                                SerializedValue.of(Map.of("value", SerializedValue.of(ActivityName))),
+                                activityMapper.getInputAsOutput().getSchema());
+  }
+
+  public Result<T, String> deserialize(
+      final Map<String, SerializedValue> arguments) {
+    try {
+      return Result.success(activityMapper.getInputType().instantiate(arguments));
+    } catch (Exception e) {
+      return Result.failure("Failed to instantiate activity DecomposingSpawnChild. Error: %s".formatted(e.getMessage()));
+    }
+  }
+
+  @Override
+  public Result<T, String> deserializeValue(
+      final SerializedValue serializedValue) {
+    return serializedValue
+        .asMap()
+        .map(Map::copyOf)
+        .map(arguments -> deserialize(arguments))
+        .orElseGet(() -> Result.failure("Expected map from string to serialized value, but got: " + serializedValue));
+  }
+
+  @Override
+  public SerializedValue serializeValue(
+      final T value) {
+    return activityMapper.getInputAsOutput().serialize(value);
+  }
+}


### PR DESCRIPTION
* **Tickets addressed:**  #1280
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

This pr adds support for using activity types as parameters from within activities. New type rules were added to recognize activity types and point to their value mappers when generating the activityMapper code. This ability required the addition of ActivityMapperRecords and ActivityValueMapperRecords for InputType records to point to the correct locations for the old ActivityMappers and new ActivityValueMappers as part of the MissionModelGenerator. One aditional autogenerated file called ActivityValueMappers will be added to the generate files of a model and will contain helper methods to retrieve value mappers for activity types to be used by activityMapper files.  The ActivityValueMapper record is the interstitial layer which takes in an activityMapper and returns a valid valueMapper for said activity. 

A new activity called RussianNestingBanana illustrates the various use cases for these types of parameters and has been added to the Banananation model. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

There is a unit test script called RussianNestingActivityTest which tests we are able to serialize an example activity utilizing this feature (RussianNestingBanana) and simulate with calls to child activities. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

At the moment we just have comments in the RussianNestingBananaActivity but we could add info to the docs if necessary. 

## Future work
<!-- What next steps can we anticipate from here, if any? -->

Perhaps we will need further testing in aerie. Further work on the aerie-ui and database is not necessary to allow this pr to work, however, applying custom UI elements for selecting presets to apply on specific activity type parameters would be very useful to help certain pointing planning workflows for the clipper model. 