### PR TITLE
Update GH Action Versions used in Workflows

### DIFF
--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install cloc
         run: |
           sudo apt-get update

--- a/.github/workflows/create_jnispice.yml
+++ b/.github/workflows/create_jnispice.yml
@@ -20,7 +20,7 @@ jobs:
           7z x JNISpice.zip
           echo "JNISpice unpacked"
       - name: Upload DLL
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Spice
           path: JNISpice/lib/JNISpice.dll
@@ -39,7 +39,7 @@ jobs:
         run: mv libJNISpice.so libJNISpice_Intel.so
         working-directory: JNISpice/lib
       - name: Upload .so
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: x86 Linux Spice
           path: JNISpice/lib/libJNISpice_Intel.so
@@ -64,7 +64,7 @@ jobs:
         working-directory: JNISpice/src/JNISpice
         shell: csh {0}
       - name: Upload Intel Mac .jnilib
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: x86 Mac Spice
           path: JNISpice/lib/libJNISpice_Intel.jnilib
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "21"
@@ -104,7 +104,7 @@ jobs:
         working-directory: JNISpice/src/JNISpice
       - name: Upload JAR
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: JNISpice Jar
           path: JNISpice/src/JNISpice/JNISpice-*.jar

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -15,12 +15,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: "21"
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
       - name: Create Pages Build Directories
         run: mkdir -p build/javadoc/examples
       - name: Build EDSL API Docs
@@ -51,7 +51,7 @@ jobs:
           cp -a ./scheduler-server/build/docs/javadoc ./build/javadoc/scheduler-server
           cp -a ./scheduler-worker/build/docs/javadoc ./build/javadoc/scheduler-worker
       - name: Upload Artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: build/
 
@@ -64,4 +64,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -17,16 +17,16 @@ jobs:
     environment: load-test
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "21"
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
       - name: Assemble
         run: ./gradlew assemble --parallel
       - name: Start Services
@@ -43,7 +43,7 @@ jobs:
           ./load-test.sh
       - name: Upload Load Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Load Test Results
           path: "**/load-tests/load-report.*"

--- a/.github/workflows/pgcmp.yml
+++ b/.github/workflows/pgcmp.yml
@@ -28,16 +28,16 @@ jobs:
     environment: e2e-test
     steps:
       - name: Checkout v1.0.1
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "v1.0.1"
       - name: Clone PGCMP
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cbbrowne/pgcmp
           path: pgcmp
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Setup Postgres Client (psql)
@@ -47,9 +47,9 @@ jobs:
       - name: Setup Hasura CLI
         run: sudo curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: Distribute SQL and Assemble Java
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: distributeSQL
       - name: Start Postgres
@@ -79,13 +79,13 @@ jobs:
           PGURI=postgres://"${AERIE_USERNAME}":"${AERIE_PASSWORD}"@localhost:5432/aerie_ui PGCMPOUTPUT=./pgdumpv1_0_1/AerieUIV1_0_1 PGCLABEL=AerieUIV1_0_1 PGBINDIR=/usr/bin ./pgcmp/pgcmp-dump
         shell: bash
       - name: Share Database Dump
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: v1_0_1-db-dump
           path: pgdumpv1_0_1
           retention-days: 1
       - name: Checkout Latest
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Restart Hasura
         run: |
           docker compose down
@@ -116,7 +116,7 @@ jobs:
           AERIE_USERNAME: "${{secrets.AERIE_USERNAME}}"
           AERIE_PASSWORD: "${{secrets.AERIE_PASSWORD}}"
       - name: Clone PGCMP
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cbbrowne/pgcmp
           path: pgcmp
@@ -132,7 +132,7 @@ jobs:
           PGURI=postgres://"${AERIE_USERNAME}":"${AERIE_PASSWORD}"@localhost:5432/aerie_ui PGCMPOUTPUT=./pgdumpmigrated/AerieUIMigrated PGCLABEL=AerieUIMigrated PGBINDIR=/usr/bin ./pgcmp/pgcmp-dump
         shell: bash
       - name: Share Database Dump
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: migrated-db-dump
           path: pgdumpmigrated
@@ -153,19 +153,19 @@ jobs:
     environment: e2e-test
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Postgres Client (psql)
         run: |
           sudo apt-get update
           sudo apt-get install --yes postgresql-client
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: Distribute SQL
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: distributeSQL
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Setup Hasura CLI
@@ -186,7 +186,7 @@ jobs:
         run: sleep 60s
         shell: bash
       - name: Clone PGCMP
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cbbrowne/pgcmp
           path: pgcmp
