### PR TITLE
Update pgjdbc to fix SQL injection vuln

### DIFF
--- a/db-tests/build.gradle
+++ b/db-tests/build.gradle
@@ -21,7 +21,7 @@ task e2eTest(type: Test) {
 }
 
 dependencies {
-  testImplementation 'org.postgresql:postgresql:42.6.0'
+  testImplementation 'org.postgresql:postgresql:42.6.1'
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
   testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.0'
   testImplementation 'com.zaxxer:HikariCP:5.0.1'

--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -84,7 +84,7 @@ dependencies {
   implementation 'org.slf4j:slf4j-simple:2.0.7'
   implementation 'org.glassfish:javax.json:1.1.4'
 
-  implementation 'org.postgresql:postgresql:42.6.0'
+  implementation 'org.postgresql:postgresql:42.6.1'
   implementation 'com.zaxxer:HikariCP:5.0.1'
 
   testImplementation project(':examples:foo-missionmodel')

--- a/merlin-worker/build.gradle
+++ b/merlin-worker/build.gradle
@@ -30,6 +30,6 @@ dependencies {
 
   implementation 'io.javalin:javalin:5.6.3'
   implementation 'org.slf4j:slf4j-simple:2.0.7'
-  implementation 'org.postgresql:postgresql:42.6.0'
+  implementation 'org.postgresql:postgresql:42.6.1'
   implementation 'com.zaxxer:HikariCP:5.0.1'
 }

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -28,7 +28,7 @@ dependencies {
   implementation 'io.javalin:javalin:5.6.3'
   implementation 'org.eclipse:yasson:3.0.3'
 
-  implementation 'org.postgresql:postgresql:42.6.0'
+  implementation 'org.postgresql:postgresql:42.6.1'
   implementation 'com.zaxxer:HikariCP:5.0.1'
 
   testImplementation project(':examples:foo-missionmodel')

--- a/scheduler-worker/build.gradle
+++ b/scheduler-worker/build.gradle
@@ -116,7 +116,7 @@ dependencies {
   implementation 'io.javalin:javalin:5.6.3'
   implementation 'org.slf4j:slf4j-simple:2.0.7'
   implementation 'org.eclipse:yasson:3.0.3'
-  implementation 'org.postgresql:postgresql:42.6.0'
+  implementation 'org.postgresql:postgresql:42.6.1'
   implementation 'com.zaxxer:HikariCP:5.0.1'
 
   testImplementation project(':examples:foo-missionmodel')


### PR DESCRIPTION
Security scans were failing as of this morning due to a newly reported SQL injection vulnerability. Looks like Aerie did not use the `PreferQueryMode=SIMPLE` mode, so we aren't affected, but this will clear up our scans to avoid missing other alerts.

Updates pgjdbc to the patched version, 46.2.1

See the following for more info: 
https://github.com/NASA-AMMOS/aerie/security
https://github.com/advisories/GHSA-xfg6-62px-cxc2
