### PR TITLE
Write parents unfinished spans

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -427,7 +427,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
 
       updateSimulatedActivityParentsAction.apply(
           datasetId,
-          simulatedActivityRecords,
+          allActivityRecords,
           simIdToPgId);
     }
   }


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
@AaronPlave noticed a bug where unfinished spans would always have their `parentId` set to `null`. This was fixed by providing the list `allActivityRecords`, which contains both complete and unfinished spans, to the `updateSimulatedActivityParentsAction` instead of `simulatedActivityRecords`, which only contains the completed spans.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
A new E2E test was added. This test simulates a plan containing two decomposing activities, one which finishes, and the other which is unfinished. It then verifies that **all** child spans have their `parentId` fields populated.
