### PR TITLE
Hook workspace fk up to the correct table in migration

### DIFF
--- a/deployment/hasura/migrations/Aerie/9_sequence_workspaces/up.sql
+++ b/deployment/hasura/migrations/Aerie/9_sequence_workspaces/up.sql
@@ -22,6 +22,7 @@ create table sequencing.workspace (
     on delete set null
 );
 
+
 comment on table sequencing.workspace is e''
   'A container for multiple sequences.';
 comment on column sequencing.workspace.name is e''
@@ -46,7 +47,7 @@ alter table sequencing.user_sequence
   add column workspace_id integer,
 
   add foreign key (workspace_id)
-    references sequencing.parcel (id)
+    references sequencing.workspace (id)
     on delete cascade;
 
 comment on column sequencing.user_sequence.workspace_id is e''


### PR DESCRIPTION
* **Tickets addressed:** AERIE-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
There was a typo in migration 9 that added an fk to the `parcel` table instead of the `workspace` table.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I have confirmed that the code is now an exact match to the files updated.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Investigate how this wasn't caught by our automated dbcmp tests.
