### PR TITLE
Bugfix for polynomial root-finding

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Expiry.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Expiry.java
@@ -8,7 +8,7 @@ import java.util.stream.Stream;
 /**
  * The time at which a value expires.
  */
-public record Expiry(Optional<Duration> value) {
+public record Expiry(Optional<Duration> value) implements Comparable<Expiry> {
   public static Expiry NEVER = expiry(Optional.empty());
 
   public static Expiry at(Duration t) {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Resources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Resources.java
@@ -99,9 +99,11 @@ public final class Resources {
     final Duration startTime = currentTime();
     Condition result = (positive, atEarliest, atLatest) -> {
       var currentDynamics = resource.getDynamics();
+      var elapsedTime = currentTime().minus(startTime);
       boolean haveChanged = startingDynamics.match(
           start -> currentDynamics.match(
-              current -> !current.data().equals(start.data().step(currentTime().minus(startTime))),
+              current -> !current.data().equals(start.data().step(elapsedTime)) ||
+                         !current.expiry().equals(start.expiry().minus(elapsedTime)),
               ignored -> true),
           startException -> currentDynamics.match(
               ignored -> true,

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/black_box/IntervalFunctions.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/black_box/IntervalFunctions.java
@@ -59,23 +59,26 @@ public final class IntervalFunctions {
           exp.data(),
           t,
           maximumError));
+      var effectiveMinSamplePeriod = Duration.min(e, minimumSamplePeriod);
+      var effectiveMaxSamplePeriod = Duration.min(e, maximumSamplePeriod);
+
       try {
         double intervalSize = solver.solve(
             100,
             errorFn,
-            Duration.min(e, minimumSamplePeriod).ratioOver(SECOND),
-            Duration.min(e, maximumSamplePeriod).ratioOver(SECOND));
+            effectiveMinSamplePeriod.ratioOver(SECOND),
+            effectiveMaxSamplePeriod.ratioOver(SECOND));
         return Duration.roundNearest(intervalSize, SECOND);
       } catch (NoBracketingException x) {
         if (errorFn.value(minimumSamplePeriod.ratioOver(SECOND)) > 0) {
           // maximum error > estimated error, best case
-          return maximumSamplePeriod;
+          return effectiveMaxSamplePeriod;
         } else {
           // maximum error < estimated error, worst case
-          return minimumSamplePeriod;
+          return effectiveMinSamplePeriod;
         }
       } catch (TooManyEvaluationsException | NumberIsTooLargeException x) {
-        return minimumSamplePeriod;
+        return effectiveMinSamplePeriod;
       }
     };
   }

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/LinearBoundaryConsistencySolver.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/LinearBoundaryConsistencySolver.java
@@ -27,7 +27,6 @@ import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.expiring;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.neverExpiring;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.whenever;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ExpiringMonad.bind;
-import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.eraseExpiry;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Context.contextualized;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Dependencies.addDependency;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.getName;
@@ -314,7 +313,7 @@ public final class LinearBoundaryConsistencySolver {
         // Expiry for driven terms is captured by re-solving rather than expiring the solution.
         // If solver has a feedback loop from last iteration (which is common)
         // feeding that expiry in here can loop the solver forever.
-        var result = eraseExpiry(drivenTerm);
+        var result = drivenTerm;
         for (var drivingVariable : drivingVariables) {
           var scale = controlledTerm.get(drivingVariable);
           var domain = domains.get(drivingVariable);

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/Polynomial.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/Polynomial.java
@@ -195,7 +195,7 @@ public record Polynomial(double[] coefficients) implements Dynamics<Double, Poly
 
     // Do a binary search to find the exact transition time
     while (end.longerThan(start.plus(EPSILON))) {
-      Duration midpoint = start.plus(end).dividedBy(2);
+      Duration midpoint = start.plus(end.minus(start).dividedBy(2));
       if (expires.test(midpoint)) {
         end = midpoint;
       } else {

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/ComparisonsTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/ComparisonsTest.java
@@ -299,6 +299,80 @@ public class ComparisonsTest {
     check_extrema(false, true);
   }
 
+  // Unrepresentable convergence:
+  // These tests reflect polynomials that in theory converge, but do so in timespans
+  // that are too large to represent. Thus, they should be treated as non-converging.
+
+  @Test
+  void comparing_linear_terms_with_convergence_unrepresentable_by_double() {
+    setup(() -> {
+      set(p, polynomial(Double.MAX_VALUE));
+      set(q, polynomial(0, 0.1));
+    });
+
+    check_comparison(p_lt_q, false, false);
+    check_comparison(p_lte_q, false, false);
+    check_comparison(p_gt_q, true, false);
+    check_comparison(p_gte_q, true, false);
+    check_extrema(true, false);
+  }
+
+  @Test
+  void comparing_linear_terms_with_convergence_unrepresentable_by_duration() {
+    setup(() -> {
+      set(p, polynomial(Duration.MAX_VALUE.ratioOver(SECOND)));
+      set(q, polynomial(0, 0.1));
+    });
+
+    check_comparison(p_lt_q, false, false);
+    check_comparison(p_lte_q, false, false);
+    check_comparison(p_gt_q, true, false);
+    check_comparison(p_gte_q, true, false);
+    check_extrema(true, false);
+  }
+
+  @Test
+  void comparing_nonlinear_terms_with_convergence_unrepresentable_by_double() {
+    setup(() -> {
+      set(p, polynomial(Double.MAX_VALUE));
+      set(q, polynomial(0, 0, 0.1));
+    });
+
+    check_comparison(p_lt_q, false, false);
+    check_comparison(p_lte_q, false, false);
+    check_comparison(p_gt_q, true, false);
+    check_comparison(p_gte_q, true, false);
+    check_extrema(true, false);
+  }
+
+  @Test
+  void comparing_nonlinear_terms_with_convergence_unrepresentable_by_duration() {
+    setup(() -> {
+      set(p, polynomial(Duration.MAX_VALUE.ratioOver(SECOND) * Duration.MAX_VALUE.ratioOver(SECOND)));
+      set(q, polynomial(0, 0, 0.1));
+    });
+
+    check_comparison(p_lt_q, false, false);
+    check_comparison(p_lte_q, false, false);
+    check_comparison(p_gt_q, true, false);
+    check_comparison(p_gte_q, true, false);
+    check_extrema(true, false);
+  }
+
+  @Test
+  void comparing_pathological_nonlinear_terms_with_convergence_unrepresentable_by_duration() {
+    setup(() -> {
+      set(p, polynomial(Duration.MAX_VALUE.ratioOver(SECOND) * Duration.MAX_VALUE.ratioOver(SECOND)));
+      set(q, polynomial(0, Duration.MIN_VALUE.ratioOver(SECOND), 1.0 + Math.ulp(1.0)));
+    });
+
+    check_comparison(p_lt_q, false, false);
+    check_comparison(p_lte_q, false, false);
+    check_comparison(p_gt_q, true, false);
+    check_comparison(p_gte_q, true, false);
+    check_extrema(true, false);
+  }
+
   private void check_comparison(Resource<Discrete<Boolean>> result, boolean expectedValue, boolean expectCrossover) {
     reset();
     var resultDynamics = result.getDynamics().getOrThrow();


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Fixes a few bugs related to rootfinding and expiry-propagation for Polynomial resources. The most important of these fixes are:
* Taking expiry into account for dynamicsChange condition. This was an unusual case exposed by the solver: A solution could expire early due to inputs that expire, but the updated inputs return the same result. In this case, the solution data remains the same, but the solution expiry is extended. This needs to count as the dynamics "changing", since downstream consumers may be interested in the expiry, not just the data.
* Stability and performance improvements for Polynomial root-finding.
    * For stability, addresses an edge case where binary search for the exact root could overflow, and conditions the problem for the Laguerre solver by normalizing the polynomial's constant term to 1. This lets the solver converge in a few extra edge cases without affecting "regular" cases much.
    * For performance, adds a special case for linear polynomials, where we directly solve for the root instead of using the Laguerre solver. This tends to be faster and possibly more stable, and a large proportion of real-world cases tend to be linear.
* Passing expiry through the solver and clampedIntegrate functions. These components used to erase expiry information, as a patch over the bug in the dynamicsChange condition described above (though I didn't know at the time that was why erasing expiry information helped.) Now, by more carefully and selectively erasing expiry information outside the solver, we can preserve expiry information from inputs to the solver and clampedIntegrate through to the output. This in turn lets downstream components like approximations make better decisions. In particular, we have a use case for the SRL model with an approximation of a quadratic clamped integral. If we don't pass expiry information through, then the approximation "overshoots" the expiry, is interrupted by the next quadratic segment, and produces a discontinuity in the output. By passing the expiry through to the approximation, the approximation can align the approximation segment's endpoint with the expiry, and hence avoid this discontinuity.

Before:
<img width="212" alt="image" src="https://github.com/NASA-AMMOS/aerie/assets/8291374/ac235df4-4852-4d60-ae7d-e86a188fad49">

After
<img width="210" alt="image" src="https://github.com/NASA-AMMOS/aerie/assets/8291374/9ba5f03b-c123-41d3-804f-66ab2d5def17">

## Verification
The changes in polynomial root-finding come with additional unit tests to detect some of these edge cases. Additionally, Brad has tested these changes with the SRL model, with positive results.

## Documentation
N/A

## Future work
N/A
