### PR TITLE
Generator Constraints and Violation Messages

### DIFF
--- a/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Constraint.kt
+++ b/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Constraint.kt
@@ -1,7 +1,7 @@
 package gov.nasa.ammos.aerie.procedural.constraints
 
-import gov.nasa.ammos.aerie.procedural.timeline.CollectOptions
-import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulatedPlan
+import gov.nasa.ammos.aerie.procedural.timeline.plan.Plan
+import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults
 
 /** The interface that all constraints must satisfy. */
 interface Constraint {
@@ -12,7 +12,7 @@ interface Constraint {
    * the constraint is run. The constraint does not need to use the options unless it collects a timeline prematurely.
    *
    * @param plan the plan to check the constraint on
-   * @param options the [CollectOptions] that the result will be collected with
+   * @param simResults the [SimulationResults] that the result will be collected with
    */
-  fun run(plan: SimulatedPlan, options: CollectOptions): Violations
+  fun run(plan: Plan, simResults: SimulationResults): Violations
 }

--- a/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Constraint.kt
+++ b/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Constraint.kt
@@ -16,11 +16,5 @@ interface Constraint {
    */
   fun run(plan: Plan, simResults: SimulationResults): Violations
 
-  /**
-   * Default violation message to be displayed to user.
-   *
-   * Can be overridden on a violation-by-violation basis by manually specifying
-   * it in the [Violation] object.
-   */
-  fun message(): String? = null
+
 }

--- a/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Constraint.kt
+++ b/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Constraint.kt
@@ -15,4 +15,12 @@ interface Constraint {
    * @param simResults the [SimulationResults] that the result will be collected with
    */
   fun run(plan: Plan, simResults: SimulationResults): Violations
+
+  /**
+   * Default violation message to be displayed to user.
+   *
+   * Can be overridden on a violation-by-violation basis by manually specifying
+   * it in the [Violation] object.
+   */
+  fun message(): String? = null
 }

--- a/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/GeneratorConstraint.kt
+++ b/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/GeneratorConstraint.kt
@@ -20,47 +20,53 @@ abstract class GeneratorConstraint: Constraint {
   private var violations = mutableListOf<Violation>()
 
   /** Finalizes one or more violations. */
-  protected fun violate(vararg v: Violation) {
+  @JvmOverloads protected fun violate(vararg v: Violation, message: String? = null) {
     violate(v.toList())
   }
 
   /** Finalizes a list of violations. */
-  protected fun violate(l: List<Violation>) {
-    violations.addAll(l)
+  @JvmOverloads protected fun violate(l: List<Violation>, message: String? = null) {
+    violations.addAll(l.map {
+      if (it.message == null) Violation(
+        it.interval,
+        message,
+        it.ids
+      ) else it
+    })
   }
 
   /** Collects a [Violations] timeline and finalizes the result. */
-  protected fun violate(tl: Violations) {
+  @JvmOverloads protected fun violate(tl: Violations, message: String? = null) {
     violate(tl.collect())
   }
 
   /** Creates a [Violations] object that violates when this profile equals a given value. */
-  protected fun <V: Any> SerialConstantOps<V, *>.violateOn(v: V) = violate(Violations.on(this, v))
+  @JvmOverloads protected fun <V: Any> SerialConstantOps<V, *>.violateOn(v: V, message: String? = null) = violate(Violations.on(this, v), message)
 
   /** Creates a [Violations] object that violates when this profile equals a given value. */
-  protected fun Real.violateOn(n: Number) = violate(Violations.on(this, n))
+  @JvmOverloads protected fun Real.violateOn(n: Number, message: String? = null) = violate(Violations.on(this, n), message)
 
   /**
    * Creates a [Violations] object that violates on every object in the timeline.
    *
    * If the object is an activity, it will record the directive or instance id.
    */
-  protected fun <I: IntervalLike<I>> ParallelOps<I, *>.violateOnAll() {
-    violate(Violations.onAll(this))
+  @JvmOverloads protected fun <I: IntervalLike<I>> ParallelOps<I, *>.violateOnAll(message: String? = null) {
+    violate(Violations.onAll(this), message)
   }
 
   /** Creates a [Violations] object that violates inside each interval. */
-  protected fun Windows.violateInside() = violate(Violations.inside(this))
+  @JvmOverloads protected fun Windows.violateInside(message: String? = null) = violate(Violations.inside(this), message)
   /** Creates a [Violations] object that violates outside each interval. */
-  protected fun Windows.violateOutside() = violate(Violations.outside(this))
+  @JvmOverloads protected fun Windows.violateOutside(message: String? = null) = violate(Violations.outside(this), message)
 
   /**
    * Creates a [Violations] object from two timelines, that violates whenever they have overlap.
    *
    * If either object is an activity, it will record the directive or instance id.
    */
-  protected fun <V: IntervalLike<V>, W: IntervalLike<W>> GeneralOps<V, *>.mutexViolations(other: GeneralOps<W, *>) {
-    violate(Violations.mutex(this, other))
+  @JvmOverloads protected fun <V: IntervalLike<V>, W: IntervalLike<W>> GeneralOps<V, *>.violateWhenSimultaneous(other: GeneralOps<W, *>, message: String? = null) {
+    violate(Violations.whenSimultaneous(this, other), message)
   }
 
   /**

--- a/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/GeneratorConstraint.kt
+++ b/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/GeneratorConstraint.kt
@@ -1,0 +1,76 @@
+package gov.nasa.ammos.aerie.procedural.constraints
+
+import gov.nasa.ammos.aerie.procedural.timeline.collections.Windows
+import gov.nasa.ammos.aerie.procedural.timeline.collections.profiles.Real
+import gov.nasa.ammos.aerie.procedural.timeline.ops.GeneralOps
+import gov.nasa.ammos.aerie.procedural.timeline.ops.ParallelOps
+import gov.nasa.ammos.aerie.procedural.timeline.ops.SerialConstantOps
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.IntervalLike
+import gov.nasa.ammos.aerie.procedural.timeline.plan.Plan
+import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults
+
+/**
+ * A generator-style implementation of [Constraint].
+ *
+ * The subclass must implement [generate], and within it call [violate] to produce violations.
+ * Or if you are using Kotlin, you can use the timeline extension functions such as [windows.violateInside()][violateInside]
+ * to more easily submit violations.
+ */
+abstract class GeneratorConstraint: Constraint {
+  private var violations = mutableListOf<Violation>()
+
+  /** Finalizes one or more violations. */
+  protected fun violate(vararg v: Violation) {
+    violate(v.toList())
+  }
+
+  /** Finalizes a list of violations. */
+  protected fun violate(l: List<Violation>) {
+    violations.addAll(l)
+  }
+
+  /** Collects a [Violations] timeline and finalizes the result. */
+  protected fun violate(tl: Violations) {
+    violate(tl.collect())
+  }
+
+  /** Creates a [Violations] object that violates when this profile equals a given value. */
+  protected fun <V: Any> SerialConstantOps<V, *>.violateOn(v: V) = violate(Violations.on(this, v))
+
+  /** Creates a [Violations] object that violates when this profile equals a given value. */
+  protected fun Real.violateOn(n: Number) = violate(Violations.on(this, n))
+
+  /**
+   * Creates a [Violations] object that violates on every object in the timeline.
+   *
+   * If the object is an activity, it will record the directive or instance id.
+   */
+  protected fun <I: IntervalLike<I>> ParallelOps<I, *>.violateOnAll() {
+    violate(Violations.onAll(this))
+  }
+
+  /** Creates a [Violations] object that violates inside each interval. */
+  protected fun Windows.violateInside() = violate(Violations.inside(this))
+  /** Creates a [Violations] object that violates outside each interval. */
+  protected fun Windows.violateOutside() = violate(Violations.outside(this))
+
+  /**
+   * Creates a [Violations] object from two timelines, that violates whenever they have overlap.
+   *
+   * If either object is an activity, it will record the directive or instance id.
+   */
+  protected fun <V: IntervalLike<V>, W: IntervalLike<W>> GeneralOps<V, *>.mutexViolations(other: GeneralOps<W, *>) {
+    violate(Violations.mutex(this, other))
+  }
+
+  /**
+   * A generator function that calls [violate] to produce violations.
+   */
+  abstract fun generate(plan: Plan, simResults: SimulationResults)
+
+  final override fun run(plan: Plan, simResults: SimulationResults): Violations {
+    violations = mutableListOf()
+    generate(plan, simResults)
+    return Violations(violations)
+  }
+}

--- a/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Violation.kt
+++ b/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Violation.kt
@@ -9,15 +9,18 @@ data class Violation @JvmOverloads constructor(
     /** Interval on which the violation occurs. */
     override val interval: Interval,
 
+    /** Violation message to be displayed to user. */
+    val message: String? = null,
+
     /** List of associated activities (directives or instances) that are related to the violation. */
     val ids: List<ActivityId> = listOf()
 ) : IntervalLike<Violation> {
 
-  override fun withNewInterval(i: Interval) = Violation(i, ids)
+  override fun withNewInterval(i: Interval) = Violation(i, message, ids)
 
   /** Constructs a violation on the same interval with a different list of ids. */
-  fun withNewIds(vararg id: ActivityId) = Violation(interval, id.asList())
+  fun withNewIds(vararg id: ActivityId) = Violation(interval, message, id.asList())
 
   /** Constructs a violation on the same interval with a different list of ids. */
-  fun withNewIds(ids: List<ActivityId>) = Violation(interval, ids)
+  fun withNewIds(ids: List<ActivityId>) = Violation(interval, message, ids)
 }

--- a/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Violation.kt
+++ b/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Violation.kt
@@ -5,7 +5,7 @@ import gov.nasa.ammos.aerie.procedural.timeline.payloads.IntervalLike
 import gov.nasa.jpl.aerie.types.ActivityId
 
 /** A single violation of a constraint. */
-data class Violation(
+data class Violation @JvmOverloads constructor(
     /** Interval on which the violation occurs. */
     override val interval: Interval,
 

--- a/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Violations.kt
+++ b/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Violations.kt
@@ -47,6 +47,7 @@ data class Violations(private val timeline: Timeline<Violation, Violations>):
         tl.unsafeMap(::Violations, BoundsTransformer.IDENTITY, false) {
           Violation(
               it.interval,
+              null,
               listOfNotNull(it.getActivityId())
           )
         }
@@ -64,6 +65,7 @@ data class Violations(private val timeline: Timeline<Violation, Violations>):
     @JvmStatic fun <V: IntervalLike<V>, W: IntervalLike<W>> mutex(left: GeneralOps<V, *>, right: GeneralOps<W, *>) =
         left.unsafeMap2(::Violations, right) { l, r, i -> Violation(
             i,
+            null,
             listOfNotNull(
                 l.getActivityId(),
                 r.getActivityId()

--- a/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Violations.kt
+++ b/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Violations.kt
@@ -31,6 +31,16 @@ data class Violations(private val timeline: Timeline<Violation, Violations>):
    */
   fun mapIds(f: (Violation) -> List<ActivityId>) = unsafeMap(BoundsTransformer.IDENTITY, false) { it.withNewIds(f(it)) }
 
+  /**
+   * Sets a default violation message for violations that don't already have one.
+   *
+   * @param message the default message to give to the user
+   */
+  fun withDefaultMessage(message: String) = unsafeMap(BoundsTransformer.IDENTITY, false) {
+    if (it.message == null) Violation(it.interval, message, it.ids)
+    else it
+  }
+
   /***/ companion object {
     /** Creates a [Violations] object that violates when the profile equals a given value. */
     @JvmStatic fun <V: Any> on(tl: SerialConstantOps<V, *>, v: V) = onAll(tl.isolateEqualTo(v))

--- a/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Violations.kt
+++ b/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Violations.kt
@@ -32,19 +32,19 @@ data class Violations(private val timeline: Timeline<Violation, Violations>):
   fun mapIds(f: (Violation) -> List<ActivityId>) = unsafeMap(BoundsTransformer.IDENTITY, false) { it.withNewIds(f(it)) }
 
   /***/ companion object {
-    /** Creates a [Violations] object that violates when this profile equals a given value. */
-    @JvmStatic fun <V: Any> SerialConstantOps<V, *>.violateOn(v: V) = isolateEqualTo(v).violations()
+    /** Creates a [Violations] object that violates when the profile equals a given value. */
+    @JvmStatic fun <V: Any> on(tl: SerialConstantOps<V, *>, v: V) = onAll(tl.isolateEqualTo(v))
 
     /** Creates a [Violations] object that violates when this profile equals a given value. */
-    @JvmStatic fun Real.violateOn(n: Number) = equalTo(n).violateOn(true)
+    @JvmStatic fun on(tl: Real, n: Number) = on(tl.equalTo(n), true)
 
     /**
      * Creates a [Violations] object that violates on every object in the timeline.
      *
      * If the object is an activity, it will record the directive or instance id.
      */
-    @JvmStatic fun <I: IntervalLike<I>> ParallelOps<I, *>.violations() =
-        unsafeMap(::Violations, BoundsTransformer.IDENTITY, false) {
+    @JvmStatic fun <I: IntervalLike<I>> onAll(tl: ParallelOps<I, *>) =
+        tl.unsafeMap(::Violations, BoundsTransformer.IDENTITY, false) {
           Violation(
               it.interval,
               listOfNotNull(it.getActivityId())
@@ -52,17 +52,17 @@ data class Violations(private val timeline: Timeline<Violation, Violations>):
         }
 
     /** Creates a [Violations] object that violates inside each interval. */
-    @JvmStatic fun Windows.violateInside() = unsafeCast(::Universal).violations()
+    @JvmStatic fun inside(tl: Windows) = onAll(tl.unsafeCast(::Universal))
     /** Creates a [Violations] object that violates outside each interval. */
-    @JvmStatic fun Windows.violateOutside() = complement().violateInside()
+    @JvmStatic fun outside(tl: Windows) = inside(tl.complement())
 
     /**
      * Creates a [Violations] object from two timelines, that violates whenever they have overlap.
      *
      * If either object is an activity, it will record the directive or instance id.
      */
-    @JvmStatic infix fun <V: IntervalLike<V>, W: IntervalLike<W>> GeneralOps<V, *>.mutex(other: GeneralOps<W, *>) =
-        unsafeMap2(::Violations, other) { l, r, i -> Violation(
+    @JvmStatic fun <V: IntervalLike<V>, W: IntervalLike<W>> mutex(left: GeneralOps<V, *>, right: GeneralOps<W, *>) =
+        left.unsafeMap2(::Violations, right) { l, r, i -> Violation(
             i,
             listOfNotNull(
                 l.getActivityId(),

--- a/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Violations.kt
+++ b/procedural/constraints/src/main/kotlin/gov/nasa/ammos/aerie/procedural/constraints/Violations.kt
@@ -62,7 +62,7 @@ data class Violations(private val timeline: Timeline<Violation, Violations>):
      *
      * If either object is an activity, it will record the directive or instance id.
      */
-    @JvmStatic fun <V: IntervalLike<V>, W: IntervalLike<W>> mutex(left: GeneralOps<V, *>, right: GeneralOps<W, *>) =
+    @JvmStatic fun <V: IntervalLike<V>, W: IntervalLike<W>> whenSimultaneous(left: GeneralOps<V, *>, right: GeneralOps<W, *>) =
         left.unsafeMap2(::Violations, right) { l, r, i -> Violation(
             i,
             null,

--- a/procedural/constraints/src/test/kotlin/gov/nasa/ammos/aerie/procedural/constraints/GeneratorTest.kt
+++ b/procedural/constraints/src/test/kotlin/gov/nasa/ammos/aerie/procedural/constraints/GeneratorTest.kt
@@ -20,6 +20,8 @@ class GeneratorTest: GeneratorConstraint() {
       .violateOn(false)
   }
 
+  override fun message() = "Plant must be greater than 0"
+
   @Test
   fun testGenerator() {
     val plan = NotImplementedPlan()

--- a/procedural/constraints/src/test/kotlin/gov/nasa/ammos/aerie/procedural/constraints/GeneratorTest.kt
+++ b/procedural/constraints/src/test/kotlin/gov/nasa/ammos/aerie/procedural/constraints/GeneratorTest.kt
@@ -14,22 +14,18 @@ import kotlin.test.Test
 
 class GeneratorTest: GeneratorConstraint() {
   override fun generate(plan: Plan, simResults: SimulationResults) {
-    violate(Violation(Interval.at(seconds(0))))
+    violate(Interval.at(seconds(0)), message = "other message")
     simResults.resource("/plant", Numbers.deserializer())
       .greaterThan(0)
       .violateOn(false)
   }
 
-  override fun message() = "Plant must be greater than 0"
+  override fun defaultMessage() = "Plant must be greater than 0"
 
   @Test
   fun testGenerator() {
     val plan = NotImplementedPlan()
-    val simResults = object : SimulationResults {
-      override fun isStale() = TODO()
-
-      override fun simBounds() = TODO()
-
+    val simResults = object : NotImplementedSimulationResults() {
       override fun <V : Any, TL : CoalesceSegmentsOp<V, TL>> resource(
         name: String,
         deserializer: (List<Segment<SerializedValue>>) -> TL
@@ -45,17 +41,16 @@ class GeneratorTest: GeneratorConstraint() {
           TODO("Not yet implemented")
         }
       }
-
-      override fun <A : Any> instances(type: String?, deserializer: (SerializedValue) -> A) = TODO()
     }
 
     val result = run(plan, simResults).collect()
 
+    val defaultMessage = "Plant must be greater than 0";
     assertIterableEquals(
       listOf(
-        Violation(seconds(-4) .. seconds(-2)),
-        Violation(Interval.at(seconds(0))),
-        Violation(seconds(1) .. seconds(2))
+        Violation(seconds(-4) .. seconds(-2), defaultMessage),
+        Violation(Interval.at(seconds(0)), "other message"),
+        Violation(seconds(1) .. seconds(2), defaultMessage)
       ),
       result
     )

--- a/procedural/constraints/src/test/kotlin/gov/nasa/ammos/aerie/procedural/constraints/GeneratorTest.kt
+++ b/procedural/constraints/src/test/kotlin/gov/nasa/ammos/aerie/procedural/constraints/GeneratorTest.kt
@@ -1,0 +1,61 @@
+package gov.nasa.ammos.aerie.procedural.constraints
+
+import gov.nasa.ammos.aerie.procedural.timeline.Interval
+import gov.nasa.ammos.aerie.procedural.timeline.collections.profiles.Numbers
+import gov.nasa.ammos.aerie.procedural.timeline.ops.coalesce.CoalesceSegmentsOp
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.Segment
+import gov.nasa.ammos.aerie.procedural.timeline.plan.Plan
+import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults
+import gov.nasa.ammos.aerie.procedural.timeline.util.duration.rangeTo
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration.seconds
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue
+import org.junit.jupiter.api.Assertions.assertIterableEquals
+import kotlin.test.Test
+
+class GeneratorTest: GeneratorConstraint() {
+  override fun generate(plan: Plan, simResults: SimulationResults) {
+    violate(Violation(Interval.at(seconds(0))))
+    simResults.resource("/plant", Numbers.deserializer())
+      .greaterThan(0)
+      .violateOn(false)
+  }
+
+  @Test
+  fun testGenerator() {
+    val plan = NotImplementedPlan()
+    val simResults = object : SimulationResults {
+      override fun isStale() = TODO()
+
+      override fun simBounds() = TODO()
+
+      override fun <V : Any, TL : CoalesceSegmentsOp<V, TL>> resource(
+        name: String,
+        deserializer: (List<Segment<SerializedValue>>) -> TL
+      ): TL {
+        if (name == "/plant") {
+          val list = listOf(
+            Segment(seconds(-4) .. seconds(-2), SerializedValue.of(-3)),
+            Segment(seconds(0) .. seconds(1), SerializedValue.of(3)),
+            Segment(seconds(1) .. seconds(2), SerializedValue.of(-1)),
+          )
+          return deserializer(list)
+        } else {
+          TODO("Not yet implemented")
+        }
+      }
+
+      override fun <A : Any> instances(type: String?, deserializer: (SerializedValue) -> A) = TODO()
+    }
+
+    val result = run(plan, simResults).collect()
+
+    assertIterableEquals(
+      listOf(
+        Violation(seconds(-4) .. seconds(-2)),
+        Violation(Interval.at(seconds(0))),
+        Violation(seconds(1) .. seconds(2))
+      ),
+      result
+    )
+  }
+}

--- a/procedural/constraints/src/test/kotlin/gov/nasa/ammos/aerie/procedural/constraints/NotImplementedPlan.kt
+++ b/procedural/constraints/src/test/kotlin/gov/nasa/ammos/aerie/procedural/constraints/NotImplementedPlan.kt
@@ -1,0 +1,26 @@
+package gov.nasa.ammos.aerie.procedural.constraints
+
+import gov.nasa.ammos.aerie.procedural.timeline.Interval
+import gov.nasa.ammos.aerie.procedural.timeline.collections.Directives
+import gov.nasa.ammos.aerie.procedural.timeline.plan.Plan
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue
+import java.time.Instant
+
+class NotImplementedPlan: Plan {
+  override fun totalBounds(): Interval {
+    TODO("Not yet implemented")
+  }
+
+  override fun toRelative(abs: Instant): Duration {
+    TODO("Not yet implemented")
+  }
+
+  override fun toAbsolute(rel: Duration): Instant {
+    TODO("Not yet implemented")
+  }
+
+  override fun <A : Any> directives(type: String?, deserializer: (SerializedValue) -> A): Directives<A> {
+    TODO("Not yet implemented")
+  }
+}

--- a/procedural/constraints/src/test/kotlin/gov/nasa/ammos/aerie/procedural/constraints/NotImplementedPlan.kt
+++ b/procedural/constraints/src/test/kotlin/gov/nasa/ammos/aerie/procedural/constraints/NotImplementedPlan.kt
@@ -7,20 +7,9 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue
 import java.time.Instant
 
-class NotImplementedPlan: Plan {
-  override fun totalBounds(): Interval {
-    TODO("Not yet implemented")
-  }
-
-  override fun toRelative(abs: Instant): Duration {
-    TODO("Not yet implemented")
-  }
-
-  override fun toAbsolute(rel: Duration): Instant {
-    TODO("Not yet implemented")
-  }
-
-  override fun <A : Any> directives(type: String?, deserializer: (SerializedValue) -> A): Directives<A> {
-    TODO("Not yet implemented")
-  }
+open class NotImplementedPlan: Plan {
+  override fun totalBounds(): Interval = TODO()
+  override fun toRelative(abs: Instant): Duration = TODO()
+  override fun toAbsolute(rel: Duration): Instant = TODO()
+  override fun <A : Any> directives(type: String?, deserializer: (SerializedValue) -> A): Directives<A> = TODO()
 }

--- a/procedural/constraints/src/test/kotlin/gov/nasa/ammos/aerie/procedural/constraints/NotImplementedSimulationResults.kt
+++ b/procedural/constraints/src/test/kotlin/gov/nasa/ammos/aerie/procedural/constraints/NotImplementedSimulationResults.kt
@@ -1,0 +1,18 @@
+package gov.nasa.ammos.aerie.procedural.constraints
+
+import gov.nasa.ammos.aerie.procedural.timeline.Interval
+import gov.nasa.ammos.aerie.procedural.timeline.collections.Instances
+import gov.nasa.ammos.aerie.procedural.timeline.ops.coalesce.CoalesceSegmentsOp
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.Segment
+import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue
+
+open class NotImplementedSimulationResults: SimulationResults {
+  override fun isStale(): Boolean = TODO()
+  override fun simBounds(): Interval = TODO()
+  override fun <V : Any, TL : CoalesceSegmentsOp<V, TL>> resource(
+    name: String,
+    deserializer: (List<Segment<SerializedValue>>) -> TL
+  ): TL = TODO()
+  override fun <A : Any> instances(type: String?, deserializer: (SerializedValue) -> A): Instances<A> = TODO()
+}

--- a/procedural/examples/foo-procedures/src/main/java/gov/nasa/ammos/aerie/procedural/examples/fooprocedures/constraints/ConstFruit.java
+++ b/procedural/examples/foo-procedures/src/main/java/gov/nasa/ammos/aerie/procedural/examples/fooprocedures/constraints/ConstFruit.java
@@ -1,22 +1,20 @@
 package gov.nasa.ammos.aerie.procedural.examples.fooprocedures.constraints;
 
+import gov.nasa.ammos.aerie.procedural.constraints.GeneratorConstraint;
 import gov.nasa.ammos.aerie.procedural.constraints.Violations;
-import gov.nasa.ammos.aerie.procedural.constraints.Constraint;
-import gov.nasa.ammos.aerie.procedural.timeline.CollectOptions;
 import gov.nasa.ammos.aerie.procedural.timeline.collections.profiles.Real;
-import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulatedPlan;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.Plan;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults;
 import org.jetbrains.annotations.NotNull;
 
-public class ConstFruit implements Constraint {
-  @NotNull
+public class ConstFruit extends GeneratorConstraint {
   @Override
-  public Violations run(SimulatedPlan plan, @NotNull CollectOptions options) {
-    final var fruit = plan.resource("/fruit", Real.deserializer());
+  public void generate(@NotNull Plan plan, @NotNull SimulationResults simResults) {
+    final var fruit = simResults.resource("/fruit", Real.deserializer());
 
-
-    return Violations.violateOn(
+    violate(Violations.on(
         fruit.equalTo(4),
         false
-    );
+    ));
   }
 }


### PR DESCRIPTION
* **Tickets addressed:**
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This adds the `GeneratorConstraint` abstract class, which is a helper class that enables a more imperative programing style in constraints. When writing goal I've found it pretty natural to switch from a functional style when getting and transforming inputs, to an imperative style when creating outputs. So I made a similar system for constraints where you can repeatedly call `violate(Violation)` or one of its derivatives instead of aggregating everything in a single `Violations` timeline.

This also adds the first step for support of violation messages, as in customizable strings that can explain the violation to the user in the UI, and can be different for each violation generated. This doesn't do anything with the messages, it just stores them in the `Violation` class.

## Verification
I made a unit test to make sure the generator aggregates the results correctly.

## Documentation
I wrote the docs after I made these changes; they are actually already live.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
