### PR TITLE
Fix Scheduling Spec Goals Delete (for develop)

### DIFF
--- a/.github/workflows/pgcmp.yml
+++ b/.github/workflows/pgcmp.yml
@@ -42,6 +42,7 @@ jobs:
         run: sudo curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
       - name: Start Postgres
         run: |
+          sed -i 's/postgres:14.8/postgres:16.2/' docker-compose.yml
           docker compose up -d postgres hasura
           docker images
           docker ps -a

--- a/deployment/hasura/migrations/Aerie/2_scheduling_goals_bulk_delete/down.sql
+++ b/deployment/hasura/migrations/Aerie/2_scheduling_goals_bulk_delete/down.sql
@@ -1,0 +1,1 @@
+call migrations.mark_migration_rolled_back('2');

--- a/deployment/hasura/migrations/Aerie/2_scheduling_goals_bulk_delete/down.sql
+++ b/deployment/hasura/migrations/Aerie/2_scheduling_goals_bulk_delete/down.sql
@@ -1,1 +1,43 @@
+-- Restore Scheduling Spec (Model) Delete function to work per-row
+create or replace trigger delete_scheduling_model_specification_goal
+  after delete on scheduler.scheduling_model_specification_goals
+  for each row
+execute function scheduler.delete_scheduling_model_specification_goal_func();
+
+create or replace function scheduler.delete_scheduling_model_specification_goal_func()
+  returns trigger
+  language plpgsql as $$
+begin
+  update scheduler.scheduling_model_specification_goals
+  set priority = priority - 1
+  where model_id = old.model_id
+    and priority > old.priority;
+  return null;
+end;
+$$;
+
+-- Restore Scheduling Spec (Plan) Delete function to work per-row
+create or replace trigger delete_scheduling_specification_goal
+  after delete on scheduler.scheduling_specification_goals
+  for each row
+execute function scheduler.delete_scheduling_specification_goal_func();
+
+create or replace function scheduler.delete_scheduling_specification_goal_func()
+  returns trigger
+  language plpgsql as $$
+begin
+  update scheduler.scheduling_specification_goals
+  set priority = priority - 1
+  where specification_id = old.specification_id
+    and priority > old.priority;
+  return null;
+end;
+$$;
+
+-- Remove the "depth" condition from this trigger
+create or replace trigger increment_revision_on_goal_update
+  before insert or update on scheduler.scheduling_specification_goals
+  for each row
+execute function scheduler.increment_spec_revision_on_goal_spec_update();
+
 call migrations.mark_migration_rolled_back('2');

--- a/deployment/hasura/migrations/Aerie/2_scheduling_goals_bulk_delete/up.sql
+++ b/deployment/hasura/migrations/Aerie/2_scheduling_goals_bulk_delete/up.sql
@@ -5,4 +5,60 @@ create or replace trigger update_scheduling_specification_goal
   when (OLD.priority is distinct from NEW.priority and pg_trigger_depth() < 1)
 execute function scheduler.update_scheduling_specification_goal_func();
 
+-- Add a "depth" condition to this trigger to avoid needlessly increasing the spec's revision
+create or replace trigger increment_revision_on_goal_update
+  before insert or update on scheduler.scheduling_specification_goals
+  for each row
+  when (pg_trigger_depth() < 1)
+execute function scheduler.increment_spec_revision_on_goal_spec_update();
+
+-- Update Scheduling Spec (Plan) Delete function to work per-statement
+create or replace function scheduler.delete_scheduling_specification_goal_func()
+  returns trigger
+  language plpgsql as $$
+  declare
+    r scheduler.scheduling_specification_goals;
+begin
+  -- Perform updates in reverse-priority order to ensure that there are no gaps
+  for r in select * from removed_rows order by priority desc loop
+    update scheduler.scheduling_specification_goals
+    set priority = priority - 1
+    where specification_id = r.specification_id
+      and priority > r.priority;
+  end loop;
+  return null;
+end;
+$$;
+
+create or replace trigger delete_scheduling_specification_goal
+  after delete on scheduler.scheduling_specification_goals
+  referencing old table as removed_rows
+  for each statement
+execute function scheduler.delete_scheduling_specification_goal_func();
+
+
+-- Update Scheduling Spec (Model) Delete function to work per-statement
+create or replace function scheduler.delete_scheduling_model_specification_goal_func()
+  returns trigger
+  language plpgsql as $$
+  declare
+    r scheduler.scheduling_model_specification_goals;
+begin
+  -- Perform updates in reverse-priority order to ensure that there are no gaps
+  for r in select * from removed_rows order by priority desc loop
+    update scheduler.scheduling_model_specification_goals
+    set priority = priority - 1
+    where model_id = r.model_id
+      and priority > r.priority;
+  end loop;
+  return null;
+end;
+$$;
+
+create or replace trigger delete_scheduling_model_specification_goal
+  after delete on scheduler.scheduling_model_specification_goals
+  referencing old table as removed_rows
+  for each statement
+execute function scheduler.delete_scheduling_model_specification_goal_func();
+
 call migrations.mark_migration_applied('2');

--- a/deployment/hasura/migrations/Aerie/2_scheduling_goals_bulk_delete/up.sql
+++ b/deployment/hasura/migrations/Aerie/2_scheduling_goals_bulk_delete/up.sql
@@ -1,0 +1,8 @@
+-- Ensure the update trigger has the correct "when" condition
+create or replace trigger update_scheduling_specification_goal
+  before update on scheduler.scheduling_specification_goals
+  for each row
+  when (OLD.priority is distinct from NEW.priority and pg_trigger_depth() < 1)
+execute function scheduler.update_scheduling_specification_goal_func();
+
+call migrations.mark_migration_applied('2');

