### PR TITLE
Add trivyignore file to ignore false positive CVEs in security scan

### DIFF
--- a/.github/config/.trivyignore
+++ b/.github/config/.trivyignore
@@ -1,0 +1,11 @@
+# List of CVEs to ignore in our security scans in Publish workflow
+# see https://aquasecurity.github.io/trivy/v0.53/docs/configuration/filtering/#trivyignore
+
+# These were determined to be false positives caused by the `gosu` library
+# which is installed by the postgres docker container and does not use the entirety of the Go stdlib
+# for details see:
+# - https://github.com/tianon/gosu/blob/master/SECURITY.md
+# - https://github.com/NASA-AMMOS/aerie/pull/1546
+CVE-2023-24538
+CVE-2023-24540
+CVE-2024-24790

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,8 +147,10 @@ jobs:
       fail-fast: false
     name: scan ${{ matrix.image }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Scan ${{ matrix.image }} for vulnerabilities
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:develop
           ignore-unfixed: true
@@ -158,6 +160,7 @@ jobs:
           template: "@/contrib/html.tpl"
           scanners: "vuln"
           output: "${{ matrix.image }}-results.html"
+          trivyignores: .github/config/.trivyignore
 
       - name: Upload ${{ matrix.image }} scan results
         if: always()


### PR DESCRIPTION
## Description
This change mitigates certain false positives that appear during the security scan of our `aerie-postgres` container by ignoring them with a `.trivyignore` file, used by the `trivy` action which runs our scans.

## Verification
To determine that these CVE's were in fact false positives, I worked with @skovati and we did the following:
* Checked the output from the `aerie-postgres` Publish workflow, security scan step, and found that the only remaining CVEs are the three in this PR, all associated with version 1.18.2 of `gobinary`'s `stdlib` package
* On [this DockerHub page](https://hub.docker.com/layers/library/postgres/16.4/images/sha256-beed0b9981711f83841b1421a04891e3e3c1b4baebfa5719038fa273f25a8404?context=explore) we confirmed that the only usage of this `stdlib` package is from `gosu`, a small utility used to setup the postgres container
* We found [this page on the `gosu` docs](https://github.com/tianon/gosu/blob/master/SECURITY.md) which explains how most Go CVEs are false positives for this tool, and how to confirm.
* We weren't able to get the [./govulncheck-with-excludes.sh](https://github.com/tianon/gosu/blob/master/govulncheck-with-excludes.sh) script provided by this document to work correctly. However we validated a different way, using the regular `govulncheck` tool which checks specifically which parts of the `Go` library are being used by a binary:
  - Copied the `gosu` binary *from* the postgres machine to local machine with `docker cp`
  - Ran the regular `govulncheck` tool against this binary with the command `govulncheck -mode=binary gosu`
  - This produced only a single applicable CVE: `GO-2023-1840 - Unsafe behavior in setuid/setgid binaries in runtime`
  - ...and ^this specific CVE is explicitly excluded by the `govulncheck-with-excludes` script above, which explains in comments why it is a false positive/mitigated risk

Therefore, we believe these other `gobinary` `stdlib` CVEs from the security scan are all false positives in our case, and should be excluded from our scans.

## Future work
Better process for tracking these down in the future?