### PR TITLE
Enable expansion again

### DIFF
--- a/sequencing-server/sql/sequencing/tables/expansion_set.sql
+++ b/sequencing-server/sql/sequencing/tables/expansion_set.sql
@@ -5,7 +5,7 @@ create table expansion_set (
 
   command_dict_id integer not null,
   mission_model_id integer not null,
-  sequence_adaptation_id integer not null,
+  sequence_adaptation_id integer,
 
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),


### PR DESCRIPTION
The new sequence editor broke sequence expansion. The adaptation should be optional as they are not needed currently by Clipper to expand their sequences. 

Frontend changes:

https://github.com/NASA-AMMOS/aerie-ui/pull/1261