### PR TITLE
Update Docker-Compose for the Sequencing Server

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -124,6 +124,9 @@ services:
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
       SEQUENCING_LOCAL_STORE: /usr/src/app/sequencing_file_store
+      SEQUENCING_WORKER_NUM: 8
+      SEQUENCING_MAX_WORKER_HEAP_MB: 1000
+      TRANSPILER_ENABLED: "true"
     image: "${REPOSITORY_DOCKER_URL}/aerie-sequencing:${DOCKER_TAG}"
     ports: ["27184:27184"]
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,8 @@ services:
   aerie_sequencing:
     build:
       context: ./sequencing-server
-      dockerfile: Dockerfile.dev
+      dockerfile: Dockerfile
+      #dockerfile: Dockerfile.dev #-- Uncomment for development
     container_name: aerie_sequencing
     depends_on: ["postgres"]
     environment:
@@ -93,6 +94,7 @@ services:
       TRANSPILER_ENABLED: "true"
     image: aerie_sequencing
     ports: ["27184:27184"]
+    #ports: [ "27184:27184",'9229:9229'] #-- Uncomment for development
     restart: always
     volumes:
       - ./sequencing-server:/app:cached


### PR DESCRIPTION
* **Tickets addressed:** NONE
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
@dandelany noticed high CPU usage on the sequencing server, even during idle periods. This seems to be caused by a development-related watcher process used when developing the sequencing server.

To address this, I set the default values in the Docker Compose to match `deployment` which makes the CPU utilization normal. If you specifically need to develop using the sequencing server and hook up a debugger within the ide, you can uncomment the necessary sections in the Docker Compose configuration file.

Additionally, I exposed the knobs to the sequencing server in the deployment Docker Compose as they were missing. 

## Verification
There is now very low CPU usage in a development environment. 
