### PR TITLE
Include the Sim Error Activity Type Stack trace

### DIFF
--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/activities/DaemonTaskActivity.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/activities/DaemonTaskActivity.java
@@ -1,0 +1,25 @@
+package gov.nasa.jpl.aerie.foomissionmodel.activities;
+
+import gov.nasa.jpl.aerie.foomissionmodel.Mission;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.ActivityType;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import static gov.nasa.jpl.aerie.foomissionmodel.generated.ActivityActions.call;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
+
+/**
+ * An activity that spawns a DaemonCheckerSpawner which spawns a DaemonCheckerActivity after delaying.
+ * Useful for testing the behavior of exceptions thrown by child activities and the stack trace back
+ * to this activity.
+ *
+ * @param minutesElapsed The expected number of minutes elapsed when the DaemonCheckerActivity begins
+ * @param spawnDelay The number of minutes to delay between the start of this activity and spawning the DaemonCheckerActivity
+ */
+@ActivityType("DaemonTaskActivity")
+public record DaemonTaskActivity(int minutesElapsed, int spawnDelay) {
+  @ActivityType.EffectModel
+  public void run(final Mission mission) {
+    delay(Duration.of(spawnDelay, Duration.MINUTE));
+    call(mission, new DaemonCheckerSpawner(minutesElapsed,spawnDelay));
+  }
+}

--- a/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/package-info.java
+++ b/examples/foo-missionmodel/src/main/java/gov/nasa/jpl/aerie/foomissionmodel/package-info.java
@@ -16,6 +16,7 @@
 @WithActivityType(ZeroDurationUncontrollableActivity.class)
 @WithActivityType(DaemonCheckerActivity.class)
 @WithActivityType(DaemonCheckerSpawner.class)
+@WithActivityType(DaemonTaskActivity.class)
 
 @WithActivityType(DecompositionTestActivities.ParentActivity.class)
 @WithActivityType(DecompositionTestActivities.ChildActivity.class)
