### PR TITLE
Improve large expansion sets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,8 @@ services:
       SEQUENCING_DB_SERVER: postgres
       SEQUENCING_DB_USER: "${AERIE_USERNAME}"
       SEQUENCING_LOCAL_STORE: /usr/src/app/sequencing_file_store
+      SEQUENCING_WORKER_NUM: 8
+      SEQUENCING_MAX_WORKER_HEAP_MB: 1000
     image: aerie_sequencing
     ports: ["27184:27184"]
     restart: always

--- a/sequencing-server/src/env.ts
+++ b/sequencing-server/src/env.ts
@@ -10,6 +10,8 @@ export type Env = {
   POSTGRES_PORT: string;
   POSTGRES_USER: string;
   STORAGE: string;
+  SEQUENCING_WORKER_NUM: string;
+  SEQUENCING_MAX_WORKER_HEAP_MB: string;
 };
 
 export const defaultEnv: Env = {
@@ -24,6 +26,8 @@ export const defaultEnv: Env = {
   POSTGRES_PORT: '5432',
   POSTGRES_USER: '',
   STORAGE: 'sequencing_file_store',
+  SEQUENCING_WORKER_NUM: '8',
+  SEQUENCING_MAX_WORKER_HEAP_MB: '1000',
 };
 
 export function getEnv(): Env {
@@ -40,6 +44,9 @@ export function getEnv(): Env {
   const POSTGRES_PORT = env['SEQUENCING_DB_PORT'] ?? defaultEnv.POSTGRES_PORT;
   const POSTGRES_USER = env['SEQUENCING_DB_USER'] ?? defaultEnv.POSTGRES_USER;
   const STORAGE = env['SEQUENCING_LOCAL_STORE'] ?? defaultEnv.STORAGE;
+  const SEQUENCING_WORKER_NUM = env['SEQUENCING_WORKER_NUM'] ?? defaultEnv.SEQUENCING_WORKER_NUM;
+  const SEQUENCING_MAX_WORKER_HEAP_MB =
+    env['SEQUENCING_MAX_WORKER_HEAP_MB'] ?? defaultEnv.SEQUENCING_MAX_WORKER_HEAP_MB;
   return {
     HASURA_GRAPHQL_ADMIN_SECRET,
     LOG_FILE,
@@ -52,5 +59,7 @@ export function getEnv(): Env {
     POSTGRES_PORT,
     POSTGRES_USER,
     STORAGE,
+    SEQUENCING_WORKER_NUM,
+    SEQUENCING_MAX_WORKER_HEAP_MB,
   };
 }

--- a/sequencing-server/src/routes/command-expansion.ts
+++ b/sequencing-server/src/routes/command-expansion.ts
@@ -1,6 +1,6 @@
-import type { CacheItem, UserCodeError } from '@nasa-jpl/aerie-ts-user-code-runner';
+import type { UserCodeError } from '@nasa-jpl/aerie-ts-user-code-runner';
 import pgFormat from 'pg-format';
-import { Context, db, piscina } from './../app.js';
+import { Context, db, piscina, promiseThrottler, typeCheckingCache } from './../app.js';
 import { Result } from '@nasa-jpl/aerie-ts-user-code-runner/build/utils/monads.js';
 import express from 'express';
 import { serializeWithTemporal } from './../utils/temporalSerializers.js';
@@ -13,6 +13,7 @@ import { unwrapPromiseSettledResults } from '../lib/batchLoaders/index.js';
 import { defaultSeqBuilder } from '../defaultSeqBuilder.js';
 import { ActivateStep, CommandStem, LoadStep } from './../lib/codegen/CommandEDSLPreface.js';
 import { getUsername } from '../utils/hasura.js';
+import * as crypto from 'crypto';
 
 const logger = getLogger('app');
 
@@ -54,17 +55,18 @@ commandExpansionRouter.post('/put-expansion', async (req, res, next) => {
     activityTypeName,
   });
   const activityTypescript = generateTypescriptForGraphQLActivitySchema(activitySchema);
-
-  const result = Result.fromJSON(
-    await (piscina.run(
-      {
-        expansionLogic,
-        commandTypes: commandTypes,
-        activityTypes: activityTypescript,
-      },
-      { name: 'typecheckExpansion' },
-    ) as ReturnType<typeof typecheckExpansion>),
-  );
+  const result = await promiseThrottler.run(() => {
+    return (
+      piscina.run(
+        {
+          commandTypes: commandTypes,
+          activityTypes: activityTypescript,
+          activityTypeName: activityTypeName,
+        },
+        { name: 'typecheckExpansion' },
+      ) as ReturnType<typeof typecheckExpansion>
+    ).then(Result.fromJSON);
+  });
 
   res.status(200).json({ id, errors: result.isErr() ? result.unwrapErr() : [] });
   return next();
@@ -90,32 +92,65 @@ commandExpansionRouter.post('/put-expansion-set', async (req, res, next) => {
       if (expansion instanceof Error) {
         throw new InheritedError(`Expansion with id: ${expansionIds[index]} could not be loaded`, expansion);
       }
+
+      const hash = crypto
+        .createHash('sha256')
+        .update(
+          JSON.stringify({
+            commandDictionaryId,
+            missionModelId,
+            id: expansion.id,
+            expansionLogic: expansion.expansionLogic,
+            activityType: expansion.activityType,
+          }),
+        )
+        .digest('hex');
+
+      if (typeCheckingCache.has(hash)) {
+        console.log(`Using cached typechecked data for ${expansion.activityType}`);
+        return typeCheckingCache.get(hash);
+      }
+
       const activitySchema = await context.activitySchemaDataLoader.load({
         missionModelId,
         activityTypeName: expansion.activityType,
       });
       const activityTypescript = generateTypescriptForGraphQLActivitySchema(activitySchema);
-      const result = Result.fromJSON(
-        await (piscina.run(
-          {
-            expansionLogic: expansion.expansionLogic,
-            commandTypes: commandTypes,
-            activityTypes: activityTypescript,
-          },
-          { name: 'typecheckExpansion' },
-        ) as ReturnType<typeof typecheckExpansion>),
-      );
+      const typeCheckResult = promiseThrottler.run(() => {
+        return (
+          piscina.run(
+            {
+              expansionLogic: expansion.expansionLogic,
+              commandTypes: commandTypes,
+              activityTypes: activityTypescript,
+              activityTypeName: expansion.activityType,
+            },
+            { name: 'typecheckExpansion' },
+          ) as ReturnType<typeof typecheckExpansion>
+        ).then(Result.fromJSON);
+      });
 
-      return result;
+      typeCheckingCache.set(hash, typeCheckResult);
+      return typeCheckResult;
     }),
   );
 
   const errors = unwrapPromiseSettledResults(typecheckErrorPromises).reduce((accum, item) => {
-    if (item instanceof Error) {
-      accum.push(item);
-    } else if (item.isErr()) {
-      accum.push(...item.unwrapErr());
+    if (item && (item instanceof Error || item.isErr)) {
+      // Check for item's existence before accessing properties
+      if (item instanceof Error) {
+        accum.push(item);
+      } else if (item.isErr()) {
+        try {
+          accum.push(...item.unwrapErr()); // Handle potential errors within unwrapErr
+        } catch (error) {
+          accum.push(new Error('Failed to unwrap error: ' + error)); // Log unwrapErr errors
+        }
+      }
+    } else {
+      accum.push(new Error('Unexpected result in resolved promises')); // Handle unexpected non-error values
     }
+
     return accum;
   }, [] as (Error | ReturnType<UserCodeError['toJSON']>)[]);
 
@@ -168,14 +203,9 @@ commandExpansionRouter.post('/expand-all-activity-instances', async (req, res, n
     context.expansionSetDataLoader.load({ expansionSetId }),
     context.simulatedActivitiesDataLoader.load({ simulationDatasetId }),
   ]);
+  const commandDictionaryId = expansionSet.commandDictionary.id;
+  const missionModelId = expansionSet.missionModel.id;
   const commandTypes = expansionSet.commandDictionary.commandTypesTypeScript;
-
-  // Note: We are keeping the Promise in the cache so that we don't have to wait for resolution to insert into
-  // the cache and consequently end up doing the compilation multiple times because of a cache miss.
-  const expansionBuildArtifactsCache = new Map<
-    number,
-    Promise<Result<CacheItem, ReturnType<UserCodeError['toJSON']>[]>>
-  >();
 
   const settledExpansionResults = await Promise.allSettled(
     simulatedActivities.map(async simulatedActivity => {
@@ -205,21 +235,36 @@ commandExpansionRouter.post('/expand-all-activity-instances', async (req, res, n
       }
       const activityTypes = generateTypescriptForGraphQLActivitySchema(activitySchema);
 
-      if (!expansionBuildArtifactsCache.has(expansion.id)) {
-        const typecheckResult = (
-          piscina.run(
-            {
-              expansionLogic: expansion.expansionLogic,
-              commandTypes: commandTypes,
-              activityTypes,
-            },
-            { name: 'typecheckExpansion' },
-          ) as ReturnType<typeof typecheckExpansion>
-        ).then(Result.fromJSON);
-        expansionBuildArtifactsCache.set(expansion.id, typecheckResult);
-      }
+      const hash = crypto
+        .createHash('sha256')
+        .update(
+          JSON.stringify({
+            commandDictionaryId,
+            missionModelId,
+            id: expansion.id,
+            expansionLogic: expansion.expansionLogic,
+            activityType: expansion.activityType,
+          }),
+        )
+        .digest('hex');
+      if (!typeCheckingCache.has(hash)) {
+        const typeCheckResult = promiseThrottler.run(() => {
+          return (
+            piscina.run(
+              {
+                expansionLogic: expansion.expansionLogic,
+                commandTypes: commandTypes,
+                activityTypes: activityTypes,
+                activityTypeName: expansion.activityType,
+              },
+              { name: 'typecheckExpansion' },
+            ) as ReturnType<typeof typecheckExpansion>
+          ).then(Result.fromJSON);
+        });
 
-      const expansionBuildArtifacts = await expansionBuildArtifactsCache.get(expansion.id)!;
+        typeCheckingCache.set(hash, typeCheckResult);
+      }
+      const expansionBuildArtifacts = await typeCheckingCache.get(hash)!;
 
       if (expansionBuildArtifacts.isErr()) {
         return {

--- a/sequencing-server/src/utils/PromiseThrottler.ts
+++ b/sequencing-server/src/utils/PromiseThrottler.ts
@@ -1,0 +1,22 @@
+export class PromiseThrottler {
+  private runningPromises: Promise<unknown>[] = [];
+  private promiseLimit: number;
+
+  public constructor(promiseLimit: number) {
+    this.promiseLimit = promiseLimit;
+  }
+
+  public async run<T>(promiseFactory: () => Promise<T>): Promise<T> {
+    while (this.runningPromises.length >= this.promiseLimit) {
+      await Promise.race(this.runningPromises);
+    }
+    const promise = promiseFactory();
+    this.runningPromises.push(promise);
+    return promise.finally(() => {
+      const index = this.runningPromises.indexOf(promise);
+      if (index !== -1) {
+        this.runningPromises.splice(index, 1);
+      }
+    });
+  }
+}

--- a/sequencing-server/src/worker.ts
+++ b/sequencing-server/src/worker.ts
@@ -26,7 +26,13 @@ export async function typecheckExpansion(opts: {
   expansionLogic: string;
   commandTypes: string;
   activityTypes: string;
+  activityTypeName?: string;
 }): Promise<SerializedResult<CacheItem, ReturnType<UserCodeError['toJSON']>[]>> {
+  const startTime = Date.now();
+  console.log(
+    `[ Worker ] started transpiling authoring logic ${opts.activityTypeName ? `- ${opts.activityTypeName}` : ''}`,
+  );
+
   const result = await codeRunner.preProcess(
     opts.expansionLogic,
     'ExpansionReturn',
@@ -37,6 +43,14 @@ export async function typecheckExpansion(opts: {
       ts.createSourceFile('TemporalPolyfillTypes.ts', temporalPolyfillTypes, compilerTarget),
     ],
   );
+
+  const endTime = Date.now();
+  console.log(
+    `[ Worker ] finished transpiling ${opts.activityTypeName ? `- ${opts.activityTypeName}` : ''}, (${
+      (endTime - startTime) / 1000
+    } s)`,
+  );
+
   if (result.isOk()) {
     return Result.Ok(result.unwrap()).toJSON();
   } else {


### PR DESCRIPTION
* **Tickets addressed:** #1025 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Part 1 of 2 for #1025 

This PR addresses a stability issue where creating large expansion sets caused server crashes due to excessive resource consumption by worker processes. Here's a summary of the improvements:

### Problem:

- Compiling individual authored logic large expansion sets led to high memory usage by worker processes.
- Queuing multiple compilation jobs per worker exacerbated the issue, contributing to server crashes.
- Workers had not cap on resources 

### Solution:

- Chunking: Implemented chunking to distribute authored logic compilation tasks among a subset of workers, preventing resource overload on individual processes.
- Caching: Introduced a TS transpilation cache to eliminate repetitive compilations for the same logic units, significantly reducing memory usage and avoiding unnecessary worker load.
- Exposing worker properties to fine-tune workers per project

By default, I am spinning up 8 workers and giving them 1GB of heap. 

## Verification
I was able to create an expansion set with 73 authored logic without a crash. Before the fix 20+ would crash the server.


## Future work
Implement a single background worker to transpile the authoring logic while the server is idle and cache the results. Help with the huge upfront cost .ex 70+ expansion logic takes about 13 minutes. This is cpu bounded so a beefier computer would help. 
