### PR TITLE
Fix pgcmp workflow

### DIFF
--- a/.github/scripts/compareDatabasesUp.sh
+++ b/.github/scripts/compareDatabasesUp.sh
@@ -3,10 +3,10 @@
 mkdir results
 mkdir comparison
 
-PGCMPINPUT1=./pgdumpmigrated/AerieMigrated \
-PGCMPINPUT2=./pgdumpraw/AerieRaw \
-PGCLABEL1=AerieMigrated \
-PGCLABEL2=AerieRaw \
+PGCMPINPUT1=./pgdumpmigrated/AerieMigratedUp \
+PGCMPINPUT2=./pgdumpcurrent/AerieCurrent \
+PGCLABEL1=AerieMigratedUp \
+PGCLABEL2=AerieCurrent \
 PGCFULLOUTPUT=./comparison/fulloutput.txt \
 PGCUNEXPLAINED=./comparison/unexplained.txt \
 PGCBADEXPLAIN=./comparison/badexplanations.txt \

--- a/.github/workflows/pgcmp.yml
+++ b/.github/workflows/pgcmp.yml
@@ -5,10 +5,14 @@ on:
     paths:
       - "deployment/hasura/migrations/**"
       - "deployment/postgres-init-db/sql/**"
+      - ".github/workflows/pgcmp.yml"
+      - ".github/workflows/scripts/compareDatabases*"
   push:
     paths:
       - "deployment/hasura/migrations/**"
       - "deployment/postgres-init-db/sql/**"
+      - ".github/workflows/pgcmp.yml"
+      - ".github/workflows/scripts/compareDatabases*"
     branches:
       - develop
       - dev-[0-9]+.[0-9]+.[0-9]+


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Our db comparison workflow is failing to catch errors it should. Testing the `pgcmp` tool against the dumps manually, however, revealed that the issue is likely in the workflow itself rather than the tool, as the tool is correctly spotting the errors locally.

[Workflow run proving the up is now working](https://github.com/NASA-AMMOS/aerie/actions/runs/10710079763/job/29696218309)

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
The workflow failing _with the correct comparison failure_ will be a success, as currently `develop` has an inconsitency in migration 9 (fix PR for that is [here](https://github.com/NASA-AMMOS/aerie/pull/1544))
