### PR TITLE
Fix Delete trigger for v2.6.3

### DIFF
--- a/.github/scripts/explanations
+++ b/.github/scripts/explanations
@@ -1,8 +1,8 @@
 schema	migrations	migrations	missing in 1st DB	From Migration 0	2
 function definition	migrations	migrations.migrations.mark_migration_applied(character varying)	missing in 1st DB	From Migration 0	3
 function definition	migrations	migrations.migrations.mark_migration_rolled_back(character varying)	missing in 1st DB	From Migration 0	3
-function permissions	migrations	migrations.mark_migration_applied(character varying)-role:aerie	missing in 1st DB	From Migration 0	3
-function permissions	migrations	migrations.mark_migration_rolled_back(character varying)-role:aerie	missing in 1st DB	From Migration 0	3
+function permissions	migrations	migrations.mark_migration_applied(character varying)-role:aerie_test_username	missing in 1st DB	From Migration 0	3
+function permissions	migrations	migrations.mark_migration_rolled_back(character varying)-role:aerie_test_username	missing in 1st DB	From Migration 0	3
 function permissions	migrations	migrations.mark_migration_applied(character varying)-role:PUBLIC	missing in 1st DB	From Migration 0	3
 function permissions	migrations	migrations.mark_migration_rolled_back(character varying)-role:PUBLIC	missing in 1st DB	From Migration 0	3
 function owner	migrations	migrations.mark_migration_applied(character varying)	missing in 1st DB	From Migration 0	3

--- a/.github/scripts/explanations_merlin_down
+++ b/.github/scripts/explanations_merlin_down
@@ -1,7 +1,7 @@
 function definition	hdb_catalog	hdb_catalog.hdb_catalog."notify_hasura_refreshResourceTypes_INSERT"()	missing in 1st DB	From_RefreshResourceTypes_Action	2
 function definition	hdb_catalog	hdb_catalog.hdb_catalog."notify_hasura_refreshResourceTypes_UPDATE"()	missing in 1st DB	From_RefreshResourceTypes_Action	2
-function permissions	hdb_catalog	hdb_catalog."notify_hasura_refreshResourceTypes_UPDATE"()-role:aerie	missing in 1st DB	From_RefreshResourceTypes_Action	2
-function permissions	hdb_catalog	hdb_catalog."notify_hasura_refreshResourceTypes_INSERT"()-role:aerie	missing in 1st DB	From_RefreshResourceTypes_Action	2
+function permissions	hdb_catalog	hdb_catalog."notify_hasura_refreshResourceTypes_UPDATE"()-role:aerie_test_username	missing in 1st DB	From_RefreshResourceTypes_Action	2
+function permissions	hdb_catalog	hdb_catalog."notify_hasura_refreshResourceTypes_INSERT"()-role:aerie_test_username	missing in 1st DB	From_RefreshResourceTypes_Action	2
 function permissions	hdb_catalog	hdb_catalog."notify_hasura_refreshResourceTypes_UPDATE"()-role:PUBLIC	missing in 1st DB	From_RefreshResourceTypes_Action	2
 function permissions	hdb_catalog	hdb_catalog."notify_hasura_refreshResourceTypes_INSERT"()-role:PUBLIC	missing in 1st DB	From_RefreshResourceTypes_Action	2
 function owner	hdb_catalog	hdb_catalog."notify_hasura_refreshResourceTypes_UPDATE"()	missing in 1st DB	From_RefreshResourceTypes_Action	2

--- a/db-tests/build.gradle
+++ b/db-tests/build.gradle
@@ -17,6 +17,26 @@ jacocoTestReport {
 }
 
 task e2eTest(type: Test) {
+  ext.parseEnvFile = { filePath ->
+    file(filePath).readLines().each() {
+      if (!it.isEmpty() && !it.startsWith("#")) {
+        def (key, value) = it.tokenize('=')
+        if (key.startsWith("export ")) {
+          key = key.split("export ")[1];
+        }
+        if (System.getenv(key) == null) {
+          environment key, value
+        }
+      }
+    }
+  }
+
+  if(file('../e2e-tests/.env').exists()) {
+    parseEnvFile('../e2e-tests/.env')
+  } else if(file('../.env').exists()){
+    parseEnvFile('../.env')
+  }
+
   useJUnitPlatform()
 }
 