--- a/deployment/postgres-init-db/sql/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/applied_migrations.sql
@@ -4,3 +4,4 @@ This file denotes which migrations occur "before" this version of the schema.
 
 call migrations.mark_migration_applied('0');
 call migrations.mark_migration_applied('1');
+call migrations.mark_migration_applied('2');

--- a/deployment/postgres-init-db/sql/tables/scheduler/scheduling_specification/scheduling_specification_goals.sql
+++ b/deployment/postgres-init-db/sql/tables/scheduler/scheduling_specification/scheduling_specification_goals.sql
@@ -9,14 +9,11 @@ create table scheduler.scheduling_specification_goals (
 
   constraint scheduling_specification_goals_primary_key
     primary key (specification_id, goal_id),
-  constraint scheduling_specification_goals_unique_priorities
-    unique (specification_id, priority) deferrable initially deferred,
   constraint scheduling_specification_goals_specification_exists
     foreign key (specification_id)
       references scheduler.scheduling_specification
       on update cascade
       on delete cascade,
-  constraint non_negative_specification_goal_priority check (priority >= 0),
   constraint scheduling_spec_goal_exists
     foreign key (goal_id)
       references scheduler.scheduling_goal_metadata
@@ -26,7 +23,11 @@ create table scheduler.scheduling_specification_goals (
     foreign key (goal_id, goal_revision)
       references scheduler.scheduling_goal_definition
       on update cascade
-      on delete restrict
+      on delete restrict,
+  constraint scheduling_specification_goals_unique_priorities
+    unique (specification_id, priority) deferrable initially deferred,
+  constraint non_negative_specification_goal_priority
+    check (priority >= 0)
 );
 
 comment on table scheduler.scheduling_specification_goals is e''


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Sister PR of #1435.

<details closed>
<summary><h3>PR Description from 1435:</h3></summary>
These PRs fix two bugs with our scheduling specifications:
1) The migration for Versioning Scheduling Goals did not update the `when` condition of the `on update` trigger for scheduling specifications, leading to the stack depth unexpectedly exploding when trying to update a spec 38+ goals (the threshold may be lower, but I did not look into this).
2) The function used for `on delete` did not properly handle bulk deletes (as in a delete statement that deletes multiple rows). This function and its trigger have been updated to operate "per-statement" and go through all the rows deleted in reverse priority order. This ensures that 

Independently of these bugs, I also put a depth check on the `increment spec update when the goals subtable is updated` trigger, as there's no reason for us to update the revision when a trigger changes a goal's priority.

A simple example of the second bug follows:
Let's say we have the following specification. Specification are being expressed as an array ordered by priority and "tailing" priorities will be expressed as `null` in order to avoid confusion caused by the array changing size mid-walkthrough.
`[ Goal 1, Goal 2, Goal 3, Goal 4, Goal 5, Goal 6 ]`

Now let us delete Goal 1, Goal 2, and Goal 5. The expected output for this action is`[Goal 3, Goal 4, Goal 6, null, null, null]`

Under the old logic, the following would happen:

1. Goal 1, Goal 2, and Goal 5 are deleted: `[null, null, Goal 3, Goal 4, null, Goal 6]`
2. The `after delete` trigger for Goal 1 is processed. As Goal 3, Goal 4, and Goal 6 have a strictly higher priority than Goal 1, their priorities are reduced by 1: `[null, Goal 3, Goal 4, null, Goal 6, null]`
3. The `after delete` trigger for Goal 2 is processed. As Goal 4 and Goal 6 have a strictly higher priority than Goal 2, their priorities are reduced by 1: `[null, Goal 3 and Goal 4, null, Goal 6, null, null]`
4. The `after delete` trigger for Goal 5 is processed. As no Goals have a strictly higher priority than Goal 5, no rows are updated: `[null, Goal 3 and Goal 4, null, Goal 6, null, null]`
5. An exception is raised, as Goal 3 and Goal 4 cannot share a priority.

Note that preserving the old per-row function but instead reducing goals with a priority greater than or equal to the current goal's would _not_ have been sufficient, as it would lead to gaps in priorities (as well as conflicting priorities in different setups). For example, in the above example, `Goal 6` has been placed at priority 4 before we process `Goal 5`'s deletion, meaning it will not be moved to priority 3, even though that's where we would expect it to be at the end of the transaction, leaving a gap at priority 3.

Under the new logic, the following occurs:

1. Goal 1, Goal 2, and Goal 5 are deleted: `[null, null, Goal 3, Goal 4, null, Goal 6]`
2. The `after delete` for step 1 begins. `Goal 5`, as the deleted Goal with the highest priority, is processed first: `[null, null, Goal 3, Goal 4, Goal 6, null]`
3. Goal 2, as the deleted Goal with the second-highest priority, is processed next: `[null, Goal 3, Goal 4, Goal 6, null, null]`
4. Goal 1, as the deleted Goal with the lowest priority, is processed last: `[Goal 3, Goal 4, Goal 6, null, null, null]`
5. The `after delete` for step 1 completes.

The output in this case is exactly as expected, as by processing in reverse priority order, we guarantee that all goals with a strictly higher priority than that of the deleted goal we're processing is still at a strictly higher priority than that deleted goal, even if that priority has changed.

</details>

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

DB Tests were added to test bulk deleting from the both types of specs in three different scenarios: a chunk out of the middle, only the middle left, and many alternating rows. Against `develop`, these tests are expected to fail.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

As said in 1435, we need to document that PGCMP does not catch `when` conditions on triggers so that viewers are aware to keep their eye out for it.

## Future work
<!-- What next steps can we anticipate from here, if any? -->

As said in 1435, looking into extending PGCMP to implement the `when` condition trigger match.

