### PR TITLE
Remove unnecessary cast from `hasura.get_event_logs`

### DIFF
--- a/deployment/hasura/migrations/Aerie/6_hasura_events_views_500_fix/down.sql
+++ b/deployment/hasura/migrations/Aerie/6_hasura_events_views_500_fix/down.sql
@@ -1,4 +1,10 @@
-create or replace function hasura.get_event_logs(_trigger_name text)
+drop view hasura.refresh_resource_type_logs;
+drop view hasura.refresh_model_parameter_logs;
+drop view hasura.refresh_activity_type_logs;
+drop function hasura.get_event_logs(_trigger_name text);
+
+-- Recreate with new function signature
+create function hasura.get_event_logs(_trigger_name text)
 returns table (
   model_id int,
   model_name text,
@@ -38,5 +44,22 @@ begin
       where trigger_name = _trigger_name);
 end;
 $$;
+comment on function hasura.get_event_logs(_trigger_name text) is e''
+ 'Get the logs for every run of a Hasura event with the specified trigger name.';
+
+create view hasura.refresh_activity_type_logs as
+  select * from hasura.get_event_logs('refreshActivityTypes');
+comment on view hasura.refresh_activity_type_logs is e''
+ 'View containing logs for every run of the Hasura event `refreshActivityTypes`.';
+
+create view hasura.refresh_model_parameter_logs as
+  select * from hasura.get_event_logs('refreshModelParameters');
+comment on view hasura.refresh_model_parameter_logs is e''
+ 'View containing logs for every run of the Hasura event `refreshModelParameters`.';
+
+create view hasura.refresh_resource_type_logs as
+  select * from hasura.get_event_logs('refreshResourceTypes');
+comment on view hasura.refresh_resource_type_logs is e''
+ 'View containing logs for every run of the Hasura event `refreshResourceTypes`.';
 
 call migrations.mark_migration_rolled_back('6');

--- a/deployment/hasura/migrations/Aerie/6_hasura_events_views_500_fix/down.sql
+++ b/deployment/hasura/migrations/Aerie/6_hasura_events_views_500_fix/down.sql
@@ -1,0 +1,42 @@
+create or replace function hasura.get_event_logs(_trigger_name text)
+returns table (
+  model_id int,
+  model_name text,
+  model_version text,
+  triggering_user text,
+  delivered boolean,
+  success boolean,
+  tries int,
+  created_at timestamp,
+  next_retry_at timestamp,
+  status int,
+  error jsonb,
+  error_message text,
+  error_type text
+)
+stable
+security invoker
+language plpgsql as $$
+begin
+  return query (
+    select
+      (el.payload->'data'->'new'->>'id')::int as model_id,
+      el.payload->'data'->'new'->>'name' as model_name,
+      el.payload->'data'->'new'->>'version' as model_version,
+      el.payload->'session_variables'->>'x-hasura-user-id' as triggering_user,
+      el.delivered,
+      eil.status is not distinct from 200 as success, -- is not distinct from to catch `null`
+      el.tries,
+      el.created_at,
+      el.next_retry_at,
+      eil.status,
+      (eil.response -> 'data'->> 'message')::jsonb as error,
+      (eil.response -> 'data'->> 'message')::jsonb->>'message' as error_message,
+      (eil.response -> 'data'->> 'message')::jsonb->>'type' as error_type
+      from hdb_catalog.event_log el
+      join hdb_catalog.event_invocation_logs eil on el.id = eil.event_id
+      where trigger_name = _trigger_name);
+end;
+$$;
+
+call migrations.mark_migration_rolled_back('6');

--- a/deployment/hasura/migrations/Aerie/6_hasura_events_views_500_fix/up.sql
+++ b/deployment/hasura/migrations/Aerie/6_hasura_events_views_500_fix/up.sql
@@ -1,4 +1,10 @@
-create or replace function hasura.get_event_logs(_trigger_name text)
+drop view hasura.refresh_resource_type_logs;
+drop view hasura.refresh_model_parameter_logs;
+drop view hasura.refresh_activity_type_logs;
+drop function hasura.get_event_logs(_trigger_name text);
+
+-- Recreate with updated signature
+create function hasura.get_event_logs(_trigger_name text)
 returns table (
   model_id int,
   model_name text,
@@ -10,7 +16,7 @@ returns table (
   created_at timestamp,
   next_retry_at timestamp,
   status int,
-  error jsonb,
+  error json,
   error_message text,
   error_type text
 )
@@ -38,4 +44,22 @@ begin
       where trigger_name = _trigger_name);
 end;
 $$;
