### PR TITLE
Added a method to check for static parameters inside of an ActivityType

### DIFF
--- a/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
+++ b/merlin-framework-processor/src/main/java/gov/nasa/jpl/aerie/merlin/processor/MissionModelParser.java
@@ -386,6 +386,10 @@ import java.util.stream.Collectors;
     final var validations = this.getExportValidations(activityTypeElement, parameters);
     final var effectModel = this.getActivityEffectModel(activityTypeElement);
 
+    if (!parameters.isEmpty()) {
+      checkForStaticParameters(name, parameters);
+    }
+
     final var durationParameterName = effectModel.flatMap(EffectModelRecord::durationParameter);
     if (durationParameterName.isPresent()) {
       validateControllableDurationParameter(name, parameters, durationParameterName.get());
@@ -407,6 +411,17 @@ import java.util.stream.Collectors;
         name,
         new InputTypeRecord(name, activityTypeElement, parameters, validations, mapper, defaultsStyle),
         effectModel);
+  }
+
+  private void checkForStaticParameters(String activityName, List<ParameterRecord> parameters) throws InvalidMissionModelException {
+    for (final var parameter: parameters) {
+      if (parameter.element.getModifiers().contains(Modifier.STATIC)) {
+        throw new InvalidMissionModelException(
+            "In activity " + activityName +
+            ", parameter \"" + parameter.name +"\"" +
+            " is declared as static, but this is not valid for activity parameters");
+      }
+    }
   }
 
   private void validateControllableDurationParameter(


### PR DESCRIPTION
* **Tickets addressed:** Closes #1309.
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
After loading the activity types during mission model building I added a check for any parameters we've loaded that are marked as being static.

## Verification
Tested manually, to test mark a parameter inside of Bananation and run the assemble task, it should fail.

## Documentation
NA

## Future work
NA
