### PR TITLE
Added the backend for sequencing workspaces

### DIFF
--- a/deployment/hasura/metadata/databases/tables/sequencing/user_sequence.yaml
+++ b/deployment/hasura/metadata/databases/tables/sequencing/user_sequence.yaml
@@ -29,24 +29,24 @@ select_permissions:
 insert_permissions:
   - role: aerie_admin
     permission:
-      columns: [definition, seq_json, name, parcel_id, workspace_id]
+      columns: [definition, seq_json, name, owner, parcel_id, workspace_id]
       check: {}
       set:
         owner: "x-hasura-user-id"
   - role: user
     permission:
-      columns: [definition, seq_json, name, parcel_id, workspace_id]
+      columns: [definition, seq_json, name, owner, parcel_id, workspace_id]
       check: {}
       set:
         owner: "x-hasura-user-id"
 update_permissions:
   - role: aerie_admin
     permission:
-      columns: [definition, seq_json, name, parcel_id, workspace_id]
+      columns: [definition, seq_json, name, owner, parcel_id, workspace_id]
       filter: {}
   - role: user
     permission:
-      columns: [definition, seq_json, name, parcel_id, workspace_id]
+      columns: [definition, seq_json, name, owner, parcel_id, workspace_id]
       filter: { "owner": { "_eq": "x-hasura-user-id" } }
 delete_permissions:
   - role: aerie_admin

--- a/deployment/hasura/metadata/databases/tables/sequencing/workspace.yaml
+++ b/deployment/hasura/metadata/databases/tables/sequencing/workspace.yaml
@@ -1,15 +1,8 @@
 table:
-  name: user_sequence
+  name: workspace
   schema: sequencing
 configuration:
-  custom_name: "user_sequence"
-object_relationships:
-- name: parcel
-  using:
-    foreign_key_constraint_on: parcel_id
-- name: workspace
-  using:
-    foreign_key_constraint_on: workspace_id
+  custom_name: "workspace"
 select_permissions:
   - role: aerie_admin
     permission:
@@ -29,24 +22,24 @@ select_permissions:
 insert_permissions:
   - role: aerie_admin
     permission:
-      columns: [definition, seq_json, name, parcel_id, workspace_id]
+      columns: [name]
       check: {}
       set:
         owner: "x-hasura-user-id"
   - role: user
     permission:
-      columns: [definition, seq_json, name, parcel_id, workspace_id]
+      columns: [name]
       check: {}
       set:
         owner: "x-hasura-user-id"
 update_permissions:
   - role: aerie_admin
     permission:
-      columns: [definition, seq_json, name, parcel_id, workspace_id]
+      columns: [name]
       filter: {}
   - role: user
     permission:
-      columns: [definition, seq_json, name, parcel_id, workspace_id]
+      columns: [name]
       filter: { "owner": { "_eq": "x-hasura-user-id" } }
 delete_permissions:
   - role: aerie_admin

--- a/deployment/hasura/metadata/databases/tables/sequencing/workspace.yaml
+++ b/deployment/hasura/metadata/databases/tables/sequencing/workspace.yaml
@@ -3,6 +3,14 @@ table:
   schema: sequencing
 configuration:
   custom_name: "workspace"
+array_relationships:
+  - name: user_sequences
+    using:
+      foreign_key_constraint_on:
+        column: workspace_id
+        table:
+          name: user_sequence
+          schema: sequencing
 select_permissions:
   - role: aerie_admin
     permission:
@@ -22,25 +30,31 @@ select_permissions:
 insert_permissions:
   - role: aerie_admin
     permission:
-      columns: [name]
+      columns: [name, owner]
       check: {}
       set:
         owner: "x-hasura-user-id"
+        updated_by: "x-hasura-user-id"
   - role: user
     permission:
-      columns: [name]
+      columns: [name, owner]
       check: {}
       set:
         owner: "x-hasura-user-id"
+        updated_by: "x-hasura-user-id"
 update_permissions:
   - role: aerie_admin
     permission:
-      columns: [name]
+      columns: [name, owner]
       filter: {}
+      set:
+        updated_by: "x-hasura-user-id"
   - role: user
     permission:
-      columns: [name]
+      columns: [name, owner]
       filter: { "owner": { "_eq": "x-hasura-user-id" } }
+      set:
+        updated_by: "x-hasura-user-id"
 delete_permissions:
   - role: aerie_admin
     permission:

--- a/deployment/hasura/metadata/databases/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/tables/tables.yaml
@@ -159,6 +159,7 @@
 - "!include sequencing/sequence_adaptation.yaml"
 - "!include sequencing/sequence_to_simulated_activity.yaml"
 - "!include sequencing/user_sequence.yaml"
+- "!include sequencing/workspace.yaml"
 
 ############
 #### UI ####

--- a/deployment/hasura/migrations/Aerie/9_sequence_workspaces/down.sql
+++ b/deployment/hasura/migrations/Aerie/9_sequence_workspaces/down.sql
@@ -1,4 +1,5 @@
 alter table sequencing.user_sequence
