### PR TITLE
Add Hasura Events Views

### DIFF
--- a/.github/workflows/pgcmp.yml
+++ b/.github/workflows/pgcmp.yml
@@ -120,7 +120,12 @@ jobs:
         env:
           AERIE_USERNAME: "${{secrets.AERIE_USERNAME}}"
           AERIE_PASSWORD: "${{secrets.AERIE_PASSWORD}}"
-      - name: Dump Databases
+      - name: Clone PGCMP
+        uses: actions/checkout@v4
+        with:
+          repository: cbbrowne/pgcmp
+          path: pgcmp
+      - name: Dump Migrated Database
         env:
           AERIE_USERNAME: "${{secrets.AERIE_USERNAME}}"
           AERIE_PASSWORD: "${{secrets.AERIE_PASSWORD}}"
@@ -193,7 +198,7 @@ jobs:
         with:
           repository: cbbrowne/pgcmp
           path: pgcmp
-      - name: Dump Databases
+      - name: Dump Current Database
         env:
           AERIE_USERNAME: "${{secrets.AERIE_USERNAME}}"
           AERIE_PASSWORD: "${{secrets.AERIE_PASSWORD}}"
@@ -224,7 +229,7 @@ jobs:
         env:
           AERIE_USERNAME: "${{secrets.AERIE_USERNAME}}"
           AERIE_PASSWORD: "${{secrets.AERIE_PASSWORD}}"
-      - name: Dump Databases
+      - name: Dump Migrated Database
         env:
           AERIE_USERNAME: "${{secrets.AERIE_USERNAME}}"
           AERIE_PASSWORD: "${{secrets.AERIE_PASSWORD}}"

--- a/deployment/hasura/metadata/databases/tables/hasura/refresh_activity_type_logs.yaml
+++ b/deployment/hasura/metadata/databases/tables/hasura/refresh_activity_type_logs.yaml
@@ -1,0 +1,30 @@
+table:
+  name: refresh_activity_type_logs
+  schema: hasura
+configuration:
+  custom_name: "refresh_activity_type_logs"
+object_relationships:
+- name: model
+  using:
+    manual_configuration:
+      remote_table:
+        name: mission_model
+        schema: merlin
+      column_mapping:
+        model_id: id
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: user
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true

--- a/deployment/hasura/metadata/databases/tables/hasura/refresh_model_parameter_logs.yaml
+++ b/deployment/hasura/metadata/databases/tables/hasura/refresh_model_parameter_logs.yaml
@@ -1,0 +1,30 @@
+table:
+  name: refresh_model_parameter_logs
+  schema: hasura
+configuration:
+  custom_name: "refresh_model_parameter_logs"
+object_relationships:
+- name: model
+  using:
+    manual_configuration:
+      remote_table:
+        name: mission_model
+        schema: merlin
+      column_mapping:
+        model_id: id
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: user
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true

--- a/deployment/hasura/metadata/databases/tables/hasura/refresh_resource_types_logs.yaml
+++ b/deployment/hasura/metadata/databases/tables/hasura/refresh_resource_types_logs.yaml
@@ -1,0 +1,30 @@
+table:
+  name: refresh_resource_type_logs
+  schema: hasura
+configuration:
+  custom_name: "refresh_resource_type_logs"
+object_relationships:
+- name: model
+  using:
+    manual_configuration:
+      remote_table:
+        name: mission_model
+        schema: merlin
+      column_mapping:
+        model_id: id
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: user
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true

--- a/deployment/hasura/metadata/databases/tables/merlin/mission_model.yaml
+++ b/deployment/hasura/metadata/databases/tables/merlin/mission_model.yaml
@@ -57,6 +57,30 @@ array_relationships:
       table:
         name: scheduling_model_specification_goals
         schema: scheduler
+- name: refresh_activity_type_logs
+  using:
+    manual_configuration:
+      remote_table:
+        name: refresh_activity_type_logs
+        schema: hasura
+      column_mapping:
+        id: model_id
+- name: refresh_model_parameter_logs
+  using:
+    manual_configuration:
+      remote_table:
+        name: refresh_model_parameter_logs
+        schema: hasura
+      column_mapping:
+        id: model_id
+- name: refresh_resource_type_logs
+  using:
+    manual_configuration:
+      remote_table:
+        name: refresh_resource_type_logs
+        schema: hasura
+      column_mapping:
+        id: model_id
 select_permissions:
   - role: aerie_admin
     permission:

