### PR TITLE
Fixed an issue where constraint runs would fail against activities wi…

### DIFF
--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/ConstraintsTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/ConstraintsTests.java
@@ -172,10 +172,9 @@ public class ConstraintsTests {
     assertEquals(1, violation.windows().size());
 
     final long activityOffset = 60 * 60 * 1000000L; // 1h in micros
-    final long planDuration = 1212 * 60 * 60 * 1000000L; // 1212h in micros
 
-    assertEquals(activityOffset, violation.windows().get(0).start());
-    assertEquals(planDuration, violation.windows().get(0).end());
+    assertEquals(0, violation.windows().get(0).start());
+    assertEquals(activityOffset, violation.windows().get(0).end());
     // Gaps
     assertTrue(constraintResult.gaps().isEmpty());
   }

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/MissionModelTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/MissionModelTests.java
@@ -311,9 +311,11 @@ public class MissionModelTests {
     activityTypes.add(new ActivityType(
         "PeelBanana",
         Map.of("peelDirection",
-               new Parameter(0, new ValueSchemaVariant(List.of(
-                   new Variant("fromStem", "fromStem"),
-                   new Variant("fromTip", "fromTip")))))));
+               new Parameter(0,
+                   new ValueSchemaMeta(Map.of("unit", Json.createObjectBuilder(Map.of("value", "direction")).build()),
+                   new ValueSchemaVariant(List.of(
+                       new Variant("fromStem", "fromStem"),
+                       new Variant("fromTip", "fromTip"))))))));
     activityTypes.add(new ActivityType("PickBanana", Map.of("quantity", new Parameter(0, VALUE_SCHEMA_INT))));
     activityTypes.add(new ActivityType("RipenBanana", Map.of()));
     activityTypes.add(new ActivityType("ThrowBanana", Map.of("speed", new Parameter(0, VALUE_SCHEMA_REAL))));

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/PeelBananaActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/PeelBananaActivity.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.banananation.activities;
 
 import gov.nasa.jpl.aerie.banananation.Mission;
+import gov.nasa.jpl.aerie.contrib.metadata.Unit;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Parameter;
@@ -25,6 +26,7 @@ public final class PeelBananaActivity {
   }
 
   @Parameter
+  @Unit("direction")
   public PeelDirectionEnum peelDirection = PeelDirectionEnum.fromStem;
 
   @EffectModel

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/json/ValueSchemaJsonParser.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/json/ValueSchemaJsonParser.java
@@ -94,6 +94,7 @@ public final class ValueSchemaJsonParser implements JsonParser<ValueSchema> {
         productP
             .field("type", literalP("variant"))
             .field("variants", listP(variantP))
+            .rest()
             .map(
                 untuple((type, variants) -> ValueSchema.ofVariant(variants)),
                 $ -> tuple(Unit.UNIT, $.asVariant().get()));


### PR DESCRIPTION
…th unitized variants

* **Tickets addressed:** Closes #1260.
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
I found this to be an issue with our variant schema type when it had units assigned to it. It turns out our parser was too strict so it didn't expect to see the `metadata` field like our other schema types.

Thanks for the help @mattdailis!

## Verification
Updated Banananation to include units on an enum and added a test to make sure we can successfully run constraints against it.

## Documentation
NA

## Future work
NA