+  drop constraint user_sequence_workspace_id_fkey,
   drop column workspace_id;
 
 drop table sequencing.workspace;

--- a/deployment/hasura/migrations/Aerie/9_sequence_workspaces/down.sql
+++ b/deployment/hasura/migrations/Aerie/9_sequence_workspaces/down.sql
@@ -2,6 +2,7 @@ alter table sequencing.user_sequence
   drop constraint user_sequence_workspace_id_fkey,
   drop column workspace_id;
 
+drop trigger set_timestamp on sequencing.workspace;
 drop table sequencing.workspace;
 
 call migrations.mark_migration_rolled_back('9');

--- a/deployment/hasura/migrations/Aerie/9_sequence_workspaces/down.sql
+++ b/deployment/hasura/migrations/Aerie/9_sequence_workspaces/down.sql
@@ -1,0 +1,6 @@
+alter table sequencing.user_sequence
+  drop column workspace_id;
+
+drop table sequencing.workspace;
+
+call migrations.mark_migration_rolled_back('9');

--- a/deployment/hasura/migrations/Aerie/9_sequence_workspaces/up.sql
+++ b/deployment/hasura/migrations/Aerie/9_sequence_workspaces/up.sql
@@ -33,7 +33,7 @@ comment on column sequencing.workspace.created_at is e''
 comment on column sequencing.workspace.updated_at is e''
   'Time the workspace was last updated.';
 comment on column sequencing.workspace.updated_by is e''
-  'THe user who last updated the workspace.';
+  'The user who last updated the workspace.';
 
 create trigger set_timestamp
   before update on sequencing.workspace

--- a/deployment/hasura/migrations/Aerie/9_sequence_workspaces/up.sql
+++ b/deployment/hasura/migrations/Aerie/9_sequence_workspaces/up.sql
@@ -1,0 +1,53 @@
+---- Add the new workspace table
+
+create table sequencing.workspace (
+  id integer generated always as identity,
+
+  name text not null,
+
+  created_at timestamptz not null default now(),
+  owner text,
+  updated_at timestamptz not null default now(),
+  updated_by text,
+
+  constraint workspace_synthetic_key
+    primary key (id),
+  foreign key (owner)
+    references permissions.users
+    on update cascade
+    on delete set null,
+  foreign key (updated_by)
+    references permissions.users
+    on update cascade
+    on delete set null
+);
+
+comment on table sequencing.workspace is e''
+  'A container for multiple sequences.';
+comment on column sequencing.workspace.name is e''
+  'The name of the workspace.';
+
+create trigger set_timestamp
+  before update on sequencing.workspace
+  for each row
+execute function util_functions.set_updated_at();
+
+---- Add the new workspace_id column to the user_sequence table
+
+alter table sequencing.user_sequence
+  add column workspace_id jsonb,
+
+  add foreign key (workspace_id)
+    references sequencing.parcel (id)
+    on delete cascade;
+
+comment on column sequencing.user_sequence.workspace_id is e''
+  'The workspace the sequence is associated with.';
+
+---- Populate the workspace table with a default workspace to contain existing sequences
+
+insert into sequencing.workspace (name, owner)
+values ('Workspace 1', 'Aerie Legacy');
+
+update sequencing.user_sequence
+  set workspace_id = 1;

--- a/deployment/hasura/migrations/Aerie/9_sequence_workspaces/up.sql
+++ b/deployment/hasura/migrations/Aerie/9_sequence_workspaces/up.sql
@@ -35,7 +35,7 @@ execute function util_functions.set_updated_at();
 ---- Add the new workspace_id column to the user_sequence table
 
 alter table sequencing.user_sequence
-  add column workspace_id jsonb,
+  add column workspace_id integer,
 
   add foreign key (workspace_id)
     references sequencing.parcel (id)

--- a/deployment/hasura/migrations/Aerie/9_sequence_workspaces/up.sql
+++ b/deployment/hasura/migrations/Aerie/9_sequence_workspaces/up.sql
@@ -26,6 +26,14 @@ comment on table sequencing.workspace is e''
   'A container for multiple sequences.';
 comment on column sequencing.workspace.name is e''
   'The name of the workspace.';
+comment on column sequencing.workspace.owner is e''
+  'The user responsible for this workspace.';
+comment on column sequencing.workspace.created_at is e''
+  'Time the workspace was created at.';
+comment on column sequencing.workspace.updated_at is e''
+  'Time the workspace was last updated.';
+comment on column sequencing.workspace.updated_by is e''
+  'THe user who last updated the workspace.';
 
 create trigger set_timestamp
   before update on sequencing.workspace
@@ -51,5 +59,8 @@ values ('Workspace 1', 'Aerie Legacy');
 
 update sequencing.user_sequence
   set workspace_id = 1;
+
+alter table sequencing.user_sequence
+  alter column workspace_id set not null;
 
 call migrations.mark_migration_applied('9');

--- a/deployment/hasura/migrations/Aerie/9_sequence_workspaces/up.sql
+++ b/deployment/hasura/migrations/Aerie/9_sequence_workspaces/up.sql
@@ -51,3 +51,5 @@ values ('Workspace 1', 'Aerie Legacy');
 
 update sequencing.user_sequence
   set workspace_id = 1;
