### PR TITLE
Add "order by" when populating a plan spec

### DIFF
--- a/deployment/merge_aerie_db/merge_db/migrate_scheduler_triggers.sql
+++ b/deployment/merge_aerie_db/merge_db/migrate_scheduler_triggers.sql
@@ -38,7 +38,8 @@ begin
   insert into scheduler.scheduling_specification_goals (specification_id, goal_id, goal_revision, priority)
   select spec_id, msg.goal_id, msg.goal_revision, msg.priority
   from scheduler.scheduling_model_specification_goals msg
-  where msg.model_id = new.model_id;
+  where msg.model_id = new.model_id
+  order by msg.priority;
 
   insert into scheduler.scheduling_specification_conditions (specification_id, condition_id, condition_revision)
   select spec_id, msc.condition_id, msc.condition_revision

--- a/deployment/postgres-init-db/sql/tables/scheduler/scheduling_specification/scheduling_specification.sql
+++ b/deployment/postgres-init-db/sql/tables/scheduler/scheduling_specification/scheduling_specification.sql
@@ -53,7 +53,8 @@ begin
   insert into scheduler.scheduling_specification_goals (specification_id, goal_id, goal_revision, priority)
   select spec_id, msg.goal_id, msg.goal_revision, msg.priority
   from scheduler.scheduling_model_specification_goals msg
-  where msg.model_id = new.model_id;
+  where msg.model_id = new.model_id
+  order by msg.priority;
 
   insert into scheduler.scheduling_specification_conditions (specification_id, condition_id, condition_revision)
   select spec_id, msc.condition_id, msc.condition_revision


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
@duranb was running into an issue where plans were failing to have their scheduling specs created and populated due to priority gaps. While I was unable to repro, I found this was caused by a missing `order by` in the function to create and populate the plan spec that enforces that the spec is populated in priority order.

This PR adds that `order by` statement in the base code and in the migration.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Manually verified on @duranb's deployment

This PR will fail the DB Migration check as 2.8.0 has yet to be released.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
