### PR TITLE
Fix Id Sequences on Constraint, Goals, and Conditions

### DIFF
--- a/deployment/hasura/migrations/AerieMerlin/39_update_constraints_sequence/down.sql
+++ b/deployment/hasura/migrations/AerieMerlin/39_update_constraints_sequence/down.sql
@@ -1,0 +1,1 @@
+call migrations.mark_migration_rolled_back('39');

--- a/deployment/hasura/migrations/AerieMerlin/39_update_constraints_sequence/up.sql
+++ b/deployment/hasura/migrations/AerieMerlin/39_update_constraints_sequence/up.sql
@@ -1,0 +1,3 @@
+SELECT setval(pg_get_serial_sequence('constraint_metadata', 'id'), coalesce(max(id),0) + 1, false) FROM constraint_metadata;
+
+call migrations.mark_migration_applied('39');

--- a/deployment/hasura/migrations/AerieScheduler/14_update_scheduling_sequences/down.sql
+++ b/deployment/hasura/migrations/AerieScheduler/14_update_scheduling_sequences/down.sql
@@ -1,0 +1,1 @@
+call migrations.mark_migration_rolled_back('14');

--- a/deployment/hasura/migrations/AerieScheduler/14_update_scheduling_sequences/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/14_update_scheduling_sequences/up.sql
@@ -1,0 +1,4 @@
+SELECT setval(pg_get_serial_sequence('scheduling_goal_metadata', 'id'), coalesce(max(id),0) + 1, false) FROM scheduling_goal_metadata;
+SELECT setval(pg_get_serial_sequence('scheduling_condition_metadata', 'id'), coalesce(max(id),0) + 1, false) FROM scheduling_condition_metadata;
+
+call migrations.mark_migration_applied('14');

--- a/merlin-server/sql/merlin/applied_migrations.sql
+++ b/merlin-server/sql/merlin/applied_migrations.sql
@@ -41,3 +41,4 @@ call migrations.mark_migration_applied('35');
 call migrations.mark_migration_applied('36');
 call migrations.mark_migration_applied('37');
 call migrations.mark_migration_applied('38');
+call migrations.mark_migration_applied('39');

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -16,3 +16,4 @@ call migrations.mark_migration_applied('10');
 call migrations.mark_migration_applied('11');
 call migrations.mark_migration_applied('12');
 call migrations.mark_migration_applied('13');
+call migrations.mark_migration_applied('14');


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
During the migrations that split constraints, goals, and conditions into metadata and definitions, we preserved the IDs. This meant, however, that the ID sequence used to generate new IDs were not advanced, causing issues with inserting new rows in these tables initially. 

This PR creates a migration that advances the ID sequence on these tables to where it should be (the current max id + 1, or 1 if the table is empty). The `down` migrations are empty aside from marking the rollback as there is nothing to revert.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I first tested the migration against an empty database. 

I then:
1) Spun up a 2.4.0 Aerie instance (the last one before versioning constraints)
2) Added 5 Constraints, Goals, and Conditions
3) Migrated to this branch
4) Created a new Constraint, Goal, and Condition

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs need to be updated.