+
+call migrations.mark_migration_applied('9');

--- a/deployment/postgres-init-db/sql/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/applied_migrations.sql
@@ -11,3 +11,4 @@ call migrations.mark_migration_applied('5');
 call migrations.mark_migration_applied('6');
 call migrations.mark_migration_applied('7');
 call migrations.mark_migration_applied('8');
+call migrations.mark_migration_applied('9');

--- a/deployment/postgres-init-db/sql/init_sequencing.sql
+++ b/deployment/postgres-init-db/sql/init_sequencing.sql
@@ -20,6 +20,7 @@ begin;
   \ir tables/sequencing/sequence.sql
   \ir tables/sequencing/sequence_to_simulated_activity.sql
   \ir tables/sequencing/parcel_to_parameter_dictionary.sql
+  \ir tables/sequencing/workspace.sql
   \ir tables/sequencing/user_sequence.sql
   \ir tables/sequencing/expanded_sequences.sql
 

--- a/deployment/postgres-init-db/sql/tables/sequencing/user_sequence.sql
+++ b/deployment/postgres-init-db/sql/tables/sequencing/user_sequence.sql
@@ -7,6 +7,7 @@ create table sequencing.user_sequence (
   owner text,
   parcel_id integer not null,
   updated_at timestamptz not null default now(),
+  workspace_id integer not null,
 
   constraint user_sequence_primary_key primary key (id),
 
@@ -16,6 +17,9 @@ create table sequencing.user_sequence (
   foreign key (owner)
     references permissions.users
     on update cascade
+    on delete cascade,
+  foreign key (workspace_id)
+    references sequencing.workspace (id)
     on delete cascade
 );
 
@@ -35,6 +39,8 @@ comment on column sequencing.user_sequence.parcel_id is e''
   'Parcel the user sequence was created with.';
 comment on column sequencing.user_sequence.updated_at is e''
   'Time the user sequence was last updated.';
+comment on column sequencing.user_sequence.workspace_id is e''
+  'The workspace the sequence is associated with.';
 
 create trigger set_timestamp
 before update on sequencing.user_sequence

--- a/deployment/postgres-init-db/sql/tables/sequencing/workspace.sql
+++ b/deployment/postgres-init-db/sql/tables/sequencing/workspace.sql
@@ -31,7 +31,7 @@ comment on column sequencing.workspace.created_at is e''
 comment on column sequencing.workspace.updated_at is e''
   'Time the workspace was last updated.';
 comment on column sequencing.workspace.updated_by is e''
-  'THe user who last updated the workspace.';
+  'The user who last updated the workspace.';
 
 create trigger set_timestamp
   before update on sequencing.workspace

--- a/deployment/postgres-init-db/sql/tables/sequencing/workspace.sql
+++ b/deployment/postgres-init-db/sql/tables/sequencing/workspace.sql
@@ -1,0 +1,31 @@
+create table sequencing.workspace (
+  id integer generated always as identity,
+
+  name text not null,
+
+  created_at timestamptz not null default now(),
+  owner text,
+  updated_at timestamptz not null default now(),
+  updated_by text,
+
+  constraint workspace_synthetic_key
+    primary key (id),
+  foreign key (owner)
+    references permissions.users
+    on update cascade
+    on delete set null,
+  foreign key (updated_by)
+    references permissions.users
+    on update cascade
+    on delete set null
+);
+
+comment on table sequencing.workspace is e''
+  'A container for multiple sequences.';
+comment on column sequencing.workspace.name is e''
+  'The name of the workspace.';
+
+create trigger set_timestamp
+  before update on sequencing.workspace
+  for each row
+execute function util_functions.set_updated_at();

--- a/deployment/postgres-init-db/sql/tables/sequencing/workspace.sql
+++ b/deployment/postgres-init-db/sql/tables/sequencing/workspace.sql
@@ -24,6 +24,14 @@ comment on table sequencing.workspace is e''
   'A container for multiple sequences.';
 comment on column sequencing.workspace.name is e''
   'The name of the workspace.';
+comment on column sequencing.workspace.owner is e''
+  'The user responsible for this workspace.';
+comment on column sequencing.workspace.created_at is e''
+  'Time the workspace was created at.';
+comment on column sequencing.workspace.updated_at is e''
+  'Time the workspace was last updated.';
+comment on column sequencing.workspace.updated_by is e''
+  'THe user who last updated the workspace.';
 
 create trigger set_timestamp
   before update on sequencing.workspace


### PR DESCRIPTION
* **Tickets addressed:** [#1393](https://github.com/orgs/NASA-AMMOS/projects/2/views/19?pane=issue&itemId=72136325)
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

Front-end PR: https://github.com/NASA-AMMOS/aerie-ui/pull/1420

## Description
Adds backend support for sequence workspaces. Migration includes creating a workspace and adding every existing sequence to that created workspace.

## Verification
Manually tested.

## Documentation
NA

## Future work
These will be improved in the future, right now we're only allowing 1 level deep.
