### PR TITLE
Allow eDSL relative times to have Days (DDD).

### DIFF
--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -3287,7 +3287,6 @@ export function hmsToDuration(hms: HMS_STRING, epoch: boolean = false): Temporal
 
   if (!epoch) {
     if (isNegative) {throw new Error(`Signed time (+/-) is not allowed for Relative Times: ${hms}`);}
-    if (daysNum !== 0) {throw new Error(`Day (DDD) is not allowed for Relative Times: ${hms}`);}
   }
   return Temporal.Duration.from({
     days: isNegative ? -daysNum : daysNum,

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -3290,7 +3290,6 @@ export function hmsToDuration(hms: HMS_STRING, epoch: boolean = false): Temporal
 
   if (!epoch) {
     if (isNegative) {throw new Error(\`Signed time (+/-) is not allowed for Relative Times: \${hms}\`);}
-    if (daysNum !== 0) {throw new Error(\`Day (DDD) is not allowed for Relative Times: \${hms}\`);}
   }
   return Temporal.Duration.from({
     days: isNegative ? -daysNum : daysNum,


### PR DESCRIPTION

* **Tickets addressed:** 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This allows uniformity with the `eDSL` and `SeqN` time formats. Relative times in the `eDSL` didn't allow for Day (DDD)

Frontend PR: https://github.com/NASA-AMMOS/aerie-ui/pull/1324

ex. 
`23T12:00:00 # not allowed in eDSL  editor but allowed in SeqN editor (This PR will allow DDD in both editors`

## Verification
Have a frontend time test that exercises the same method calls the eDSL uses. 

