### PR TITLE
Naming efficiency

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2.java
@@ -39,8 +39,8 @@ public final class CellRefV2 {
       public void apply(Cell<D> cell, E effect) {
         cell.initialDynamics = effect.apply(cell.dynamics).match(
             ErrorCatching::success,
-            error -> failure(new RuntimeException(
-                "Applying '%s' failed.".formatted(getEffectName(effect)), error)));
+                error -> failure(new RuntimeException(
+                    "Applying effect '%s' failed.".formatted(getName(effect, "...")), error)));
         cell.dynamics = cell.initialDynamics;
         cell.elapsedTime = ZERO;
       }
@@ -120,7 +120,7 @@ public final class CellRefV2 {
       @Override
       public DynamicsEffect<D> sequentially(final DynamicsEffect<D> prefix, final DynamicsEffect<D> suffix) {
         final DynamicsEffect<D> result = x -> suffix.apply(prefix.apply(x));
-        name(result, "(%s) then (%s)".formatted(getEffectName(prefix), getEffectName(suffix)));
+        name(result, "(%s) then (%s)", prefix, suffix);
         return result;
       }
 
@@ -135,20 +135,15 @@ public final class CellRefV2 {
                   return failure(e);
                 }
               };
-          name(result, "(%s) and (%s)".formatted(getEffectName(left), getEffectName(right)));
+          name(result, "(%s) and (%s)", left, right);
           return result;
         } catch (Throwable e) {
           final DynamicsEffect<D> result = $ -> failure(e);
-          name(result, "Failed to combine concurrent effects: (%s) and (%s)".formatted(
-                  getEffectName(left), getEffectName(right)));
+          name(result, "Failed to combine concurrent effects: (%s) and (%s)", left, right);
           return result;
         }
       }
     };
