### PR TITLE
Fix rootfinding by enforcing bounds of initial x-values

### DIFF
--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/EquationSolvingAlgorithms.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/EquationSolvingAlgorithms.java
@@ -131,7 +131,7 @@ public class EquationSolvingAlgorithms {
       int i = 0;
       do {
         //we should not come back to previously visited values
-        if (!history.alreadyVisited(cur)) {
+        if (!history.alreadyVisited(cur) && cur.between(min, max)) {
           i++;
           try {
             final var value = function.valueAt(cur, history);

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/RootfindingTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/RootfindingTest.java
@@ -127,7 +127,7 @@ public class RootfindingTest {
         Duration.of(-2, Duration.SECONDS),
         twoSecond,
         100);
-    assertEquals(29, solution.history().getHistory().size());
+    assertEquals(30, solution.history().getHistory().size());
     assertEquals(new EquationSolvingAlgorithms.FunctionCoordinate<>(Duration.of(0, Duration.MICROSECONDS), Duration.of(0, Duration.MICROSECONDS)), solution.functionCoordinate());
   }
 
@@ -164,7 +164,7 @@ public class RootfindingTest {
         Duration.of(-2, Duration.SECONDS),
         twoSecond,
         100);
-    assertEquals(2, solution.history().getHistory().size());
-    assertEquals(new EquationSolvingAlgorithms.FunctionCoordinate<>(Duration.of(0, Duration.MICROSECONDS), Duration.of(0, Duration.MICROSECONDS)), solution.functionCoordinate());
+    assertEquals(1, solution.history().getHistory().size());
+    assertEquals(new EquationSolvingAlgorithms.FunctionCoordinate<>(Duration.of(-860925, Duration.MICROSECONDS), Duration.of(0, Duration.MICROSECONDS)), solution.functionCoordinate());
   }
 }


### PR DESCRIPTION
* **Tickets addressed:** Closes #1336 #1468 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
There was a bug in the rootfinding algorithm. A heuristic value was provided without checking its bounds. Then the algorithm was using it and going off bound, causing it to find a solution that did not exist, violating the mutex conditions. 

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Validated against the clipper case, the bug disappeared. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None. 

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None.