### PR TITLE
Include Pending Events in Event Log

### DIFF
--- a/deployment/hasura/metadata/databases/tables/merlin/mission_model.yaml
+++ b/deployment/hasura/metadata/databases/tables/merlin/mission_model.yaml
@@ -119,18 +119,12 @@ delete_permissions:
 
 event_triggers:
   - definition:
-      enable_manual: false
+      enable_manual: true
       insert:
         columns: "*"
       update:
         columns:
-          - id
-          - revision
           - jar_id
-          - mission
-          - name
-          - version
-          - owner
     name: refreshActivityTypes
     retry_conf:
       interval_sec: 10
@@ -138,18 +132,12 @@ event_triggers:
       timeout_sec: 300
     webhook: "{{AERIE_MERLIN_URL}}/refreshActivityTypes"
   - definition:
-      enable_manual: false
+      enable_manual: true
       insert:
         columns: "*"
       update:
         columns:
-          - id
-          - revision
-          - jar_id
-          - mission
-          - name
-          - version
-          - owner
+        - jar_id
     name: refreshModelParameters
     retry_conf:
       interval_sec: 10
@@ -157,7 +145,7 @@ event_triggers:
       timeout_sec: 300
     webhook: "{{AERIE_MERLIN_URL}}/refreshModelParameters"
   - definition:
-      enable_manual: false
+      enable_manual: true
       insert:
         columns: "*"
       update:

--- a/deployment/hasura/migrations/Aerie/7_pending_hasura_events/up.sql
+++ b/deployment/hasura/migrations/Aerie/7_pending_hasura_events/up.sql
@@ -1,3 +1,8 @@
+drop view hasura.refresh_resource_type_logs;
+drop view hasura.refresh_model_parameter_logs;
+drop view hasura.refresh_activity_type_logs;
+drop function hasura.get_event_logs(_trigger_name text);
+
 create function hasura.get_event_logs(_trigger_name text)
 returns table (
   model_id int,
@@ -59,3 +64,5 @@ create view hasura.refresh_resource_type_logs as
   select * from hasura.get_event_logs('refreshResourceTypes');
 comment on view hasura.refresh_resource_type_logs is e''
  'View containing logs for every run of the Hasura event `refreshResourceTypes`.';
+
+call migrations.mark_migration_applied('7')

--- a/deployment/postgres-init-db/sql/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/applied_migrations.sql
@@ -9,3 +9,4 @@ call migrations.mark_migration_applied('3');
 call migrations.mark_migration_applied('4');
 call migrations.mark_migration_applied('5');
 call migrations.mark_migration_applied('6');
+call migrations.mark_migration_applied('7');

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/MissionModelTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/MissionModelTests.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import static gov.nasa.jpl.aerie.e2e.types.ValueSchema.*;
 import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -377,14 +378,17 @@ public class MissionModelTests {
     // Check Activity Type Refresh Event Logs
     final var activityTypeRefreshLogs = modelLogs.refreshActivityTypesLogs();
     assertEquals(1, activityTypeRefreshLogs.size());
-    final var activityTypeLog = activityTypeRefreshLogs.get(0);
+    final var activityTypeLog = activityTypeRefreshLogs.getFirst();
 
     assertEquals("Aerie Legacy", activityTypeLog.triggeringUser());
 
+    assertFalse(activityTypeLog.pending());
     assertTrue(activityTypeLog.delivered());
     assertTrue(activityTypeLog.success());
     assertEquals(1, activityTypeLog.tries());
-    assertEquals(200, activityTypeLog.status());
+
+    assertTrue(activityTypeLog.status().isPresent());
+    assertEquals(200, activityTypeLog.status().get());
 
     assertTrue(activityTypeLog.error().isEmpty());
     assertTrue(activityTypeLog.errorMessage().isEmpty());
@@ -393,14 +397,17 @@ public class MissionModelTests {
     // Check Model Parameter Refresh Event Logs
     final var modelParamRefreshLogs = modelLogs.refreshModelParamsLogs();
     assertEquals(1, modelParamRefreshLogs.size());
-    final var modelParamLog = modelParamRefreshLogs.get(0);
+    final var modelParamLog = modelParamRefreshLogs.getFirst();
 
     assertEquals("Aerie Legacy", modelParamLog.triggeringUser());
 
+    assertFalse(modelParamLog.pending());
     assertTrue(modelParamLog.delivered());
     assertTrue(modelParamLog.success());
     assertEquals(1, modelParamLog.tries());
-    assertEquals(200, modelParamLog.status());
+
+    assertTrue(modelParamLog.status().isPresent());
+    assertEquals(200, modelParamLog.status().get());
 
     assertTrue(modelParamLog.error().isEmpty());
     assertTrue(modelParamLog.errorMessage().isEmpty());
@@ -409,14 +416,17 @@ public class MissionModelTests {
     // Check Resource Type Refresh Event Logs
     final var resourceTypeRefreshLogs = modelLogs.refreshResourceTypesLogs();
     assertEquals(1, resourceTypeRefreshLogs.size());
-    final var resourceTypeLog = resourceTypeRefreshLogs.get(0);
+    final var resourceTypeLog = resourceTypeRefreshLogs.getFirst();
 
     assertEquals("Aerie Legacy", resourceTypeLog.triggeringUser());
 
+    assertFalse(resourceTypeLog.pending());
     assertTrue(resourceTypeLog.delivered());
     assertTrue(resourceTypeLog.success());
     assertEquals(1, resourceTypeLog.tries());
-    assertEquals(200, resourceTypeLog.status());
+
+    assertTrue(resourceTypeLog.status().isPresent());
+    assertEquals(200, resourceTypeLog.status().get());
 
     assertTrue(resourceTypeLog.error().isEmpty());
     assertTrue(resourceTypeLog.errorMessage().isEmpty());

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ModelEventLogs.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ModelEventLogs.java
@@ -14,17 +14,20 @@ public record ModelEventLogs(
 ) {
   public record EventLog(
     String triggeringUser,
+    boolean pending,
     boolean delivered,
     boolean success,
     int tries,
     String createdAt,
-    int status,
+    Optional<Integer> status,
     Optional<JsonObject> error,
     Optional<String> errorMessage,
     Optional<String> errorType
   )
   {
     public static EventLog fromJSON(JsonObject json) {
+      final Optional<Integer> status = json.isNull("status") ?
+          Optional.empty() : Optional.of(json.getInt("status"));
       final Optional<JsonObject> error = json.isNull("error") ?
           Optional.empty() : Optional.of(json.getJsonObject("error"));
       final Optional<String> errorMsg = json.isNull("error_message") ?
@@ -34,11 +37,12 @@ public record ModelEventLogs(
 
       return new EventLog(
           json.getString("triggering_user"),
+          json.getBoolean("pending"),
           json.getBoolean("delivered"),
           json.getBoolean("success"),
           json.getInt("tries"),
           json.getString("created_at"),
-          json.getInt("status"),
+          status,
           error,
           errorMsg,
           errorType);

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
@@ -273,6 +273,7 @@ public enum GQL {
         version
         refresh_activity_type_logs(order_by: {created_at: desc}) {
           triggering_user
+          pending
           delivered
           success
           tries
@@ -284,6 +285,7 @@ public enum GQL {
         }
         refresh_model_parameter_logs(order_by: {created_at: desc}) {
           triggering_user
+          pending
           delivered
           success
           tries
@@ -295,6 +297,7 @@ public enum GQL {
         }
         refresh_resource_type_logs(order_by: {created_at: desc}) {
           triggering_user
+          pending
           delivered
           success
           tries

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -12,6 +12,7 @@ import gov.nasa.jpl.aerie.merlin.server.models.HasuraAction;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.services.GenerateConstraintsLibAction;
 import gov.nasa.jpl.aerie.merlin.server.services.GetSimulationResultsAction;
+import gov.nasa.jpl.aerie.merlin.server.services.LocalMissionModelService;
 import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService;
 import gov.nasa.jpl.aerie.merlin.server.services.PlanService;
 import gov.nasa.jpl.aerie.permissions.Action;
@@ -126,6 +127,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
+    } catch (final LocalMissionModelService.MissionModelLoadException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeMissionModelLoadException(ex).toString());
     }
   }
 
@@ -140,6 +143,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
+    } catch (final LocalMissionModelService.MissionModelLoadException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeMissionModelLoadException(ex).toString());
     }
   }
 
@@ -154,6 +159,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
+    } catch (final LocalMissionModelService.MissionModelLoadException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeMissionModelLoadException(ex).toString());
     }
   }
 
@@ -171,6 +178,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
+    } catch (final LocalMissionModelService.MissionModelLoadException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeMissionModelLoadException(ex).toString());
     }
   }
 
