### PR TITLE
Add streamline Logger

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Logger.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Logger.java
@@ -1,0 +1,60 @@
+package gov.nasa.jpl.aerie.contrib.streamline.debugging;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
+import gov.nasa.jpl.aerie.merlin.framework.Registrar;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Map;
+
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
+import static java.util.stream.Collectors.toMap;
+
+public class Logger {
+    private static final int LEVEL_INDICATOR_SIZE = Arrays.stream(LogLevel.values())
+            .map(v -> v.toString().length())
+            .max(Integer::compareTo)
+            .orElseThrow();
+    private static final String LOG_MESSAGE_FORMAT = "%s [%-" + LEVEL_INDICATOR_SIZE + "s] %s";
+
+    private final Map<LogLevel, SimpleLogger> subLoggers;
+    private final Instant planStart;
+
+    public Logger(Registrar registrar, Instant planStart) {
+        // TODO - refactor the plan start out, by instead building a global sim clock to do the same job.
+        //  To do that "right", the global clock should be a resource with custom dynamics for continuous Instant clocks.
+        subLoggers = Arrays.stream(LogLevel.values()).collect(toMap(
+                level -> level,
+                level -> new SimpleLogger(level.name(), registrar)));
+        this.planStart = planStart;
+    }
+
+    public void log(LogLevel level, String messageFormat, Object... args) {
+        Instant time = planStart.plusNanos(Resources.currentTime().in(MICROSECONDS) * 1_000);
+        String message = messageFormat.formatted(args);
+        subLoggers.get(level).log(LOG_MESSAGE_FORMAT.formatted(time, level, message));
+    }
+
+    public void debug(String messageFormat, Object... args) {
+        log(LogLevel.DEBUG, messageFormat, args);
+    }
+
+    public void info(String messageFormat, Object... args) {
+        log(LogLevel.INFO, messageFormat, args);
+    }
+
+    public void warning(String messageFormat, Object... args) {
+        log(LogLevel.WARNING, messageFormat, args);
+    }
+
+    public void error(String messageFormat, Object... args) {
+        log(LogLevel.ERROR, messageFormat, args);
+    }
+
+    public enum LogLevel {
+        DEBUG,
+        INFO,
+        WARNING,
+        ERROR
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Logger.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Logger.java
@@ -1,13 +1,10 @@
 package gov.nasa.jpl.aerie.contrib.streamline.debugging;
 
-import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Map;
 
-import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECONDS;
 import static java.util.stream.Collectors.toMap;
 
 public class Logger {
@@ -15,24 +12,19 @@ public class Logger {
             .map(v -> v.toString().length())
             .max(Integer::compareTo)
             .orElseThrow();
-    private static final String LOG_MESSAGE_FORMAT = "%s [%-" + LEVEL_INDICATOR_SIZE + "s] %s";
+    private static final String LOG_MESSAGE_FORMAT = "[%-" + LEVEL_INDICATOR_SIZE + "s] %s";
 
     private final Map<LogLevel, SimpleLogger> subLoggers;
-    private final Instant planStart;
 
-    public Logger(Registrar registrar, Instant planStart) {
-        // TODO - refactor the plan start out, by instead building a global sim clock to do the same job.
-        //  To do that "right", the global clock should be a resource with custom dynamics for continuous Instant clocks.
+    public Logger(Registrar registrar) {
         subLoggers = Arrays.stream(LogLevel.values()).collect(toMap(
                 level -> level,
                 level -> new SimpleLogger(level.name(), registrar)));
-        this.planStart = planStart;
     }
 
     public void log(LogLevel level, String messageFormat, Object... args) {
-        Instant time = planStart.plusNanos(Resources.currentTime().in(MICROSECONDS) * 1_000);
         String message = messageFormat.formatted(args);
-        subLoggers.get(level).log(LOG_MESSAGE_FORMAT.formatted(time, level, message));
+        subLoggers.get(level).log(LOG_MESSAGE_FORMAT.formatted(level, message));
     }
 
     public void debug(String messageFormat, Object... args) {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Logging.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Logging.java
@@ -1,0 +1,29 @@
+package gov.nasa.jpl.aerie.contrib.streamline.debugging;
+
+import gov.nasa.jpl.aerie.merlin.framework.Registrar;
+
+import java.time.Instant;
+
+public final class Logging {
+    private Logging() {}
+
+    /**
+     * The "main" logger. Unless you have a compelling reason to direct logging somewhere else,
+     * this logger should be used by virtually all model components.
+     * This logger will be initialized automatically when a registrar is constructed.
+     */
+    public static Logger LOGGER;
+
+    /**
+     * Initialize the primary logger.
+     * This is called when constructing a {@link gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar},
+     * and does not need to be called directly by the model.
+     */
+    public static void init(final Registrar registrar, final Instant planStart) {
+        if (LOGGER == null) {
+            LOGGER = new Logger(registrar, planStart);
+        } else {
+            LOGGER.warning("Attempting to re-initialize primary logger. This attempt is being ignored.");
+        }
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Logging.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Logging.java
@@ -2,8 +2,6 @@ package gov.nasa.jpl.aerie.contrib.streamline.debugging;
 
 import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 
-import java.time.Instant;
-
 public final class Logging {
     private Logging() {}
 
@@ -19,9 +17,9 @@ public final class Logging {
      * This is called when constructing a {@link gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar},
      * and does not need to be called directly by the model.
      */
-    public static void init(final Registrar registrar, final Instant planStart) {
+    public static void init(final Registrar registrar) {
         if (LOGGER == null) {
-            LOGGER = new Logger(registrar, planStart);
+            LOGGER = new Logger(registrar);
         } else {
             LOGGER.warning("Attempting to re-initialize primary logger. This attempt is being ignored.");
         }

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/SimpleLogger.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/SimpleLogger.java
@@ -1,0 +1,51 @@
+package gov.nasa.jpl.aerie.contrib.streamline.debugging;
+
+import gov.nasa.jpl.aerie.merlin.framework.CellRef;
+import gov.nasa.jpl.aerie.merlin.framework.Registrar;
+import gov.nasa.jpl.aerie.merlin.protocol.model.CellType;
+import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
+
+import static gov.nasa.jpl.aerie.contrib.serialization.rulesets.BasicValueMappers.string;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Unit.UNIT;
+
+public class SimpleLogger {
+    private final CellRef<String, Unit> cellRef = CellRef.allocate(UNIT, new CellType<>() {
+        @Override
+        public EffectTrait<String> getEffectType() {
+            return new EffectTrait<>() {
+                @Override
+                public String empty() {
+                    return null;
+                }
+
+                @Override
+                public String sequentially(String prefix, String suffix) {
+                    return null;
+                }
+
+                @Override
+                public String concurrently(String left, String right) {
+                    return null;
+                }
+            };
+        }
+
+        @Override
+        public Unit duplicate(Unit unit) {
+            return unit;
+        }
+
+        @Override
+        public void apply(Unit unit, String s) {
+        }
+    });
+
+    public SimpleLogger(String name, Registrar registrar) {
+        registrar.topic(name, cellRef, string());
+    }
+
+    public void log(String message) {
+        cellRef.emit(message);
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/SimpleLogger.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/SimpleLogger.java
@@ -12,21 +12,21 @@ import static gov.nasa.jpl.aerie.merlin.protocol.types.Unit.UNIT;
 public class SimpleLogger {
     private final CellRef<String, Unit> cellRef = CellRef.allocate(UNIT, new CellType<>() {
         @Override
-        public EffectTrait<String> getEffectType() {
+        public EffectTrait<Unit> getEffectType() {
             return new EffectTrait<>() {
                 @Override
-                public String empty() {
-                    return null;
+                public Unit empty() {
+                    return UNIT;
                 }
 
                 @Override
-                public String sequentially(String prefix, String suffix) {
-                    return null;
+                public Unit sequentially(Unit prefix, Unit suffix) {
+                    return UNIT;
                 }
 
                 @Override
-                public String concurrently(String left, String right) {
-                    return null;
+                public Unit concurrently(Unit left, Unit right) {
+                    return UNIT;
                 }
             };
         }
@@ -37,9 +37,9 @@ public class SimpleLogger {
         }
 
         @Override
-        public void apply(Unit unit, String s) {
+        public void apply(Unit unit, Unit s) {
         }
-    });
+    }, $ -> UNIT);
 
     public SimpleLogger(String name, Registrar registrar) {
         registrar.topic(name, cellRef, string());

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
@@ -2,12 +2,12 @@ package gov.nasa.jpl.aerie.contrib.streamline.modeling;
 
 import gov.nasa.jpl.aerie.contrib.serialization.mappers.IntegerValueMapper;
 import gov.nasa.jpl.aerie.contrib.serialization.mappers.NullableValueMapper;
-import gov.nasa.jpl.aerie.contrib.serialization.mappers.StringValueMapper;
 import gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ThinResourceMonad;
+import gov.nasa.jpl.aerie.contrib.streamline.debugging.Logger;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteResourceMonad;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.linear.Linear;
@@ -16,11 +16,8 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
+import java.time.Instant;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.whenever;
@@ -30,9 +27,8 @@ import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Profiling.profile;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Tracing.trace;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar.ErrorBehavior.*;
-import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.not;
-import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.when;
-import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteDynamicsMonad.effect;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteEffects.increment;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteResourceMonad.map;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.linear.Linear.linear;
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.waitUntil;
@@ -49,8 +45,8 @@ public class Registrar {
   private final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar;
   private boolean trace = false;
   private boolean profile = false;
-  private final MutableResource<Discrete<Map<Throwable, Set<String>>>> errors;
   private final ErrorBehavior errorBehavior;
+  private final MutableResource<Discrete<Integer>> numberOfErrors = discreteResource(0);
 
   public enum ErrorBehavior {
     /**
@@ -64,17 +60,20 @@ public class Registrar {
     Throw
   }
 
-  public Registrar(final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar, final ErrorBehavior errorBehavior) {
+  /**
+   * The "main" logger. Unless you have a compelling reason to direct logging somewhere else,
+   * this logger should be used by virtually all model components.
+   * This logger will be initialized automatically when a registrar is constructed.
+   */
+  public static Logger LOGGER;
+
+  public Registrar(final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar, final Instant planStart, final ErrorBehavior errorBehavior) {
     Resources.init();
+    LOGGER = new Logger(baseRegistrar, planStart);
     this.baseRegistrar = baseRegistrar;
     this.errorBehavior = errorBehavior;
-    errors = resource(Discrete.discrete(Map.of()));
-    var errorString = map(errors, errors$ -> errors$.entrySet().stream().map(entry -> formatError(entry.getKey(), entry.getValue())).collect(joining("\n\n")));
 
-    // Register the errors and number of errors resources for output
-    // TODO consider using serializable events, rather than resources, to log errors
-    discrete("errors", errorString, new StringValueMapper());
-    discrete("numberOfErrors", map(errors, Map::size), new IntegerValueMapper());
+    discrete("numberOfErrors", numberOfErrors, new IntegerValueMapper());
   }
 
   private static String formatError(Throwable e, Collection<String> affectedResources) {
@@ -148,21 +147,9 @@ public class Registrar {
     });
   }
 
-  // TODO: Consider using a MultiMap instead of doing this by hand below
   private Unit logError(String resourceName, Throwable e) {
-    errors.emit(effect(s -> {
-      var s$ = new HashMap<>(s);
-      s$.compute(e, (e$, affectedResources) -> {
-        if (affectedResources == null) {
-          return Set.of(resourceName);
-        } else {
-          var affectedResources$ = new HashSet<>(affectedResources);
-          affectedResources$.add(resourceName);
-          return affectedResources$;
-        }
-      });
-      return s$;
-    }));
+    LOGGER.error("Error affecting %s: %s", resourceName, e);
+    increment(numberOfErrors);
     return Unit.UNIT;
   }
 

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
@@ -14,10 +14,6 @@ import gov.nasa.jpl.aerie.contrib.streamline.modeling.linear.Linear;
 import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-
-import java.time.Instant;
-import java.util.Collection;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.whenever;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentData;
@@ -31,7 +27,6 @@ import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteEf
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.linear.Linear.linear;
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.waitUntil;
-import static java.util.stream.Collectors.joining;
 
 /**
  * Wrapper for {@link gov.nasa.jpl.aerie.merlin.framework.Registrar} specialized for {@link Resource}.
@@ -59,25 +54,13 @@ public class Registrar {
     Throw
   }
 
-  public Registrar(final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar, final Instant planStart, final ErrorBehavior errorBehavior) {
+  public Registrar(final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar, final ErrorBehavior errorBehavior) {
     Resources.init();
-    Logging.init(baseRegistrar, planStart);
+    Logging.init(baseRegistrar);
     this.baseRegistrar = baseRegistrar;
     this.errorBehavior = errorBehavior;
 
     discrete("numberOfErrors", numberOfErrors, new IntegerValueMapper());
-  }
-
-  private static String formatError(Throwable e, Collection<String> affectedResources) {
-    return "Error affecting %s:%n%s".formatted(
-        String.join(", ", affectedResources),
-        formatException(e));
-  }
-
-  private static String formatException(Throwable e) {
-    return ExceptionUtils.stream(e)
-        .map(ExceptionUtils::getMessage)
-        .collect(joining("\nCaused by: "));
   }
 
   public void setTrace() {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
@@ -7,7 +7,7 @@ import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ThinResourceMonad;
-import gov.nasa.jpl.aerie.contrib.streamline.debugging.Logger;
+import gov.nasa.jpl.aerie.contrib.streamline.debugging.Logging;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteResourceMonad;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.linear.Linear;
@@ -19,17 +19,16 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import java.time.Instant;
 import java.util.Collection;
 
-import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.whenever;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentData;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
+import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Logging.LOGGER;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Profiling.profile;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Tracing.trace;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar.ErrorBehavior.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteEffects.increment;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.*;
-import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteResourceMonad.map;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.linear.Linear.linear;
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.waitUntil;
 import static java.util.stream.Collectors.joining;
@@ -50,7 +49,7 @@ public class Registrar {
 
   public enum ErrorBehavior {
     /**
-     * Log errors to the error state,
+     * Log errors to {@link Logging#LOGGER}
      * and replace resource value with null.
      */
     Log,
@@ -60,16 +59,9 @@ public class Registrar {
     Throw
   }
 
-  /**
-   * The "main" logger. Unless you have a compelling reason to direct logging somewhere else,
-   * this logger should be used by virtually all model components.
-   * This logger will be initialized automatically when a registrar is constructed.
-   */
-  public static Logger LOGGER;
-
   public Registrar(final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar, final Instant planStart, final ErrorBehavior errorBehavior) {
     Resources.init();
-    LOGGER = new Logger(baseRegistrar, planStart);
+    Logging.init(baseRegistrar, planStart);
     this.baseRegistrar = baseRegistrar;
     this.errorBehavior = errorBehavior;
 

--- a/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
+++ b/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
@@ -5,13 +5,15 @@ import gov.nasa.jpl.aerie.contrib.streamline.debugging.Profiling;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.ModelActions;
 
+import java.time.Instant;
+
 public final class Mission {
   public final DataModel dataModel;
   public final ErrorTestingModel errorTestingModel;
   public final ApproximationModel approximationModel;
 
-  public Mission(final gov.nasa.jpl.aerie.merlin.framework.Registrar registrar$, final Configuration config) {
-    var registrar = new Registrar(registrar$, Registrar.ErrorBehavior.Log);
+  public Mission(final gov.nasa.jpl.aerie.merlin.framework.Registrar registrar$, final Instant planStart, final Configuration config) {
+    var registrar = new Registrar(registrar$, planStart, Registrar.ErrorBehavior.Log);
     if (config.traceResources) registrar.setTrace();
     if (config.profileResources) Resource.profileAllResources();
     dataModel = new DataModel(registrar, config);

--- a/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
+++ b/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
@@ -5,15 +5,13 @@ import gov.nasa.jpl.aerie.contrib.streamline.debugging.Profiling;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.ModelActions;
 
-import java.time.Instant;
-
 public final class Mission {
   public final DataModel dataModel;
   public final ErrorTestingModel errorTestingModel;
   public final ApproximationModel approximationModel;
 
-  public Mission(final gov.nasa.jpl.aerie.merlin.framework.Registrar registrar$, final Instant planStart, final Configuration config) {
-    var registrar = new Registrar(registrar$, planStart, Registrar.ErrorBehavior.Log);
+  public Mission(final gov.nasa.jpl.aerie.merlin.framework.Registrar registrar$, final Configuration config) {
+    var registrar = new Registrar(registrar$, Registrar.ErrorBehavior.Log);
     if (config.traceResources) registrar.setTrace();
     if (config.profileResources) Resource.profileAllResources();
     dataModel = new DataModel(registrar, config);


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds a Logger class to the streamline framework, which uses topics to emit log messages directly as events. Also builds such a Logger when the Registrar is initialized, and reconfigures errors to go to that logger when the error behavior is set to LOG. Before this, errors were collected awkwardly into a discrete string resource.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Since the logger is connected to the Registrar's error behavior, this was tested using the streamline-demo example model. By adding "CauseError" activities to the plan, we can trip the resource error handling machinery, and verify that appropriate error messages appear in the Simulation Events tab.

<img width="1792" alt="image" src="https://github.com/NASA-AMMOS/aerie/assets/13932065/a97a9009-521e-4738-9960-d5627c5a58e1">

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None yet - #1494 should probably be updated to tell users how to use the logger in their model/activities.

This does remove the `errors` resource, but it leaves the `numberOfErrors` resource intact, which we should note for any users who may have depended on `errors`.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None planned
