### PR TITLE
Return the Executing Directive Id in Simulation Error Response

### DIFF
--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
@@ -590,6 +590,13 @@ public enum GQL {
         affected_rows
       }
     }"""),
+  UPDATE_SIMULATION_ARGUMENTS("""
+    mutation updateSimulationArguments($plan_id: Int!, $arguments: jsonb!) {
+      update_simulation(where: {plan_id: {_eq: $plan_id}},
+      _set: { arguments: $arguments }) {
+        affected_rows
+       }
+    }"""),
   UPDATE_SIMULATION_BOUNDS("""
     mutation updateSimulationBounds($plan_id: Int!, $simulation_start_time: timestamptz!, $simulation_end_time: timestamptz!) {
       update_simulation(where: {plan_id: {_eq: $plan_id}},

--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/Configuration.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/Configuration.java
@@ -7,11 +7,20 @@ public final class Configuration {
   @Export.Parameter
   public Double sinkRate;
 
-  public Configuration(final Double sinkRate) {
+  // If enabled, will raise an exception 30 min into a plan
+  @Export.Parameter
+  public Boolean raiseException;
+
+  public Configuration(final Double sinkRate, final Boolean raiseException) {
     this.sinkRate = sinkRate;
+    this.raiseException = raiseException;
+  }
+
+  public Configuration(final Double sinkRate) {
+    this(sinkRate, false);
   }
 
   public Configuration() {
-    this(0.5);
+    this(0.5, false);
   }
 }

--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/Mission.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/Mission.java
@@ -81,6 +81,13 @@ public final class Mission {
         ModelActions.delay(Duration.SECOND);
       }
     });
+
+    if(config.raiseException) {
+      spawn(() -> {
+        delay(Duration.HOUR);
+        throw new RuntimeException("Daemon task exception raised.");
+      });
+    }
   }
 
   public void test() {

--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/activities/DaemonCheckerSpawner.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/activities/DaemonCheckerSpawner.java
@@ -1,0 +1,24 @@
+package gov.nasa.jpl.aerie.foomissionmodel.activities;
+
+import gov.nasa.jpl.aerie.foomissionmodel.Mission;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import static gov.nasa.jpl.aerie.foomissionmodel.generated.ActivityActions.call;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
+
+/**
+ * An activity that spawns a DaemonCheckerActivity after delaying.
+ * Useful for testing the behavior of exceptions thrown by child activities.
+ *
+ * @param minutesElapsed The expected number of minutes elapsed when the DaemonCheckerActivity begins
+ * @param spawnDelay The number of minutes to delay between the start of this activity and spawning the DaemonCheckerActivity
+ */
+@ActivityType("DaemonCheckerSpawner")
+public record DaemonCheckerSpawner(int minutesElapsed, int spawnDelay) {
+  @ActivityType.EffectModel
+  public void run(final Mission mission) {
+    delay(Duration.of(spawnDelay, Duration.MINUTE));
+    call(mission, new DaemonCheckerActivity(minutesElapsed));
+  }
+}

--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/package-info.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/package-info.java
@@ -15,6 +15,7 @@
 @WithActivityType(BasicFooActivity.class)
 @WithActivityType(ZeroDurationUncontrollableActivity.class)
 @WithActivityType(DaemonCheckerActivity.class)
+@WithActivityType(DaemonCheckerSpawner.class)
 
 @WithActivityType(DecompositionTestActivities.ParentActivity.class)
 @WithActivityType(DecompositionTestActivities.ChildActivity.class)
@@ -28,6 +29,7 @@ import gov.nasa.jpl.aerie.foomissionmodel.activities.BasicActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.BasicFooActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.ControllableDurationActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.DaemonCheckerActivity;
+import gov.nasa.jpl.aerie.foomissionmodel.activities.DaemonCheckerSpawner;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.DecompositionTestActivities;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.FooActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.LateRiserActivity;

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationException.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationException.java
@@ -7,6 +7,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.util.Optional;
 
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.HOUR;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECOND;
@@ -26,9 +27,21 @@ public class SimulationException extends RuntimeException {
   public final Duration elapsedTime;
   public final Instant instant;
   public final Throwable cause;
+  public final Optional<ActivityDirectiveId> directiveId;
 
   public SimulationException(final Duration elapsedTime, final Instant startTime, final Throwable cause) {
     super("Exception occurred " + formatDuration(elapsedTime) + " into the simulation at " + formatInstant(addDurationToInstant(startTime, elapsedTime)), cause);
+    this.directiveId = Optional.empty();
+    this.elapsedTime = elapsedTime;
+    this.instant = addDurationToInstant(startTime, elapsedTime);
+    this.cause = cause;
+  }
+
+  public SimulationException(final Duration elapsedTime, final Instant startTime, final ActivityDirectiveId directiveId, final Throwable cause) {
+    super("Exception occurred " + formatDuration(elapsedTime)
+            + " into the simulation at " + formatInstant(addDurationToInstant(startTime, elapsedTime))
+            + " while simulating activity directive with id " +directiveId.id(), cause);
+    this.directiveId = Optional.of(directiveId);
     this.elapsedTime = elapsedTime;
     this.instant = addDurationToInstant(startTime, elapsedTime);
     this.cause = cause;

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SpanException.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SpanException.java
@@ -1,0 +1,12 @@
+package gov.nasa.jpl.aerie.merlin.driver.engine;
+
+public class SpanException extends RuntimeException {
+    public final SpanId spanId;
+    public final Throwable cause;
+
+    public SpanException(final SpanId spanId, final Throwable cause) {
+        super(cause.getMessage(), cause);
+        this.spanId = spanId;
+        this.cause = cause;
+    }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SynchronousSimulationAgent.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SynchronousSimulationAgent.java
@@ -92,12 +92,14 @@ public record SynchronousSimulationAgent (
             plan.configuration), extentListener::updateValue, canceledListener);
       }
     } catch (SimulationException ex) {
+      final var errorMsgBuilder = Json.createObjectBuilder()
+                    .add("elapsedTime", SimulationException.formatDuration(ex.elapsedTime))
+                    .add("utcTimeDoy", SimulationException.formatInstant(ex.instant));
+      ex.directiveId.ifPresent(directiveId -> errorMsgBuilder.add("executingDirectiveId", directiveId.id()));
       writer.failWith(b -> b
           .type("SIMULATION_EXCEPTION")
-          .data(Json.createObjectBuilder()
-                    .add("elapsedTime", SimulationException.formatDuration(ex.elapsedTime))
-                    .add("utcTimeDoy", SimulationException.formatInstant(ex.instant))
-                    .build())
+          .message(ex.cause.getMessage())
+          .data(errorMsgBuilder.build())
           .trace(ex.cause));
       return;
     } catch (final MissionModelService.NoSuchMissionModelException ex) {


### PR DESCRIPTION
* **Tickets addressed:** Closes #659 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
If an activity directive throws an exception while executing, the offending directive id will now be included in the `data` part of the `reason` under the `executingDirectiveId` key.

This was accomplished by wrapping exceptions raised while stepping tasks in a `SpanException`. When this exception is caught, the driver will attempt to get the `directiveId` from that span before rewrapping the exception into a `SimulationException`, providing this id if it was found. Additionally, when a SimulationException is returned as the `reason` for a SimFailure, the `message` field is now populated with the exceptions message;

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
The `SimulationExceptionResponse` tests were added.

In order to support these tests, the foo mission model gained a simulation configuration parameter and a new activity type. 
- The `raiseException` parameter will trigger a daemon task that throws a runtime exception 1hr in a plan if enabled
- The `DaemonCheckerSpawner` will call a `DaemonCheckerActivity` after `spawnDelay` minutes have passed, allowing us to throw runtime exceptions on demand/see the interaction between child activities and daemon tasks.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs need to be updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Posting the failed sim results to the DB
- Returning more information about the executing directive (ie name, the lineage from the source directive if it was a child that threw)
- If a daemon task throws an exception, is there anything we can return?
