### PR TITLE
Support events emitted from daemon tasks

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -884,7 +884,7 @@ public final class SimulationEngine implements AutoCloseable {
                       }
                     }
                   }
-                  var activitySpanID = Optional.of(spanToActivities.get(event.provenance()).id());
+                  var activitySpanID = Optional.ofNullable(spanToActivities.get(event.provenance())).map(ActivityInstanceId::id);
                   output = EventGraph.concurrently(
                       output,
                       EventGraph.atom(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/InsertSimulationEventsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/InsertSimulationEventsAction.java
@@ -10,6 +10,7 @@ import org.intellij.lang.annotations.Language;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.List;
 import java.util.Map;
 
@@ -65,7 +66,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PreparedStatemen
       statement.setString(5, causalTime);
       statement.setInt(6, event.topicId());
       statement.setString(7, serializedValueP.unparse(event.value()).toString());
-      statement.setLong(8, event.spanId().isPresent() ? event.spanId().get() : null);
+      statement.setObject(8, event.spanId().orElse(null), Types.INTEGER);
       statement.addBatch();
     }
   }


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Tweaks the handling of event provenance to account for events emitted from daemon tasks to avoid NullPointerException.

All credit to @mattdailis for this fix.

## Verification
I did some manual testing with a local Aerie instance, on a model that used the streamline Logger to emit events from daemon tasks, and verified that the simulation completes without error and the events appear in the simulation events table in the UI.

## Documentation
N/A - bug fix

## Future work
N/A
