### PR TITLE
Fix DiscreteEffects.remove

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffects.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffects.java
@@ -115,10 +115,10 @@ public final class DiscreteEffects {
     final var currentQueue = currentValue(resource);
     if (currentQueue.isEmpty()) return Optional.empty();
 
-    final T result = currentQueue.get(currentQueue.size() - 1);
+    final T result = currentQueue.get(0);
     resource.emit(name(effect(q -> {
       var q$ = new LinkedList<>(q);
-      T purportedResult = q$.removeLast();
+      T purportedResult = q$.removeFirst();
       if (!result.equals(purportedResult)) {
         throw new IllegalStateException("Detected effect conflicting with queue remove operation");
       }


### PR DESCRIPTION

* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
DiscreteEffects.remove is one of two methods meant to implement a FIFO queue resource (the other is DiscreteEffects.add). However, it was written to remove the last element of the queue, when it should have removed the first element.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Tested in the CADRE model while working with @bashbash 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Documentation for this function was correct, now the code matches that documentation.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A
