### PR TITLE
Handle 'null' values when deserializing for command expansion

### DIFF
--- a/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
+++ b/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
@@ -231,6 +231,9 @@ export function mapGraphQLActivityInstance(
 function convertType(value: any, schema: Schema): any {
   switch (schema.type) {
     case SchemaTypes.Int:
+      if (value === null) {
+        return value;
+      }
       if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER) {
         return value.toString();
       }
@@ -238,7 +241,10 @@ function convertType(value: any, schema: Schema): any {
     case SchemaTypes.Real:
       return value;
     case SchemaTypes.Duration:
-      return Temporal.Duration.from(parse(value).toISOString());
+      if (value !== null) {
+        return Temporal.Duration.from(parse(value).toISOString());
+      }
+      return value;
     case SchemaTypes.Boolean:
       return value;
     case SchemaTypes.Path:
@@ -246,15 +252,21 @@ function convertType(value: any, schema: Schema): any {
     case SchemaTypes.String:
       return value;
     case SchemaTypes.Series:
+      if (value === null) {
+        return value;
+      }
       return value.map((value: any) => convertType(value, schema.items));
     case SchemaTypes.Struct:
+      if (value === null) {
+        return value;
+      }
       const struct: { [attributeName: string]: any } = {};
       for (const [attributeKey, attributeSchema] of Object.entries(schema.items)) {
         struct[attributeKey] = convertType(value[attributeKey], attributeSchema);
       }
       return struct;
     case SchemaTypes.Variant:
-      if (schema.variants.length === 1 && schema.variants[0]?.key === 'VOID') {
+      if (value === null || (schema.variants.length === 1 && schema.variants[0]?.key === 'VOID')) {
         return null;
       }
       return value;


### PR DESCRIPTION
* **Tickets addressed:** Closes #1346
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Establishing a default behavior to gracefully handle schemas with null values. Instead of encountering server-side errors that disrupt sequence expansion, null values will now be implicitly passed through. This decision places the onus on the expansion logic to implement appropriate null checks and handle potential null cases accordingly.

## Future work
Find a better way to allow for an OptionalValueMapper with the ValueMapperSchema
