### PR TITLE
Serialize `NoSuchMissionModel` exception out in activity validations

### DIFF
--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/AutomaticValidationTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/AutomaticValidationTests.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
 import java.io.IOException;
 import java.util.List;
 
@@ -128,6 +130,30 @@ public class AutomaticValidationTests {
             "temperature",
             "Expected real number, got StringValue[value=this is a string]"))
     ), activityValidation);
+  }
+
+  @Test
+  void noSuchMissionModelError() throws IOException, InterruptedException {
+    final var activityId = hasura.insertActivity(
+        planId,
+        "BiteBanana",
+        "1h",
+        JsonValue.EMPTY_JSON_OBJECT
+    );
+    Thread.sleep(1000); // TODO consider a while loop here
+
+    hasura.deleteMissionModel(modelId);
+
+    final var arguments = Json.createObjectBuilder().add("biteSize", 2).build();
+    hasura.updateActivityDirectiveArguments(planId, activityId, arguments);
+    Thread.sleep(1000); // TODO consider a while loop here
+
+    final var activityValidations = hasura.getActivityValidations(planId);
+    final ActivityValidation activityValidation = activityValidations.get((long) activityId);
+    assertEquals(
+        new ActivityValidation.NoSuchMissionModelFailure("no such mission model", "0"),
+        activityValidation
+    );
   }
 
   @Test

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/AutomaticValidationTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/AutomaticValidationTests.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import javax.json.Json;
-import javax.json.JsonObject;
 import javax.json.JsonValue;
 import java.io.IOException;
 import java.util.List;

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ActivityValidation.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ActivityValidation.java
@@ -11,6 +11,7 @@ public sealed interface ActivityValidation {
   record InstantiationFailure(List<String> extraneousArguments, List<String> missingArguments, List<?> unconstructableArguments) implements ActivityValidation {}
   record ValidationFailure(List<ValidationNotice> notices) implements ActivityValidation {}
   record NoSuchActivityTypeFailure(String message, String activityType) implements ActivityValidation {}
+  record NoSuchMissionModelFailure(String message, String modelId) implements ActivityValidation {}
 
   record ValidationNotice(List<String> subjects, String message) { }
   record UnconstructableArgument(String name, String failure) { }
@@ -44,6 +45,10 @@ public sealed interface ActivityValidation {
                         getStringArray($, "subjects"),
                         $.asJsonObject().getString("message"))));
       case "NO_SUCH_ACTIVITY_TYPE" -> new NoSuchActivityTypeFailure(errors.getJsonObject("noSuchActivityError").getString("message"), errors.getJsonObject("noSuchActivityError").getString("activity_type"));
