### PR TITLE
Add more utilities for profiling resources

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Resource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Resource.java
@@ -1,8 +1,31 @@
 package gov.nasa.jpl.aerie.contrib.streamline.core;
 
+import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad;
+import gov.nasa.jpl.aerie.contrib.streamline.debugging.Profiling;
+
 /**
  * A function returning a fully-wrapped dynamics,
  * and the primary way models track state and report results.
  */
 public interface Resource<D> extends ThinResource<ErrorCatching<Expiring<D>>> {
+    /**
+     * Turn on profiling for all resources derived through {@link ResourceMonad}
+     * or created by {@link MutableResource#resource}.
+     *
+     * <p>
+     *     Calling this method once before constructing your model will profile virtually every resource.
+     *     Profiling may be compute and/or memory intensive, and should not be used in production.
+     * </p>
+     * <p>
+     *     If only a few resources are suspect, you can also call {@link Profiling#profile}
+     *     directly on just those resource, rather than profiling every resource.
+     * </p>
+     * <p>
+     *     Call {@link Profiling#dump()} to see results.
+     * </p>
+     */
+    static void profileAllResources() {
+        ResourceMonad.profileAllResources();
+        MutableResource.profileAllResources();
+    }
 }

--- a/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Configuration.java
+++ b/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Configuration.java
@@ -8,6 +8,9 @@ public final class Configuration {
   public boolean traceResources = false;
 
   @Parameter
+  public boolean profileResources = false;
+
+  @Parameter
   public double approximationTolerance = 1e-2;
 
   @Parameter

--- a/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
+++ b/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.streamline_demo;
 
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.debugging.Profiling;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.ModelActions;
@@ -12,6 +13,7 @@ public final class Mission {
   public Mission(final gov.nasa.jpl.aerie.merlin.framework.Registrar registrar$, final Configuration config) {
     var registrar = new Registrar(registrar$, Registrar.ErrorBehavior.Log);
     if (config.traceResources) registrar.setTrace();
+    if (config.profileResources) Resource.profileAllResources();
     dataModel = new DataModel(registrar, config);
     errorTestingModel = new ErrorTestingModel(registrar, config);
     approximationModel = new ApproximationModel(registrar, config);


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds more support for profiling resource performance, especially around mutable resources.
Most importantly, it adds the static method `Resource.profileAllResources()`.
When called before constructing the model, this method turns on profiling for virtually every resource in the model.
This casts a broad net for early stages in a performance investigation, to highlight resources that are called unexpectedly frequently.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
These changes have been spot-checked by hand in the streamline example model and with the SRL model. As developer-oriented debugging tools with loose requirements, I don't think automated tests are appropriate for most of the behavior here.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Only in-line javadoc comments.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A