--- a/deployment/hasura/metadata/databases/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/tables/tables.yaml
@@ -46,6 +46,9 @@
 - "!include hasura/get_conflicting_activities_return_value.yaml"
 - "!include hasura/get_non_conflicting_activities_return_value.yaml"
 - "!include hasura/get_plan_history_return_value.yaml"
+- "!include hasura/refresh_activity_type_logs.yaml"
+- "!include hasura/refresh_model_parameter_logs.yaml"
+- "!include hasura/refresh_resource_types_logs.yaml"
 - "!include hasura/resource_at_start_offset_return_value.yaml"
 - "!include hasura/withdraw_merge_request_return_value.yaml"
 

--- a/deployment/hasura/migrations/Aerie/1_hasura_events_views/down.sql
+++ b/deployment/hasura/migrations/Aerie/1_hasura_events_views/down.sql
@@ -1,0 +1,7 @@
+drop view hasura.refresh_resource_type_logs;
+drop view hasura.refresh_model_parameter_logs;
+drop view hasura.refresh_activity_type_logs;
+
+drop function hasura.get_event_logs(_trigger_name text);
+
+call migrations.mark_migration_rolled_back('1');

--- a/deployment/hasura/migrations/Aerie/1_hasura_events_views/up.sql
+++ b/deployment/hasura/migrations/Aerie/1_hasura_events_views/up.sql
@@ -1,0 +1,59 @@
+create function hasura.get_event_logs(_trigger_name text)
+returns table (
+  model_id int,
+  model_name text,
+  model_version text,
+  triggering_user text,
+  delivered boolean,
+  success boolean,
+  tries int,
+  created_at timestamp,
+  next_retry_at timestamp,
+  status int,
+  error jsonb,
+  error_message text,
+  error_type text
+)
+stable
+security invoker
+language plpgsql as $$
+begin
+  return query (
+    select
+      (el.payload->'data'->'new'->>'id')::int as model_id,
+      el.payload->'data'->'new'->>'name' as model_name,
+      el.payload->'data'->'new'->>'version' as model_version,
+      el.payload->'session_variables'->>'x-hasura-user-id' as triggering_user,
+      el.delivered,
+      eil.status is not distinct from 200 as success, -- is not distinct from to catch `null`
+      el.tries,
+      el.created_at,
+      el.next_retry_at,
+      eil.status,
+      (eil.response -> 'data'->> 'message')::jsonb as error,
+      (eil.response -> 'data'->> 'message')::jsonb->>'message' as error_message,
+      (eil.response -> 'data'->> 'message')::jsonb->>'type' as error_type
+      from hdb_catalog.event_log el
+      join hdb_catalog.event_invocation_logs eil on el.id = eil.event_id
+      where trigger_name = _trigger_name);
+end;
+$$;
+comment on function hasura.get_event_logs(_trigger_name text) is e''
+ 'Get the logs for every run of a Hasura event with the specified trigger name.';
+
+create view hasura.refresh_activity_type_logs as
+  select * from hasura.get_event_logs('refreshActivityTypes');
+comment on view hasura.refresh_activity_type_logs is e''
+ 'View containing logs for every run of the Hasura event `refreshActivityTypes`.';
+
+create view hasura.refresh_model_parameter_logs as
+  select * from hasura.get_event_logs('refreshModelParameters');
+comment on view hasura.refresh_model_parameter_logs is e''
+ 'View containing logs for every run of the Hasura event `refreshModelParameters`.';
+
+create view hasura.refresh_resource_type_logs as
+  select * from hasura.get_event_logs('refreshResourceTypes');
+comment on view hasura.refresh_resource_type_logs is e''
+ 'View containing logs for every run of the Hasura event `refreshResourceTypes`.';
+
+call migrations.mark_migration_applied('1');

--- a/deployment/postgres-init-db/sql/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/applied_migrations.sql
@@ -3,3 +3,4 @@ This file denotes which migrations occur "before" this version of the schema.
 */
 
 call migrations.mark_migration_applied('0');
