### PR TITLE
Handle null values when deserializing series and structs for command expansion

### DIFF
--- a/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
+++ b/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
@@ -246,9 +246,10 @@ function convertType(value: any, schema: Schema): any {
     case SchemaTypes.String:
       return value;
     case SchemaTypes.Series:
-      return value.map((value: any) => convertType(value, schema.items));
+      return value == null ? null : value.map((value: any) => convertType(value, schema.items));
     case SchemaTypes.Struct:
       const struct: { [attributeName: string]: any } = {};
+      if (value == null) {return null;}
       for (const [attributeKey, attributeSchema] of Object.entries(schema.items)) {
         struct[attributeKey] = convertType(value[attributeKey], attributeSchema);
       }


### PR DESCRIPTION
* **Tickets addressed:** Fixes #1346 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** squash and merge

## Description

Pass `null` values for series and structs to TS simulated activity instances for command expansion when deserializing simulation datasets.

## Verification

Tested locally on one test case, but not tested extensively.

## Documentation

None

## Future work

Add the expected/allowed behavior of `null` values to the "Value Schema" documentation.
