### PR TITLE
GH workflow to publish images for PRs labeled 'publish'

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,18 +7,28 @@ on:
       - dev-[0-9]+.[0-9]+.[0-9]+
     tags:
       - v*
+  pull_request:
+    types:
+      # publish images for PRs labeled "publish" whenever changed/labeled
+      [opened, reopened, synchronize, labeled]
   workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
   OWNER: nasa-ammos
   IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  SHOULD_PUBLISH_IMAGES: ${{ (github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'publish') }}
+  SHOULD_PUBLISH_DEPLOYMENT: ${{ (github.event_name != 'pull_request') }}
 
 jobs:
   init:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      # set these as outputs to make available later, since `env` context isn't available in `jobs.if`
+      SHOULD_PUBLISH_IMAGES: ${{ env.SHOULD_PUBLISH_IMAGES }}
+      SHOULD_PUBLISH_DEPLOYMENT: ${{ env.SHOULD_PUBLISH_DEPLOYMENT }}
     steps:
       - uses: actions/checkout@v4
 
@@ -34,6 +44,7 @@ jobs:
   containers:
     runs-on: ubuntu-latest
     needs: init
+    if: needs.init.outputs.SHOULD_PUBLISH_IMAGES == 'true'
     permissions:
       contents: read
       packages: write
@@ -63,6 +74,9 @@ jobs:
             file: docker/Dockerfile.postgres
     name: ${{ matrix.components.image }}
     steps:
+      - name: Log SHOULD_PUBLISH_IMAGES
+        run: echo ${{ needs.init.outputs.SHOULD_PUBLISH_IMAGES }}
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-java@v4
@@ -119,6 +133,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     needs: containers
+    if: needs.init.outputs.SHOULD_PUBLISH_IMAGES == 'true'
     strategy:
       matrix:
         image:
@@ -155,6 +170,7 @@ jobs:
     name: gradle publish
     runs-on: ubuntu-latest
     needs: init
+    if: needs.init.outputs.SHOULD_PUBLISH_DEPLOYMENT == 'true'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Supporting this issue: https://github.com/NASA-AMMOS/aerie/issues/1538

This change will cause the GH "Publish" workflow to run whenever an `aerie` PR is given the "publish" label, which will cause Docker images to be published from the PR branch, tagged with the PR number eg. `pr-1540`

The published aerie PR can then be referenced in an `aerie-ui` PR with a flag in the PR body that looks like eg. `___REQUIRES_AERIE_PR___="1540"`, which will cause the `aerie-ui` e2e tests to use the published `pr-1540` aerie images during testing rather than the default `develop` branch.