+call migrations.mark_migration_applied('1');

--- a/deployment/postgres-init-db/sql/init_hasura.sql
+++ b/deployment/postgres-init-db/sql/init_hasura.sql
@@ -13,4 +13,7 @@ begin;
   \ir functions/hasura/plan_branching_functions.sql
   \ir functions/hasura/plan_merge_functions.sql
   \ir functions/hasura/snapshot_functions.sql
+
+  -- Event Views
+  \ir views/hasura/hasura_event_logs.sql
 end;

--- a/deployment/postgres-init-db/sql/views/hasura/hasura_event_logs.sql
+++ b/deployment/postgres-init-db/sql/views/hasura/hasura_event_logs.sql
@@ -1,0 +1,60 @@
+create function hasura.get_event_logs(_trigger_name text)
+returns table (
+  model_id int,
+  model_name text,
+  model_version text,
+  triggering_user text,
+  delivered boolean,
+  success boolean,
+  tries int,
+  created_at timestamp,
+  next_retry_at timestamp,
+  status int,
+  error jsonb,
+  error_message text,
+  error_type text
+)
+stable
+security invoker
+language plpgsql as $$
+begin
+  return query (
+    select
+      (el.payload->'data'->'new'->>'id')::int as model_id,
+      el.payload->'data'->'new'->>'name' as model_name,
+      el.payload->'data'->'new'->>'version' as model_version,
+      el.payload->'session_variables'->>'x-hasura-user-id' as triggering_user,
+      el.delivered,
+      eil.status is not distinct from 200 as success, -- is not distinct from to catch `null`
+      el.tries,
+      el.created_at,
+      el.next_retry_at,
+      eil.status,
+      (eil.response -> 'data'->> 'message')::jsonb as error,
+      (eil.response -> 'data'->> 'message')::jsonb->>'message' as error_message,
+      (eil.response -> 'data'->> 'message')::jsonb->>'type' as error_type
+      from hdb_catalog.event_log el
+      join hdb_catalog.event_invocation_logs eil on el.id = eil.event_id
+      where trigger_name = _trigger_name);
+end;
+$$;
+comment on function hasura.get_event_logs(_trigger_name text) is e''
+ 'Get the logs for every run of a Hasura event with the specified trigger name.';
+
+create view hasura.refresh_activity_type_logs as
+  select * from hasura.get_event_logs('refreshActivityTypes');
+comment on view hasura.refresh_activity_type_logs is e''
+ 'View containing logs for every run of the Hasura event `refreshActivityTypes`.';
+
+create view hasura.refresh_model_parameter_logs as
+  select * from hasura.get_event_logs('refreshModelParameters');
+comment on view hasura.refresh_model_parameter_logs is e''
+ 'View containing logs for every run of the Hasura event `refreshModelParameters`.';
+
+create view hasura.refresh_resource_type_logs as
+  select * from hasura.get_event_logs('refreshResourceTypes');
+comment on view hasura.refresh_resource_type_logs is e''
+ 'View containing logs for every run of the Hasura event `refreshResourceTypes`.';
+
+
+

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/MissionModelTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/MissionModelTests.java
@@ -48,7 +48,6 @@ public class MissionModelTests {
           "aerie_e2e_tests",
           "Mission Model Tests");
     }
-    Thread.sleep(1000);
   }
 
   @AfterAll
@@ -362,5 +361,65 @@ public class MissionModelTests {
       final var actualComputedAttributes = activityTypes.get(i).computedAttributes();
       assertEquals(expectedComputedAttributes, actualComputedAttributes);
     }
