### PR TITLE
Remove incorrect activity directive map operation

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinService.java
@@ -1621,7 +1621,7 @@ public record GraphQLMerlinService(URI merlinGraphqlURI, String hasuraGraphQlAdm
         Optional.ofNullable(activity.parentId()).map(SimulatedActivityId::id),
         activity.childIds().stream().map(SimulatedActivityId::id).collect(Collectors.toList()),
         new ActivityAttributesRecord(
-            activity.directiveId().map(id -> simulationActivityDirectiveIdToMerlinActivityDirectiveId.get(id).id()),
+            activity.directiveId().map(ActivityDirectiveId::id),
             activity.arguments(),
             Optional.of(activity.computedAttributes())));
   }


### PR DESCRIPTION
* **Tickets addressed:** none
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
While debugging things with Adrien we discovered that the activity directive id in sim results is already correct and does not need to be mapped.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Lets see those e2e tests