### PR TITLE
Quiet down successful builds

### DIFF
--- a/constraints/build.gradle
+++ b/constraints/build.gradle
@@ -34,6 +34,8 @@ dependencies {
   implementation project(':parsing-utilities')
 
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 publishing {

--- a/contrib/build.gradle
+++ b/contrib/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
   testImplementation project(':merlin-framework-junit')
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 publishing {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialResources.java
@@ -579,13 +579,6 @@ public final class PolynomialResources {
   }
 
   /**
-   * Add polynomial resources.
-   */
-  public static UnitAware<Resource<Polynomial>> sum$(Stream<UnitAware<? extends Resource<Polynomial>>> summands) {
-    return add(summands.<UnitAware<? extends Resource<Polynomial>>>toArray(UnitAware[]::new));
-  }
-
-  /**
    * Subtract polynomial resources.
    */
   public static UnitAware<Resource<Polynomial>> subtract(UnitAware<? extends Resource<Polynomial>> p, UnitAware<? extends Resource<Polynomial>> q) {
@@ -602,13 +595,6 @@ public final class PolynomialResources {
     return unitAware(
         product(stream(factors).map(UnitAware::value)),
         stream(factors).map(UnitAware::unit).reduce(Unit.SCALAR, Unit::multiply));
-  }
-
-  /**
-   * Multiply polynomial resources.
-   */
-  public static UnitAware<Resource<Polynomial>> product$(Stream<UnitAware<? extends Resource<Polynomial>>> factors) {
-    return multiply(factors.<UnitAware<? extends Resource<Polynomial>>>toArray(UnitAware[]::new));
   }
 
   /**

--- a/db-tests/build.gradle
+++ b/db-tests/build.gradle
@@ -16,6 +16,10 @@ jacocoTestReport {
   }
 }
 
+test {
+  onlyIf { false }
+}
+
 task e2eTest(type: Test) {
   ext.parseEnvFile = { filePath ->
     file(filePath).readLines().each() {

--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -16,6 +16,10 @@ jacocoTestReport {
   }
 }
 
+test {
+  onlyIf { false }
+}
+
 task e2eTest(type: Test) {
   ext.parseEnvFile = { filePath ->
     file(filePath).readLines().each() {

--- a/examples/banananation/build.gradle
+++ b/examples/banananation/build.gradle
@@ -46,6 +46,8 @@ dependencies {
   testImplementation 'org.assertj:assertj-core:3.24.2'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 javadoc.options.tags = [ "contact", "subsystem" ]

--- a/examples/config-with-defaults/build.gradle
+++ b/examples/config-with-defaults/build.gradle
@@ -41,4 +41,6 @@ dependencies {
   testImplementation 'org.assertj:assertj-core:3.24.2'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/examples/config-without-defaults/build.gradle
+++ b/examples/config-without-defaults/build.gradle
@@ -41,4 +41,6 @@ dependencies {
   testImplementation 'org.assertj:assertj-core:3.24.2'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/examples/foo-missionmodel/build.gradle
+++ b/examples/foo-missionmodel/build.gradle
@@ -41,4 +41,6 @@ dependencies {
   testImplementation 'org.assertj:assertj-core:3.24.2'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/examples/minimal-mission-model/build.gradle
+++ b/examples/minimal-mission-model/build.gradle
@@ -41,4 +41,6 @@ dependencies {
   testImplementation 'org.assertj:assertj-core:3.24.2'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/examples/streamline-demo/build.gradle
+++ b/examples/streamline-demo/build.gradle
@@ -41,5 +41,7 @@ dependencies {
   testImplementation 'org.assertj:assertj-core:3.23.1'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/merlin-driver/build.gradle
+++ b/merlin-driver/build.gradle
@@ -46,6 +46,8 @@ dependencies {
   testImplementation project(':contrib')
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
   testImplementation "net.jqwik:jqwik:1.6.5"
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 publishing {

--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelProcessor.java
@@ -142,9 +142,6 @@ public final class MissionModelProcessor implements Processor {
         }
 
         for (final var generatedFile : generatedFiles) {
-          this.messager.printMessage(
-              Diagnostic.Kind.NOTE,
-              "Generating " + generatedFile.packageName + "." + generatedFile.typeSpec.name);
           generatedFile.writeTo(this.filer);
         }
       } catch (final InvalidMissionModelException ex) {

--- a/merlin-framework/build.gradle
+++ b/merlin-framework/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 
   testImplementation project(':merlin-sdk')
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 publishing {

--- a/merlin-sdk/build.gradle
+++ b/merlin-sdk/build.gradle
@@ -31,6 +31,8 @@ javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 
 dependencies {
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 publishing {

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/DirectiveType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/DirectiveType.java
@@ -13,7 +13,7 @@ import java.util.Map;
  * request to store and forward a given payload to another node in the system. </p>
  *
  * <p> A directive can be instantiated using its associated {@link InputType}, and its associated behavior can be
- * extracted using the {@link #createTask(Model, Arguments)} method. When the directive's behavior is finished, its
+ * extracted using the {@link #getTaskFactory(Model, Arguments)} method. When the directive's behavior is finished, its
  * result value can be manipulated using its associated {@link OutputType}. </p>
  *
  * <p> As a reflective interface, {@code DirectiveType} is analogous to {@link java.lang.reflect.Method}. It represents
@@ -63,10 +63,9 @@ public interface DirectiveType<Model, Arguments, Result> {
    *   Arguments uniquely determining the directive to perform.
    * @return
    *   An executable task operating on the model's state, terminating with a {@code Result} value.
-   * @throws InvalidArgumentsException
+   * @throws InstantiationException
    *   When the given arguments do not uniquely determine a directive instance.
    * @see InputType#instantiate(Map)
-   * @see #createTask(Model, Arguments)
    */
   default TaskFactory<Result> getTaskFactory(final Model model, final Map<String, SerializedValue> arguments)
   throws InstantiationException

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/InputType.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/model/InputType.java
@@ -82,7 +82,7 @@ public interface InputType<T> {
 
   /**
    * Names a subset of parameters returned by {@link #getParameters()} whose absence on instantiation would
-   * certainly result in an {@link InvalidArgumentsException}.
+   * certainly result in an {@link InstantiationException}.
    *
    * <p> Providing a schematically-valid argument for every "required" parameter does not guarantee success in
    * instantiating a value of type {@code T}. For example, two parameters may be inter-derivable: if only one is not
@@ -121,7 +121,7 @@ public interface InputType<T> {
    *   The arguments determining a value of type {@code T}.
    * @return
    *   The instance of type {@code T} corresponding to the given arguments.
-   * @throws InvalidArgumentsException
+   * @throws InstantiationException
    *   When the given arguments do not uniquely (or at all) determine a value of type {@code T}.
    */
   // TODO: Define distinct exceptions for under-specification and over-specification failures,
@@ -189,7 +189,7 @@ public interface InputType<T> {
    *   The arguments determining a value of type {@code T}.
    * @return
    *   An ordered list of informational notices for a human operator.
-   * @throws InvalidArgumentsException
+   * @throws InstantiationException
    *   When the given arguments do not uniquely (or at all) determine a value of type {@code T}.
    * @see #instantiate(Map)
    * @see #getValidationFailures(T)
@@ -214,7 +214,7 @@ public interface InputType<T> {
    *   The arguments determining a value of type {@code T}.
    * @return
    *   The completed set of arguments determining the same unique value as the given arguments.
-   * @throws InvalidArgumentsException
+   * @throws InstantiationException
    *   When the given arguments do not uniquely (or at all) determine a value of type {@code T}.
    * @see #instantiate(Map)
    * @see #getArguments(T)

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/package-info.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/package-info.java
@@ -53,7 +53,7 @@
  *   {@link gov.nasa.jpl.aerie.merlin.protocol.model.DirectiveType}s the model can react to. </li>
  *
  *   <li> For each scheduled directive to simulate, Driver calls {@link gov.nasa.jpl.aerie.merlin.protocol.model.DirectiveType#getInputType()}
- *   and then {@link gov.nasa.jpl.aerie.merlin.protocol.model.DirectiveType#createTask(java.lang.Object, java.util.Map)} to instantiate
+ *   and then {@link gov.nasa.jpl.aerie.merlin.protocol.model.DirectiveType#getTaskFactory(java.lang.Object, java.util.Map)} to instantiate
  *   a {@link gov.nasa.jpl.aerie.merlin.protocol.model.Task} modeling the model's reaction to the directive. </li>
  *
  *   <li>
@@ -83,7 +83,7 @@
  *         </ul>
  *       </li>
  *
- *       <li> Model calls {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler#spawn(gov.nasa.jpl.aerie.merlin.protocol.model.Task)}
+ *       <li> Model calls {@link gov.nasa.jpl.aerie.merlin.protocol.driver.Scheduler#spawn(InSpan taskSpan, TaskFactory task)}
  *       any number of times to spawn additional concurrent {@link gov.nasa.jpl.aerie.merlin.protocol.model.Task}s. </li>
  *
  *       <li> Model returns a {@link gov.nasa.jpl.aerie.merlin.protocol.types.TaskStatus} describing the conditions
@@ -110,3 +110,6 @@
  * @see gov.nasa.jpl.aerie.merlin.protocol.model
  */
 package gov.nasa.jpl.aerie.merlin.protocol;
+
+import gov.nasa.jpl.aerie.merlin.protocol.model.TaskFactory;
+import gov.nasa.jpl.aerie.merlin.protocol.types.InSpan;

--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -95,4 +95,6 @@ dependencies {
   testImplementation project(':merlin-framework')
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
   testImplementation 'net.jqwik:jqwik:1.6.5'
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -20,7 +20,7 @@ node {
 task assembleConstraintsDSLCompiler(type: NpmTask) {
   dependsOn processResources
   dependsOn npmInstall
-  args = ['run', 'build']
+  args = ['--silent', 'run', 'build']
   inputs.files('package.json', 'package-lock.json', 'tsconfig.json')
   inputs.dir('src')
 }
@@ -29,7 +29,7 @@ task generateDocumentation(type: NpmTask) {
   dependsOn npmInstall
   dependsOn processResources
   dependsOn assembleConstraintsDSLCompiler
-  args = ['run', 'generate-doc']
+  args = ['--silent', 'run', 'generate-doc']
   inputs.files('package.json', 'package-lock.json', 'tsconfig.json')
   inputs.dir('src')
 }

--- a/merlin-server/constraints-dsl-compiler/package.json
+++ b/merlin-server/constraints-dsl-compiler/package.json
@@ -7,7 +7,7 @@
     "build": "rm -rf build; tsc",
     "test": "npm run build && node build/main.js",
     "reformat": "npx prettier --config ./.prettierrc -w ./src",
-    "generate-doc": "rm -rf build/docs; npx typedoc src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Constraints eDSL Documentation\" --readme none --gitRevision develop"
+    "generate-doc": "rm -rf build/docs; npx typedoc src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Constraints eDSL Documentation\" --readme none --gitRevision develop --validation.notExported false --logLevel Warn"
   },
   "dependencies": {
     "@nasa-jpl/aerie-ts-user-code-runner": "0.5.0",

--- a/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
+++ b/merlin-server/constraints-dsl-compiler/src/libs/constraints-edsl-fluent-api.ts
@@ -1143,6 +1143,7 @@ export class Interval {
   /** @internal */
   public readonly __astNode: AST.IntervalExpression;
 
+  /** @suppress */
   public constructor(node: AST.IntervalExpression) {
     this.__astNode = node;
   }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/Fallible.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/Fallible.java
@@ -7,7 +7,7 @@ import java.util.Optional;
  *
  * @param <T> The type of the value.
  */
-public class Failable<T> {
+public class Fallible<T> {
 
   private final T value;
 
@@ -21,7 +21,7 @@ public class Failable<T> {
    * @param message
    * @param isFailure Indicates whether the operation was a failure.
    */
-  public Failable(T value, final String message, boolean isFailure) {
+  public Fallible(T value, final String message, boolean isFailure) {
     this.value = value;
     this.message = message;
     this.isFailure = isFailure;
@@ -72,8 +72,8 @@ public class Failable<T> {
    * @param <T>   The type of the value.
    * @return A successful Fallible.
    */
-  public static <T> Failable<T> of(T value) {
-    return new Failable<>(value, "", false);
+  public static <T> Fallible<T> of(T value) {
+    return new Fallible<>(value, "", false);
   }
 
   /**
@@ -82,8 +82,8 @@ public class Failable<T> {
    * @param <T> The type of the value.
    * @return A failed Fallible.
    */
-  public static <T> Failable<T> failure() {
-    return new Failable<>(null, "", true);
+  public static <T> Fallible<T> failure() {
+    return new Fallible<>(null, "", true);
   }
 
   /**
@@ -93,8 +93,8 @@ public class Failable<T> {
    * @param <T>   The type of the value.
    * @return A failed Fallible with a value.
    */
-  public static <T> Failable<T> failure(T value) {
-    return new Failable<>(value, "", true);
+  public static <T> Fallible<T> failure(T value) {
+    return new Fallible<>(value, "", true);
   }
 
   /**
@@ -105,7 +105,7 @@ public class Failable<T> {
    * @param <T>     The type of the value.
    * @return A failed Fallible with a value and a message.
    */
-  public static <T> Failable<T> failure(T value, String message) {
-    return new Failable<>(value, message, true);
+  public static <T> Fallible<T> failure(T value, String message) {
+    return new Fallible<>(value, message, true);
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintsDSLCompilationService.java
@@ -33,10 +33,11 @@ public class ConstraintsDSLCompilationService {
     final var constraintsDslCompilerRoot = System.getenv("CONSTRAINTS_DSL_COMPILER_ROOT");
     final var constraintsDslCompilerCommand = System.getenv("CONSTRAINTS_DSL_COMPILER_COMMAND");
     final var nodePath = System.getenv("NODE_PATH");
-    this.nodeProcess = new ProcessBuilder(nodePath, "--experimental-vm-modules", constraintsDslCompilerCommand)
+    final var processBuilder = new ProcessBuilder(nodePath, "--experimental-vm-modules", constraintsDslCompilerCommand)
         .redirectError(ProcessBuilder.Redirect.INHERIT)
-        .directory(new File(constraintsDslCompilerRoot))
-        .start();
+        .directory(new File(constraintsDslCompilerRoot));
+    processBuilder.environment().put("NODE_NO_WARNINGS", "1");
+    this.nodeProcess = processBuilder.start();
 
     final var inputStream = this.nodeProcess.outputWriter();
     inputStream.write("ping\n");

--- a/parsing-utilities/build.gradle
+++ b/parsing-utilities/build.gradle
@@ -29,6 +29,8 @@ dependencies {
   api 'org.apache.commons:commons-lang3:3.13.0'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 publishing {

--- a/procedural/constraints/build.gradle
+++ b/procedural/constraints/build.gradle
@@ -18,6 +18,8 @@ dependencies {
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
   testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.withType(KotlinJvmCompile.class).configureEach {

--- a/procedural/timeline/build.gradle
+++ b/procedural/timeline/build.gradle
@@ -20,6 +20,8 @@ dependencies {
   testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 //  dokkaHtmlPlugin 'org.jetbrains.dokka:kotlin-as-java-plugin:1.9.10'
 }
 

--- a/scheduler-driver/build.gradle
+++ b/scheduler-driver/build.gradle
@@ -40,6 +40,8 @@ dependencies {
   testImplementation project(':examples:foo-missionmodel')
   testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
   testImplementation 'com.google.guava:guava-testlib:32.1.2-jre'
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 publishing {

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -37,6 +37,8 @@ dependencies {
   testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.0'
 
   testFixturesImplementation project(':merlin-driver')
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 processResources {

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -47,10 +47,6 @@ processResources {
 
 test {
   useJUnitPlatform()
-  testLogging {
-      events 'passed', 'skipped', 'failed'
-      exceptionFormat 'full'
-  }
 }
 
 jacocoTestReport {

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/SchedulingDSL.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/SchedulingDSL.java
@@ -111,8 +111,8 @@ public class SchedulingDSL {
               untuple(TimingConstraint.ActivityTimingConstraintFlexibleRange::new),
               (TimingConstraint.ActivityTimingConstraintFlexibleRange $) -> tuple($.lowerBound(), $.upperBound(), $.singleton()));
 
-  private static final JsonObjectParser<GoalSpecifier.CoexistenceGoalDefinition> coexistenceGoalDefinitionP(
-  MerlinService.MissionModelTypes activityTypes)
+  private static JsonObjectParser<GoalSpecifier.CoexistenceGoalDefinition> coexistenceGoalDefinitionP(
+          MerlinService.MissionModelTypes activityTypes)
   {
     return
         productP
@@ -129,6 +129,7 @@ public class SchedulingDSL {
   /**
    * This convert is in a helper function in order to define the generic variables T1 and T2
    */
+  @SuppressWarnings("unchecked")
   private static <T1 extends TimingConstraint, T2 extends TimingConstraint>
   Convert<
       Pair<Pair<Pair<Pair<Pair<Pair<ActivityTemplate, Optional<ConstraintExpression.ActivityExpression>>, String>, ConstraintExpression>, Optional<T1>>, Optional<T2>>, Boolean>,
@@ -145,8 +146,8 @@ public class SchedulingDSL {
     ));
   }
 
-  private static final JsonObjectParser<GoalSpecifier.CardinalityGoalDefinition> cardinalityGoalDefinitionP(
-      MerlinService.MissionModelTypes activityTypes) {
+  private static JsonObjectParser<GoalSpecifier.CardinalityGoalDefinition> cardinalityGoalDefinitionP(
+          MerlinService.MissionModelTypes activityTypes) {
     return
         productP
             .field("activityTemplate", new ActivityTemplateJsonParser(activityTypes))
@@ -243,7 +244,7 @@ public class SchedulingDSL {
             globalSchedulingConditionP)
   )));
 
-  public static final JsonParser<GoalSpecifier> schedulingJsonP(MerlinService.MissionModelTypes missionModelTypes){
+  public static JsonParser<GoalSpecifier> schedulingJsonP(MerlinService.MissionModelTypes missionModelTypes){
     return goalSpecifierF(missionModelTypes);
   }
 

--- a/scheduler-worker/build.gradle
+++ b/scheduler-worker/build.gradle
@@ -123,6 +123,8 @@ dependencies {
   testImplementation testFixtures(project(':scheduler-server'))
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
   testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.0'
+
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 publishing {

--- a/scheduler-worker/build.gradle
+++ b/scheduler-worker/build.gradle
@@ -40,7 +40,7 @@ task assembleSchedulingDSLCompiler(type: NpmTask) {
   dependsOn copyConstraintsTypescript
   dependsOn processResources
   dependsOn npmInstall
-  args = ['run', 'build']
+  args = ['--silent', 'run', 'build']
   inputs.files('package.json', 'package-lock.json', 'tsconfig.json')
   inputs.dir('src')
 }
@@ -50,7 +50,7 @@ task generateDocumentation(type: NpmTask) {
   dependsOn processResources
   dependsOn copyConstraintsTypescript
   dependsOn assembleSchedulingDSLCompiler
-  args = ['run', 'generate-doc']
+  args = ['--silent', 'run', 'generate-doc']
   inputs.files('package.json', 'package-lock.json', 'tsconfig.json')
   inputs.dir('src')
 }

--- a/scheduler-worker/scheduling-dsl-compiler/package.json
+++ b/scheduler-worker/scheduling-dsl-compiler/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "rm -rf build; tsc",
     "test": "npm run build && node build/main.js",
-    "generate-doc": "rm -rf build/docs; npx typedoc src/libs/scheduler-edsl-fluent-api.ts src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Scheduling eDSL Documentation\" --readme none --gitRevision develop"
+    "generate-doc": "rm -rf build/docs; npx typedoc src/libs/scheduler-edsl-fluent-api.ts src/libs/constraints-edsl-fluent-api.ts --excludePrivate --excludeInternal --out ./build/docs --name \"Scheduling eDSL Documentation\" --readme none --gitRevision develop --validation.notExported false --logLevel Warn"
   },
   "dependencies": {
     "@nasa-jpl/aerie-ts-user-code-runner": "0.5.0",

--- a/scheduler-worker/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
+++ b/scheduler-worker/scheduling-dsl-compiler/src/libs/scheduler-edsl-fluent-api.ts
@@ -509,7 +509,7 @@ export class Goal {
    *
    *
    * NOTE: In order to avoid placing multiple activities at the same start time, the Cardinality goal introduces an assumed mutual exclusion constraint - namely that new activities will not be allowed to overlap with existing activities.
-   * @param opts an object containing the activity template and a  {@link ActivityCardinalityGoal} specification of what kind of cardinality is considered
+   * @param opts an object containing the activity template and a CardinalityGoalArguments specification of what kind of cardinality is considered
    */
   public static CardinalityGoal <A extends WindowsEDSL.Gen.ActivityType, B extends WindowsEDSL.Gen.ActivityType>(opts: {
     activityTemplate: ActivityTemplate<A>,

--- a/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingDSLCompilationService.java
+++ b/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingDSLCompilationService.java
@@ -33,10 +33,11 @@ public class SchedulingDSLCompilationService {
     final var schedulingDslCompilerRoot = System.getenv("SCHEDULING_DSL_COMPILER_ROOT");
     final var schedulingDslCompilerCommand = System.getenv("SCHEDULING_DSL_COMPILER_COMMAND");
     final var nodePath = System.getenv("NODE_PATH");
-    this.nodeProcess = new ProcessBuilder(nodePath, "--experimental-vm-modules", schedulingDslCompilerCommand)
+    final var processBuilder = new ProcessBuilder(nodePath, "--experimental-vm-modules", schedulingDslCompilerCommand)
         .redirectError(ProcessBuilder.Redirect.INHERIT)
-        .directory(new File(schedulingDslCompilerRoot))
-        .start();
+        .directory(new File(schedulingDslCompilerRoot));
+    processBuilder.environment().put("NODE_NO_WARNINGS", "1");
+    this.nodeProcess = processBuilder.start();
 
     final var inputStream = this.nodeProcess.outputWriter();
     inputStream.write("ping\n");

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingIntegrationTests.java
@@ -1754,7 +1754,7 @@ public class SchedulingIntegrationTests {
         List.of(
             new Segment<>(Interval.between(HOURS.times(2), HOURS.times(4)), SerializedValue.of(true))
         )
-    ).assignGaps(new DiscreteProfile(List.of(new Segment(Interval.FOREVER, SerializedValue.of(false)))));
+    ).assignGaps(new DiscreteProfile(List.of(new Segment<>(Interval.FOREVER, SerializedValue.of(false)))));
 
     final var results = runScheduler(
         BANANANATION,

--- a/sequencing-server/build.gradle
+++ b/sequencing-server/build.gradle
@@ -9,7 +9,7 @@ node {
 
 task assemble(type: NpmTask) {
   dependsOn npmInstall
-  args = ['run', 'build']
+  args = ['--silent', 'run', 'build']
 }
 
 task build {
@@ -28,5 +28,5 @@ task clean(type: Delete) {
 
 task e2eTest(type: NpmTask) {
   dependsOn npmInstall
-  args = ['run', 'test']
+  args = ['--silent', 'run', 'test']
 }

--- a/sequencing-server/tsconfig.json
+++ b/sequencing-server/tsconfig.json
@@ -9,6 +9,7 @@
     "lib": [
       "esnext"
     ],
+    "module": "esnext",
     "resolveJsonModule": true,
     "ignoreDeprecations": "5.0"
   }


### PR DESCRIPTION
* **Tickets addressed:** none
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR fixes or silences all warnings in the current build process. For silenced warnings that need justification, I've put my reasons in the commit descriptions.

The only one that I'm not sure about is the first commit. @goetzrrGit I specifically need your review for that one line. Basically, the TS compiler in sequencing-server gave a warning that said something like "import assertions aren't allowed unless module is set to esnext or nodenext". So I set `"module": "esnext"` in tsconfig. I have no idea what this change means or if it will cause problems.

## Verification
If tests pass and successful builds are silent, I'm happy. You should be able run `./gradlew build --warning-mode all` and see no output other than the Build Successful message.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
The war for quiet builds is eternal.