+  }
+
+  /**
+   * The logs for the Hasura events triggered during model upload are accessible.
+   */
+  @Test
+  void hasuraEventLogsAreAccessible() throws IOException {
+    final var modelLogs = hasura.awaitModelEventLogs(modelId);
+
+    assertEquals(modelId, modelLogs.modelId());
+    assertEquals("Banananation (e2e tests)", modelLogs.modelName());
+    assertEquals("Mission Model Tests", modelLogs.modelVersion());
+
+    // Check Activity Type Refresh Event Logs
+    final var activityTypeRefreshLogs = modelLogs.refreshActivityTypesLogs();
+    assertEquals(1, activityTypeRefreshLogs.size());
+    final var activityTypeLog = activityTypeRefreshLogs.get(0);
+
+    assertEquals("Aerie Legacy", activityTypeLog.triggeringUser());
+
+    assertTrue(activityTypeLog.delivered());
+    assertTrue(activityTypeLog.success());
+    assertEquals(1, activityTypeLog.tries());
+    assertEquals(200, activityTypeLog.status());
+
+    assertTrue(activityTypeLog.error().isEmpty());
+    assertTrue(activityTypeLog.errorMessage().isEmpty());
+    assertTrue(activityTypeLog.errorType().isEmpty());
+
+    // Check Model Parameter Refresh Event Logs
+    final var modelParamRefreshLogs = modelLogs.refreshModelParamsLogs();
+    assertEquals(1, modelParamRefreshLogs.size());
+    final var modelParamLog = modelParamRefreshLogs.get(0);
+
+    assertEquals("Aerie Legacy", modelParamLog.triggeringUser());
+
+    assertTrue(modelParamLog.delivered());
+    assertTrue(modelParamLog.success());
+    assertEquals(1, modelParamLog.tries());
+    assertEquals(200, modelParamLog.status());
+
+    assertTrue(modelParamLog.error().isEmpty());
+    assertTrue(modelParamLog.errorMessage().isEmpty());
+    assertTrue(modelParamLog.errorType().isEmpty());
+
+    // Check Resource Type Refresh Event Logs
+    final var resourceTypeRefreshLogs = modelLogs.refreshResourceTypesLogs();
+    assertEquals(1, resourceTypeRefreshLogs.size());
+    final var resourceTypeLog = resourceTypeRefreshLogs.get(0);
+
+    assertEquals("Aerie Legacy", resourceTypeLog.triggeringUser());
+
+    assertTrue(resourceTypeLog.delivered());
+    assertTrue(resourceTypeLog.success());
+    assertEquals(1, resourceTypeLog.tries());
+    assertEquals(200, resourceTypeLog.status());
+
+    assertTrue(resourceTypeLog.error().isEmpty());
+    assertTrue(resourceTypeLog.errorMessage().isEmpty());
+    assertTrue(resourceTypeLog.errorType().isEmpty());
   }
 }

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/SchedulingTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/SchedulingTests.java
@@ -97,7 +97,7 @@ public class SchedulingTests {
   }
 
   @BeforeEach
