### PR TITLE
Add @MaximumDuration annotation and use it in scheduling

### DIFF
--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/PeelBananaActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/PeelBananaActivity.java
@@ -5,6 +5,9 @@ import gov.nasa.jpl.aerie.contrib.metadata.Unit;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Parameter;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.HOURS;
 
 /**
  * Peel a banana, in preparation for consumption.
@@ -28,6 +31,9 @@ public final class PeelBananaActivity {
   @Parameter
   @Unit("direction")
   public PeelDirectionEnum peelDirection = PeelDirectionEnum.fromStem;
+
+  @ActivityType.MaximumDuration
+  public static final Duration DURATION_UPPER_BOUND = Duration.of(1, HOURS);
 
   @EffectModel
   public void run(final Mission mission) {

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -302,6 +302,32 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                     .addStatement("return result")
                     .build())
             .addMethod(MethodSpec
+                           .methodBuilder("getMaximumDurations")
+                           .addModifiers(Modifier.PUBLIC)
+                           .addAnnotation(Override.class)
+                           .returns(ParameterizedTypeName.get(Map.class, String.class, Duration.class))
+                           .addStatement("final var result = new $T()", ParameterizedTypeName.get(HashMap.class, String.class, Duration.class))
+                           .addCode(
+                               missionModel
+                                   .activityTypes()
+                                   .stream()
+                                   .filter(a -> a.effectModel().isPresent())
+                                   .filter(a -> a.effectModel().get().maximumDuration().isPresent())
+                                   .map(
+                                       activityTypeRecord ->
+                                           CodeBlock
+                                               .builder()
+                                               .addStatement("result.put(\"$L\", $L)",
+                                                             activityTypeRecord.name(),
+                                                             activityTypeRecord
+                                                                 .effectModel()
+                                                                 .map($ -> CodeBlock.of("$L.$L", activityTypeRecord.fullyQualifiedClass(), $.maximumDuration().get()))
+                                                                 .get()))
+                                   .reduce((x, y) -> x.add("$L", y.build()))
+                                   .orElse(CodeBlock.builder()).build())
+                           .addStatement("return result")
+                           .build())
+            .addMethod(MethodSpec
                            .methodBuilder("serializeDuration")
                            .addModifiers(Modifier.PUBLIC)
                            .addAnnotation(Override.class)

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
@@ -11,6 +11,7 @@ public record EffectModelRecord(
     Optional<TypeMirror> returnType,
     Optional<String> durationParameter,
     Optional<String> fixedDurationExpr,
-    Optional<String> parametricDuration
+    Optional<String> parametricDuration,
+    Optional<String> maximumDuration
 ) {
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/ActivityType.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/ActivityType.java
@@ -134,4 +134,57 @@ public @interface ActivityType {
   @Retention(RetentionPolicy.CLASS)
   @Target(ElementType.METHOD)
   @interface ParametricDuration {}
+
+  /**
+   * Use when the duration of an activity can be upper-bounded,
+   * Apply to either a static {@link Duration} field or a static no-arg method
+   * that returns {@link Duration}.
+   *
+   * This annotation can be used when the activity has an uncontrollable or parametric duration (see @ParametricDuration).
+   *
+   * Apply either like the following on a static field:
+   * <pre>{@code
+   * @ActivityType("Activity")
+   * public record Activity() {
+   *   @MaximumDuration
+   *   public static final Duration MAXIMUM_DURATION = Duration.HOUR;
+   *
+   *   @EffectModel
+   *   public void run(Mission mission) {
+   *     if(mission.resourceA.equals(true){
+   *       delay(MAXIMUM_DURATION)
+   *     } else{
+   *       delay(Duration.MINUTE);
+   *     }
+   *   }
+   * }
+   * }</pre>
+   *
+   * Or like the following on a static method:
+   *
+   * <pre>{@code
+   * @ActivityType("Activity")
+   * public record Activity() {
+   *   @MaximumDuration
+   *   public static Duration maximumDuration() {
+   *     return Duration.HOUR;
+   *   }
+   *
+   *   @EffectModel
+   *   public void run(Mission mission) {
+   *     if(mission.resourceA.equals(true){
+   *       delay(maximumDuration())
+   *     } else{
+   *       delay(Duration.MINUTE);
+   *     }
+   *   }
+   * }
+   * }</pre>
+   *
+   * This annotation is optional, but it is highly recommended if applicable. This annotation allows to perform less simulations.
+   *
+   */
+  @Retention(RetentionPolicy.CLASS)
+  @Target({ ElementType.FIELD, ElementType.METHOD })
+    @interface MaximumDuration {}
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/SchedulerModel.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/SchedulerModel.java
@@ -10,4 +10,5 @@ public interface SchedulerModel {
   Map<String, DurationType> getDurationTypes();
   SerializedValue serializeDuration(final Duration duration);
   Duration deserializeDuration(final SerializedValue serializedValue);
+  Map<String, Duration> getMaximumDurations();
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CardinalityGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CardinalityGoal.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.scheduler.conflicts.UnsatisfiableGoalConflict;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
@@ -123,7 +124,11 @@ public class CardinalityGoal extends ActivityTemplateGoal {
    * should probably be created!)
    */
   @Override
-  public Collection<Conflict> getConflicts(Plan plan, final SimulationResults simulationResults, final EvaluationEnvironment evaluationEnvironment) {
+  public Collection<Conflict> getConflicts(
+      final Plan plan,
+      final SimulationResults simulationResults,
+      final EvaluationEnvironment evaluationEnvironment,
+      final SchedulerModel schedulerModel) {
 
     //unwrap temporalContext
     final var windows = getTemporalContext().evaluate(simulationResults, evaluationEnvironment);

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Goal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Goal.java
@@ -7,6 +7,7 @@ import gov.nasa.jpl.aerie.constraints.time.Windows;
 import gov.nasa.jpl.aerie.constraints.tree.And;
 import gov.nasa.jpl.aerie.constraints.tree.Expression;
 import gov.nasa.jpl.aerie.constraints.tree.WindowsWrapperExpression;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.scheduler.conflicts.Conflict;
 import gov.nasa.jpl.aerie.scheduler.model.Plan;
@@ -287,8 +288,9 @@ public class Goal {
   public java.util.Collection<Conflict> getConflicts(
       Plan plan,
       final SimulationResults simulationResults,
-      final EvaluationEnvironment evaluationEnvironment
-  ) {
+      final EvaluationEnvironment evaluationEnvironment,
+      final SchedulerModel schedulerModel
+      ) {
     return java.util.Collections.emptyList();
   }
 

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/OptionGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/OptionGoal.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.scheduler.goals;
 
 import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.scheduler.conflicts.Conflict;
 import gov.nasa.jpl.aerie.scheduler.model.Plan;
 import gov.nasa.jpl.aerie.scheduler.solver.optimizers.Optimizer;
@@ -29,9 +30,11 @@ public class OptionGoal extends Goal {
   }
 
   @Override
-  public java.util.Collection<Conflict> getConflicts(Plan plan,
-                                                     final SimulationResults simulationResults,
-                                                     final EvaluationEnvironment evaluationEnvironment) {
+  public java.util.Collection<Conflict> getConflicts(
+      final Plan plan,
+      final SimulationResults simulationResults,
+      final EvaluationEnvironment evaluationEnvironment,
+      final SchedulerModel schedulerModel) {
     throw new NotImplementedException("Conflict detection is performed at solver level");
   }
 

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/ProceduralCreationGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/ProceduralCreationGoal.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.scheduler.goals;
 import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
 import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivityDirective;
 import gov.nasa.jpl.aerie.scheduler.conflicts.Conflict;
@@ -109,7 +110,11 @@ public class ProceduralCreationGoal extends ActivityExistentialGoal {
    * arguments must be identical.
    */
   @Override
-  public Collection<Conflict> getConflicts(Plan plan, final SimulationResults simulationResults, final EvaluationEnvironment evaluationEnvironment) {
+  public Collection<Conflict> getConflicts(
+      final Plan plan,
+      final SimulationResults simulationResults,
+      final EvaluationEnvironment evaluationEnvironment,
+      final SchedulerModel schedulerModel) {
     final var conflicts = new java.util.LinkedList<Conflict>();
 
     //run the generator to see what acts are still desired

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/RecurrenceGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/RecurrenceGoal.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.constraints.model.SimulationResults;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Windows;
+import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
 import gov.nasa.jpl.aerie.scheduler.constraints.activities.ActivityExpression;
@@ -109,7 +110,11 @@ public class RecurrenceGoal extends ActivityTemplateGoal {
    * probably be created!)
    */
   @Override
-  public java.util.Collection<Conflict> getConflicts(@NotNull Plan plan, final SimulationResults simulationResults, final EvaluationEnvironment evaluationEnvironment) {
+  public java.util.Collection<Conflict> getConflicts(
+      @NotNull final Plan plan,
+      final SimulationResults simulationResults,
+      final EvaluationEnvironment evaluationEnvironment,
+      final SchedulerModel schedulerModel) {
     final var conflicts = new java.util.LinkedList<Conflict>();
 
     //unwrap temporalContext
@@ -218,9 +223,6 @@ public class RecurrenceGoal extends ActivityTemplateGoal {
       final var windows = new Windows(false).set(Interval.betweenClosedOpen(intervalT.minus(recurrenceInterval.max), Duration.min(intervalT, end)), true);
       if(windows.iterateEqualTo(true).iterator().hasNext()){
         conflicts.add(new MissingActivityTemplateConflict(this, windows, this.getActTemplate(), evaluationEnvironment, 1, Optional.empty()));
-      }
-      else{
-        System.out.println();
       }
       if(intervalT.compareTo(end) >= 0){
         break;

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/stn/TaskNetworkAdapter.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/stn/TaskNetworkAdapter.java
@@ -3,11 +3,17 @@ package gov.nasa.jpl.aerie.scheduler.solver.stn;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Adapter for TaskNetwork for use with Interval and Duration
  */
 public class TaskNetworkAdapter {
+  private static final Logger logger = LoggerFactory.getLogger(TaskNetworkAdapter.class);
 
   private final TaskNetwork tw;
 
@@ -89,26 +95,37 @@ public class TaskNetworkAdapter {
     return toWin(pair.getLeft(), pair.getRight());
   }
 
-  public static TNActData solve(Interval start, Interval end, Interval dur, Interval enveloppe){
-    TaskNetwork tw = new TaskNetwork();
-    String actName = "ACT";
-    TaskNetworkAdapter tnw = new TaskNetworkAdapter(tw);
-    if(start!=null){
-      tnw.addStartInterval(actName, start.start, start.end);
+  public static Optional<TNActData> reduceActivityTemporalConstraints(
+      final Interval startInterval,
+      final Interval endInterval,
+      final Interval durationInterval,
+      final Collection<Interval> envelopes){
+    final TaskNetwork tw = new TaskNetwork();
+    final String actName = "ACT";
+    final TaskNetworkAdapter tnw = new TaskNetworkAdapter(tw);
+    tnw.addAct(actName);
+    if(startInterval != null){
+      tnw.addStartInterval(actName, startInterval.start, startInterval.end);
     }
-    if(end!=null){
-      tnw.addStartInterval(actName, end.start, end.end);
+    if(endInterval != null){
+      tnw.addEndInterval(actName, endInterval.start, endInterval.end);
     }
-    if(dur!=null){
-      tnw.addDurationInterval(actName, dur.start, dur.end);
+    if(durationInterval != null){
+      tnw.addDurationInterval(actName, durationInterval.start, durationInterval.end);
     }
-    if(enveloppe!=null){
-      tnw.addEnveloppe(actName, "ENV", enveloppe.start, enveloppe.end);
+    var i = 0;
+    for(final var enveloppe: envelopes){
+      tnw.addEnveloppe(actName, "ENV"+(i++), enveloppe.start, enveloppe.end);
     }
     if(tnw.solveConstraints()){
-      return tnw.getAllData(actName);
+      return Optional.of(tnw.getAllData(actName));
     } else{
-      return null;
+      logger.debug("Inconsistent static temporal constraints, cannot place activity in interval");
+      logger.debug("Start range " + startInterval);
+      logger.debug("End range " + endInterval);
+      logger.debug("Duration range " + durationInterval);
+      logger.debug("Envelopes: " + envelopes);
+      return Optional.empty();
     }
   }
 

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
@@ -1519,6 +1519,37 @@ public class SchedulingIntegrationTests {
     assertEquals(Duration.of(4, HOURS), growBanana.startOffset());
   }
 
+  private static List<ActivityDirective> onePickEveryTenMinutes(final Interval interval){
+    final var plan = new ArrayList<ActivityDirective>();
+    for(var cur = interval.start; cur.shorterThan(interval.end); cur = cur.plus(Duration.of(10, MINUTES))){
+      plan.add(new ActivityDirective(
+          cur,
+          "PickBanana",
+          Map.of("quantity", SerializedValue.of(100)),
+          null,
+          true));
+    }
+    return plan;
+  }
+
+  @Test
+  void testBigCoexistence(){
+    final var growBananaDuration = Duration.of(1, Duration.HOUR);
+    final var results = runScheduler(
+        BANANANATION,
+        onePickEveryTenMinutes(PLANNING_HORIZON.getHor()),
+        List.of(new SchedulingGoal(new GoalId(0L, 0L), """
+                export default (): Goal => {
+                 return Goal.CoexistenceGoal({
+                   activityTemplate: ActivityTemplates.PeelBanana({peelDirection: "fromStem"}),
+                   forEach: ActivityExpression.ofType(ActivityTypes.PickBanana),
+                   startsAt: TimingConstraint.singleton(WindowProperty.START)
+                 })
+               }""", true)),
+        PLANNING_HORIZON);
+    assertEquals(1152, results.updatedPlan().size());
+  }
+
   @Test
   void testNotEqualTo_satisfied() {
     // Initial plant count is 200 in default configuration


### PR DESCRIPTION
* **Tickets addressed:** Resolves #1172 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
An optional `@MaximumDuration` mission model annotation has been added. This annotation can be used in conjunction of @ParametricDuration and @UncontrollableDuration to signify the maximum duration that an activity 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I have verified that the domain of coexistence goal was actually cut. I have added a test with a coexistence goal that inserts a lot of coexisting activities and noticed a difference between the use of the maximum duration bounding and no use. 
The gain with this test is not significant yet (15-20%) because the simulation domain is dominated by simulation to get child activities. With changes proposed in #1364 related to dependency analysis, we would be able to bypass this step if new activities do no produce child activities. Then this change will have a significant effect on the runtime of`CoexistenceGoal` and rootfinding. Indeed, with future user option (in #1364) to bypass rootfinding when placing activities, knowing the maximum duration of an activity allows to place it without violating temporal constraints. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Code documentation has been added for the annotation. User documentation has to be done. 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Changes in #1364. 