### PR TITLE
Allow Users to write to Model Scheduling Spec's `priority` Column

### DIFF
--- a/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_model_specification_goals.yaml
+++ b/deployment/hasura/metadata/databases/AerieScheduler/tables/public_scheduling_model_specification_goals.yaml
@@ -41,20 +41,20 @@ select_permissions:
 insert_permissions:
   - role: aerie_admin
     permission:
-      columns: [model_id, goal_id, goal_revision]
+      columns: [model_id, goal_id, goal_revision, priority]
       check: {}
   - role: user
     permission:
-      columns: [model_id, goal_id, goal_revision]
+      columns: [model_id, goal_id, goal_revision, priority]
       check: {}
 update_permissions:
   - role: aerie_admin
     permission:
-      columns: [goal_revision]
+      columns: [goal_revision, priority]
       filter: {}
   - role: user
     permission:
-      columns: [goal_revision]
+      columns: [goal_revision, priority]
       filter: {}
 delete_permissions:
   - role: aerie_admin


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Users need to be able to set and update the priority of scheduling goals on the mission model spec, but this column was initially excluded from the insert/update set.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Verified via the UI's upsert query for model specs.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs update are needed.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
