### PR TITLE
Bug fix for clampedIntegrate

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialResources.java
@@ -374,7 +374,7 @@ public final class PolynomialResources {
     // Set up slack variables for under-/overflow
     rateSolver.declare(lx(overflowRate), GreaterThanOrEquals, lx(0));
     rateSolver.declare(lx(underflowRate), GreaterThanOrEquals, lx(0));
-    rateSolver.declare(lx(rate).add(lx(underflowRate)).subtract(lx(overflowRate)), Equals, lx(integrand));
+    rateSolver.declare(lx(rate).subtract(lx(underflowRate)).add(lx(overflowRate)), Equals, lx(integrand));
 
     // Set up rate clamping conditions
     var integrandUB = choose(


### PR DESCRIPTION

* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

There was a sign error in the definition of the overflow and underflow slack variables for clampedIntegrate.

This caused the meaning of "overflow" and "underflow" to be reversed.


## Verification
Verified manually while debugging the simplified CADRE data model, which makes use of overflow and underflow rates.

## Documentation
N/A - bug fix

## Future work
N/A
