### PR TITLE
Add @AllChildren annotation

### DIFF
--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/DecomposingActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/DecomposingActivity.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.banananation.activities;
 import gov.nasa.jpl.aerie.banananation.Mission;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.AllChildren;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Parameter;
 
 import static gov.nasa.jpl.aerie.banananation.generated.ActivityActions.call;
@@ -15,6 +16,7 @@ public final class DecomposingActivity {
     @Parameter
     public String label = "unlabeled";
 
+    @AllChildren(children = {"child"})
     @EffectModel
     public void run(final Mission mission) {
       call(mission, new ChildActivity(1));
@@ -34,6 +36,7 @@ public final class DecomposingActivity {
       this.counter = counter;
     }
 
+    @ActivityType.AllChildren(children = {"grandchild"})
     @EffectModel
     public void run(final Mission mission) {
       call(mission, new GrandchildActivity(1));
@@ -54,6 +57,7 @@ public final class DecomposingActivity {
     }
 
     @EffectModel
+    @AllChildren(children = {})
     public void run(final Mission mission) {
       delay(6*24, HOURS);
     }

--- a/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/DecomposingSpawnActivity.java
+++ b/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/DecomposingSpawnActivity.java
@@ -6,8 +6,7 @@ import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType.EffectModel;
 import gov.nasa.jpl.aerie.merlin.framework.annotations.Export.Parameter;
 
 import static gov.nasa.jpl.aerie.banananation.generated.ActivityActions.spawn;
-import static gov.nasa.jpl.aerie.banananation.generated.ActivityActions.call;
-import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.*;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECOND;
 
 public final class DecomposingSpawnActivity {

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/metamodel/EffectModelRecord.java
@@ -11,6 +11,7 @@ public record EffectModelRecord(
     Optional<TypeMirror> returnType,
     Optional<String> durationParameter,
     Optional<String> fixedDurationExpr,
-    Optional<String> parametricDuration
+    Optional<String> parametricDuration,
+    Optional<String[]> children
 ) {
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/ActivityType.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/annotations/ActivityType.java
@@ -134,4 +134,10 @@ public @interface ActivityType {
   @Retention(RetentionPolicy.CLASS)
   @Target(ElementType.METHOD)
   @interface ParametricDuration {}
+
+  @Retention(RetentionPolicy.CLASS)
+  @Target(ElementType.METHOD)
+  @interface AllChildren {
+    String[] children();
+  }
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/SchedulerModel.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/SchedulerModel.java
@@ -4,10 +4,12 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.DurationType;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
+import java.util.List;
 import java.util.Map;
 
 public interface SchedulerModel {
   Map<String, DurationType> getDurationTypes();
   SerializedValue serializeDuration(final Duration duration);
   Duration deserializeDuration(final SerializedValue serializedValue);
+  Map<String, List<String>> getChildren();
 }

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/AllChildrenTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/AllChildrenTest.java
@@ -1,0 +1,29 @@
+package gov.nasa.jpl.aerie.scheduler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AllChildrenTest {
+  @Test
+  public void testAllChildrenAnnotation(){
+    final var bananaSchedulerModel = SimulationUtility.getBananaSchedulerModel();
+    final var children = bananaSchedulerModel.getChildren();
+    final var bananaMissionModel = SimulationUtility.getBananaMissionModel();
+    final var allActivityTypes = bananaMissionModel.getDirectiveTypes().directiveTypes().keySet();
+    //there is one key per activity type in the children map
+    allActivityTypes.forEach(at -> assertTrue(children.containsKey(at)));
+    //the only declared child of parent is the one present in the children map
+    assertEquals(List.of("child"), children.get("parent"));
+    //the declared absence of children of grandchild is reported in the children map
+    assertEquals(List.of(), children.get("grandchild"));
+    //an activity without effect model does not have any children
+    assertEquals(List.of(), children.get("ParameterTest"));
+    //an activity with an effect model but with no @AllChildren annotation will result in all activity types of the mission model being reported as its potential children
+    assertEquals(new HashSet<>(allActivityTypes.stream().toList()), new HashSet<>(children.get("BiteBanana")));
+  }
+}


### PR DESCRIPTION
* **Tickets addressed:** Part of #1364 but does not resolve it
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Add a `@AllChildren` annotation to mission model so mission modelers can report, for a given activity, what other activity is called/spawned. This information will be used by the scheduler to evaluate whether it is useful to resimulate or not before goal evaluation: let's have G goal being satisfied by an activity of type A, G is the next goal to be evaluated. If an activity of type B was inserted at the last iteration, has B any chance of generating A and thus of satisfying the goal G ? If yes, simulation is required, otherwise it's not (for that only purpose, there might be other things that warrant a simulation, e.g. the goal needs to also evaluate an expression...).

Some edge cases:
- If the user does not use the annotation for an activity, we make the worst case assumption that the activity might generate all activities (itself included). 
- Activities without effect model cannot generate children 

This PR does not contain changed to the scheduler to use this information. These changes would overlap too much  with changes under review in #1323 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
A test with the banananation model has been added to verify that the generated code is accurate.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
To be done.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Other things in #1364 + use the annotation in the scheduler.