@@ -286,6 +295,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     } catch (final InvalidEntityException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
+    } catch (final LocalMissionModelService.MissionModelLoadException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeMissionModelLoadException(ex).toString());
     }
   }
 
@@ -307,6 +318,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     } catch (final InvalidEntityException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
+    } catch (final LocalMissionModelService.MissionModelLoadException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeMissionModelLoadException(ex).toString());
     }
   }
 
@@ -329,6 +342,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchPlanException(ex).toString());
     } catch (final MissionModelService.NoSuchMissionModelException ex) {
       ctx.status(404).result(ResponseSerializers.serializeNoSuchMissionModelException(ex).toString());
+    } catch (final LocalMissionModelService.MissionModelLoadException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeMissionModelLoadException(ex).toString());
     }
   }
 
@@ -348,6 +363,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     } catch (final InvalidEntityException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
+    } catch (final LocalMissionModelService.MissionModelLoadException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeMissionModelLoadException(ex).toString());
     }
   }
 
@@ -373,6 +390,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     } catch (final InvalidEntityException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
+    } catch (final LocalMissionModelService.MissionModelLoadException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeMissionModelLoadException(ex).toString());
     }
   }
 
@@ -391,6 +410,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(400).result(ResponseSerializers.serializeInvalidJsonException(ex).toString());
     } catch (final InvalidEntityException ex) {
       ctx.status(400).result(ResponseSerializers.serializeInvalidEntityException(ex).toString());
+    } catch (final LocalMissionModelService.MissionModelLoadException ex) {
+      ctx.status(400).result(ResponseSerializers.serializeMissionModelLoadException(ex).toString());
     }
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -538,6 +538,7 @@ public final class ResponseSerializers {
     // TODO: Improve diagnostic information?
     return Json.createObjectBuilder()
                .add("message", ex.getMessage())
+               .add("type", "Mission Model Load Failure")
                .build();
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -94,12 +94,10 @@ public final class LocalMissionModelService implements MissionModelService {
    * @param missionModelId The ID of the mission model to load.
    * @return The set of all activity types in the named mission model, indexed by name.
    * @throws NoSuchMissionModelException If no mission model is known by the given ID.
-   * @throws MissionModelLoadException If the mission model cannot be loaded -- the JAR may be invalid, or the mission model
-   * it contains may not abide by the expected contract at load time.
    */
   @Override
   public Map<String, ActivityType> getActivityTypes(final String missionModelId)
-  throws NoSuchMissionModelException, MissionModelLoadException
+  throws NoSuchMissionModelException
   {
     try {
       return missionModelRepository.getActivityTypes(missionModelId);


### PR DESCRIPTION
* **Tickets addressed:** Closes #1465 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Two changes have been made to support https://github.com/NASA-AMMOS/aerie-ui/issues/1326:
1. The function to get the event logs now includes pending events. This was done by performing a `left join` from `hdb_catalog.event_log` to the invocation logs instead of the default `inner join`. The return of the function has also been tweaked to include a `pending` status column to easily identify these rows. An event is `pending` if it has not been invoked (identified by the invocation log's primary key being `NULL`).
2. The event triggers for Mission Model have been updated so that they will now only automatically trigger when `jar_id` is updated. Additionally, then can now be manually triggered via either the Hasura Console or the Hasura Metadata API (the latter of which is used by the Gateway in [this PR](https://github.com/NASA-AMMOS/aerie-gateway/pull/93))

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
E2E tests have been updated to fetch and check the new `pending` column.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
No docs need to be updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