@@ -30,6 +31,7 @@ import gov.nasa.jpl.aerie.foomissionmodel.activities.BasicFooActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.ControllableDurationActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.DaemonCheckerActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.DaemonCheckerSpawner;
+import gov.nasa.jpl.aerie.foomissionmodel.activities.DaemonTaskActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.DecompositionTestActivities;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.FooActivity;
 import gov.nasa.jpl.aerie.foomissionmodel.activities.LateRiserActivity;

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/CachedSimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/CachedSimulationEngine.java
@@ -40,9 +40,14 @@ public record CachedSimulationEngine(
     } catch (SpanException ex) {
       // Swallowing the spanException as the internal `spanId` is not user meaningful info.
       final var topics = missionModel.getTopics();
-      final var directiveId = engine.getDirectiveIdFromSpan(activityTopic, topics, ex.spanId);
-      if (directiveId.isPresent()) {
-        throw new SimulationException(Duration.ZERO, simulationStartTime, directiveId.get(), ex.cause);
+      final var directiveDetail = engine.getDirectiveDetailsFromSpan(activityTopic, topics, ex.spanId);
+      if (directiveDetail.directiveId().isPresent()) {
+        throw new SimulationException(
+            Duration.ZERO,
+            simulationStartTime,
+            directiveDetail.directiveId().get(),
+            directiveDetail.activityStackTrace(),
+            ex.cause);
       }
       throw new SimulationException(Duration.ZERO, simulationStartTime, ex.cause);
     } catch (Throwable ex) {

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/CheckpointSimulationDriver.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/CheckpointSimulationDriver.java
@@ -305,9 +305,14 @@ public class CheckpointSimulationDriver {
       elapsedTime = engine.getElapsedTime();
       // Swallowing the spanException as the internal `spanId` is not user meaningful info.
       final var topics = missionModel.getTopics();
-      final var directiveId = engine.getDirectiveIdFromSpan(activityTopic, topics, ex.spanId);
-      if (directiveId.isPresent()) {
-        throw new SimulationException(elapsedTime, simulationStartTime, directiveId.get(), ex.cause);
+      final var directiveDetail = engine.getDirectiveDetailsFromSpan(activityTopic, topics, ex.spanId);
+      if (directiveDetail.directiveId().isPresent()) {
+        throw new SimulationException(
+            elapsedTime,
+            simulationStartTime,
+            directiveDetail.directiveId().get(),
+            directiveDetail.activityStackTrace(),
+            ex.cause);
       }
       throw new SimulationException(elapsedTime, simulationStartTime, ex.cause);
     } catch (Throwable ex) {

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
@@ -109,9 +109,14 @@ public final class SimulationDriver {
       } catch (SpanException ex) {
         // Swallowing the spanException as the internal `spanId` is not user meaningful info.
         final var topics = missionModel.getTopics();
-        final var directiveId = engine.getDirectiveIdFromSpan(activityTopic, topics, ex.spanId);
-        if(directiveId.isPresent()) {
-          throw new SimulationException(engine.getElapsedTime(), simulationStartTime, directiveId.get(), ex.cause);
+        final var directiveDetail = engine.getDirectiveDetailsFromSpan(activityTopic, topics, ex.spanId);
+        if(directiveDetail.directiveId().isPresent()) {
+          throw new SimulationException(
+              engine.getElapsedTime(),
+              simulationStartTime,
+              directiveDetail.directiveId().get(),
+              directiveDetail.activityStackTrace(),
+              ex.cause);
         }
         throw new SimulationException(engine.getElapsedTime(), simulationStartTime, ex.cause);
       } catch (Throwable ex) {

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/DirectiveDetail.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/DirectiveDetail.java
@@ -1,0 +1,10 @@
+package gov.nasa.jpl.aerie.merlin.driver.engine;
+
+import gov.nasa.jpl.aerie.merlin.driver.ActivityDirectiveId;
+import gov.nasa.jpl.aerie.merlin.driver.SerializedActivity;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+
+import java.util.List;
+import java.util.Optional;
+
+public record DirectiveDetail(Optional<ActivityDirectiveId> directiveId, List<SerializedActivity> activityStackTrace) {}

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -699,7 +699,7 @@ public final class SimulationEngine implements AutoCloseable {
     }
 
     // Add final top level parent activity to the stack trace if present
-    if( directiveSpanId.isPresent()){
+    if (directiveSpanId.isPresent()) {
       activityStackTrace.add(spanInfo.input().get(directiveSpanId.get()));
     }
 

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -53,6 +53,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * A representation of the work remaining to do during a simulation, and its accumulated results.
@@ -676,29 +677,36 @@ public final class SimulationEngine implements AutoCloseable {
     }
   }
 
+
   /**
    * Get an Activity Directive Id from a SpanId, if the span is a descendent of a directive.
    */
-  public Optional<ActivityDirectiveId> getDirectiveIdFromSpan(
+  public DirectiveDetail getDirectiveDetailsFromSpan(
       final Topic<ActivityDirectiveId> activityTopic,
       final Iterable<SerializableTopic<?>> serializableTopics,
       final SpanId spanId
   ) {
     // Collect per-span information from the event graph.
-    final var spanInfo = new SpanInfo();
-    for (final var point : this.timeline) {
-      if (!(point instanceof TemporalEventSource.TimePoint.Commit p)) continue;
+    final var spanInfo = computeSpanInfo(activityTopic, serializableTopics, this.timeline);
 
-      final var trait = new SpanInfo.Trait(serializableTopics, activityTopic);
-      p.events().evaluate(trait, trait::atom).accept(spanInfo);
-    }
-
-    // Identify the nearest ancestor directive
+    // Identify the nearest ancestor directive by walking up the parent
+    // span tree. Save the activity trace along the way
     Optional<SpanId> directiveSpanId = Optional.of(spanId);
+    final var activityStackTrace = new LinkedList<SerializedActivity>();
     while (directiveSpanId.isPresent() && !spanInfo.isDirective(directiveSpanId.get())) {
+      activityStackTrace.add(spanInfo.input().get(directiveSpanId.get()));
       directiveSpanId = this.getSpan(directiveSpanId.get()).parent();
     }
-    return directiveSpanId.map(spanInfo::getDirective);
+
+    // Add final top level parent activity to the stack trace if present
+    if( directiveSpanId.isPresent()){
+      activityStackTrace.add(spanInfo.input().get(directiveSpanId.get()));
+    }
+
+    return new DirectiveDetail(
+        directiveSpanId.map(spanInfo::getDirective),
+        // remove null activities from the stack trace and reverse order
+        activityStackTrace.stream().filter(a -> a != null).collect(Collectors.toList()).reversed());
   }
 
   public record SimulationActivityExtract(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationAgent.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/SimulationAgent.java
@@ -97,6 +97,8 @@ public record SimulationAgent (
                                       .add("elapsedTime", SimulationException.formatDuration(ex.elapsedTime))
                                       .add("utcTimeDoy", SimulationException.formatInstant(ex.instant));
       ex.directiveId.ifPresent(directiveId -> errorMsgBuilder.add("executingDirectiveId", directiveId.id()));
+      ex.activityType.ifPresent(activityType -> errorMsgBuilder.add("executingActivityType", activityType));
+      ex.activityStackTrace.ifPresent(activityStackTrace -> errorMsgBuilder.add("activityStackTrace", activityStackTrace));
       writer.failWith(b -> b
           .type("SIMULATION_EXCEPTION")
           .message(ex.cause.getMessage())


### PR DESCRIPTION
* **Tickets addressed:** Closes #1415 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR provides more detailed error information and improves debugging capabilities for Clipper. The error message includes the name of the affected activity type and provides a stack trace-like representation of the activity type hierarchy when errors occur in child activities.

```json
{
  "utcTimeDoy": "2023-001T01:02:00",
  "elapsedTime": "01:02:00.000000",
  "activityStackTrace": 

        "DaemonTaskActivity
        |-DaemonCheckerSpawner
        |--DaemonCheckerActivity",

  "executingDirectiveId": 5,
  "executingActivityType": "DaemonTaskActivity"
}

```

## Verification
e2e test pass and I am including a new parent activity, which will be used to spawn children 2 levels deep. This allows for the error message to have a more detailed stack trace.
