### PR TITLE
Make Scheduler containers use the correct Envvar

### DIFF
--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/SchedulerAppDriver.java
@@ -142,7 +142,7 @@ public final class SchedulerAppDriver {
     return new AppConfiguration(
         Integer.parseInt(getEnv("SCHEDULER_PORT", "27185")),
         logger.isDebugEnabled(),
-        new PostgresStore(getEnv("AERIE_DB_SERVER", "postgres"),
+        new PostgresStore(getEnv("AERIE_DB_HOST", "postgres"),
                           getEnv("SCHEDULER_DB_USER", ""),
                           Integer.parseInt(getEnv("AERIE_DB_PORT", "5432")),
                           getEnv("SCHEDULER_DB_PASSWORD", ""),

--- a/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/SchedulerWorkerAppDriver.java
+++ b/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/SchedulerWorkerAppDriver.java
@@ -137,7 +137,7 @@ public final class SchedulerWorkerAppDriver {
       maxNbCachedSimulationEngine = 1;
     }
     return new WorkerAppConfiguration(
-        new PostgresStore(getEnv("AERIE_DB_SERVER", "postgres"),
+        new PostgresStore(getEnv("AERIE_DB_HOST", "postgres"),
                           getEnv("SCHEDULER_DB_USER", ""),
                           Integer.parseInt(getEnv("AERIE_DB_PORT", "5432")),
                           getEnv("SCHEDULER_DB_PASSWORD", ""),


### PR DESCRIPTION
* **Tickets addressed:** Closes #1462 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
It now matches our docs, our docker containers, and is in sync with the rest of Aerie. 

Flagged as "breaking" as this may impact customer deployments.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Manually verified the correct envvar is now being used.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
This change will need to be called out in our upgrade docs, but the rest of our docs already assumed that the envvar was called this.

Sister PR to update the v2.8.0 upgrade docs is [here](https://github.com/NASA-AMMOS/aerie-docs/pull/174)
