### PR TITLE
Bug fix for coexistence goal valueAt usage

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ValueAt.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ValueAt.java
@@ -26,9 +26,9 @@ public record ValueAt<P extends Profile<P>>(
       final Interval bounds,
       final EvaluationEnvironment environment)
   {
-    final var res = this.profile.evaluate(results, bounds, environment);
-    final var time = timepoint.evaluate(results, bounds, environment);
+    final var time = timepoint.evaluate(results, Interval.FOREVER, environment);
     final var timepoint = time.iterator().next().interval().start;
+    final var res = this.profile.evaluate(results, Interval.at(timepoint), environment);
     //REVIEW: SHOULD ASSERT A BUNCH OF THINGS HERE SO IT IS NOT WRONGLY USED
     final var value = res.valueAt(timepoint);
     if(value.isEmpty()){


### PR DESCRIPTION
* **Tickets addressed:** Closes #1378 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The interval for instantiating parameters of an activity has been relaxed to `Interval.FOREVER` instead of restricting it to the start time of the activity.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
A new test reproducing the failure has been added and is now passing.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None. 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
I found #1484 while working on this one. 