### PR TITLE
reduce simulation memory usage for long plans

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -208,7 +208,8 @@ public final class SimulationEngine implements AutoCloseable {
 
     // Based on the task's return status, update its execution state and schedule its resumption.
     if (status instanceof TaskStatus.Completed<Return>) {
-      final var children = new LinkedList<>(this.taskChildren.getOrDefault(task, Collections.emptySet()));
+      final var children = new LinkedList<>(Optional.ofNullable(this.taskChildren.remove(task))
+                                            .orElseGet(Collections::emptySet));
 
       this.tasks.put(task, progress.completedAt(currentTime, children));
       this.scheduledJobs.schedule(JobId.forTask(task), SubInstant.Tasks.at(currentTime));

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
@@ -30,8 +30,12 @@ public interface Context {
   <Event> void emit(Event event, Topic<Event> topic);
 
   void spawn(TaskFactory<?> task);
+
   <Return> void call(TaskFactory<Return> task);
 
+  <Return> void tailCall(TaskFactory<Return> task);
+
   void delay(Duration duration);
+
   void waitUntil(Condition condition);
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
@@ -62,6 +62,11 @@ public final class InitializationContext implements Context {
   }
 
   @Override
+  public <Return> void tailCall(final TaskFactory<Return> task) {
+    throw new IllegalStateException("Cannot yield during initialization");
+  }
+
+  @Override
   public void delay(final Duration duration) {
     throw new IllegalStateException("Cannot yield during initialization");
   }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
@@ -69,6 +69,18 @@ public /*non-final*/ class ModelActions {
     context.get().call(task);
   }
 
+  public static void tailCall(final Runnable task) {
+    tailCall(threaded(task));
+  }
+
+  public static <T> void tailCall(final Supplier<T> task) {
+    tailCall(threaded(task));
+  }
+
+  public static <T> void tailCall(final TaskFactory<T> task) {
+    context.get().tailCall(task);
+  }
+
   public static void defer(final Duration duration, final Runnable task) {
     spawn(replaying(() -> { delay(duration); spawn(task); }));
   }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/QueryContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/QueryContext.java
@@ -53,6 +53,11 @@ public final class QueryContext implements Context {
   }
 
   @Override
+  public <Return> void tailCall(final TaskFactory<Return> task) {
+    throw new IllegalStateException("Cannot schedule tasks in a query-only context");
+  }
+
+  @Override
   public void delay(final Duration duration) {
     throw new IllegalStateException("Cannot yield in a query-only context");
   }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Registrar.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Registrar.java
@@ -13,10 +13,25 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 public final class Registrar {
+
+  /**
+   * Whether to allow run length compression when saving resource profiles at the end of simulation by default.
+   *
+   * This compression is lossless in terms of the overall shape of the profile, but it will combine adjacent profile
+   * segments with the same value, thus obscuring the fact that multiple resource samples (again, all returning the same
+   * value) were taken within the segment.
+   */
+  private static final boolean ALLOW_RUN_LENGTH_COMPRESSION_BY_DEFAULT = false;
+
   private final Initializer builder;
+  private boolean allowRunLengthCompression = ALLOW_RUN_LENGTH_COMPRESSION_BY_DEFAULT;
 
   public Registrar(final Initializer builder) {
     this.builder = Objects.requireNonNull(builder);
+  }
+
+  public void allowRunLengthCompression(final boolean allow) {
+    this.allowRunLengthCompression = allow;
   }
 
   public boolean isInitializationComplete() {
@@ -24,7 +39,8 @@ public final class Registrar {
   }
 
   public <Value> void discrete(final String name, final Resource<Value> resource, final ValueMapper<Value> mapper) {
-    this.builder.resource(name, makeResource("discrete", resource, mapper.getValueSchema(), mapper::serializeValue));
+    this.builder.resource(name, makeResource("discrete", resource, mapper.getValueSchema(), mapper::serializeValue,
+                                             allowRunLengthCompression));
   }
 
   public void real(final String name, final Resource<RealDynamics> resource) {
@@ -46,14 +62,16 @@ public final class Registrar {
                 "rate", ValueSchema.REAL))),
             dynamics -> SerializedValue.of(Map.of(
                 "initial", SerializedValue.of(dynamics.initial),
-                "rate", SerializedValue.of(dynamics.rate)))));
+                "rate", SerializedValue.of(dynamics.rate))),
+            allowRunLengthCompression));
   }
 
   private static <Value> gov.nasa.jpl.aerie.merlin.protocol.model.Resource<Value> makeResource(
       final String type,
       final Resource<Value> resource,
       final ValueSchema valueSchema,
-      final Function<Value, SerializedValue> serializer
+      final Function<Value, SerializedValue> serializer,
+      final boolean allowRunLengthCompression
   ) {
     return new gov.nasa.jpl.aerie.merlin.protocol.model.Resource<>() {
       @Override
@@ -81,6 +99,11 @@ public final class Registrar {
         try (final var _token = ModelActions.context.set(new QueryContext(querier))) {
           return resource.getDynamics();
         }
+      }
+
+      @Override
+      public boolean allowRunLengthCompression() {
+        return allowRunLengthCompression;
       }
     };
   }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
