### PR TITLE
Added a default value to sequence adaptation names so migrations dont…

### DIFF
--- a/deployment/hasura/migrations/Aerie/5_sequence_adaptation_name/down.sql
+++ b/deployment/hasura/migrations/Aerie/5_sequence_adaptation_name/down.sql
@@ -1,5 +1,5 @@
 alter table sequencing.sequence_adaptation
-  drop constraint sequence_adaptation_natural_key,
+  drop constraint sequence_adaptation_unique_key,
   drop column name;
 
 call migrations.mark_migration_rolled_back('5');

--- a/deployment/hasura/migrations/Aerie/5_sequence_adaptation_name/down.sql
+++ b/deployment/hasura/migrations/Aerie/5_sequence_adaptation_name/down.sql
@@ -1,5 +1,5 @@
 alter table sequencing.sequence_adaptation
-  drop constraint sequence_adaptation_unique_key,
+  drop constraint sequence_adaptation_name_unique_key,
   drop column name;
 
 call migrations.mark_migration_rolled_back('5');

--- a/deployment/hasura/migrations/Aerie/5_sequence_adaptation_name/up.sql
+++ b/deployment/hasura/migrations/Aerie/5_sequence_adaptation_name/up.sql
@@ -1,6 +1,6 @@
 alter table sequencing.sequence_adaptation
   add column name text not null default gen_random_uuid(),
-  add constraint sequence_adaptation_unique_key
+  add constraint sequence_adaptation_name_unique_key
     unique (name);
 
 comment on column sequencing.sequence_adaptation.name is e''

--- a/deployment/hasura/migrations/Aerie/5_sequence_adaptation_name/up.sql
+++ b/deployment/hasura/migrations/Aerie/5_sequence_adaptation_name/up.sql
@@ -1,6 +1,6 @@
 alter table sequencing.sequence_adaptation
-  add column name text not null,
-  add constraint sequence_adaptation_natural_key
+  add column name text not null default gen_random_uuid(),
+  add constraint sequence_adaptation_unique_key
     unique (name);
 
 comment on column sequencing.sequence_adaptation.name is e''

--- a/deployment/postgres-init-db/sql/tables/sequencing/sequence_adaptation.sql
+++ b/deployment/postgres-init-db/sql/tables/sequencing/sequence_adaptation.sql
@@ -9,7 +9,7 @@ create table sequencing.sequence_adaptation (
 
   constraint sequence_adaptation_synthetic_key
     primary key (id),
-  constraint sequence_adaptation_unique_key
+  constraint sequence_adaptation_name_unique_key
     unique (name),
   foreign key (owner)
     references permissions.users

--- a/deployment/postgres-init-db/sql/tables/sequencing/sequence_adaptation.sql
+++ b/deployment/postgres-init-db/sql/tables/sequencing/sequence_adaptation.sql
@@ -1,7 +1,7 @@
 create table sequencing.sequence_adaptation (
   id integer generated always as identity,
   adaptation text not null,
-  name text not null,
+  name text not null default gen_random_uuid(),
   created_at timestamptz not null default now(),
   owner text,
   updated_at timestamptz not null default now(),
@@ -9,7 +9,7 @@ create table sequencing.sequence_adaptation (
 
   constraint sequence_adaptation_synthetic_key
     primary key (id),
-  constraint sequence_adaptation_natural_key
+  constraint sequence_adaptation_unique_key
     unique (name),
   foreign key (owner)
     references permissions.users


### PR DESCRIPTION
… break

* **Tickets addressed:** NA
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The previous PR broke against a real migration because we didn't provide a default value for the `name` of a `sequence_adaptation`. This adds a UUID.

I tried using the current ID but that seemed more complicated for a problem that should be very low impact.

## Verification
NA

## Documentation
NA

## Future work
NA
