### PR TITLE
Add Ability to Forcibly Resimulate

### DIFF
--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -97,7 +97,7 @@ type Query {
 }
 
 type Query {
-  simulate(planId: Int!): MerlinSimulationResponse
+  simulate(planId: Int!, force: Boolean): MerlinSimulationResponse
 }
 
 type Query {

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/SimulationConfiguration.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/SimulationConfiguration.java
@@ -1,0 +1,25 @@
+package gov.nasa.jpl.aerie.e2e.types;
+
+import javax.json.JsonObject;
+import java.util.Optional;
+
+public record SimulationConfiguration(
+    int id,
+    int revision,
+    int planId,
+    Optional<Integer> simulationTemplateId,
+    JsonObject arguments,
+    String simulationStartTime,
+    String simulationEndTime
+) {
+  public static SimulationConfiguration fromJSON(JsonObject json) {
+    return new SimulationConfiguration(
+        json.getInt("id"),
+        json.getInt("revision"),
+        json.getInt("plan_id"),
+        json.isNull("simulation_template_id") ? Optional.empty() : Optional.of(json.getInt("simulation_template_id")),
+        json.getJsonObject("arguments"),
+        json.getString("simulation_start_time"),
+        json.getString("simulation_end_time"));
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
@@ -384,6 +384,18 @@ public enum GQL {
         status
       }
     }"""),
+  GET_SIMULATION_CONFIGURATION("""
+    query GetSimConfig($planId: Int!) {
+      sim_config: simulation(where: {plan_id: {_eq:$planId}}) {
+        id
+        revision
+        plan_id
+        simulation_template_id
+        arguments
+        simulation_start_time
+        simulation_end_time
+      }
+    }"""),
   GET_SIMULATION_DATASET("""
     query GetSimulationDataset($id: Int!) {
       simulationDataset: simulation_dataset_by_pk(id: $id) {
@@ -496,6 +508,14 @@ public enum GQL {
   SIMULATE("""
     query Simulate($plan_id: Int!) {
       simulate(planId: $plan_id){
+        status
+        reason
+        simulationDatasetId
+      }
+    }"""),
+  SIMULATE_FORCE("""
+    query SimulateForce($plan_id: Int!, $force: Boolean) {
+      simulate(planId: $plan_id, force: $force){
         status
         reason
         simulationDatasetId

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/HasuraParsers.java
@@ -7,6 +7,7 @@ import gov.nasa.jpl.aerie.merlin.server.models.HasuraMissionModelEvent;
 
 import java.util.Optional;
 
+import static gov.nasa.jpl.aerie.json.BasicParsers.boolP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.listP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.longP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.mapP;
@@ -53,6 +54,17 @@ public abstract class HasuraParsers {
       = hasuraActionF(productP
                           .field("planId", planIdP)
                           .map(HasuraAction.PlanInput::new, HasuraAction.PlanInput::planId));
+
+  public static final JsonParser<HasuraAction<HasuraAction.SimulateInput>> hasuraSimulateActionP
+      = hasuraActionF(
+          productP
+              .field("planId", planIdP)
+              .optionalField("force", nullableP(boolP))
+              .map(
+                  untuple((planId, force) -> new HasuraAction.SimulateInput(planId, force.flatMap($ -> $))),
+                  $ -> tuple($.planId(), Optional.of($.force()))
+              )
+  );
 
   public static final JsonParser<HasuraAction<HasuraAction.ConstraintViolationsInput>> hasuraConstraintsViolationsActionP
       = hasuraActionF(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -35,6 +35,7 @@ import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraActivity
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraActivityBulkActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraConstraintsCodeAction;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraConstraintsViolationsActionP;
+import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraSimulateActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraUploadExternalDatasetActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelActionP;
 import static gov.nasa.jpl.aerie.merlin.server.http.HasuraParsers.hasuraMissionModelArgumentsActionP;
@@ -175,7 +176,7 @@ public final class MerlinBindings implements Plugin {
 
   private void getSimulationResults(final Context ctx) {
     try {
-      final var body = parseJson(ctx.body(), hasuraPlanActionP);
+      final var body = parseJson(ctx.body(), hasuraSimulateActionP);
       final var planId = body.input().planId();
 
       this.checkPermissions(Action.simulate, body.session(), planId);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -178,10 +178,11 @@ public final class MerlinBindings implements Plugin {
     try {
       final var body = parseJson(ctx.body(), hasuraSimulateActionP);
       final var planId = body.input().planId();
+      final var force = body.input().force().orElse(false);
 
       this.checkPermissions(Action.simulate, body.session(), planId);
 
-      final var response = this.simulationAction.run(planId, body.session());
+      final var response = this.simulationAction.run(planId, force, body.session());
       ctx.result(ResponseSerializers.serializeSimulationResultsResponse(response).toString());
     } catch (final InvalidEntityException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/HasuraAction.java
@@ -15,6 +15,7 @@ public record HasuraAction<I extends HasuraAction.Input>(String name, I input, S
 
   public record MissionModelInput(String missionModelId) implements Input { }
   public record PlanInput(PlanId planId) implements Input { }
+  public record SimulateInput(PlanId planId, Optional<Boolean> force) implements Input {}
   public record ConstraintViolationsInput(PlanId planId, Optional<SimulationDatasetId> simulationDatasetId) implements Input { }
   public record ActivityInput(String missionModelId,
                               String activityTypeName,

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/InMemoryResultsCellRepository.java
@@ -47,6 +47,11 @@ public final class InMemoryResultsCellRepository implements ResultsCellRepositor
   }
 
   @Override
+  public ResultsProtocol.OwnerRole forceAllocate(PlanId planId, String requestedBy) {
+    return allocate(planId, requestedBy);
+  }
+
+  @Override
   public Optional<ResultsProtocol.OwnerRole> claim(final PlanId planId, final Long datasetId) {
     return Optional.empty();
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/ResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/ResultsCellRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 public interface ResultsCellRepository {
   ResultsProtocol.OwnerRole allocate(PlanId planId, String requestedBy);
+  ResultsProtocol.OwnerRole forceAllocate(PlanId planId, String requestedBy);
 
   Optional<ResultsProtocol.OwnerRole> claim(PlanId planId, Long datasetId);
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -89,6 +89,20 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
   }
 
   /**
+   * Forcibly allocate a simulation by updating the Simulation Configuration's revision
+   */
+  @Override
+  public ResultsProtocol.OwnerRole forceAllocate(PlanId planId, String requestedBy) {
+    try (final var connection = this.dataSource.getConnection();
+         final var updateSimConfig = new UpdateSimulationConfigurationRevisionAction(connection)) {
+      updateSimConfig.apply(planId.id());
+    } catch (final SQLException ex) {
+      throw new DatabaseException("Failed to allocation simulation cell", ex);
+    }
+    return allocate(planId, requestedBy);
+  }
+
+  /**
    * Claim a simulation
    *
    * <p>

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateSimulationConfigurationRevisionAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/UpdateSimulationConfigurationRevisionAction.java
@@ -1,0 +1,35 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/*package-local*/ final class UpdateSimulationConfigurationRevisionAction implements AutoCloseable {
+  private final @Language("SQL") String sql = """
+        update simulation
+        set revision = revision
+        where plan_id = ?;
+        """;
+
+  private final PreparedStatement statement;
+
+  public UpdateSimulationConfigurationRevisionAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public void apply(final long planId)
+  throws SQLException
+  {
+    this.statement.setLong(1, planId);
+    final var count = this.statement.executeUpdate();
+    if (count > 1) throw new Error("More than one row affected by sim config update by unique key. Is the database corrupted?");
+    if (count == 0) throw new SQLException("No simulation configuration exists for plan "+planId);
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
@@ -14,7 +14,12 @@ public record CachedSimulationService (
 ) implements SimulationService {
 
   @Override
-  public ResultsProtocol.State getSimulationResults(final PlanId planId, final RevisionData revisionData, final String requestedBy) {
+  public ResultsProtocol.State getSimulationResults(
+      final PlanId planId,
+      final boolean forceResim,
+      final RevisionData revisionData,
+      final String requestedBy)
+  {
     final var cell$ = this.store.lookup(planId);
     if (cell$.isPresent()) {
       return cell$.get().get();

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/CachedSimulationService.java
@@ -20,16 +20,20 @@ public record CachedSimulationService (
       final RevisionData revisionData,
       final String requestedBy)
   {
+    // If force resimulation is enabled, allocate a new cell regardless of whether there was already a valid cell
+    if (forceResim) {
+      return this.store.forceAllocate(planId, requestedBy).get();
+    }
+
     final var cell$ = this.store.lookup(planId);
     if (cell$.isPresent()) {
       return cell$.get().get();
-    } else {
-      // Allocate a fresh cell.
-      final var cell = this.store.allocate(planId, requestedBy);
-
-      // Return the current value of the reader; if it's incomplete, the caller can check it again later.
-      return cell.get();
     }
+
+    // Allocate a fresh cell.
+    final var cell = this.store.allocate(planId, requestedBy);
+    // Return the current value of the reader; if it's incomplete, the caller can check it again later.
+    return cell.get();
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/GetSimulationResultsAction.java
@@ -35,11 +35,11 @@ public final class GetSimulationResultsAction {
     this.simulationService = Objects.requireNonNull(simulationService);
   }
 
-  public Response run(final PlanId planId, final HasuraAction.Session session)
+  public Response run(final PlanId planId, final boolean forceResim, final HasuraAction.Session session)
   throws NoSuchPlanException, MissionModelService.NoSuchMissionModelException {
     final var revisionData = this.planService.getPlanRevisionData(planId);
 
-    final var response = this.simulationService.getSimulationResults(planId, revisionData, session.hasuraUserId());
+    final var response = this.simulationService.getSimulationResults(planId, forceResim, revisionData, session.hasuraUserId());
 
     if (response instanceof ResultsProtocol.State.Pending r) {
       return new Response.Pending(r.simulationDatasetId());

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationService.java
@@ -9,7 +9,7 @@ import gov.nasa.jpl.aerie.merlin.server.models.SimulationResultsHandle;
 import java.util.Optional;
 
 public interface SimulationService {
-  ResultsProtocol.State getSimulationResults(PlanId planId, RevisionData revisionData, final String requestedBy);
+  ResultsProtocol.State getSimulationResults(PlanId planId, final boolean forceResim, RevisionData revisionData, final String requestedBy);
 
   Optional<SimulationResultsHandle> get(PlanId planId, RevisionData revisionData);
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/UncachedSimulationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/UncachedSimulationService.java
@@ -14,7 +14,7 @@ public record UncachedSimulationService (
 ) implements SimulationService {
 
   @Override
-  public ResultsProtocol.State getSimulationResults(final PlanId planId, final RevisionData revisionData, final String requestedBy) {
+  public ResultsProtocol.State getSimulationResults(final PlanId planId, final boolean forceResim, final RevisionData revisionData, final String requestedBy) {
     if (!(revisionData instanceof InMemoryRevisionData inMemoryRevisionData)) {
       throw new Error("UncachedSimulationService only accepts InMemoryRevisionData");
     }
@@ -40,7 +40,7 @@ public record UncachedSimulationService (
   @Override
   public Optional<SimulationResultsHandle> get(final PlanId planId, final RevisionData revisionData) {
     return Optional.ofNullable(
-        getSimulationResults(planId, revisionData, null) instanceof ResultsProtocol.State.Success s ?
+        getSimulationResults(planId, false, revisionData, null) instanceof ResultsProtocol.State.Success s ?
             s.results() :
             null);
   }


### PR DESCRIPTION
* **Tickets addressed:** Closes #1317
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Adds a new optional parameter to the `Simulate` action, `force`. If this parameter is present and set to `true`, the backend will ignore any cached sim results that may satisfy request and create a new request, updating the revision of the sim config in order to avoid there existing two requests for the exact same revision sets.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
New tests were added to `Bindings` and `SimulationTests` exercising this new parameter.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
API Docs will need to be updated. PR to do so is open [here](https://github.com/NASA-AMMOS/aerie-docs/pull/134).

## Future work
<!-- What next steps can we anticipate from here, if any? -->
