### PR TITLE
Enable continuous validation thread by default

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -35,7 +35,6 @@ services:
       MERLIN_DB_USER: "${AERIE_USERNAME}"
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
       MERLIN_PORT: 27183
-      ENABLE_CONTINUOUS_VALIDATION_THREAD: true
       JAVA_OPTS: >
         -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
         -Dorg.slf4j.simpleLogger.logFile=System.err

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,6 @@ services:
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
       UNTRUE_PLAN_START: "2000-01-01T11:58:55.816Z"
-      ENABLE_CONTINUOUS_VALIDATION_THREAD: true
     image: aerie_merlin
     ports: ["27183:27183", "5005:5005"]
     restart: always

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -46,7 +46,6 @@ services:
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
       UNTRUE_PLAN_START: '2000-01-01T11:58:55.816Z'
-      ENABLE_CONTINUOUS_VALIDATION_THREAD: true
     image: aerie_merlin
     ports: ['27183:27183', '5005:5005']
     restart: always

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
@@ -180,7 +180,7 @@ public final class AerieAppDriver {
         Instant.parse(getEnv("UNTRUE_PLAN_START", "")),
         URI.create(getEnv("HASURA_GRAPHQL_URL", "http://localhost:8080/v1/graphql")),
         getEnv("HASURA_GRAPHQL_ADMIN_SECRET", ""),
-        Boolean.parseBoolean(getEnv("ENABLE_CONTINUOUS_VALIDATION_THREAD", "false")),
+        Boolean.parseBoolean(getEnv("ENABLE_CONTINUOUS_VALIDATION_THREAD", "true")),
         Integer.parseInt(getEnv("VALIDATION_THREAD_POLLING_PERIOD", "500"))
     );
   }


### PR DESCRIPTION
* **Tickets addressed:** closes #1333 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
s/false/true

Additionally, I removed this env var from the `docker-compose.yml` files, to avoid cluttering these files with an env var that will very likely never change from the default.

# Future work
Could be nice to clean up / consolidate all non-default env vars we set into a single `.env` that [`docker compose` could source](https://docs.docker.com/compose/environment-variables/set-environment-variables/#use-the-env_file-attribute)