-  void beforeEach() throws IOException {
+  void beforeEach() throws IOException, InterruptedException {
     // Insert the Mission Model
     try (final var gateway = new GatewayRequests(playwright)) {
       modelId = hasura.createMissionModel(
@@ -105,8 +105,6 @@ public class SchedulingTests {
           "Banananation (e2e tests)",
           "aerie_e2e_tests",
           "Scheduling Tests");
-    } catch (InterruptedException e) {
-        throw new RuntimeException(e);
     }
     // Insert the Plan
     planId = hasura.createPlan(

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ModelEventLogs.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ModelEventLogs.java
@@ -1,0 +1,58 @@
+package gov.nasa.jpl.aerie.e2e.types;
+
+import javax.json.JsonObject;
+import java.util.List;
+import java.util.Optional;
+
+public record ModelEventLogs(
+    int modelId,
+    String modelName,
+    String modelVersion,
+    List<EventLog> refreshActivityTypesLogs,
+    List<EventLog> refreshModelParamsLogs,
+    List<EventLog> refreshResourceTypesLogs
+) {
+  public record EventLog(
+    String triggeringUser,
+    boolean delivered,
+    boolean success,
+    int tries,
+    String createdAt,
+    int status,
+    Optional<JsonObject> error,
+    Optional<String> errorMessage,
+    Optional<String> errorType
+  )
+  {
+    public static EventLog fromJSON(JsonObject json) {
+      final Optional<JsonObject> error = json.isNull("error") ?
+          Optional.empty() : Optional.of(json.getJsonObject("error"));
+      final Optional<String> errorMsg = json.isNull("error_message") ?
+          Optional.empty() : Optional.of(json.getString("error_message"));
+      final Optional<String> errorType = json.isNull("error") ?
+          Optional.empty() : Optional.of(json.getString("error"));
+
+      return new EventLog(
+          json.getString("triggering_user"),
+          json.getBoolean("delivered"),
+          json.getBoolean("success"),
+          json.getInt("tries"),
+          json.getString("created_at"),
+          json.getInt("status"),
+          error,
+          errorMsg,
+          errorType);
+    }
+  }
+
+  public static ModelEventLogs fromJSON(JsonObject json) {
+    return new ModelEventLogs(
+      json.getInt("id"),
+      json.getString("name"),
+      json.getString("version"),
+      json.getJsonArray("refresh_activity_type_logs").getValuesAs(EventLog::fromJSON),
+      json.getJsonArray("refresh_model_parameter_logs").getValuesAs(EventLog::fromJSON),
+      json.getJsonArray("refresh_resource_type_logs").getValuesAs(EventLog::fromJSON)
+    );
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
@@ -265,6 +265,47 @@ public enum GQL {
         }
       }
     }"""),
+  GET_MODEL_EVENT_LOGS("""
+    query getModelLogs($modelId: Int!) {
+      mission_model: mission_model_by_pk(id:$modelId) {
+        id
+        name
+        version
+        refresh_activity_type_logs(order_by: {created_at: desc}) {
+          triggering_user
+          delivered
+          success
+          tries
+          created_at
+          status
+          error
+          error_message
+          error_type
+        }
+        refresh_model_parameter_logs(order_by: {created_at: desc}) {
+          triggering_user
+          delivered
+          success
+          tries
+          created_at
+          status
+          error
+          error_message
+          error_type
+        }
+        refresh_resource_type_logs(order_by: {created_at: desc}) {
+          triggering_user
+          delivered
+          success
+          tries
+          created_at
+          status
+          error
+          error_message
+          error_type
+        }
+      }
+    }"""),
   GET_PLAN("""
     query GetPlan($id: Int!) {
       plan: plan_by_pk(id: $id) {


### PR DESCRIPTION
* **Tickets addressed:** Closes #1273 (backend portion)
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Creates a SQL function to get the event logs for a specified Hasura event, and three views that select from this function, one for each of our Hasura events.

While the views could not be necessary had I actually created and tracked a custom table for the function return type in order to [satisfy the Hasura Custom Function API ](https://hasura.io/docs/latest/schema/postgres/custom-functions/#pg-supported-sql-functions)(as is done with our other Hasura functions), by using views we can establish relationships between the results and the `mission_model` table, allowing for queries like so:

```gql
query {
  mission_model{
    id
    refresh_activity_type_logs { success }
    refresh_resource_type_logs { success }
    refresh_model_parameter_logs { success }
  }
}
```

Note that using a function for the view definitions is required, as the Hasura tables the views reference _**do not exist**_ during database initialization (Hasura creates and manages them). View definitions must be executable at the time of creation, but functions do not have this restriction.

This PR also fixes some minor bugs in our Migrations pipeline. Specifically:
- Fixed the PGCMP Workflow. Checking out `develop` requires re-cloning the `PGCMP` repo. The workflow was doing this pre-2.8.0, but I accidentally removed it when updating it for 2.8.0.
- Fixed a bug in the migration script that was causing hasura to reapply migration 1 when bulk migrating down from version 1. This bug was introduced in 2.8.0. 
- Fixed a typo in the migration script preventing the "mark correct version" command from applying. The `hasura` command is case-sensitive. This bug was introduced in 2.8.0.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Manual verification was done to figure out the schema for errors and to check the Hasura metadata.

An E2E test was added to the `MissionModelTests` suite for testing the ability to get these logs. Additionally, the model upload process now awaits these logs, replacing the `Thread.sleep` in `HasuraFunctions.uploadMissionModel`

While checking if any tests were delaying for these events to complete, I noticed that `SchedulingTests.BeforeEach` was inconsistent in how it uploaded the model compared to other tests classes (it caught and rethrew the potential `InterruptedException` as a `RuntimeException`). This has been resolved.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Docs ticket here: https://github.com/NASA-AMMOS/aerie-docs/issues/147

## Future work
<!-- What next steps can we anticipate from here, if any? -->
A front-end ticket is needed to track displaying success/failures for model uploads.

