### PR TITLE
Update Plan Metadata

### DIFF
--- a/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan.yaml
+++ b/deployment/hasura/metadata/databases/AerieMerlin/tables/public_plan.yaml
@@ -67,10 +67,10 @@ array_relationships:
         name: plan
         schema: public
 remote_relationships:
-- name: scheduling_specifications
+- name: scheduling_specification
   definition:
     to_source:
-      relationship_type: array
+      relationship_type: object
       source: AerieScheduler
       table:
         schema: public

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
@@ -315,7 +315,7 @@ public enum GQL {
         }
         name
         revision
-        scheduling_specifications {
+        scheduling_specification {
           id
         }
         simulations {


### PR DESCRIPTION
* **Tickets addressed:** none
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
#711 changed the relationship of plan to scheduling spec from an array relationship to an object relationship but did not update the Hasura metadata to reflect this. This PR updates that metadata and renames the relationship from the plural `scheduling_specifications` to the singular `scheduling_specification`. This metadata change is minorly breaking for anyone using that relationship.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
The `GET_PLAN` query in the E2E tests was updated, but no other changes were necessary.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

No docs need to be updated, as we never referred to this relationship in them.