### PR TITLE
Using a libjemalloc Allocator for Better Memory Management

### DIFF
--- a/sequencing-server/Dockerfile
+++ b/sequencing-server/Dockerfile
@@ -1,4 +1,21 @@
-FROM node:18.13.0-alpine
+
+## Use a Debian-based image for apt-get compatibility
+FROM ubuntu:24.04
+
+# Update package lists
+RUN apt-get update && apt-get install --no-install-recommends  -y curl gnupg ca-certificates
+
+# Install NodeSource repository for node 18 LTS
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+
+# Update package lists again after adding NodeSource
+RUN apt-get update && apt-get install --no-install-recommends -y nodejs
+
+# Install jemalloc and set the path
+RUN apt-get update && apt-get install --no-install-recommends -y libjemalloc-dev \
+ && echo "/usr/lib/x86_64-linux-gnu/libjemalloc.so" >> /etc/ld.so.preload
+
+# Set working directory (optiona
 COPY . /app
 WORKDIR /app
 CMD [ "npm", "start" ]

--- a/sequencing-server/Dockerfile
+++ b/sequencing-server/Dockerfile
@@ -1,21 +1,13 @@
+FROM node:18.20-bookworm-slim
 
-## Use a Debian-based image for apt-get compatibility
-FROM ubuntu:24.04
+# Install jemalloc
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y libjemalloc-dev
 
-# Update package lists
-RUN apt-get update && apt-get install --no-install-recommends  -y curl gnupg ca-certificates
+# Set the path for jemalloc
+RUN echo "/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so" >> /etc/ld.so.preload
 
-# Install NodeSource repository for node 18 LTS
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
-
-# Update package lists again after adding NodeSource
-RUN apt-get update && apt-get install --no-install-recommends -y nodejs
-
-# Install jemalloc and set the path
-RUN apt-get update && apt-get install --no-install-recommends -y libjemalloc-dev \
- && echo "/usr/lib/x86_64-linux-gnu/libjemalloc.so" >> /etc/ld.so.preload
-
-# Set working directory (optiona
+# Set working directory
 COPY . /app
 WORKDIR /app
 CMD [ "npm", "start" ]


### PR DESCRIPTION
* **Tickets addressed:** AERIE-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
We are still noticing a slow climb in the RSS for the sequencing server. @dandelany found this thread on Node about using a different allocator. https://github.com/nodejs/help/issues/1518#issuecomment-991798619

I have implemented the suggested fix and noticed during my 13 expansion runs with a Clippers plan, expansion logic, and dictionaries that the RSS doesn't climb past 3.6GB where as before I was getting past 4GB

