### PR TITLE
Add Missing Filter in Commit Merge

### DIFF
--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MerlinDatabaseTestHelper.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/MerlinDatabaseTestHelper.java
@@ -210,6 +210,17 @@ final class MerlinDatabaseTestHelper {
     }
   }
 
+  void unassignPreset(int presetId, int activityId, int planId) throws SQLException {
+    try(final var statement = connection.createStatement()){
+      statement.execute(
+         //language=sql
+         """
+         delete from preset_to_directive
+         where (preset_id, activity_id, plan_id) = (%d, %d, %d);
+         """.formatted(presetId, activityId, planId));
+    }
+  }
+
 
   int insertConstraintPlan(int plan_id, String name, String definition, User user) throws SQLException {
     try(final var statement = connection.createStatement()) {

--- a/deployment/hasura/migrations/AerieMerlin/37_commit_merge_filter_presets/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/37_commit_merge_filter_presets/up.sql
@@ -1,8 +1,4 @@
-/*
-  Commit merge takes all of the contents of the staging area and all of the resolved conflicts
-  and applies the changes to the plan getting merged into.
- */
-create procedure commit_merge(_request_id integer)
+create or replace procedure commit_merge(_request_id integer)
   language plpgsql as $$
   declare
     validate_noConflicts integer;
@@ -171,3 +167,5 @@ begin
   where id = _request_id;
 end
 $$;
+
+call migrations.mark_migration_applied('37');

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -39,3 +39,4 @@ call migrations.mark_migration_applied('33');
 call migrations.mark_migration_applied('34');
 call migrations.mark_migration_applied('35');
 call migrations.mark_migration_applied('36');
+call migrations.mark_migration_applied('37');


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Upserting the Presets for Activity Directives was missing filters on the snapshot id and the merge request id.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
DBTests were added.
- The test `presetOnlyPullsFromSourceSnapshot` asserts that the potential bug caused by a lack of snapshot id filter does not occur. 
- The test `presetUnaffectedByUnrelatedSnapshot` mirrors a strange scenario seen on a Clipper venue that was causing merge issues, where for some reason a preset recorded on an unrelated plan's snapshot was attempting to be set when committing the merge.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs need to be updated

## Future work
<!-- What next steps can we anticipate from here, if any? -->