@@ -79,6 +79,14 @@ final class ReplayingReactionContext implements Context {
   }
 
   @Override
+  public <T> void tailCall(final TaskFactory<T> task) {
+    this.memory.doOnce(() -> {
+      this.scheduler = null;  // Relinquish the current scheduler before yielding, in case an exception is thrown.
+      this.scheduler = this.handle.tailCall(task);
+    });
+  }
+
+  @Override
   public void delay(final Duration duration) {
     this.memory.doOnce(() -> {
       this.scheduler = null;  // Relinquish the current scheduler before yielding, in case an exception is thrown.

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingTask.java
@@ -57,6 +57,11 @@ public final class ReplayingTask<Return> implements Task<Return> {
     }
 
     @Override
+    public Scheduler tailCall(final TaskFactory<?> child) {
+      return this.yield(TaskStatus.tailCalling(child, ReplayingTask.this));
+    }
+
+    @Override
     public Scheduler await(final gov.nasa.jpl.aerie.merlin.protocol.model.Condition condition) {
       return this.yield(TaskStatus.awaiting(condition, ReplayingTask.this));
     }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/TaskHandle.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/TaskHandle.java
@@ -9,5 +9,7 @@ public interface TaskHandle {
 
   Scheduler call(TaskFactory<?> child);
 
+  Scheduler tailCall(TaskFactory<?> child);
+
   Scheduler await(gov.nasa.jpl.aerie.merlin.protocol.model.Condition condition);
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
@@ -64,6 +64,12 @@ final class ThreadedReactionContext implements Context {
   }
 
   @Override
+  public <T> void tailCall(final TaskFactory<T> task) {
+    this.scheduler = null;  // Relinquish the current scheduler before yielding, in case an exception is thrown.
+    this.scheduler = this.handle.tailCall(task);
+  }
+
+  @Override
   public void delay(final Duration duration) {
     this.scheduler = null;  // Relinquish the current scheduler before yielding, in case an exception is thrown.
     this.scheduler = this.handle.delay(duration);

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTask.java
@@ -208,6 +208,11 @@ public final class ThreadedTask<Return> implements Task<Return> {
     }
 
     @Override
+    public Scheduler tailCall(final TaskFactory<?> child) {
+      return this.yield(TaskStatus.tailCalling(child, ThreadedTask.this));
+    }
+
+    @Override
     public Scheduler await(final gov.nasa.jpl.aerie.merlin.protocol.model.Condition condition) {
       return this.yield(TaskStatus.awaiting(condition, ThreadedTask.this));
     }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/Resource.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/Resource.java
@@ -16,4 +16,18 @@ public interface Resource<Dynamics> {
    * this resource. In other words, it cannot depend on any hidden state. </p>
    */
   Dynamics getDynamics(Querier querier);
+
+  /**
+   * After a simulation completes the entire evolution of the dynamics of this resource will typically be serialized as
+   * a resource profile consisting of some number of sequential segments.
+   *
+   * If run length compression is allowed for this resource then whenever there is a "run" of two or more such segments,
+   * one after another with the same dynamics, they will be compressed into a single segment during that serialization.
+   * This does not change the represented evolution of the dynamics of the resource, but it loses the information that a
+   * sample was taken at the start of each segment after the first in such a run.  If a mission model prefers not to
+   * lose that information then it can return false here.
+   */
+  default boolean allowRunLengthCompression() {
+    return false;
+  }
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/SerializedValue.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/SerializedValue.java
@@ -147,7 +147,7 @@ public sealed interface SerializedValue {
     }
 
     private BigDecimal toBigDecimal() {
-      //without MathContext.DECIMAL64 then a double assigned to from a string (or code literal) "3.14"
+      //without MathContext.DECIMAL64 then a double assigned from a string (or code literal) "3.14"
       //converts to a BigDecimal=3.140000000000000124344978758017532527446746826171875
       //but since a double can only represent up to 15 decimal digits when going from string -> double -> string
       //the nonzero values in the smaller decimal places are just an artifact of the representation

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskStatus.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskStatus.java
@@ -9,7 +9,8 @@ public sealed interface TaskStatus<Return> {
 
   record Delayed<Return>(Duration delay, Task<Return> continuation) implements TaskStatus<Return> {}
 
-  record CallingTask<Return>(TaskFactory<?> child, Task<Return> continuation) implements TaskStatus<Return> {}
+  record CallingTask<Return>(TaskFactory<?> child, Task<Return> continuation, boolean tailCall)
+    implements TaskStatus<Return> {}
 
   record AwaitingCondition<Return>(Condition condition, Task<Return> continuation) implements TaskStatus<Return> {}
 
@@ -23,7 +24,11 @@ public sealed interface TaskStatus<Return> {
   }
 
   static <Return> CallingTask<Return> calling(final TaskFactory<?> child, final Task<Return> continuation) {
-    return new CallingTask<>(child, continuation);
+    return new CallingTask<>(child, continuation, false);
+  }
+
+  static <Return> CallingTask<Return> tailCalling(final TaskFactory<?> child, final Task<Return> continuation) {
+    return new CallingTask<>(child, continuation, true);
   }
 
   static <Return> AwaitingCondition<Return> awaiting(final Condition condition, final Task<Return> continuation) {


### PR DESCRIPTION
This PR contains several adjustments to reduce memory usage for long plans. These were developed by [analyzing](https://eclipse.dev/mat) memory dumps acquired while simulating a 5-year Clipper plan with about 7.5k activities. This plan was running out of memory in the default simulation configuration with the standard 32GB docker memory limit.

With the changes in this PR, combined with changes in a corresponding [clipper-aerie PR](https://github.jpl.nasa.gov/Europa-PESS/clipper-aerie/pull/3129), that plan now successfully simulates with a 32GB docker memory limit, I believe with at least a few GB to spare.

The changes in these PRs address several memory bottlenecks.  In this specific Aerie PR those are:
* The "trampolining" approach used for runtime performance in Clipper's `ExtendedModelActions.spawn(RepeatingTask)` appears to be a form of tail recursion, but it without tall call optimization, this was using a lot of memory. There are several possible ways to address this; here I'm proposing a relatively minimal way that I feel is practical though perhaps not as elegant as [some other more complex possibilities](https://github.jpl.nasa.gov/Europa-PESS/clipper-aerie/issues/2740#issuecomment-571711).
* The current implementation of simulation results builds up the entire history of all resource profiles in memory. While there is some intention that this will eventually be replaced by streaming the data incrementally in some form, for now this is a memory bottleneck. This PR adds some new `SerializedValue` implementations intended to help avoid using a large number of `BigDecimal` instances in this codepath. It also add an opt-in feature that allows resource profiles to use a form of run-length compression.

This is still a draft PR for now for the following reasons:
1. I would still like to run some additional tests with docker configured with memory limits that more closely mimic actual deployments
1. DONE ~I didn't know about `./gradlew e2eTest`, looks like there are some regressions I will need to fix there.~
1. I still need to run @DavidLegg's `compare_resources.py` to make sure that there are no regressions in the simulation results. I suppose I will do this by running only some prefix of the test plan to stay within memory limits in the baseline configuration.