@@ -202,7 +202,7 @@ jobs:
           PGURI=postgres://"${AERIE_USERNAME}":"${AERIE_PASSWORD}"@localhost:5432/aerie_ui PGCMPOUTPUT=./pgdumpraw/AerieUIRaw PGCLABEL=AerieUIRaw PGBINDIR=/usr/bin ./pgcmp/pgcmp-dump
         shell: bash
       - name: Share Database Dump
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raw-sql-db-dump
           path: pgdumpraw
@@ -232,7 +232,7 @@ jobs:
           PGURI=postgres://"${AERIE_USERNAME}":"${AERIE_PASSWORD}"@localhost:5432/aerie_ui PGCMPOUTPUT=./pgdumpmigrateddown/AerieUIMigratedDown PGCLABEL=AerieUIMigratedDown PGBINDIR=/usr/bin ./pgcmp/pgcmp-dump
         shell: bash
       - name: Share Database Dump
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: migrated-down-db-dump
           path: pgdumpmigrateddown
@@ -252,9 +252,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Clone PGCMP
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cbbrowne/pgcmp
           path: pgcmp
@@ -268,11 +268,11 @@ jobs:
         run: sleep 5s
         shell: bash
       - name: Download Shared Dumps
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: migrated-db-dump
           path: pgcmp/pgdumpmigrated
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: raw-sql-db-dump
           path: pgcmp/pgdumpraw