--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/DatabaseTestHelper.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/DatabaseTestHelper.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.database;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 
 import java.io.File;
@@ -30,13 +31,20 @@ public class DatabaseTestHelper {
    * Sets up the test database
    */
   public void startDatabase() throws SQLException, IOException, InterruptedException {
+    // Load database admin credentials from the environment
+    final var aerieUsername = getEnv("AERIE_USERNAME");
+    final var aeriePassword = getEnv("AERIE_PASSWORD");
+
+    final var postgresUsername = getEnv("POSTGRES_USER");
+    final var postgresPassword = getEnv("POSTGRES_PASSWORD");
+
     // Create test database and grant privileges
     {
       final var pb = new ProcessBuilder("psql",
-                                        "postgresql://postgres:postgres@localhost:5432",
+                                        "postgresql://"+postgresUsername+":"+postgresPassword+"@localhost:5432/postgres",
                                         "-v", "ON_ERROR_STOP=1",
                                         "-c", "CREATE DATABASE " + dbName + ";",
-                                        "-c", "GRANT ALL PRIVILEGES ON DATABASE " + dbName + " TO aerie;"
+                                        "-c", "GRANT ALL PRIVILEGES ON DATABASE " + dbName + " TO "+aerieUsername+";"
       );
 
       final var proc = pb.start();
@@ -45,7 +53,7 @@ public class DatabaseTestHelper {
       final var errors = new String(proc.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
       Assumptions.assumeFalse(
           (  errors.contains("Connection refused")
-          || errors.contains("role \"postgres\" does not exist")));
+          || errors.contains("role \""+postgresUsername+"\" does not exist")));
       proc.waitFor();
       proc.destroy();
     }
@@ -54,9 +62,9 @@ public class DatabaseTestHelper {
     // Apparently, the previous privileges are insufficient on their own
     {
       final var pb = new ProcessBuilder("psql",
-                                        "postgresql://aerie:aerie@localhost:5432/" + dbName,
+                                        "postgresql://"+aerieUsername+":"+aeriePassword+"@localhost:5432/" + dbName,
                                         "-v", "ON_ERROR_STOP=1",
-                                        "-c", "ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO aerie;",
+                                        "-c", "ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO "+aerieUsername+";",
                                         "-c", "\\ir %s".formatted(initSqlScriptFile.getAbsolutePath())
       );
 
@@ -73,8 +81,9 @@ public class DatabaseTestHelper {
     hikariConfig.addDataSourceProperty("portNumber", "5432");
     hikariConfig.addDataSourceProperty("databaseName", dbName);
     hikariConfig.addDataSourceProperty("applicationName", appName);
-    hikariConfig.setUsername("aerie");
-    hikariConfig.setPassword("aerie");
+
+    hikariConfig.setUsername(aerieUsername);
+    hikariConfig.setPassword(aeriePassword);
 
     hikariConfig.setConnectionInitSql("set time zone 'UTC'");
 
@@ -91,12 +100,16 @@ public class DatabaseTestHelper {
     Assumptions.assumeTrue(connection != null);
     connection.close();
 
+    // Grab postgres credentials from environment
+    final var postgresUsername = getEnv("POSTGRES_USER");
+    final var postgresPassword = getEnv("POSTGRES_PASSWORD");
+
     // Clear out all data from the database on test conclusion
     // This is done WITH (FORCE) so there aren't issues with trying
     // to drop a database while there are connected sessions from
     // dev tools
     final var pb = new ProcessBuilder("psql",
-                                      "postgresql://postgres:postgres@localhost:5432",
+                                      "postgresql://"+postgresUsername+":"+postgresPassword+"@localhost:5432/postgres",
                                       "-v", "ON_ERROR_STOP=1",
                                       "-c", "DROP DATABASE IF EXISTS " + dbName + " WITH (FORCE);"
     );
@@ -109,6 +122,11 @@ public class DatabaseTestHelper {
 
   public Connection connection() {
     return connection;
+  }
+
+  private static String getEnv(final String key) {
+    final var env = System.getenv(key);
+    return env == null ? Assertions.fail("Could not find envvar: " + key) : env;
   }
 
   public void clearTable(String table) throws SQLException {

--- a/deployment/hasura/migrations/AerieScheduler/15_scheduling_goals_bulk_delete/down.sql
+++ b/deployment/hasura/migrations/AerieScheduler/15_scheduling_goals_bulk_delete/down.sql
@@ -1,0 +1,1 @@
+call migrations.mark_migration_rolled_back('15');

--- a/deployment/hasura/migrations/AerieScheduler/15_scheduling_goals_bulk_delete/down.sql
+++ b/deployment/hasura/migrations/AerieScheduler/15_scheduling_goals_bulk_delete/down.sql
@@ -1,1 +1,43 @@
+-- Restore Scheduling Spec (Model) Delete function to work per-row
+create or replace trigger delete_scheduling_model_specification_goal
+  after delete on scheduling_model_specification_goals
+  for each row
+execute function delete_scheduling_model_specification_goal_func();
+
+create or replace function delete_scheduling_model_specification_goal_func()
+  returns trigger
+  language plpgsql as $$
+begin
+  update scheduling_model_specification_goals
+  set priority = priority - 1
+  where model_id = old.model_id
+    and priority > old.priority;
+  return null;
+end;
+$$;
+
+-- Restore Scheduling Spec (Plan) Delete function to work per-row
+create or replace trigger delete_scheduling_specification_goal
+  after delete on scheduling_specification_goals
+  for each row
+execute function delete_scheduling_specification_goal_func();
+
+create or replace function delete_scheduling_specification_goal_func()
+  returns trigger
+  language plpgsql as $$
+begin
+  update scheduling_specification_goals
+  set priority = priority - 1
+  where specification_id = old.specification_id
+    and priority > old.priority;
+  return null;
+end;
+$$;
+
+-- Remove the "depth" condition from this trigger
+create or replace trigger increment_revision_on_goal_update
+  before insert or update on scheduling_specification_goals
+  for each row
+execute function increment_spec_revision_on_goal_spec_update();
+
 call migrations.mark_migration_rolled_back('15');

--- a/deployment/hasura/migrations/AerieScheduler/15_scheduling_goals_bulk_delete/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/15_scheduling_goals_bulk_delete/up.sql
@@ -5,4 +5,60 @@ create or replace trigger update_scheduling_specification_goal
   when (OLD.priority is distinct from NEW.priority and pg_trigger_depth() < 1)
 execute function update_scheduling_specification_goal_func();
 
+-- Add a "depth" condition to this trigger to avoid needlessly increasing the spec's revision
+create or replace trigger increment_revision_on_goal_update
+  before insert or update on scheduling_specification_goals
+  for each row
+  when (pg_trigger_depth() < 1)
+execute function increment_spec_revision_on_goal_spec_update();
+
+-- Update Scheduling Spec (Plan) Delete function to work per-statement
+create or replace function delete_scheduling_specification_goal_func()
+  returns trigger
+  language plpgsql as $$
+  declare
+    r scheduling_specification_goals;
+begin
+  -- Perform updates in reverse-priority order to ensure that there are no gaps
+  for r in select * from removed_rows order by priority desc loop
+    update scheduling_specification_goals
+    set priority = priority - 1
+    where specification_id = r.specification_id
+      and priority > r.priority;
+  end loop;
+  return null;
+end;
+$$;
+
+create or replace trigger delete_scheduling_specification_goal
+  after delete on scheduling_specification_goals
+  referencing old table as removed_rows
+  for each statement
+execute function delete_scheduling_specification_goal_func();
+
+
+-- Update Scheduling Spec (Model) Delete function to work per-statement
+create or replace function delete_scheduling_model_specification_goal_func()
+  returns trigger
+  language plpgsql as $$
+  declare
+    r scheduling_model_specification_goals;
+begin
+  -- Perform updates in reverse-priority order to ensure that there are no gaps
+  for r in select * from removed_rows order by priority desc loop
+    update scheduling_model_specification_goals
+    set priority = priority - 1
+    where model_id = r.model_id
+      and priority > r.priority;
+  end loop;
+  return null;
+end;
+$$;
+
+create or replace trigger delete_scheduling_model_specification_goal
+  after delete on scheduling_model_specification_goals
+  referencing old table as removed_rows
+  for each statement
+execute function delete_scheduling_model_specification_goal_func();
+
 call migrations.mark_migration_applied('15');

--- a/deployment/hasura/migrations/AerieScheduler/15_scheduling_goals_bulk_delete/up.sql
+++ b/deployment/hasura/migrations/AerieScheduler/15_scheduling_goals_bulk_delete/up.sql
@@ -1,0 +1,8 @@
+-- Ensure the update trigger has the correct "when" condition
+create or replace trigger update_scheduling_specification_goal
+  before update on scheduling_specification_goals
+  for each row
+  when (OLD.priority is distinct from NEW.priority and pg_trigger_depth() < 1)
+execute function update_scheduling_specification_goal_func();
+
+call migrations.mark_migration_applied('15');

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -19,7 +19,7 @@ services:
       POSTGRES_PASSWORD: '${AERIE_PASSWORD}'
       POSTGRES_PORT: 5432
       POSTGRES_USER: '${AERIE_USERNAME}'
-    image: 'ghcr.io/nasa-ammos/aerie-gateway:develop'
+    image: 'ghcr.io/nasa-ammos/aerie-gateway:v2.6.0'
     ports: ['9000:9000']
     restart: always
     volumes:

--- a/scheduler-server/sql/scheduler/applied_migrations.sql
+++ b/scheduler-server/sql/scheduler/applied_migrations.sql
@@ -17,3 +17,4 @@ call migrations.mark_migration_applied('11');
 call migrations.mark_migration_applied('12');
 call migrations.mark_migration_applied('13');
 call migrations.mark_migration_applied('14');
+call migrations.mark_migration_applied('15');

--- a/scheduler-server/sql/scheduler/tables/scheduling_specification_goals.sql
+++ b/scheduler-server/sql/scheduler/tables/scheduling_specification_goals.sql
@@ -136,11 +136,16 @@ execute function update_scheduling_specification_goal_func();
 create function delete_scheduling_specification_goal_func()
   returns trigger
   language plpgsql as $$
+  declare
+    r scheduling_specification_goals;
 begin
-  update scheduling_specification_goals
-  set priority = priority - 1
-  where specification_id = old.specification_id
-    and priority > old.priority;
+  -- Perform updates in reverse-priority order to ensure that there are no gaps
+  for r in select * from removed_rows order by priority desc loop
+    update scheduling_specification_goals
+    set priority = priority - 1
+    where specification_id = r.specification_id
+      and priority > r.priority;
+  end loop;
   return null;
 end;
 $$;
@@ -151,7 +156,8 @@ comment on function delete_scheduling_specification_goal_func() is e''
 create trigger delete_scheduling_specification_goal
   after delete
   on scheduling_specification_goals
-  for each row
+  referencing old table as removed_rows
+  for each statement
 execute function delete_scheduling_specification_goal_func();
 
 create function increment_spec_revision_on_goal_spec_update()
@@ -167,6 +173,7 @@ end$$;
 create trigger increment_revision_on_goal_update
   before insert or update on scheduling_specification_goals
   for each row
+  when (pg_trigger_depth() < 1)
   execute function increment_spec_revision_on_goal_spec_update();
 
 create function increment_spec_revision_on_goal_spec_delete()


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

This PR and its sister PR against develop fix two bugs with our scheduling specifications:
1) The migration for Versioning Scheduling Goals did not update the `when` condition of the `on update` trigger for scheduling specifications, leading to the stack depth unexpectedly exploding when trying to update a spec 38+ goals (the threshold may be lower, but I did not look into this).
2) The function used for `on delete` did not properly handle bulk deletes (as in a delete statement that deletes multiple rows). This function and its trigger have been updated to operate "per-statement" and go through all the rows deleted in reverse priority order. This ensures that 

Independently of these bugs, I also put a depth check on the `increment spec update when the goals subtable is updated` trigger, as there's no reason for us to update the revision when a trigger changes a goal's priority.

A simple example of the second bug follows:
Let's say we have the following specification. Specification are being expressed as an array ordered by priority and "tailing" priorities will be expressed as `null` in order to avoid confusion caused by the array changing size mid-walkthrough.
`[ Goal 1, Goal 2, Goal 3, Goal 4, Goal 5, Goal 6 ]`

Now let us delete Goal 1, Goal 2, and Goal 5. The expected output for this action is`[Goal 3, Goal 4, Goal 6, null, null, null]`

Under the old logic, the following would happen:

1. Goal 1, Goal 2, and Goal 5 are deleted: `[null, null, Goal 3, Goal 4, null, Goal 6]`
2. The `after delete` trigger for Goal 1 is processed. As Goal 3, Goal 4, and Goal 6 have a strictly higher priority than Goal 1, their priorities are reduced by 1: `[null, Goal 3, Goal 4, null, Goal 6, null]`
3. The `after delete` trigger for Goal 2 is processed. As Goal 4 and Goal 6 have a strictly higher priority than Goal 2, their priorities are reduced by 1: `[null, Goal 3 and Goal 4, null, Goal 6, null, null]`
4. The `after delete` trigger for Goal 5 is processed. As no Goals have a strictly higher priority than Goal 5, no rows are updated: `[null, Goal 3 and Goal 4, null, Goal 6, null, null]`
5. An exception is raised, as Goal 3 and Goal 4 cannot share a priority.

Note that preserving the old per-row function but instead reducing goals with a priority greater than or equal to the current goal's would _not_ have been sufficient, as it would lead to gaps in priorities (as well as conflicting priorities in different setups). For example, in the above example, `Goal 6` has been placed at priority 4 before we process `Goal 5`'s deletion, meaning it will not be moved to priority 3, even though that's where we would expect it to be at the end of the transaction, leaving a gap at priority 3.

Under the new logic, the following occurs:

1. Goal 1, Goal 2, and Goal 5 are deleted: `[null, null, Goal 3, Goal 4, null, Goal 6]`
2. The `after delete` for step 1 begins. `Goal 5`, as the deleted Goal with the highest priority, is processed first: `[null, null, Goal 3, Goal 4, Goal 6, null]`
3. Goal 2, as the deleted Goal with the second-highest priority, is processed next: `[null, Goal 3, Goal 4, Goal 6, null, null]`
4. Goal 1, as the deleted Goal with the lowest priority, is processed last: `[Goal 3, Goal 4, Goal 6, null, null, null]`
5. The `after delete` for step 1 completes.

The output in this case is exactly as expected, as by processing in reverse priority order, we guarantee that all goals with a strictly higher priority than that of the deleted goal we're processing is still at a strictly higher priority than that deleted goal, even if that priority has changed.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

New DB tests will be included in the variant of this branch to be merge into main.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

We need to document that PGCMP does not catch `when` conditions on triggers so that viewers are aware to keep their eye out for it.

## Future work
<!-- What next steps can we anticipate from here, if any? -->

Looking into extending PGCMP to implement the `when` condition trigger match.