+      case "NO_SUCH_MISSION_MODEL" -> new NoSuchMissionModelFailure(
+          errors.getJsonObject("noSuchMissionModelError").getString("message"),
+          errors.getJsonObject("noSuchMissionModelError").getString("mission_model_id")
+      );
       default -> throw new RuntimeException("Unhandled error type: " + type);
     };
   }

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
@@ -501,6 +501,15 @@ public enum GQL {
         simulationDatasetId
       }
     }"""),
+  UPDATE_ACTIVITY_DIRECTIVE_ARGUMENTS("""
+    mutation updateActivityDirectiveArguments($id: Int!, $plan_id: Int!, $arguments: jsonb!) {
+      updateActivityDirectiveArguments: update_activity_directive_by_pk(
+        pk_columns: {id: $id, plan_id: $plan_id},
+        _set: {arguments: $arguments}
+      ) {
+        id
+      }
+  }"""),
   UPDATE_CONSTRAINT("""
     mutation updateConstraint($constraintId: Int!, $constraintDefinition: String!) {
       constraint: insert_constraint_definition_one(object: {constraint_id: $constraintId, definition: $constraintDefinition}) {

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/HasuraRequests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/HasuraRequests.java
@@ -192,6 +192,16 @@ public class HasuraRequests implements AutoCloseable {
     return makeRequest(GQL.CREATE_ACTIVITY_DIRECTIVE, variables).getJsonObject("createActivityDirective").getInt("id");
   }
 
+  public void updateActivityDirectiveArguments(int planId, int activityId, JsonObject arguments) throws IOException {
+    final var variables = Json.createObjectBuilder()
+                              .add("plan_id", planId)
+                              .add("id", activityId)
+                              .add("arguments", arguments)
+                              .build();
+
+    makeRequest(GQL.UPDATE_ACTIVITY_DIRECTIVE_ARGUMENTS, variables);
+  }
+
   public void deleteActivity(int planId, int activityId) throws IOException {
     final var variables = Json.createObjectBuilder()
                               .add("plan_id", planId)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -191,6 +191,14 @@ public final class ResponseSerializers {
       return Json.createObjectBuilder(serializeInstantiationException(f.ex()).asJsonObject())
           .add("type", "INSTANTIATION_ERRORS")
           .build();
+    } else if (response instanceof BulkArgumentValidationResponse.NoSuchMissionModelError m) {
+      return Json.createObjectBuilder()
+                 .add("errors", Json.createObjectBuilder()
+                     .add("noSuchMissionModelError", serializeNoSuchMissionModelException(m.ex()))
+                     .build())
+                 .add("success", JsonValue.FALSE)
+                 .add("type", "NO_SUCH_MISSION_MODEL")
+                 .build();
     }
 
     // This should never happen, but we don't have exhaustive pattern matching

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -193,11 +193,11 @@ public final class ResponseSerializers {
           .build();
     } else if (response instanceof BulkArgumentValidationResponse.NoSuchMissionModelError m) {
       return Json.createObjectBuilder()
+                 .add("success", JsonValue.FALSE)
+                 .add("type", "NO_SUCH_MISSION_MODEL")
                  .add("errors", Json.createObjectBuilder()
                      .add("noSuchMissionModelError", serializeNoSuchMissionModelException(m.ex()))
                      .build())
-                 .add("success", JsonValue.FALSE)
-                 .add("type", "NO_SUCH_MISSION_MODEL")
                  .build();
     }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetUnvalidatedDirectivesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetUnvalidatedDirectivesAction.java
@@ -5,7 +5,6 @@ import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveForValidation;
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.merlin.server.models.MissionModelId;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
-import gov.nasa.jpl.aerie.merlin.server.models.Timestamp;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -133,8 +133,7 @@ public final class LocalMissionModelService implements MissionModelService {
 
   public List<BulkArgumentValidationResponse> validateActivityArgumentsBulk(
       final MissionModelId modelId,
-      final List<ActivityDirectiveForValidation> activities
-  ) throws NoSuchMissionModelException, MissionModelLoadException {
+      final List<ActivityDirectiveForValidation> activities) {
     // load mission model once for all activities
     ModelType<?, ?> modelType;
     try {
@@ -145,6 +144,10 @@ public final class LocalMissionModelService implements MissionModelService {
       return activities.stream()
           .map(directive -> new BulkArgumentValidationResponse.NoSuchMissionModelError(e))
           .collect(Collectors.toList());
+    } catch (MissionModelLoadException e) {
+      log.error("Caught MissionModelLoadException, skipping this batch but leaving validations pending...");
+      log.error(e.toString());
+      return List.of();
     }
     final var registry = DirectiveTypeRegistry.extract(modelType);
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -139,6 +139,8 @@ public final class LocalMissionModelService implements MissionModelService {
     ModelType<?, ?> modelType;
     try {
       modelType = this.loadMissionModelType(modelId.toString());
+      // try and catch NoSuchMissionModel here, so we can serialize it out to each activity validation
+      // rather than catching it at a higher level in the workerLoop itself
     } catch (NoSuchMissionModelException e) {
       return activities.stream()
           .map(directive -> new BulkArgumentValidationResponse.NoSuchMissionModelError(e))

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -136,7 +136,14 @@ public final class LocalMissionModelService implements MissionModelService {
       final List<ActivityDirectiveForValidation> activities
   ) throws NoSuchMissionModelException, MissionModelLoadException {
     // load mission model once for all activities
-    final var modelType = this.loadMissionModelType(modelId.toString());
+    ModelType<?, ?> modelType;
+    try {
+      modelType = this.loadMissionModelType(modelId.toString());
+    } catch (NoSuchMissionModelException e) {
+      return activities.stream()
+          .map(directive -> new BulkArgumentValidationResponse.NoSuchMissionModelError(e))
+          .collect(Collectors.toList());
+    }
     final var registry = DirectiveTypeRegistry.extract(modelType);
 
     // map all directives to validation response

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -105,6 +105,7 @@ public interface MissionModelService {
   sealed interface BulkArgumentValidationResponse {
     record Success() implements BulkArgumentValidationResponse { }
     record Validation(List<ValidationNotice> notices) implements BulkArgumentValidationResponse { }
+    record NoSuchMissionModelError(NoSuchMissionModelException ex) implements BulkArgumentValidationResponse { }
     record NoSuchActivityError(NoSuchActivityTypeException ex) implements BulkArgumentValidationResponse { }
     record InstantiationError(InstantiationException ex) implements BulkArgumentValidationResponse { }
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ValidationWorker.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ValidationWorker.java
@@ -1,7 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
 import gov.nasa.jpl.aerie.merlin.server.models.ActivityDirectiveForValidation;
-import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService.NoSuchMissionModelException;
 import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService.BulkArgumentValidationResponse;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ValidationWorker.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ValidationWorker.java
@@ -49,9 +49,6 @@ public record ValidationWorker(LocalMissionModelService missionModelService, int
           final var duration = (endTime - beginTime) / 1_000_000.0;
           logger.debug("processed model batch of size {} in {} ms", unvalidatedDirectives.size(), duration);
         }
-
-      } catch (NoSuchMissionModelException ex) {
-        logger.error("Validation request failed due to no such mission model: {}", ex.toString());
       } catch (InterruptedException ex) {
         // we were interrupted, so exit gracefully
         return;


### PR DESCRIPTION
* **Tickets addressed:** closes #1329 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds a `try` `catch (NoSuchMissionModelException` deeper within the validation worker loop, so we can catch these exceptions within each model batch iteration, generate a `NoSuchMissionModelError` for each validation requested for that model batch, and write them out to the database.

This avoids the issue of the worker loop only catching this exception at its outer iteration layer, which would simply print an error and then restart the main validation loop without resolving the `pending` validation, so it would run into the same issue over and over.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Added a new test `AutomaticValidationTests::noSuchMissionModel`. Running this test without the second commit of this PR will fail and output
```
Expected :NoSuchMissionModelFailure[message=no such mission model, modelId=0]
Actual   :Pending[]
```

After applying the second commit, the test will pass.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None
