### PR TITLE
Update env vars in `docker-compose.yml`s

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       MERLIN_DB_USER: "${AERIE_USERNAME}"
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
       MERLIN_PORT: 27183
+      ENABLE_CONTINUOUS_VALIDATION_THREAD: true
       JAVA_OPTS: >
         -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
         -Dorg.slf4j.simpleLogger.logFile=System.err
@@ -143,7 +144,6 @@ services:
     environment:
       ORIGIN: http://localhost
       PUBLIC_AERIE_FILE_STORE_PREFIX: "/usr/src/app/merlin_file_store/"
-      PUBLIC_LOGIN_PAGE: "enabled"
       PUBLIC_GATEWAY_CLIENT_URL: http://localhost:9000
       PUBLIC_GATEWAY_SERVER_URL: http://aerie_gateway:9000
       PUBLIC_HASURA_CLIENT_URL: http://localhost:8080/v1/graphql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,6 @@ services:
     environment:
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
       PUBLIC_AERIE_FILE_STORE_PREFIX: "/usr/src/app/merlin_file_store/"
-      PUBLIC_LOGIN_PAGE: "enabled"
       ORIGIN: http://localhost
       PUBLIC_GATEWAY_CLIENT_URL: http://localhost:9000
       PUBLIC_GATEWAY_SERVER_URL: http://aerie_gateway:9000

--- a/e2e-tests/docker-compose-many-workers.yml
+++ b/e2e-tests/docker-compose-many-workers.yml
@@ -104,7 +104,6 @@ services:
     environment:
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
       PUBLIC_AERIE_FILE_STORE_PREFIX: "/usr/src/app/merlin_file_store/"
-      PUBLIC_LOGIN_PAGE: "enabled"
       ORIGIN: http://localhost
       PUBLIC_GATEWAY_CLIENT_URL: http://localhost:9000
       PUBLIC_GATEWAY_SERVER_URL: http://aerie_gateway:9000


### PR DESCRIPTION
## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
`PUBLIC_LOGIN_PAGE` is no longer used in the UI.
`ENABLE_CONTINUOUS_VALIDATION_THREAD` should be enabled by default after https://github.com/NASA-AMMOS/aerie/issues/1333 is closed, but enabling it now should clear up some confusion.
## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Realizing that we have a _lot_ of places env vars can be set: several `docker-compose.yml` files within the Aerie repo (root, deployment, e2e-test, etc), `docker-compose.yml` files within example mission model repos, `.env` files, and `env:` within Github Actions.