### PR TITLE
Update Postgres 16.2 -> 16.4

### DIFF
--- a/.github/workflows/pgcmp.yml
+++ b/.github/workflows/pgcmp.yml
@@ -66,7 +66,7 @@ jobs:
         run: sudo curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
       - name: Start Postgres
         run: |
-          sed -i 's/postgres:14.8/postgres:16.2/' docker-compose.yml
+          sed -i 's/postgres:14.8/postgres:16.4/' docker-compose.yml
           docker compose up -d postgres hasura
           docker images
           docker ps -a
@@ -251,7 +251,7 @@ jobs:
           sudo apt update
           sudo apt -y install postgresql-client-16
       - name: Start Postgres
-        run: docker run -d -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust --name=postgres postgres:16.2
+        run: docker run -d -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust --name=postgres postgres:16.4
       - name: Sleep for 5 Seconds
         run: sleep 5s
         shell: bash
@@ -312,7 +312,7 @@ jobs:
           sudo apt update
           sudo apt -y install postgresql-client-16
       - name: Start Postgres
-        run: docker run -d -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust --name=postgres postgres:16.2
+        run: docker run -d -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust --name=postgres postgres:16.4
       - name: Sleep for 5 Seconds
         run: sleep 5s
         shell: bash

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -191,7 +191,7 @@ services:
       SCHEDULER_DB_PASSWORD: "${SCHEDULER_PASSWORD}"
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
-    image: postgres:16.2
+    image: postgres:16.4
     ports: ["5432:5432"]
     restart: always
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,7 +255,7 @@ services:
       SCHEDULER_DB_PASSWORD: "${SCHEDULER_PASSWORD}"
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
-    image: postgres:16.2
+    image: postgres:16.4
     ports: ["5432:5432"]
     restart: always
     volumes:

--- a/docker/Dockerfile.postgres
+++ b/docker/Dockerfile.postgres
@@ -1,2 +1,2 @@
-FROM postgres:16.2
+FROM postgres:16.4
 COPY deployment/postgres-init-db /docker-entrypoint-initdb.d

--- a/e2e-tests/docker-compose-many-workers.yml
+++ b/e2e-tests/docker-compose-many-workers.yml
@@ -200,7 +200,7 @@ services:
       SCHEDULER_DB_PASSWORD: "${SCHEDULER_PASSWORD}"
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
-    image: postgres:16.2
+    image: postgres:16.4
     ports: ["5432:5432"]
     restart: always
     volumes:

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -245,7 +245,7 @@ services:
       SCHEDULER_DB_PASSWORD: "${SCHEDULER_PASSWORD}"
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
-    image: postgres:16.2
+    image: postgres:16.4
     ports: ['5432:5432']
     restart: always
     volumes:


### PR DESCRIPTION
Upgrading Postgres from 16.2 to **16.4**, since 16.2 has known security issues that flag our vulnerability scanner. Submitting a PR as a draft for now to see if it breaks any CI tests & if it fixes the "scan" step of the Publish workflow.

Per [Postgres Docs](https://www.postgresql.org/docs/release/16.4/) I think this should be a safe change that does not require dump/restore or any other instructions/considerations, but let me know if you have any concerns with this, @Mythicaeda  