### PR TITLE
Update parents for all activities, not just finished ones

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -427,7 +427,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
 
       updateSimulatedActivityParentsAction.apply(
           datasetId,
-          simulatedActivityRecords,
+          allActivityRecords,
           simIdToPgId);
     }
   }


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
@AaronPlave pointed out that unfinished spans always have `null` parent ids. This is undesirable - we do have all the necessary information to document a span's parent id.

The issue occurs in the `PostgresResultsCell::postActivities` method, which performs the following actions:
1. Insert all spans, without parent ids. Use this step to collect the assigned postgres ids for these spans
2. Update the spans that were just inserted to poke in the parent ids

Step 2 was taking as input only the `simulatedActivityRecords` (read: finished activities), when it should be operating on `allActivityRecords`.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
No tests were added - I'm open to ideas for how to incorporate this edge case into our tests

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No documentation has been invalidated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- The two-step span insert process seems a bit heavyweight to me - instead of having span ids always be auto-generated, we could allow the merlin worker to specify an id. This would allow us to do a single, self-consistent bulk insert, rather than an insert-then-update