+comment on function hasura.get_event_logs(_trigger_name text) is e''
+ 'Get the logs for every run of a Hasura event with the specified trigger name.';
+
+create view hasura.refresh_activity_type_logs as
+  select * from hasura.get_event_logs('refreshActivityTypes');
+comment on view hasura.refresh_activity_type_logs is e''
+ 'View containing logs for every run of the Hasura event `refreshActivityTypes`.';
+
+create view hasura.refresh_model_parameter_logs as
+  select * from hasura.get_event_logs('refreshModelParameters');
+comment on view hasura.refresh_model_parameter_logs is e''
+ 'View containing logs for every run of the Hasura event `refreshModelParameters`.';
+
+create view hasura.refresh_resource_type_logs as
+  select * from hasura.get_event_logs('refreshResourceTypes');
+comment on view hasura.refresh_resource_type_logs is e''
+ 'View containing logs for every run of the Hasura event `refreshResourceTypes`.';
+
 call migrations.mark_migration_applied('6');

--- a/deployment/hasura/migrations/Aerie/6_hasura_events_views_500_fix/up.sql
+++ b/deployment/hasura/migrations/Aerie/6_hasura_events_views_500_fix/up.sql
@@ -1,4 +1,4 @@
-create function hasura.get_event_logs(_trigger_name text)
+create or replace function hasura.get_event_logs(_trigger_name text)
 returns table (
   model_id int,
   model_name text,
@@ -38,23 +38,4 @@ begin
       where trigger_name = _trigger_name);
 end;
 $$;
-comment on function hasura.get_event_logs(_trigger_name text) is e''
- 'Get the logs for every run of a Hasura event with the specified trigger name.';
-
-create view hasura.refresh_activity_type_logs as
-  select * from hasura.get_event_logs('refreshActivityTypes');
-comment on view hasura.refresh_activity_type_logs is e''
- 'View containing logs for every run of the Hasura event `refreshActivityTypes`.';
-
-create view hasura.refresh_model_parameter_logs as
-  select * from hasura.get_event_logs('refreshModelParameters');
-comment on view hasura.refresh_model_parameter_logs is e''
- 'View containing logs for every run of the Hasura event `refreshModelParameters`.';
-
-create view hasura.refresh_resource_type_logs as
-  select * from hasura.get_event_logs('refreshResourceTypes');
-comment on view hasura.refresh_resource_type_logs is e''
- 'View containing logs for every run of the Hasura event `refreshResourceTypes`.';
-
-
-
+call migrations.mark_migration_applied('6');

--- a/deployment/postgres-init-db/sql/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/applied_migrations.sql
@@ -8,3 +8,4 @@ call migrations.mark_migration_applied('2');
 call migrations.mark_migration_applied('3');
 call migrations.mark_migration_applied('4');
 call migrations.mark_migration_applied('5');
+call migrations.mark_migration_applied('6');

--- a/deployment/postgres-init-db/sql/views/hasura/hasura_event_logs.sql
+++ b/deployment/postgres-init-db/sql/views/hasura/hasura_event_logs.sql
@@ -10,7 +10,7 @@ returns table (
   created_at timestamp,
   next_retry_at timestamp,
   status int,
-  error jsonb,
+  error json,
   error_message text,
   error_type text
 )


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Grabbing the `message` field from `errors` as a `json` rather than as `text` that is then converted back to `jsonb` is more efficient, more straightforward, and avoids unnecessary errors when `message` is not a valid json.

Additionally, the type of `errors` in the function has been updated from `jsonb` to `json` to reflect the type that Hasura stores the underlying field as.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Query was tested against the `aerie_dev` database, which contains mission model logs where `message` is not a valid json.

