### PR TITLE
Enable tighter attribution of exceptions to spans

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModel.java
@@ -5,6 +5,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.model.OutputType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Resource;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
@@ -55,7 +56,7 @@ public final class MissionModel<Model> {
 
   public TaskFactory<Unit> getDaemon() {
     return executor -> scheduler -> {
-      MissionModel.this.daemons.forEach(scheduler::spawn);
+      MissionModel.this.daemons.forEach($ -> scheduler.spawn(InSpan.Fresh, $));
       return TaskStatus.completed(Unit.UNIT);
     };
   }

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
@@ -6,6 +6,7 @@ import gov.nasa.jpl.aerie.merlin.driver.timeline.TemporalEventSource;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
@@ -232,17 +233,15 @@ public final class SimulationDriver {
   )
   {
     // Emit the current activity (defined by directiveId)
-    return executor -> scheduler0 -> TaskStatus.calling((TaskFactory<Output>) (executor1 -> scheduler1 -> {
-      scheduler1.pushSpan();
+    return executor -> scheduler0 -> TaskStatus.calling(InSpan.Fresh, (TaskFactory<Output>) (executor1 -> scheduler1 -> {
       scheduler1.emit(directiveId, activityTopic);
       return task.create(executor1).step(scheduler1);
     }), scheduler2 -> {
-      scheduler2.popSpan();
       // When the current activity finishes, get the list of the activities that needed this activity to finish to know their start time
       final List<Pair<ActivityDirectiveId, Duration>> dependents = resolved.get(directiveId) == null ? List.of() : resolved.get(directiveId);
       // Iterate over the dependents
       for (final var dependent : dependents) {
-        scheduler2.spawn(executor2 -> scheduler3 ->
+        scheduler2.spawn(InSpan.Parent, executor2 -> scheduler3 ->
             // Delay until the dependent starts
             TaskStatus.delayed(dependent.getRight(), scheduler4 -> {
               final var dependentDirectiveId = dependent.getLeft();
@@ -260,7 +259,7 @@ public final class SimulationDriver {
 
               // Schedule the dependent
               // When it finishes, it will schedule the activities depending on it to know their start time
-              scheduler4.spawn(makeTaskFactory(
+              scheduler4.spawn(InSpan.Parent, makeTaskFactory(
                   dependentDirectiveId,
                   dependantTask,
                   schedule,

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -516,7 +516,7 @@ public final class SimulationEngine implements AutoCloseable {
             state.endOffset().get().minus(state.startOffset()),
             spanToSimulatedActivityId.get(activityParents.get(span)),
             activityChildren.getOrDefault(span, Collections.emptyList()).stream().map(spanToSimulatedActivityId::get).toList(),
-            (activityParents.containsKey(span)) ? Optional.empty() : Optional.of(directiveId),
+            (activityParents.containsKey(span)) ? Optional.empty() : Optional.ofNullable(directiveId),
             outputAttributes
         ));
       } else {

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -21,6 +21,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.Resource;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
@@ -36,8 +37,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -88,7 +87,7 @@ public final class SimulationEngine implements AutoCloseable {
 
     final var task = TaskId.generate();
     this.spanContributorCount.put(span, new MutableInt(1));
-    this.tasks.put(task, new ExecutionState<>(span, 0, Optional.empty(), state.create(this.executor)));
+    this.tasks.put(task, new ExecutionState<>(span, Optional.empty(), state.create(this.executor)));
     this.scheduledJobs.schedule(JobId.forTask(task), SubInstant.Tasks.at(startTime));
 
     return span;
@@ -191,7 +190,7 @@ public final class SimulationEngine implements AutoCloseable {
       final Duration currentTime
   ) {
     // Step the modeling state forward.
-    final var scheduler = new EngineScheduler(currentTime, progress.shadowedSpans(), progress.span(), progress.caller(), frame);
+    final var scheduler = new EngineScheduler(currentTime, progress.span(), progress.caller(), frame);
     final var status = progress.state().step(scheduler);
 
     // TODO: Report which topics this activity wrote to at this point in time. This is useful insight for any user.
@@ -223,27 +222,45 @@ public final class SimulationEngine implements AutoCloseable {
             }
           });
         }
+
         case TaskStatus.Delayed<Output> s -> {
           if (s.delay().isNegative()) throw new IllegalArgumentException("Cannot schedule a task in the past");
 
-          this.tasks.put(task, progress.continueWith(scheduler.span, scheduler.shadowedSpans, s.continuation()));
+          this.tasks.put(task, progress.continueWith(s.continuation()));
           this.scheduledJobs.schedule(JobId.forTask(task), SubInstant.Tasks.at(currentTime.plus(s.delay())));
         }
-        case TaskStatus.CallingTask<Output> s -> {
-          final var target = TaskId.generate();
-          SimulationEngine.this.spanContributorCount.get(scheduler.span).increment();
-          SimulationEngine.this.tasks.put(target, new ExecutionState<>(scheduler.span, 0, Optional.of(task), s.child().create(this.executor)));
-          SimulationEngine.this.blockedTasks.put(task, new MutableInt(1));
-          frame.signal(JobId.forTask(target));
 
-          this.tasks.put(task, progress.continueWith(scheduler.span, scheduler.shadowedSpans, s.continuation()));
+        case TaskStatus.CallingTask<Output> s -> {
+          // Prepare a span for the child task.
+          final var childSpan = switch (s.childSpan()) {
+            case Parent ->
+              scheduler.span;
+
+            case Fresh -> {
+              final var freshSpan = SpanId.generate();
+              SimulationEngine.this.spans.put(freshSpan, new Span(Optional.of(scheduler.span), currentTime, Optional.empty()));
+              SimulationEngine.this.spanContributorCount.put(freshSpan, new MutableInt(1));
+              yield freshSpan;
+            }
+          };
+
+          // Spawn the child task.
+          final var childTask = TaskId.generate();
+          SimulationEngine.this.spanContributorCount.get(scheduler.span).increment();
+          SimulationEngine.this.tasks.put(childTask, new ExecutionState<>(childSpan, Optional.of(task), s.child().create(this.executor)));
+          frame.signal(JobId.forTask(childTask));
+
+          // Arrange for the parent task to resume.... later.
+          SimulationEngine.this.blockedTasks.put(task, new MutableInt(1));
+          this.tasks.put(task, progress.continueWith(s.continuation()));
         }
+
         case TaskStatus.AwaitingCondition<Output> s -> {
           final var condition = ConditionId.generate();
           this.conditions.put(condition, s.condition());
           this.scheduledJobs.schedule(JobId.forCondition(condition), SubInstant.Conditions.at(currentTime));
 
-          this.tasks.put(task, progress.continueWith(scheduler.span, scheduler.shadowedSpans, s.continuation()));
+          this.tasks.put(task, progress.continueWith(s.continuation()));
           this.waitingTasks.put(condition, task);
         }
       }
@@ -447,17 +464,15 @@ public final class SimulationEngine implements AutoCloseable {
     engine.spans.forEach((span, state) -> {
       if (!spanInfo.isActivity(span)) return;
 
+      if (spanInfo.isDirective(span)) activityDirectiveIds.put(span, spanInfo.getDirective(span));
+
       var parent = state.parent();
-      while (parent.isPresent() && !spanInfo.isActivity(parent.get()) && !spanInfo.isDirective(parent.get())) {
+      while (parent.isPresent() && !spanInfo.isActivity(parent.get())) {
         parent = engine.spans.get(parent.get()).parent();
       }
 
       if (parent.isPresent()) {
-        if (spanInfo.isActivity(parent.get())) {
-          activityParents.put(span, parent.get());
-        } else if (spanInfo.isDirective(parent.get())) {
-          activityDirectiveIds.put(span, spanInfo.getDirective(parent.get()));
-        }
+        activityParents.put(span, parent.get());
       }
     });
 
@@ -651,20 +666,17 @@ public final class SimulationEngine implements AutoCloseable {
   /** A handle for processing requests and effects from a modeled task. */
   private final class EngineScheduler implements Scheduler {
     private final Duration currentTime;
-    private int shadowedSpans;
-    private SpanId span;
+    private final SpanId span;
     private final Optional<TaskId> caller;
     private final TaskFrame<JobId> frame;
 
     public EngineScheduler(
         final Duration currentTime,
-        final int shadowedSpans,
         final SpanId span,
         final Optional<TaskId> caller,
         final TaskFrame<JobId> frame)
     {
       this.currentTime = Objects.requireNonNull(currentTime);
-      this.shadowedSpans = shadowedSpans;
       this.span = Objects.requireNonNull(span);
       this.caller = Objects.requireNonNull(caller);
       this.frame = Objects.requireNonNull(frame);
@@ -691,45 +703,26 @@ public final class SimulationEngine implements AutoCloseable {
     }
 
     @Override
-    public void spawn(final TaskFactory<?> state) {
-      final var task = TaskId.generate();
+    public void spawn(final InSpan inSpan, final TaskFactory<?> state) {
+      // Prepare a span for the child task
+      final var childSpan = switch (inSpan) {
+        case Parent ->
+          this.span;
+
+        case Fresh -> {
+          final var freshSpan = SpanId.generate();
+          SimulationEngine.this.spans.put(freshSpan, new Span(Optional.of(this.span), currentTime, Optional.empty()));
+          SimulationEngine.this.spanContributorCount.put(freshSpan, new MutableInt(1));
+          yield freshSpan;
+        }
+      };
+
+      final var childTask = TaskId.generate();
       SimulationEngine.this.spanContributorCount.get(this.span).increment();
-      SimulationEngine.this.tasks.put(task, new ExecutionState<>(this.span, 0, this.caller, state.create(SimulationEngine.this.executor)));
+      SimulationEngine.this.tasks.put(childTask, new ExecutionState<>(childSpan, this.caller, state.create(SimulationEngine.this.executor)));
+      this.frame.signal(JobId.forTask(childTask));
+
       this.caller.ifPresent($ -> SimulationEngine.this.blockedTasks.get($).increment());
-      this.frame.signal(JobId.forTask(task));
-    }
-
-    @Override
-    public void pushSpan() {
-      final var parentSpan = this.span;
-      this.shadowedSpans += 1;
-      this.span = SpanId.generate();
-
-      SimulationEngine.this.spans.put(this.span, new Span(Optional.of(parentSpan), this.currentTime, Optional.empty()));
-      SimulationEngine.this.spanContributorCount.put(this.span, new MutableInt(1));
-    }
-
-    @Override
-    public void popSpan() {
-      // TODO: Do we want to throw an error instead?
-      if (this.shadowedSpans == 0) return;
-      final SpanId parentSpan = SimulationEngine.this.spans.get(this.span).parent().orElseThrow();
-
-      if (SimulationEngine.this.spanContributorCount.get(this.span).decrementAndGet() == 0) {
-        SimulationEngine.this.spanContributorCount.remove(this.span);
-        SimulationEngine.this.spans.compute(this.span, (_id, $) -> $.close(currentTime));
-        // Parent span contributor count remains constant, because this.span is removed, and this task is added
-      } else {
-        // Parent span contributor count increases by one, because this task is added without removing this.span
-        SimulationEngine.this.spanContributorCount.get(parentSpan).increment();
-      }
-
-      // NOTE: We don't need to propagate completion any further, because the next shadowed span
-      // has by definition not been completed: this task may still contribute to it, and this task
-      // has not terminated.
-
-      this.shadowedSpans -= 1;
-      this.span = parentSpan;
     }
   }
 
@@ -765,9 +758,9 @@ public final class SimulationEngine implements AutoCloseable {
   }
 
   /** The state of an executing task. */
-  private record ExecutionState<Output>(SpanId span, int shadowedSpans, Optional<TaskId> caller, Task<Output> state) {
-    public ExecutionState<Output> continueWith(final SpanId span, final int shadowedSpans, final Task<Output> newState) {
-      return new ExecutionState<>(span, shadowedSpans, this.caller, newState);
+  private record ExecutionState<Output>(SpanId span, Optional<TaskId> caller, Task<Output> state) {
+    public ExecutionState<Output> continueWith(final Task<Output> newState) {
+      return new ExecutionState<>(this.span, this.caller, newState);
     }
   }
 

--- a/merlin-driver/src/test/java/gov/nasa/jpl/aerie/merlin/driver/AnchorSimulationTest.java
+++ b/merlin-driver/src/test/java/gov/nasa/jpl/aerie/merlin/driver/AnchorSimulationTest.java
@@ -9,6 +9,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.ModelType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.OutputType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
@@ -1083,7 +1084,6 @@ public final class AnchorSimulationTest {
       @Override
       public TaskFactory<Object> getTaskFactory(final Object o, final Object o2) {
         return executor -> $ -> {
-          $.pushSpan();
           $.emit(this, delayedActivityDirectiveInputTopic);
           return TaskStatus.delayed(oneMinute, $$ -> {
             $$.emit(Unit.UNIT, delayedActivityDirectiveOutputTopic);
@@ -1109,20 +1109,19 @@ public final class AnchorSimulationTest {
       @Override
       public TaskFactory<Object> getTaskFactory(final Object o, final Object o2) {
         return executor -> scheduler -> {
-          scheduler.pushSpan();
           scheduler.emit(this, decomposingActivityDirectiveInputTopic);
           return TaskStatus.delayed(
               Duration.ZERO,
               $ -> {
                 try {
-                  $.spawn(delayedActivityDirective.getTaskFactory(null, null));
+                  $.spawn(InSpan.Fresh, delayedActivityDirective.getTaskFactory(null, null));
                 } catch (final InstantiationException ex) {
                   throw new Error("Unexpected state: activity instantiation of DelayedActivityDirective failed with: %s".formatted(
                       ex.toString()));
                 }
                 return TaskStatus.delayed(Duration.of(120, Duration.SECOND), $$ -> {
                   try {
-                    $$.spawn(delayedActivityDirective.getTaskFactory(null, null));
+                    $$.spawn(InSpan.Fresh, delayedActivityDirective.getTaskFactory(null, null));
                   } catch (final InstantiationException ex) {
                     throw new Error(
                         "Unexpected state: activity instantiation of DelayedActivityDirective failed with: %s".formatted(

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/generator/MissionModelGenerator.java
@@ -376,7 +376,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                     missionModel.getTypesName(),
                                     entry.inputType().mapper().name.canonicalName().replace(".", "_"))
                                 .addStatement(
-                                    "$T.spawn($L.getTaskFactory($L, $L))",
+                                    "$T.spawnWithSpan($L.getTaskFactory($L, $L))",
                                     gov.nasa.jpl.aerie.merlin.framework.ModelActions.class,
                                     "mapper",
                                     "model",
@@ -403,7 +403,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                     missionModel.getTypesName(),
                                     entry.inputType().mapper().name.canonicalName().replace(".", "_"))
                                 .addStatement(
-                                    "$T.defer($L, $L.getTaskFactory($L, $L))",
+                                    "$T.deferWithSpan($L, $L.getTaskFactory($L, $L))",
                                     gov.nasa.jpl.aerie.merlin.framework.ModelActions.class,
                                     "duration",
                                     "mapper",
@@ -459,7 +459,7 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                                     missionModel.getTypesName(),
                                     entry.inputType().mapper().name.canonicalName().replace(".", "_"))
                                 .addStatement(
-                                    "$T.call($L.getTaskFactory($L, $L))",
+                                    "$T.callWithSpan($L.getTaskFactory($L, $L))",
                                     gov.nasa.jpl.aerie.merlin.framework.ModelActions.class,
                                     "mapper",
                                     "model",
@@ -808,14 +808,12 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                         .map(effectModel -> CodeBlock
                             .builder()
                             .add(
-                                "return $T.$L(() -> $T.$L(() -> {$>\n$L$<}));\n",
+                                "return $T.$L(() -> {$>\n$L$<});\n",
                                 ModelActions.class,
                                 switch (effectModel.executor()) {
                                   case Threaded -> "threaded";
                                   case Replaying -> "replaying";
                                 },
-                                ModelActions.class,
-                                "scoped",
                                 effectModel.returnType()
                                     .map(returnType -> CodeBlock
                                         .builder()
@@ -837,7 +835,6 @@ public record MissionModelGenerator(Elements elementUtils, Types typeUtils, Mess
                             .add(
                                 "return executor -> scheduler -> {$>\n$L$<};\n",
                                 CodeBlock.builder()
-                                    .addStatement("scheduler.pushSpan()")
                                     .addStatement("scheduler.emit($L, this.$L)", "activity", "inputTopic")
                                     .addStatement("scheduler.emit($T.UNIT, this.$L)", Unit.class, "outputTopic")
                                     .addStatement("return $T.completed($T.UNIT)", TaskStatus.class, Unit.class)

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Context.java
@@ -5,6 +5,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.model.CellType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 
 import java.util.function.Function;
 
@@ -29,10 +30,8 @@ public interface Context {
   // Usable during simulation
   <Event> void emit(Event event, Topic<Event> topic);
 
-  void spawn(TaskFactory<?> task);
-  <Return> void call(TaskFactory<Return> task);
-  void pushSpan();
-  void popSpan();
+  void spawn(InSpan inSpan, TaskFactory<?> task);
+  <Return> void call(InSpan inSpan, TaskFactory<Return> task);
 
   void delay(Duration duration);
   void waitUntil(Condition condition);

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/InitializationContext.java
@@ -6,6 +6,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.model.CellType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 
 import java.util.Objects;
 import java.util.function.Function;
@@ -52,23 +53,15 @@ public final class InitializationContext implements Context {
   }
 
   @Override
-  public void spawn(final TaskFactory<?> task) {
+  public void spawn(final InSpan _inSpan, final TaskFactory<?> task) {
+    // As top-level tasks, daemons always get their own span.
+    // TODO: maybe produce a warning if inSpan is not Fresh in initialization context
     this.builder.daemon(task);
   }
 
   @Override
-  public <Return> void call(final TaskFactory<Return> task) {
+  public <Return> void call(final InSpan inSpan, final TaskFactory<Return> task) {
     throw new IllegalStateException("Cannot yield during initialization");
-  }
-
-  @Override
-  public void pushSpan() {
-    // Do nothing.
-  }
-
-  @Override
-  public void popSpan() {
-    // Do nothing.
   }
 
   @Override

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ModelActions.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.framework;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
 
 import java.util.function.Supplier;
@@ -36,22 +37,6 @@ public /*non-final*/ class ModelActions {
     });
   }
 
-  public static <T> T scoped(final Supplier<T> block) {
-    context.get().pushSpan();
-    try {
-      return block.get();
-    } finally {
-      context.get().popSpan();
-    }
-  }
-
-  public static void scoped(final Runnable block) {
-    scoped(() -> {
-      block.run();
-      return Unit.UNIT;
-    });
-  }
-
 
   public static <T> void emit(final T event, final Topic<T> topic) {
     context.get().emit(event, topic);
@@ -70,7 +55,7 @@ public /*non-final*/ class ModelActions {
   }
 
   public static <T> void spawn(final TaskFactory<T> task) {
-    context.get().spawn(task);
+    context.get().spawn(InSpan.Parent, task);
   }
 
   public static void call(final Runnable task) {
@@ -82,7 +67,35 @@ public /*non-final*/ class ModelActions {
   }
 
   public static <T> void call(final TaskFactory<T> task) {
-    context.get().call(task);
+    context.get().call(InSpan.Parent, task);
+  }
+
+
+  public static <T> void spawnWithSpan(final Supplier<T> task) {
+    spawnWithSpan(threaded(task));
+  }
+
+  public static void spawnWithSpan(final Runnable task) {
+    spawnWithSpan(() -> {
+      task.run();
+      return Unit.UNIT;
+    });
+  }
+
+  public static <T> void spawnWithSpan(final TaskFactory<T> task) {
+    context.get().spawn(InSpan.Fresh, task);
+  }
+
+  public static void callWithSpan(final Runnable task) {
+    callWithSpan(threaded(task));
+  }
+
+  public static <T> void callWithSpan(final Supplier<T> task) {
+    callWithSpan(threaded(task));
+  }
+
+  public static <T> void callWithSpan(final TaskFactory<T> task) {
+    context.get().call(InSpan.Fresh, task);
   }
 
   public static void defer(final Duration duration, final Runnable task) {
@@ -99,6 +112,22 @@ public /*non-final*/ class ModelActions {
 
   public static void defer(final long quantity, final Duration unit, final TaskFactory<?> task) {
     spawn(replaying(() -> { delay(quantity, unit); spawn(task); }));
+  }
+
+  public static void deferWithSpan(final Duration duration, final Runnable task) {
+    spawn(replaying(() -> { delay(duration); spawnWithSpan(task); }));
+  }
+
+  public static void deferWithSpan(final Duration duration, final TaskFactory<?> task) {
+    spawn(replaying(() -> { delay(duration); spawnWithSpan(task); }));
+  }
+
+  public static void deferWithSpan(final long quantity, final Duration unit, final Runnable task) {
+    spawn(replaying(() -> { delay(quantity, unit); spawnWithSpan(task); }));
+  }
+
+  public static void deferWithSpan(final long quantity, final Duration unit, final TaskFactory<?> task) {
+    spawn(replaying(() -> { delay(quantity, unit); spawnWithSpan(task); }));
   }
 
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/QueryContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/QueryContext.java
@@ -6,6 +6,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.model.CellType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 
 import java.util.function.Function;
 
@@ -43,23 +44,13 @@ public final class QueryContext implements Context {
   }
 
   @Override
-  public void spawn(final TaskFactory<?> task) {
+  public void spawn(final InSpan inSpan, final TaskFactory<?> task) {
     throw new IllegalStateException("Cannot schedule tasks in a query-only context");
   }
 
   @Override
-  public <Return> void call(final TaskFactory<Return> task) {
+  public <Return> void call(final InSpan inSpan, final TaskFactory<Return> task) {
     throw new IllegalStateException("Cannot schedule tasks in a query-only context");
-  }
-
-  @Override
-  public void pushSpan() {
-    // Do nothing.
-  }
-
-  @Override
-  public void popSpan() {
-    // Do nothing.
   }
 
   @Override

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingReactionContext.java
@@ -6,6 +6,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.model.CellType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 import org.apache.commons.lang3.mutable.MutableInt;
 
 import java.util.List;
@@ -64,31 +65,17 @@ final class ReplayingReactionContext implements Context {
   }
 
   @Override
-  public void spawn(final TaskFactory<?> task) {
+  public void spawn(final InSpan inSpan, final TaskFactory<?> task) {
     this.memory.doOnce(() -> {
-      this.scheduler.spawn(task);
+      this.scheduler.spawn(inSpan, task);
     });
   }
 
   @Override
-  public <T> void call(final TaskFactory<T> task) {
+  public <T> void call(final InSpan inSpan, final TaskFactory<T> task) {
     this.memory.doOnce(() -> {
       this.scheduler = null;  // Relinquish the current scheduler before yielding, in case an exception is thrown.
-      this.scheduler = this.handle.call(task);
-    });
-  }
-
-  @Override
-  public void pushSpan() {
-    this.memory.doOnce(() -> {
-      this.scheduler.pushSpan();
-    });
-  }
-
-  @Override
-  public void popSpan() {
-    this.memory.doOnce(() -> {
-      this.scheduler.popSpan();
+      this.scheduler = this.handle.call(inSpan, task);
     });
   }
 

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ReplayingTask.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 import org.apache.commons.lang3.mutable.MutableInt;
 
@@ -52,8 +53,8 @@ public final class ReplayingTask<Return> implements Task<Return> {
     }
 
     @Override
-    public Scheduler call(final TaskFactory<?> child) {
-      return this.yield(TaskStatus.calling(child, ReplayingTask.this));
+    public Scheduler call(final InSpan inSpan, final TaskFactory<?> child) {
+      return this.yield(TaskStatus.calling(inSpan, child, ReplayingTask.this));
     }
 
     @Override

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/TaskHandle.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/TaskHandle.java
@@ -3,11 +3,12 @@ package gov.nasa.jpl.aerie.merlin.framework;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 
 public interface TaskHandle {
   Scheduler delay(Duration delay);
 
-  Scheduler call(TaskFactory<?> child);
+  Scheduler call(InSpan inSpan, TaskFactory<?> child);
 
   Scheduler await(gov.nasa.jpl.aerie.merlin.protocol.model.Condition condition);
 }

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedReactionContext.java
@@ -6,6 +6,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.model.CellType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 
 import java.util.Objects;
 import java.util.function.Function;
@@ -53,24 +54,14 @@ final class ThreadedReactionContext implements Context {
   }
 
   @Override
-  public void spawn(final TaskFactory<?> task) {
-    this.scheduler.spawn(task);
+  public void spawn(final InSpan inSpan, final TaskFactory<?> task) {
+    this.scheduler.spawn(inSpan, task);
   }
 
   @Override
-  public <T> void call(final TaskFactory<T> task) {
+  public <T> void call(final InSpan inSpan, final TaskFactory<T> task) {
     this.scheduler = null;  // Relinquish the current scheduler before yielding, in case an exception is thrown.
-    this.scheduler = this.handle.call(task);
-  }
-
-  @Override
-  public void pushSpan() {
-    this.scheduler.pushSpan();
-  }
-
-  @Override
-  public void popSpan() {
-    this.scheduler.popSpan();
+    this.scheduler = this.handle.call(inSpan, task);
   }
 
   @Override

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTask.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTask.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.model.Task;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
 
 import java.util.Objects;
@@ -203,8 +204,8 @@ public final class ThreadedTask<Return> implements Task<Return> {
     }
 
     @Override
-    public Scheduler call(final TaskFactory<?> child) {
-      return this.yield(TaskStatus.calling(child, ThreadedTask.this));
+    public Scheduler call(final InSpan inSpan, final TaskFactory<?> child) {
+      return this.yield(TaskStatus.calling(inSpan, child, ThreadedTask.this));
     }
 
     @Override

--- a/merlin-framework/src/test/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTaskTest.java
+++ b/merlin-framework/src/test/java/gov/nasa/jpl/aerie/merlin/framework/ThreadedTaskTest.java
@@ -4,6 +4,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.driver.CellId;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -28,17 +29,7 @@ public final class ThreadedTaskTest {
       }
 
       @Override
-      public void spawn(final TaskFactory<?> task) {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public void pushSpan() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public void popSpan() {
+      public void spawn(final InSpan inSpan, final TaskFactory<?> task) {
         throw new UnsupportedOperationException();
       }
     };

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Scheduler.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/driver/Scheduler.java
@@ -1,15 +1,12 @@
 package gov.nasa.jpl.aerie.merlin.protocol.driver;
 
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 
 public interface Scheduler {
   <State> State get(CellId<State> cellId);
 
   <Event> void emit(Event event, Topic<Event> topic);
 
-  void spawn(TaskFactory<?> task);
-
-  void pushSpan();
-
-  void popSpan();
+  void spawn(InSpan taskSpan, TaskFactory<?> task);
 }

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/InSpan.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/InSpan.java
@@ -1,0 +1,12 @@
+package gov.nasa.jpl.aerie.merlin.protocol.types;
+
+public enum InSpan {
+  /**
+   * Spawn a child task into the same span as its parent.
+   */
+  Parent,
+  /**
+   * Spawn a child task into a fresh span under its parent's span.
+   */
+  Fresh
+}

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskStatus.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/TaskStatus.java
@@ -9,7 +9,7 @@ public sealed interface TaskStatus<Return> {
 
   record Delayed<Return>(Duration delay, Task<Return> continuation) implements TaskStatus<Return> {}
 
-  record CallingTask<Return>(TaskFactory<?> child, Task<Return> continuation) implements TaskStatus<Return> {}
+  record CallingTask<Return>(InSpan childSpan, TaskFactory<?> child, Task<Return> continuation) implements TaskStatus<Return> {}
 
   record AwaitingCondition<Return>(Condition condition, Task<Return> continuation) implements TaskStatus<Return> {}
 
@@ -22,8 +22,8 @@ public sealed interface TaskStatus<Return> {
     return new Delayed<>(delay, continuation);
   }
 
-  static <Return> CallingTask<Return> calling(final TaskFactory<?> child, final Task<Return> continuation) {
-    return new CallingTask<>(child, continuation);
+  static <Return> CallingTask<Return> calling(final InSpan childSpan, final TaskFactory<?> child, final Task<Return> continuation) {
+    return new CallingTask<>(childSpan, child, continuation);
   }
 
   static <Return> AwaitingCondition<Return> awaiting(final Condition condition, final Task<Return> continuation) {

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/ResumableSimulationDriver.java
@@ -395,7 +395,6 @@ public class ResumableSimulationDriver<Model> implements AutoCloseable {
       final TaskFactory<Output> task,
       final Topic<ActivityDirectiveId> activityTopic) {
     return executor -> scheduler -> {
-      scheduler.pushSpan();
       scheduler.emit(directiveId, activityTopic);
       return task.create(executor).step(scheduler);
     };

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/AnchorSchedulerTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/AnchorSchedulerTest.java
@@ -17,6 +17,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.model.ModelType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.OutputType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus;
@@ -666,7 +667,6 @@ public class AnchorSchedulerTest {
     @Override
     public TaskFactory<Object> getTaskFactory(final Object o, final Object o2) {
       return executor -> $ -> {
-        $.pushSpan();
         $.emit(this, delayedActivityDirectiveInputTopic);
         return TaskStatus.delayed(oneMinute, $$ -> {
           $$.emit(Unit.UNIT, delayedActivityDirectiveOutputTopic);
@@ -692,20 +692,19 @@ public class AnchorSchedulerTest {
     @Override
     public TaskFactory<Object> getTaskFactory(final Object o, final Object o2) {
       return executor -> scheduler -> {
-        scheduler.pushSpan();
         scheduler.emit(this, decomposingActivityDirectiveInputTopic);
         return TaskStatus.delayed(
             Duration.ZERO,
             $ -> {
               try {
-                $.spawn(delayedActivityDirective.getTaskFactory(null, null));
+                $.spawn(InSpan.Fresh, delayedActivityDirective.getTaskFactory(null, null));
               } catch (final InstantiationException ex) {
                 throw new Error("Unexpected state: activity instantiation of DelayedActivityDirective failed with: %s".formatted(
                     ex.toString()));
               }
               return TaskStatus.delayed(Duration.of(120, Duration.SECOND), $$ -> {
                 try {
-                  $$.spawn(delayedActivityDirective.getTaskFactory(null, null));
+                  $$.spawn(InSpan.Fresh, delayedActivityDirective.getTaskFactory(null, null));
                 } catch (final InstantiationException ex) {
                   throw new Error(
                       "Unexpected state: activity instantiation of DelayedActivityDirective failed with: %s".formatted(


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

This work was done while pairing with @mattdailis. As Matt describes it:

> While debugging #659, we discovered that an exception thrown inside of a ModelActions.scoped() call causes that span to be closed, which means that the simulation engine cannot tell which span resulted in the exception. While this was not exactly a blocker - we're still able to recover the directive id - we felt that this is an unfortunate property of the new span semantics defined in #1174. This PR adjusts those semantics to require that a new span always be paired with a new task (adding the `callWithSpan` and `spawnWithSpan` methods), which means that any exception originating in a span will be more readily available to the simulation engine.

This PR preserves the one-to-many relationship between tasks and spans that is key to the memory gains of #1174. Morally, it just makes it so that `scoped()` accepts a `Task`(`Factory`) rather than a mere `Runnable`, which gives us finer-grained visibility into when exceptions cross span boundaries. A task is "just" a simulation-aware runnable, anyway!

As a bonus, because of this increased visibility into the model, we were able to remove the somewhat convoluted logic surrounding `shadowedSpans`. This is because every span is created for some task (even if more are attached to it later), so it is now simply impossible for a task to enter a span other than the one it was spawned into.

## Verification
This PR is opened from a branch in the Aerie repo, so we can actually watch the tests pass or fail!

- [x] @mattdailis will also do a sanity check with the TT6 plan.

## Documentation
The `ModelActions.scoped()` method has been replaced by `ModelActions.callWithSpan()`, along with a small menagerie of similar methods.

## Future work
Ideally, reporting the span in which an exception occurred would allow finer-grained debugging when attempting to suss out the source of an issue. This is also in-line with a future intention to propagate exceptions (and return values) from a called task to its caller.