@@ -285,7 +285,7 @@ jobs:
         shell: bash
       - name: Upload Invalid
         if: ${{ failure() && steps.dbcmp.conclusion == 'failure' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pgcmpresultsup
           path: "**/results/"
@@ -305,9 +305,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Clone PGCMP
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cbbrowne/pgcmp
           path: pgcmp
@@ -321,11 +321,11 @@ jobs:
         run: sleep 5s
         shell: bash
       - name: Download Shared Dumps
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: v1_0_1-db-dump
           path: pgcmp/pgdumpv1_0_1
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: migrated-down-db-dump
           path: pgcmp/pgdumpmigrateddown
@@ -340,7 +340,7 @@ jobs:
         shell: bash
       - name: Upload Invalid
         if: ${{ failure() && steps.dbcmp.conclusion == 'failure' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pgcmpresultsdown
           path: "**/results/"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -150,7 +150,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Vuln Scan Results
+          name: Vuln Scan Results - ${{ matrix.image }}
           path: "${{ matrix.image }}-results.html"
 
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@v2
 
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           generate-job-summary: false
 
@@ -63,28 +63,28 @@ jobs:
             file: docker/Dockerfile.postgres
     name: ${{ matrix.components.image }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "21"
 
       - name: Init Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           generate-job-summary: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to ${{ env.REGISTRY }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -92,7 +92,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for ${{ matrix.components.image }}
         id: metadata-step
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.components.image }}
 
@@ -109,7 +109,7 @@ jobs:
           fi
 
       - name: Build and push ${{ matrix.components.image }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.components.context }}
           file: ${{ matrix.components.file }}
@@ -148,7 +148,7 @@ jobs:
 
       - name: Upload ${{ matrix.image }} scan results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Vuln Scan Results
           path: "${{ matrix.image }}-results.html"
@@ -161,10 +161,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Gradle Cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           generate-job-summary: false
 
@@ -177,7 +177,7 @@ jobs:
         run: ./gradlew archiveDeployment
 
       - name: Publish deployment
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Deployment
           path: deployment.tar

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -91,5 +91,5 @@ jobs:
       - name: Upload Security Scan Results
         uses: actions/upload-artifact@v4
         with:
-          name: Security Scan Results
+          name: Security Scan Results - ${{ matrix.language }}
           path: ${{ env.RESULTS_DIR }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -28,15 +28,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-extended
           tools: latest
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "21"
@@ -44,7 +44,7 @@ jobs:
         run: |
           ./gradlew testClasses
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
       - name: Gradle Dependency Submission
         uses: mikepenz/gradle-dependency-submission@v0.9.0
         with:
@@ -89,7 +89,7 @@ jobs:
 
           echo "RESULTS_DIR=$results_dir" >> $GITHUB_ENV
       - name: Upload Security Scan Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Security Scan Results
           path: ${{ env.RESULTS_DIR }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -45,33 +45,8 @@ jobs:
           ./gradlew testClasses
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
-      - name: Gradle Dependency Submission
-        uses: mikepenz/gradle-dependency-submission@v0.9.0
-        with:
-          gradle-build-module: |-
-            :merlin-sdk
-            :merlin-driver
-            :merlin-framework
-            :merlin-framework-junit
-            :merlin-framework-processor
-            :contrib
-            :parsing-utilities
-            :permissions
-            :merlin-server
-            :merlin-worker
-            :scheduler-server
-            :scheduler-worker
-            :sequencing-server
-            :constraints
-            :scheduler-driver
-            :db-tests
-            :e2e-tests
-            :examples:banananation
-            :examples:foo-missionmodel
-            :examples:config-with-defaults
-            :examples:config-without-defaults
-            :examples:minimal-mission-model
-          sub-module-mode: "COMBINED"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: NASA Scrub
         run: |
           python3 -m pip install nasa-scrub

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,29 +25,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "21"
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
       - name: Assemble
         run: ./gradlew assemble --parallel
       - name: Run Unit Tests
         run: ./gradlew test --parallel
       - name: Upload Test Results as XML
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
           path: "**/build/test-results/test"
       - name: Upload Test Results as HTML
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
           path: "**/build/reports/tests/test"
@@ -57,9 +57,9 @@ jobs:
     environment: e2e-test
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "21"
@@ -68,9 +68,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes postgresql-client
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
       - name: Assemble
         run: ./gradlew assemble --parallel
       - name: Start Services
@@ -85,19 +85,19 @@ jobs:
         run: ./gradlew e2eTest
       - name: Upload E2E Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
           path: "**/e2e-tests/build/reports/tests/e2eTest"
       - name: Upload DB Test Results as HTML
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
           path: "**/db-tests/build/reports/tests/e2eTest"
       - name: Upload Sequencing Server Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
           path: "**/sequencing-server/test-report.*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,18 +39,14 @@ jobs:
         run: ./gradlew assemble --parallel
       - name: Run Unit Tests
         run: ./gradlew test --parallel
-      - name: Upload Test Results as XML
+      - name: Upload Test Results as XML and HTML
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Test Results
-          path: "**/build/test-results/test"
-      - name: Upload Test Results as HTML
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Results
-          path: "**/build/reports/tests/test"
+          name: Unit Test Results
+          path: |
+            **/build/test-results/test
+            **/build/reports/tests/test
 
   e2e-test:
     runs-on: ubuntu-latest
@@ -87,20 +83,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Test Results
-          path: "**/e2e-tests/build/reports/tests/e2eTest"
-      - name: Upload DB Test Results as HTML
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Results
-          path: "**/db-tests/build/reports/tests/e2eTest"
-      - name: Upload Sequencing Server Test Results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Results
-          path: "**/sequencing-server/test-report.*"
+          name: E2E Test Results
+          path: |
+            **/e2e-tests/build/reports/tests/e2eTest
+            **/db-tests/build/reports/tests/e2eTest
+            **/sequencing-server/test-report.*
       - name: Print Logs for Services
         if: always()
         run: docker compose -f ./e2e-tests/docker-compose-test.yml logs -t

--- a/load-tests/src/db-lockup-test.ts
+++ b/load-tests/src/db-lockup-test.ts
@@ -6,7 +6,7 @@ import {ActivityInsertInput} from "./types/activity";
 
 export const options = {
   // A number specifying the number of VUs to run concurrently.
-  vus: 50,
+  vus: 15, // set to at least 50 when running locally
   // A string specifying the total duration of the test run.
   duration: '10s',
 


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
[Github actions are transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). This PR is to update our workflows to use the node 20 versions of all actions (v4).

[There were some breaking changes in the `upload/download artifact` action](https://github.com/actions/download-artifact?tab=readme-ov-file#v4---whats-new), that will impact our usage, specifically being unable to upload two artifacts with the same name. This specifically impacts our Security Scan, Publish, and Test workflows.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Successful execution of each workflow with no Node16 warnings will validate this PR:

- [x] CLOC
- [x] DB Migrations
- [x] Load Test
- [x] Test/E2E Tests
- [x] Create JNISPICE
- [x] Deploy to GH Pages 
- [x] Publish (Deploy step is untestable due to branch restrictions)
- [x] Security Scan

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

No doc updates needed.

