### PR TITLE
Bug fix for clock "asLinear"

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableClockResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableClockResources.java
@@ -16,6 +16,7 @@ import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete.d
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.not;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.linear.Linear.linear;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.EPSILON;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECOND;
 
 public final class VariableClockResources {
   private VariableClockResources() {}
@@ -51,7 +52,7 @@ public final class VariableClockResources {
   }
 
   public static Resource<Linear> asLinear(Resource<VariableClock> clock, Duration unit) {
-    return map(clock, c -> linear(c.extract().ratioOver(unit), c.multiplier()));
+    return map(clock, c -> linear(c.extract().ratioOver(unit), c.multiplier() * SECOND.ratioOver(unit)));
   }
 
   public static Resource<VariableClock> asVariableClock(Resource<Clock> clock) {


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds a missing unit conversion for the multiplier in VariableClockResources.asLinear When converting a clock resource to a linear resource in units of U, the multiplier needs to be converted to "U / second".

## Verification
Tested manually as part of another model I was working on.

## Documentation
N/A

## Future work
N/A