-  }
-
-  private static <D extends Dynamics<?, D>, E extends DynamicsEffect<D>> String getEffectName(E effect) {
-    return getName(effect).orElse("anonymous effect");
   }
 
   public static class Cell<D> {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2.java
@@ -40,7 +40,7 @@ public final class CellRefV2 {
         cell.initialDynamics = effect.apply(cell.dynamics).match(
             ErrorCatching::success,
                 error -> failure(new RuntimeException(
-                    "Applying effect '%s' failed.".formatted(getName(effect, "...")), error)));
+                    "Applying effect '%s' failed.".formatted(getName(effect, null)), error)));
         cell.dynamics = cell.initialDynamics;
         cell.elapsedTime = ZERO;
       }

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Expiry.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Expiry.java
@@ -20,8 +20,14 @@ public record Expiry(Optional<Duration> value) implements Comparable<Expiry> {
   }
 
   public Expiry or(Expiry other) {
-    return expiry(
-        Stream.concat(value().stream(), other.value().stream()).reduce(Duration::min));
+    // If this has a value...
+    //   If other has a value, compare and return the minimum
+    //   Else other is NEVER, so return this
+    // Else (this is NEVER), so return other
+    return this.value.map(thisValue ->
+            other.value.map(otherValue -> Expiry.at(Duration.min(thisValue, otherValue)))
+                    .orElse(this))
+            .orElse(other);
   }
 
   public Expiry minus(Duration t) {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Resources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Resources.java
@@ -183,8 +183,7 @@ public final class Resources {
    */
   public static <D extends Dynamics<?, D>> void forward(Resource<D> source, MutableResource<D> destination) {
     wheneverDynamicsChange(source, s -> destination.emit(
-            "Forward %s dynamics: %s".formatted(getName(source).orElse("anonymous"), s),
-            $ -> s));
+            name($ -> s, "Forward %s dynamics to %s", source, destination)));
     addDependency(destination, source);
   }
 

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Profiling.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Profiling.java
@@ -152,7 +152,7 @@ public final class Profiling {
     MutableResource<D> result = new MutableResource<>() {
       @Override
       public void emit(DynamicsEffect<D> effect) {
-        resource.emit(x -> accrue(effectsEmitted, getName(this, "..."), () -> effect.apply(x)));
+        resource.emit(x -> accrue(effectsEmitted, getName(this, null), () -> effect.apply(x)));
       }
 
       @Override
@@ -167,7 +167,7 @@ public final class Profiling {
   private static Supplier<String> computeName(String explicitName, Object profiledThing) {
     return explicitName != null
             ? () -> explicitName
-            : () -> getName(profiledThing, "...");
+            : () -> getName(profiledThing, null);
   }
 
   private static long ANONYMOUS_ID = 0;

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/black_box/Approximation.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/black_box/Approximation.java
@@ -46,7 +46,7 @@ public final class Approximation {
   private static <D extends Dynamics<?, D>, E extends Dynamics<?, E>> void updateApproximation(
       ErrorCatching<Expiring<D>> resourceDynamics, Function<Expiring<D>, Expiring<E>> approximation, MutableResource<E> result) {
     var newDynamics = resourceDynamics.map(approximation);
-    result.emit("Update approximation to " + newDynamics, $ -> newDynamics);
+    result.emit(name($ -> newDynamics, "Update approximation to %s", newDynamics));
   }
 
   /**

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/black_box/UnstructuredResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/black_box/UnstructuredResources.java
@@ -23,7 +23,8 @@ public final class UnstructuredResources {
 
   public static <A> Resource<Unstructured<A>> constant(A value) {
     var result = UnstructuredResourceApplicative.pure(value);
-    name(result, value.toString());
+    // Use an edge in the naming graph directly to the value to lazily compute the name
+    name(result, "%s", value);
     return result;
   }
 

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffects.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffects.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
+import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.name;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteDynamicsMonad.effect;
 
 public final class DiscreteEffects {
@@ -19,7 +20,7 @@ public final class DiscreteEffects {
    * Set the resource to the given value.
    */
   public static <A> void set(MutableResource<Discrete<A>> resource, A newValue) {
-    resource.emit("Set " + newValue, effect(x -> newValue));
+    resource.emit(name(effect(x -> newValue), "Set %s", newValue));
   }
 
   // Flag/Switch style operations
@@ -58,7 +59,7 @@ public final class DiscreteEffects {
    * Add the given amount to the resource's value.
    */
   public static void increment(MutableResource<Discrete<Integer>> resource, int amount) {
-    resource.emit("Increment by " + amount, effect(x -> x + amount));
+    resource.emit(name(effect(x -> x + amount), "Increment by %s", amount));
   }
 
   /**
@@ -72,7 +73,7 @@ public final class DiscreteEffects {
    * Subtract the given amount from the resource's value.
    */
   public static void decrement(MutableResource<Discrete<Integer>> resource, int amount) {
-    resource.emit("Decrement by " + amount, effect(x -> x - amount));
+    resource.emit(name(effect(x -> x - amount), "Decrement by %s", amount));
   }
 
   // General numeric resources
@@ -81,14 +82,14 @@ public final class DiscreteEffects {
    * Add amount to resource's value
    */
   public static void increase(MutableResource<Discrete<Double>> resource, double amount) {
-    resource.emit("Increase by " + amount, effect(x -> x + amount));
+    resource.emit(name(effect(x -> x + amount), "Increase by %s", amount));
   }
 
   /**
    * Subtract amount from resource's value
    */
   public static void decrease(MutableResource<Discrete<Double>> resource, double amount) {
-    resource.emit("Decrease by " + amount, effect(x -> x - amount));
+    resource.emit(name(effect(x -> x - amount), "Decrease by %s", amount));
   }
 
   // Queue style operations, mirroring the Queue interface
@@ -97,11 +98,11 @@ public final class DiscreteEffects {
    * Add element to the end of the queue resource
    */
   public static <T> void add(MutableResource<Discrete<List<T>>> resource, T element) {
-    resource.emit("Add %s to queue".formatted(element), effect(q -> {
+    resource.emit(name(effect(q -> {
       var q$ = new LinkedList<>(q);
       q$.add(element);
       return q$;
-    }));
+    }), "Add %s to queue", element));
   }
 
   /**
@@ -115,14 +116,14 @@ public final class DiscreteEffects {
     if (currentQueue.isEmpty()) return Optional.empty();
 
     final T result = currentQueue.get(currentQueue.size() - 1);
-    resource.emit("Remove %s from queue".formatted(result), effect(q -> {
+    resource.emit(name(effect(q -> {
       var q$ = new LinkedList<>(q);
       T purportedResult = q$.removeLast();
       if (!result.equals(purportedResult)) {
         throw new IllegalStateException("Detected effect conflicting with queue remove operation");
       }
       return q$;
-    }));
+    }), "Remove %s from queue", result));
     return Optional.of(result);
   }
 
@@ -132,14 +133,14 @@ public final class DiscreteEffects {
    * Subtract the given amount from resource.
    */
   public static void consume(MutableResource<Discrete<Double>> resource, double amount) {
-    resource.emit("Consume " + amount, effect(x -> x - amount));
+    resource.emit(name(effect(x -> x - amount), "Consume %s", amount));
   }
 
   /**
    * Add the given amount to resource.
    */
   public static void restore(MutableResource<Discrete<Double>> resource, double amount) {
-    resource.emit("Restore " + amount, effect(x -> x + amount));
+    resource.emit(name(effect(x -> x + amount), "Restore %s", amount));
   }
 
   // Non-consumable style operations

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/Polynomial.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/Polynomial.java
@@ -229,7 +229,18 @@ public record Polynomial(double[] coefficients) implements Dynamics<Double, Poly
     return other.greaterThanOrEquals(this);
   }
 
-  private boolean dominates$(Polynomial other) {
+  /**
+   * Computes if this polynomial "dominates" another right now.
+   * <p>
+   *     A polynomial P dominates Q in this context if it is greater than Q in the first coefficient that differs,
+   *     or equal to Q exactly.
+   * </p>
+   * <p>
+   *     Intuitively, P dominates Q when max(P, Q) = P, potentially with a shorter expiry if Q crosses P sometime in the future.
+   *     Consider using {@link Polynomial#dominates(Polynomial)} instead to get this expiry / crossover time as well.
+   * </p>
+   */
+  public boolean dominates$(Polynomial other) {
     for (int i = 0; i <= Math.max(this.degree(), other.degree()); ++i) {
       if (this.getCoefficient(i) > other.getCoefficient(i)) return true;
       if (this.getCoefficient(i) < other.getCoefficient(i)) return false;
@@ -238,7 +249,10 @@ public record Polynomial(double[] coefficients) implements Dynamics<Double, Poly
     return true;
   }
 
-  private Expiring<Discrete<Boolean>> dominates(Polynomial other) {
+  /**
+   * Returns a boolean dynamics, describing the value of {@link Polynomial#dominates$(Polynomial)} and when it will change.
+   */
+  public Expiring<Discrete<Boolean>> dominates(Polynomial other) {
     boolean result = this.dominates$(other);
     var expiry = this.subtract(other).findExpiryNearRoot(t -> this.step(t).dominates$(other.step(t)) != result);
     return expiring(discrete(result), expiry);

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialResources.java
@@ -1,9 +1,7 @@
 package gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial;
 
+import gov.nasa.jpl.aerie.contrib.streamline.core.*;
 import gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.CommutativityTestInput;
-import gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource;
-import gov.nasa.jpl.aerie.contrib.streamline.core.Expiring;
-import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.monads.DynamicsMonad;
 import gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.black_box.*;
@@ -18,11 +16,14 @@ import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAware;
 import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAwareOperations;
 import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAwareResources;
 import gov.nasa.jpl.aerie.contrib.streamline.utils.DoubleUtils;
+import gov.nasa.jpl.aerie.merlin.framework.Condition;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.apache.commons.lang3.mutable.MutableObject;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -33,6 +34,7 @@ import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resourc
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.expiring;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.neverExpiring;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiry.NEVER;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.set;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.wheneverDynamicsChange;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.DynamicsMonad.bindEffect;
@@ -359,50 +361,123 @@ public final class PolynomialResources {
    *   0   /             \-----
    * time  0        10        20
    * </pre>
+   * <p>
+   *     NOTE: This method assumes that lowerBound <= upperBound at all times.
+   *     Failure to meet this precondition may incorrect outputs, crashing the simulation, stalling in an infinite loop,
+   *     or other misbehavior.
+   *     If this condition cannot be guaranteed a priori, consider using
+   *     {@link gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources#assertThat(String, Resource)}
+   *     to guarantee this condition at runtime.
+   * </p>
    */
   public static ClampedIntegrateResult clampedIntegrate(
-      Resource<Polynomial> integrand, Resource<Polynomial> lowerBound, Resource<Polynomial> upperBound, double startingValue) {
-    LinearBoundaryConsistencySolver rateSolver = new LinearBoundaryConsistencySolver("clampedIntegrate rate solver");
-    var integral = resource(polynomial(startingValue));
-    var neverExpiringIntegral = eraseExpiry(integral);
+          Resource<Polynomial> integrand, Resource<Polynomial> lowerBound, Resource<Polynomial> upperBound, double startingValue) {
+    // There are more elegant ways to write this method, but profiling suggests this is often a bottleneck to models that use it.
+    // So, we're writing it very carefully to maximize performance.
 
-    // Solve for the rate as a function of value
-    var overflowRate = rateSolver.variable("overflowRate", Domain::lowerBound);
-    var underflowRate = rateSolver.variable("underflowRate", Domain::lowerBound);
-    var rate = rateSolver.variable("rate", Domain::upperBound);
+    MutableResource<Polynomial> integral = polynomialResource(startingValue);
+    MutableResource<Polynomial> overflow = polynomialResource(0);
+    MutableResource<Polynomial> underflow = polynomialResource(0);
 
-    // Set up slack variables for under-/overflow
-    rateSolver.declare(lx(overflowRate), GreaterThanOrEquals, lx(0));
-    rateSolver.declare(lx(underflowRate), GreaterThanOrEquals, lx(0));
-    rateSolver.declare(lx(rate).subtract(lx(underflowRate)).add(lx(overflowRate)), Equals, lx(integrand));
+    MutableObject<Condition> condition = new MutableObject<>(Condition.TRUE); // Run once immediately to get the loop started.
+    Reactions.whenever(condition::getValue, () -> {
+      // Note we need to call dynamicsChange on each iteration because it depends on the resource's current value,
+      // so *don't* factor these out of the loop.
+      Condition someInputChanges = dynamicsChange(integrand)
+              .or(dynamicsChange(lowerBound))
+              .or(dynamicsChange(upperBound));
 
-    // Set up rate clamping conditions
-    var integrandUB = choose(
-        greaterThanOrEquals(neverExpiringIntegral, upperBound),
-        differentiate(upperBound),
-        constant(Double.POSITIVE_INFINITY));
-    var integrandLB = choose(
-        lessThanOrEquals(neverExpiringIntegral, lowerBound),
-        differentiate(lowerBound),
-        constant(Double.NEGATIVE_INFINITY));
+      // Get all dynamics once per update loop to minimize sampling cost.
+      ErrorCatching<Expiring<ClampedIntegrateInternalResult>> result = DynamicsMonad.map(
+              integrand.getDynamics(),
+              lowerBound.getDynamics(),
+              upperBound.getDynamics(),
+              (integrandDynamics$, lowerBoundDynamics$, upperBoundDynamics$) -> {
+                // Clamp the integral value to take care of small overshoots due to the discretization of time
+                // and discrete changes in bounds that cut into the integral.
+                // Also, just get the current value, don't try to derive a value.
+                // This intentionally erases expiry info from the integral since this is a resource-graph back-edge,
+                // and will throw and blow up this resource if integral fails.
+                var integralValue = Double.max(
+                        Double.min(currentValue(integral), upperBoundDynamics$.extract()),
+                        lowerBoundDynamics$.extract());
+                var integralDynamics$ = integrandDynamics$.integral(integralValue);
 
-    rateSolver.declare(lx(rate), LessThanOrEquals, lx(integrandUB));
-    rateSolver.declare(lx(rate), GreaterThanOrEquals, lx(integrandLB));
+                if (lowerBoundDynamics$.dominates$(integralDynamics$)) {
+                  // Lower bound dominates "real" integral, so we clamp to the lower bound
+                  // We stop clamping to the lower bound when the integrand rate exceeds the lowerBound rate.
+                  // Since we already know that lowerBound dominates integral and integral value is at least lower value,
+                  // we know that lower rate dominates integrand. Hence, there's no need to check that value here.
+                  var lowerRate = lowerBoundDynamics$.derivative();
+                  var clampingStops = fixedTimeCondition(lowerRate.dominates(integrandDynamics$).expiry().value());
+                  // We change out of this condition when we stop clamping to the lower bound, or something changes.
+                  return new ClampedIntegrateInternalResult(
+                          lowerBoundDynamics$,
+                          polynomial(0),
+                          lowerRate.subtract(integrandDynamics$),
+                          clampingStops.or(someInputChanges));
+                }
 
-    // Use a simple feedback loop on volumes to do the integration and clamping.
-    // Clamping here takes care of discrete under-/overflows and overshooting bounds due to discrete time steps.
-    var clampedCell = clamp(neverExpiringIntegral, lowerBound, upperBound);
-    var correctedCell = map(clampedCell, rate.resource(), (v, r) -> r.integral(v.extract()));
-    // Use the corrected integral values to set volumes, but erase expiry information in the process to avoid loops
-    forward(correctedCell, integral);
+                if (!upperBoundDynamics$.dominates$(integralDynamics$)) {
+                  // Upper bound doesn't dominate integral, so we clamp to the upper bound
+                  // We stop clamping to the upper bound when the integrand rate falls below the upperBound rate.
+                  // Since we already know that lowerBound dominates integral and integral value is at least lower value,
+                  // we know that lower rate dominates integrand. Hence, there's no need to check that value here.
+                  var upperRate = upperBoundDynamics$.derivative();
+                  var clampingStops = fixedTimeCondition(upperRate.dominates(integrandDynamics$).expiry().value());
+                  // We change out of this condition when we stop clamping to the upper bound, or something changes.
+                  return new ClampedIntegrateInternalResult(
+                          upperBoundDynamics$,
+                          integrandDynamics$.subtract(upperRate),
+                          polynomial(0),
+                          clampingStops.or(someInputChanges));
+                }
 
-    name(integral, "Clamped Integral (%s)", integrand);
-    name(overflowRate.resource(), "Overflow of %s", integral);
-    name(underflowRate.resource(), "Underflow of %s", integral);
-    return new ClampedIntegrateResult(
-        integral,
-        overflowRate.resource(),
-        underflowRate.resource());
+                // Otherwise, the integral is between the bounds, so we just set it as-is.
+                // We start clamping when one or the other bound impacts this integral, i.e., when a dominates value changes.
+                // Although we re-compute the value of dominates$ here, that's cheap.
+                // We avoid computing the more expensive expiry when we're clamping, which is a win overall.
+                var startClampingToLowerBound = lowerBoundDynamics$.dominates(integralDynamics$).expiry();
+                var startClampingToUpperBound = upperBoundDynamics$.dominates(integralDynamics$).expiry();
+                var clampingStarts = fixedTimeCondition(startClampingToLowerBound.or(startClampingToUpperBound).value());
+                return new ClampedIntegrateInternalResult(
+                        integralDynamics$,
+                        polynomial(0),
+                        polynomial(0),
+                        clampingStarts.or(someInputChanges)
+                );
+              });
+
+      var newIntegralDynamics = DynamicsMonad.map(result, ClampedIntegrateInternalResult::integral);
+      var newOverflowDynamics = DynamicsMonad.map(result, ClampedIntegrateInternalResult::overflow);
+      var newUnderflowDynamics = DynamicsMonad.map(result, ClampedIntegrateInternalResult::underflow);
+      // If there was an error, that disturbs the integral value, and we can't recover. Don't bother retrying in that case.
+      var newRetryCondition = result.match($ -> $.data().retryCondition(), $ -> Condition.FALSE);
+
+      integral.emit("Update clamped integral", $ -> newIntegralDynamics);
+      overflow.emit("Update clamped integral overflow", $ -> newOverflowDynamics);
+      underflow.emit("Update clamped integral underflow", $ -> newUnderflowDynamics);
+      condition.setValue(newRetryCondition);
+    });
+
+    return new ClampedIntegrateResult(integral, overflow, underflow);
+  }
+
+  private static Condition fixedTimeCondition(Optional<Duration> time) {
+    return time.<Condition>map(time$ -> (positive, atEarliest, atLatest) -> {
+      if (positive) {
+        return time.filter(atLatest::noShorterThan).map(t -> Duration.max(atEarliest, t));
+      } else {
+        return Optional.of(atEarliest).filter(time$::longerThan);
+      }
+    }).orElse(Condition.FALSE);
+  }
+
+  private record ClampedIntegrateInternalResult(
+          Polynomial integral,
+          Polynomial overflow,
+          Polynomial underflow,
+          Condition retryCondition) {
   }
 
   /**

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialResources.java
@@ -363,7 +363,7 @@ public final class PolynomialResources {
    * </pre>
    * <p>
    *     NOTE: This method assumes that lowerBound <= upperBound at all times.
-   *     Failure to meet this precondition may incorrect outputs, crashing the simulation, stalling in an infinite loop,
+   *     Failure to meet this precondition may lead to incorrect outputs, crashing the simulation, stalling in an infinite loop,
    *     or other misbehavior.
    *     If this condition cannot be guaranteed a priori, consider using
    *     {@link gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources#assertThat(String, Resource)}


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Several proposed performance optimizations for the Aerie streamline framework, all indicated by profiling done on the CADRE simplified data model. In particular:
1. Changes many more string operations done when computing names to be lazy; those string operations are only done if a name is requested. Since names are primarily a debugging concept, in the vast majority of cases, names are assigned but never requested, making this a significant performance improvement.
2. Refrains from adding duplicate constraints to the active queue in LinearBoundaryConsistencySolver, limiting re-work when solving.
3. Optimizes Expiry.or to use Optional methods instead of converting to Streams. This is less elegant but much more performant.
4. Using effectively immutable lists for Context, so that daemon tasks can share references with their parent task's context rather than copying and rebuilding the list. Since daemon tasks contribute most of the load of context management, it makes sense to optimize for their primary use case.
5. Re-writing the clampedIntegrate function to directly calculate its results, rather than leaning on the LinearBoundaryConsistencySolver. While this requires some tinkering with lower-level concepts, it roughly doubles the speed of clampedIntegrate. For models that use this function, it can be a performance bottleneck.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
All changes were tested by hand on the CADRE simplified data model.

That model, running a 1 day plan, went from taking a few minutes to taking ~15s, with all the changes in this PR. Also, it looks like ~5s of that time is spent in simulation, and the remaining ~10s are spent saving the results.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
N/A - pure refactor

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A


Note: This PR makes #1483 and #1405 obsolete.