### PR TITLE
Schedule Activities Based On External Events

### DIFF
--- a/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventsSimpleGoal.java
+++ b/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventsSimpleGoal.java
@@ -1,0 +1,24 @@
+package gov.nasa.jpl.aerie.e2e.procedural.scheduling.procedures;
+
+import gov.nasa.ammos.aerie.procedural.scheduling.annotations.SchedulingProcedure;
+import gov.nasa.ammos.aerie.procedural.scheduling.Goal;
+import gov.nasa.ammos.aerie.procedural.scheduling.plan.EditablePlan;
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.DirectiveStart;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.EventQuery;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+@SchedulingProcedure
+public record ExternalEventsSimpleGoal() implements Goal {
+  @Override
+  public void run(@NotNull final EditablePlan plan) {
+    EventQuery eventQuery = new EventQuery("TestGroup", null, null);
+
+    for (final var e: plan.events(eventQuery)) {
+      plan.create("BiteBanana", new DirectiveStart.Absolute(e.getInterval().start), Map.of("biteSize", SerializedValue.of(1)));
+    }
+    plan.commit();
+  }
+}

--- a/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventsSourceQueryGoal.java
+++ b/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventsSourceQueryGoal.java
@@ -1,0 +1,39 @@
+package gov.nasa.jpl.aerie.e2e.procedural.scheduling.procedures;
+
+import gov.nasa.ammos.aerie.procedural.scheduling.Goal;
+import gov.nasa.ammos.aerie.procedural.scheduling.annotations.SchedulingProcedure;
+import gov.nasa.ammos.aerie.procedural.scheduling.plan.EditablePlan;
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalSource;
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.DirectiveStart;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.EventQuery;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+
+@SchedulingProcedure
+public record ExternalEventsSourceQueryGoal() implements Goal {
+  @Override
+  public void run(@NotNull final EditablePlan plan) {
+
+    // extract events belonging to the second source
+    EventQuery eventQuery = new EventQuery(
+        null,
+        null,
+        List.of(new ExternalSource("NewTest.json", "TestGroup_2"))
+    );
+
+    for (final var e: plan.events(eventQuery)) {
+      // filter events that we schedule off of by key
+      if (e.key.contains("01")) {
+        plan.create(
+            "BiteBanana",
+            // place the directive such that it is coincident with the event's start
+            new DirectiveStart.Absolute(e.getInterval().start),
+            Map.of("biteSize", SerializedValue.of(1)));
+      }
+    }
+    plan.commit();
+  }
+}

--- a/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventsTypeQueryGoal.java
+++ b/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventsTypeQueryGoal.java
@@ -1,0 +1,31 @@
+package gov.nasa.jpl.aerie.e2e.procedural.scheduling.procedures;
+
+import gov.nasa.ammos.aerie.procedural.scheduling.Goal;
+import gov.nasa.ammos.aerie.procedural.scheduling.annotations.SchedulingProcedure;
+import gov.nasa.ammos.aerie.procedural.scheduling.plan.EditablePlan;
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.DirectiveStart;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.EventQuery;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+
+@SchedulingProcedure
+public record ExternalEventsTypeQueryGoal() implements Goal {
+  @Override
+  public void run(@NotNull final EditablePlan plan) {
+
+    // demonstrate more complicated query functionality
+    EventQuery eventQuery = new EventQuery(
+        List.of("TestGroup", "TestGroup_2"),
+        List.of("TestType"),
+        null
+    );
+
+    for (final var e: plan.events(eventQuery)) {
+      plan.create("BiteBanana", new DirectiveStart.Absolute(e.getInterval().start), Map.of("biteSize", SerializedValue.of(1)));
+    }
+    plan.commit();
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalEventsTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalEventsTests.java
@@ -1,0 +1,234 @@
+package gov.nasa.jpl.aerie.e2e.procedural.scheduling;
+
+import gov.nasa.jpl.aerie.e2e.types.GoalInvocationId;
+import gov.nasa.jpl.aerie.e2e.types.Plan;
+import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
+import gov.nasa.jpl.aerie.e2e.utils.HasuraRequests;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ExternalEventsTests extends ProceduralSchedulingSetup {
+  private GoalInvocationId procedureId;
+  private final static String SOURCE_TYPE = "TestType";
+  private final static String EVENT_TYPE = "TestType";
+  private final static String ADDITIONAL_EVENT_TYPE = EVENT_TYPE + "_2";
+  private final static String DERIVATION_GROUP = "TestGroup";
+  private final static String ADDITIONAL_DERIVATION_GROUP = DERIVATION_GROUP + "_2";
+
+  private final HasuraRequests.ExternalSource externalSource = new HasuraRequests.ExternalSource(
+      "Test.json",
+      SOURCE_TYPE,
+      DERIVATION_GROUP,
+      "2024-01-01T00:00:00Z",
+      "2023-01-01T00:00:00Z",
+      "2023-01-08T00:00:00Z",
+      "2024-10-01T00:00:00Z"
+  );
+  private final List<HasuraRequests.ExternalEvent> externalEvents = List.of(
+      new HasuraRequests.ExternalEvent(
+          "Event_01",
+          EVENT_TYPE,
+          externalSource.key(),
+          externalSource.derivation_group_name(),
+          "2023-01-01T01:00:00Z",
+          "01:00:00"
+      ),
+      new HasuraRequests.ExternalEvent(
+          "Event_02",
+          EVENT_TYPE,
+          externalSource.key(),
+          externalSource.derivation_group_name(),
+          "2023-01-01T03:00:00Z",
+          "01:00:00"
+      ),
+      new HasuraRequests.ExternalEvent(
+          "Event_03",
+          EVENT_TYPE,
+          externalSource.key(),
+          externalSource.derivation_group_name(),
+          "2023-01-01T05:00:00Z",
+          "01:00:00"
+      )
+  );
+
+  private final HasuraRequests.ExternalSource additionalExternalSource = new HasuraRequests.ExternalSource(
+      "NewTest.json",
+      SOURCE_TYPE,
+      ADDITIONAL_DERIVATION_GROUP,
+      "2024-01-01T00:00:00Z",
+      "2023-01-01T00:00:00Z",
+      "2023-01-08T00:00:00Z",
+      "2024-10-01T00:00:00Z"
+  );
+
+  private final List<HasuraRequests.ExternalEvent> additionalExternalEvents = List.of(
+      new HasuraRequests.ExternalEvent(
+          "Event_01",
+          EVENT_TYPE,
+          additionalExternalSource.key(),
+          additionalExternalSource.derivation_group_name(),
+          "2023-01-02T01:00:00Z",
+          "01:00:00"
+      ),
+      new HasuraRequests.ExternalEvent(
+          "Event_02",
+          ADDITIONAL_EVENT_TYPE,
+          additionalExternalSource.key(),
+          additionalExternalSource.derivation_group_name(),
+          "2023-01-02T03:00:00Z",
+          "01:00:00"
+      ),
+      new HasuraRequests.ExternalEvent(
+          "Event_03",
+          ADDITIONAL_EVENT_TYPE,
+          additionalExternalSource.key(),
+          additionalExternalSource.derivation_group_name(),
+          "2023-01-02T05:00:00Z",
+          "01:00:00"
+      )
+  );
+
+  @BeforeEach
+  void localBeforeEach() throws IOException {
+    // Upload some External Events (and associated infrastructure)
+    hasura.insertExternalSourceType(SOURCE_TYPE);
+    hasura.insertExternalEventType(EVENT_TYPE);
+    hasura.insertDerivationGroup(DERIVATION_GROUP, SOURCE_TYPE);
+    hasura.insertExternalSource(externalSource);
+    hasura.insertExternalEvents(externalEvents);
+    hasura.insertPlanDerivationGroupAssociation(planId, DERIVATION_GROUP);
+
+    // Upload additional External Events in a different derivation group and of a different type
+    hasura.insertExternalEventType(ADDITIONAL_EVENT_TYPE);
+    hasura.insertDerivationGroup(ADDITIONAL_DERIVATION_GROUP, SOURCE_TYPE);
+    hasura.insertExternalSource(additionalExternalSource);
+    hasura.insertExternalEvents(additionalExternalEvents);
+    hasura.insertPlanDerivationGroupAssociation(planId, ADDITIONAL_DERIVATION_GROUP);
+  }
+
+  @AfterEach
+  void localAfterEach() throws IOException {
+    hasura.deleteSchedulingGoal(procedureId.goalId());
+
+    // External Event Related
+    hasura.deletePlanDerivationGroupAssociation(planId, DERIVATION_GROUP);
+    hasura.deletePlanDerivationGroupAssociation(planId, ADDITIONAL_DERIVATION_GROUP);
+    hasura.deleteExternalSource(externalSource);
+    hasura.deleteExternalSource(additionalExternalSource);
+    hasura.deleteDerivationGroup(DERIVATION_GROUP);
+    hasura.deleteDerivationGroup(ADDITIONAL_DERIVATION_GROUP);
+    hasura.deleteExternalSourceType(SOURCE_TYPE);
+    hasura.deleteExternalEventType(EVENT_TYPE);
+    hasura.deleteExternalEventType(ADDITIONAL_EVENT_TYPE);
+  }
+
+  @Test
+  void testExternalEventSimple() throws IOException {
+    // first, run the goal
+    try (final var gateway = new GatewayRequests(playwright)) {
+      int procedureJarId = gateway.uploadJarFile("build/libs/ExternalEventsSimpleGoal.jar");
+      // Add Scheduling Procedure
+      procedureId = hasura.createSchedulingSpecProcedure(
+          "Test Scheduling Procedure",
+          procedureJarId,
+          specId,
+          0
+      );
+    }
+    hasura.awaitScheduling(specId);
+    final var plan = hasura.getPlan(planId);
+    final var activities = plan.activityDirectives();
+
+    // ensure the order lines up with the events'
+    activities.sort(Comparator.comparing(Plan.ActivityDirective::startOffset));
+
+    // compare arrays
+    assertEquals(externalEvents.size(), activities.size());
+    for (int i = 0; i < activities.size(); i++) {
+      Instant activityStartTime = Duration.addToInstant(
+          Instant.parse(planStartTimestamp),
+          Duration.fromString(activities.get(i).startOffset())
+      );
+      assertEquals(externalEvents.get(i).start_time(), activityStartTime.toString());
+    }
+  }
+
+  @Test
+  void testExternalEventTypeQuery() throws IOException {
+    // first, run the goal
+    try (final var gateway = new GatewayRequests(playwright)) {
+      int procedureJarId = gateway.uploadJarFile("build/libs/ExternalEventsTypeQueryGoal.jar");
+      // Add Scheduling Procedure
+      procedureId = hasura.createSchedulingSpecProcedure(
+          "Test Scheduling Procedure",
+          procedureJarId,
+          specId,
+          0
+      );
+    }
+    hasura.awaitScheduling(specId);
+    final var plan = hasura.getPlan(planId);
+    final var activities = plan.activityDirectives();
+
+    // ensure the orderings line up
+    activities.sort(Comparator.comparing(Plan.ActivityDirective::startOffset));
+
+    // get the set of events we expect (anything in TestGroup or TestGroup_2, and of type TestType)
+    List<HasuraRequests.ExternalEvent> expected = new ArrayList<>();
+    expected.addAll(externalEvents);
+    expected.addAll(
+        additionalExternalEvents.stream()
+                                .filter(e -> e.event_type_name().equals(EVENT_TYPE))
+                                .toList()
+    );
+
+    // explicitly ensure the orderings line up
+    expected.sort(Comparator.comparing(HasuraRequests.ExternalEvent::start_time));
+
+    // compare arrays
+    assertEquals(expected.size(), activities.size());
+    for (int i = 0; i < activities.size(); i++) {
+      Instant activityStartTime = Duration.addToInstant(
+          Instant.parse(planStartTimestamp),
+          Duration.fromString(activities.get(i).startOffset())
+      );
+      assertEquals(activityStartTime.toString(), expected.get(i).start_time());
+    }
+  }
+
+  @Test
+  void testExternalEventSourceQuery() throws IOException {
+    // first, run the goal
+    try (final var gateway = new GatewayRequests(playwright)) {
+      int procedureJarId = gateway.uploadJarFile("build/libs/ExternalEventsSourceQueryGoal.jar");
+      // Add Scheduling Procedure
+      procedureId = hasura.createSchedulingSpecProcedure(
+          "Test Scheduling Procedure",
+          procedureJarId,
+          specId,
+          0
+      );
+    }
+    hasura.awaitScheduling(specId);
+    final var plan = hasura.getPlan(planId);
+    final var activities = plan.activityDirectives();
+
+    // only 1 activity this time
+    assertEquals(1, activities.size());
+    Instant activityStartTime = Duration.addToInstant(
+        Instant.parse(planStartTimestamp),
+        Duration.fromString(activities.get(0).startOffset())
+    );
+    assertEquals(activityStartTime.toString(), additionalExternalEvents.get(0).start_time());
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
@@ -82,6 +82,38 @@ public enum GQL {
         id
       }
     }"""),
+  CREATE_EXTERNAL_EVENT_TYPE("""
+    mutation CreateExternalEventType($eventType: external_event_type_insert_input!) {
+      createExternalEventType: insert_external_event_type_one(object: $eventType) {
+        name
+      }
+    }"""),
+  CREATE_EXTERNAL_EVENTS("""
+    mutation InsertExternalEvents($objects: [external_event_insert_input!]!) {
+      insertExternalEvents: insert_external_event(objects: $objects) {
+        returning {
+           key
+        }
+      }
+    }"""),
+  CREATE_EXTERNAL_SOURCE("""
+    mutation InsertExternalSource($object: external_source_insert_input!) {
+      insertExternalSource: insert_external_source_one(object: $object) {
+        key
+      }
+    }"""),
+  CREATE_EXTERNAL_SOURCE_TYPE("""
+    mutation CreateExternalSourceType($sourceType: external_source_type_insert_input!) {
+      createExternalSourceType: insert_external_source_type_one(object: $sourceType) {
+        name
+      }
+    }"""),
+  CREATE_DERIVATION_GROUP("""
+    mutation CreateDerivationGroup($derivationGroup: derivation_group_insert_input!) {
+      createDerivationGroup: insert_derivation_group_one(object: $derivationGroup) {
+        name
+      }
+    }"""),
   CREATE_MISSION_MODEL("""
     mutation CreateMissionModel($model: mission_model_insert_input!) {
       insert_mission_model_one(object: $model) {
@@ -93,6 +125,12 @@ public enum GQL {
       insert_plan_one(object: $plan) {
         id
         revision
+      }
+    }"""),
+  CREATE_PLAN_DERIVATION_GROUP("""
+    mutation CreatePlanDerivationGroup($source: plan_derivation_group_insert_input!) {
+      planExternalSourceLink: insert_plan_derivation_group_one(object: $source) {
+        derivation_group_name
       }
     }"""),
   CREATE_SCHEDULING_SPEC_GOAL("""
@@ -140,10 +178,36 @@ public enum GQL {
         id
       }
     }"""),
+  DELETE_DERIVATION_GROUP("""
+    mutation DeleteDerivationGroup($name: String!) {
+      deleteDerivationGroup: delete_derivation_group(where: { name: { _eq: $name } }) {
+        returning {
+          name
+        }
+      }
+    }"""),
   DELETE_EXTERNAL_DATASET("""
     mutation deleteExtProfile($plan_id: Int!, $dataset_id: Int!) {
       delete_plan_dataset_by_pk(plan_id:$plan_id, dataset_id:$dataset_id) {
         dataset_id
+      }
+    }"""),
+  DELETE_EXTERNAL_EVENT_TYPE("""
+    mutation DeleteExternalEventType($name: String!) {
+      deleteExternalEventType: delete_external_event_type_by_pk(name: $name) {
+        name
+      }
+    }"""),
+  DELETE_EXTERNAL_SOURCE("""
+    mutation DeleteExternalSource($derivationGroupName: String!, $sourceKey: String!) {
+      deleteExternalSource: delete_external_source_by_pk(derivation_group_name: $derivationGroupName, key: $sourceKey) {
+        key
+      }
+    }"""),
+  DELETE_EXTERNAL_SOURCE_TYPE("""
+    mutation DeleteExternalSourceType($name: String!) {
+      deleteExternalSourceType: delete_external_source_type_by_pk(name: $name) {
+        name
       }
     }"""),
   DELETE_MISSION_MODEL("""
@@ -172,6 +236,12 @@ public enum GQL {
           constraint_id
           constraint_revision
         }
+      }
+    }"""),
+  DELETE_PLAN_DERIVATION_GROUP("""
+    mutation DeletePlanExternalSource($derivationGroupName: String!, $planId: Int!) {
+      planDerivationGroupLink: delete_plan_derivation_group_by_pk(derivation_group_name: $derivationGroupName, plan_id: $planId) {
+        derivation_group_name
       }
     }"""),
   DELETE_SCHEDULING_GOAL("""

--- a/procedural/README.md
+++ b/procedural/README.md
@@ -4,4 +4,4 @@ This subproject holds the libraries provided to the users for procedural schedul
 
 ## Documentation
 
-To generate the unified docs, run `./gradlew :procedural:dokkaHtmlMultiModule`. It will be available in `procedural/build/dokka/htmlMultiModule/index.html`. To view it locally, you'll need a static file server to avoid CORS problems. In IntelliJ, you can right-click on `index.html` and select `Open In -> Browser -> ...` and this will start a server for you.
+To generate the unified docs, run `./gradlew dokkaHtmlMultiModule`. It will be available in `procedural/build/dokka/htmlMultiModule/index.html`. To view it locally, you'll need a static file server to avoid CORS problems. In IntelliJ, you can right-click on `index.html` and select `Open In -> Browser -> ...` and this will start a server for you.

--- a/procedural/constraints/src/test/java/gov/nasa/ammos/aerie/procedural/constraints/NotImplementedPlan.java
+++ b/procedural/constraints/src/test/java/gov/nasa/ammos/aerie/procedural/constraints/NotImplementedPlan.java
@@ -2,8 +2,10 @@ package gov.nasa.ammos.aerie.procedural.constraints;
 
 import gov.nasa.ammos.aerie.procedural.timeline.Interval;
 import gov.nasa.ammos.aerie.procedural.timeline.collections.Directives;
+import gov.nasa.ammos.aerie.procedural.timeline.collections.ExternalEvents;
 import gov.nasa.ammos.aerie.procedural.timeline.ops.SerialSegmentOps;
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.Segment;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.EventQuery;
 import gov.nasa.ammos.aerie.procedural.timeline.plan.Plan;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
@@ -49,6 +51,12 @@ public class NotImplementedPlan implements Plan {
       @NotNull final String name,
       @NotNull final Function1<? super List<Segment<SerializedValue>>, ? extends TL> deserializer)
   {
+    throw new NotImplementedError();
+  }
+
+  @NotNull
+  @Override
+  public ExternalEvents events(@NotNull final EventQuery query) {
     throw new NotImplementedError();
   }
 }

--- a/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/collections/ExternalEvents.kt
+++ b/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/collections/ExternalEvents.kt
@@ -1,0 +1,31 @@
+package gov.nasa.ammos.aerie.procedural.timeline.collections
+
+import gov.nasa.ammos.aerie.procedural.timeline.Timeline
+import gov.nasa.ammos.aerie.procedural.timeline.BaseTimeline
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.Instance
+import gov.nasa.ammos.aerie.procedural.timeline.ops.*
+import gov.nasa.ammos.aerie.procedural.timeline.ops.coalesce.CoalesceNoOp
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalSource
+import gov.nasa.ammos.aerie.procedural.timeline.util.preprocessList
+
+/**
+ * A timeline of external events.
+ */
+data class ExternalEvents(private val timeline: Timeline<ExternalEvent, ExternalEvents>):
+    Timeline<ExternalEvent, ExternalEvents> by timeline,
+    NonZeroDurationOps<ExternalEvent, ExternalEvents>,
+    ParallelOps<ExternalEvent, ExternalEvents>
+{
+  constructor(vararg events: ExternalEvent): this(events.asList())
+  constructor(events: List<ExternalEvent>): this(BaseTimeline(::ExternalEvents, preprocessList(events, null)))
+
+  /** Filter by one or more types. */
+  fun filterByType(vararg types: String) = filter { it.type in types }
+
+  /** Filter by one or more event sources. */
+  fun filterBySource(vararg sources: ExternalSource) = filter { it.source in sources }
+
+  /** Filter by one or more derivation groups. */
+  fun filterByDerivationGroup(vararg groups: String) = filter { it.source.derivationGroup in groups }
+}

--- a/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/payloads/ExternalEvent.kt
+++ b/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/payloads/ExternalEvent.kt
@@ -1,0 +1,20 @@
+package gov.nasa.ammos.aerie.procedural.timeline.payloads
+
+import gov.nasa.ammos.aerie.procedural.timeline.Interval
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue
+
+/** An external event instance. */
+data class ExternalEvent(
+  /** The string name of this event. */
+  @JvmField
+  val key: String,
+  /** The type of the event. */
+  @JvmField
+  val type: String,
+  /** The source this event comes from. */
+  @JvmField
+  val source: ExternalSource,
+  override val interval: Interval,
+): IntervalLike<ExternalEvent> {
+  override fun withNewInterval(i: Interval) = ExternalEvent(key, type, source, i)
+}

--- a/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/payloads/ExternalSource.kt
+++ b/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/payloads/ExternalSource.kt
@@ -1,0 +1,14 @@
+package gov.nasa.ammos.aerie.procedural.timeline.payloads
+
+/**
+ * An external source instance. Used for querying purposes - see EventQuery.kt.
+ * The included fields represent the primary key used to identify External Sources.
+ */
+data class ExternalSource(
+  /** The string name of this source. */
+  @JvmField
+  val key: String,
+  /** The derivation group that this source is a member of. */
+  @JvmField
+  val derivationGroup: String,
+)

--- a/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/plan/EventQuery.kt
+++ b/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/plan/EventQuery.kt
@@ -1,0 +1,35 @@
+package gov.nasa.ammos.aerie.procedural.timeline.plan
+
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalSource
+
+/** Fields for filtering events as they are queried. */
+data class EventQuery(
+  /**
+   * A nullable list of derivation groups; the event must belong to one of them if present.
+   *
+   * If null, all derivation groups are allowed.
+   */
+  val derivationGroups: List<String>?,
+
+  /**
+   * A nullable list of eventTypes; the event must belong to one of them if present.
+   *
+   * If null, all types are allowed.
+   */
+  val eventTypes: List<String>?,
+
+  /**
+   * A nullable list of sources (described as a tuple of the source's (key, derivation group name)); the event must
+   *    belong to one of them if present.
+   *
+   * If null, all sources are allowed.
+   */
+  val sources: List<ExternalSource>?,
+) {
+  constructor(derivationGroup: String?, eventType: String?, source: ExternalSource?): this(
+    derivationGroup?.let { listOf(it) },
+    eventType?.let { listOf(it) },
+    source?.let { listOf(it) }
+  )
+  constructor(): this(null as String?, null, null)
+}

--- a/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/plan/Plan.kt
+++ b/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/plan/Plan.kt
@@ -7,6 +7,7 @@ import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.AnyDirective
 import gov.nasa.ammos.aerie.procedural.timeline.collections.Directives
 import gov.nasa.ammos.aerie.procedural.timeline.ops.SerialSegmentOps
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.Segment
+import gov.nasa.ammos.aerie.procedural.timeline.collections.ExternalEvents
 import java.time.Instant
 
 /** An interface for querying plan information and simulation results. */
@@ -41,4 +42,9 @@ interface Plan {
    * @param name string name of the resource
    */
   fun <V: Any, TL: SerialSegmentOps<V, TL>> resource(name: String, deserializer: (List<Segment<SerializedValue>>) -> TL): TL
+
+  /** Get external events associated with this plan. */
+  fun events(query: EventQuery): ExternalEvents
+  /** Get all external events across all derivation groups associated with this plan. */
+  fun events() = events(EventQuery())
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Procedure.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Procedure.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.scheduler.goals;
 
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.ammos.aerie.procedural.scheduling.ProcedureMapper;
@@ -43,7 +44,8 @@ public class Procedure extends Goal {
       final MissionModel<?> missionModel,
       final Function<String, ActivityType> lookupActivityType,
       final SimulationFacade simulationFacade,
-      final DirectiveIdGenerator idGenerator
+      final DirectiveIdGenerator idGenerator,
+      Map<String, List<ExternalEvent>> eventsByDerivationGroup
   ) {
     final ProcedureMapper<?> procedureMapper;
     try {
@@ -57,6 +59,7 @@ public class Procedure extends Goal {
     final var planAdapter = new SchedulerToProcedurePlanAdapter(
         plan,
         planHorizon,
+        eventsByDerivationGroup,
         problem.getDiscreteExternalProfiles(),
         problem.getRealExternalProfiles()
     );

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/Problem.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/Problem.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.scheduler.model;
 
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile;
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
@@ -47,6 +48,7 @@ public class Problem {
 
   private final Map<String, LinearProfile> realExternalProfiles = new HashMap<>();
   private final Map<String, DiscreteProfile> discreteExternalProfiles = new HashMap<>();
+  private Map<String, List<ExternalEvent>> eventsByDerivationGroup = new HashMap<>();
 
   /**
    * the initial seed plan to start scheduling from
@@ -171,6 +173,10 @@ public class Problem {
     this.discreteExternalProfiles.putAll(discreteExternalProfiles);
   }
 
+  public void setEventsByDerivationGroup(final Map<String, List<ExternalEvent>> events) {
+    this.eventsByDerivationGroup = events;
+  }
+
   public Map<String, LinearProfile> getRealExternalProfiles(){
     return this.realExternalProfiles;
   }
@@ -178,6 +184,8 @@ public class Problem {
   public Map<String, DiscreteProfile> getDiscreteExternalProfiles(){
     return this.discreteExternalProfiles;
   }
+
+  public Map<String, List<ExternalEvent>> getEventsByDerivationGroup() { return this.eventsByDerivationGroup; }
 
   public void setGoals(List<Goal> goals){
     goalsOrderedByPriority.clear();

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -46,7 +46,6 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MICROSECOND;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.ZERO;
-import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.min;
 
 /**
  * prototype scheduling algorithm that schedules activities for a plan
@@ -323,7 +322,16 @@ public class PrioritySolver implements Solver {
       satisfyOptionGoal(optionGoal);
     } else if (goal instanceof Procedure procedure) {
       if (!analysisOnly) {
-        procedure.run(problem, plan.getEvaluation(), plan, problem.getMissionModel(), this.problem::getActivityType, this.simulationFacade, this.idGenerator);
+        procedure.run(
+            problem,
+            plan.getEvaluation(),
+            plan,
+            problem.getMissionModel(),
+            this.problem::getActivityType,
+            this.simulationFacade,
+            this.idGenerator,
+            this.problem.getEventsByDerivationGroup()
+        );
       }
     } else {
       satisfyGoalGeneral(goal);

--- a/scheduler-server/build.gradle
+++ b/scheduler-server/build.gradle
@@ -24,6 +24,7 @@ dependencies {
   implementation project(':permissions')
   implementation project(':constraints')
   implementation project(':scheduler-driver')
+  implementation project(':procedural:timeline')
   implementation project(':procedural:scheduling')
   implementation project(':type-utils')
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/MerlinDatabaseService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/MerlinDatabaseService.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.scheduler.server.services;
 
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -26,6 +27,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -99,6 +101,9 @@ public interface MerlinDatabaseService {
      */
     ExternalProfiles getExternalProfiles(final PlanId planId)
     throws MerlinServiceException, IOException;
+
+    Map<String, List<ExternalEvent>> getExternalEvents(final PlanId planId, final Instant horizonStart)
+      throws MerlinServiceException, IOException;
 
     /**
      * Gets resource types associated to a plan, those coming from the mission model as well as those coming from external dataset resources

--- a/scheduler-worker/build.gradle
+++ b/scheduler-worker/build.gradle
@@ -113,6 +113,8 @@ dependencies {
   implementation project(':scheduler-server')
   implementation project(':parsing-utilities')
   implementation project(':constraints')
+  implementation project(':procedural:timeline')
+  implementation project(':procedural:scheduling')
 
   implementation 'io.javalin:javalin:5.6.3'
   implementation 'org.slf4j:slf4j-simple:2.0.7'

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/MockMerlinDatabaseService.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/MockMerlinDatabaseService.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.scheduler.worker.services;
 
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationResults;
 import gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerModel;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -18,11 +19,13 @@ import gov.nasa.jpl.aerie.scheduler.server.models.PlanId;
 import gov.nasa.jpl.aerie.scheduler.server.models.PlanMetadata;
 import gov.nasa.jpl.aerie.scheduler.server.models.ResourceType;
 import gov.nasa.jpl.aerie.scheduler.server.services.MerlinDatabaseService;
+import gov.nasa.jpl.aerie.scheduler.server.services.MerlinServiceException;
 import gov.nasa.jpl.aerie.types.ActivityDirective;
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.types.MissionModelId;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -155,6 +158,13 @@ class MockMerlinDatabaseService implements MerlinDatabaseService.OwnerRole {
   @Override
   public ExternalProfiles getExternalProfiles(final PlanId planId) {
     return externalProfiles;
+  }
+
+  @Override
+  public Map<String, List<ExternalEvent>> getExternalEvents(final PlanId planId, final Instant horizonStart)
+  throws MerlinServiceException, IOException
+  {
+    return Map.of();
   }
 
   @Override

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingDSLCompilationServiceTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingDSLCompilationServiceTests.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.scheduler.worker.services;
 
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
 import gov.nasa.jpl.aerie.constraints.tree.ActivitySpan;
 import gov.nasa.jpl.aerie.constraints.tree.DiscreteProfileFromDuration;
 import gov.nasa.jpl.aerie.constraints.tree.DiscreteResource;
@@ -49,6 +50,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -107,6 +109,13 @@ class SchedulingDSLCompilationServiceTests {
     @Override
     public ExternalProfiles getExternalProfiles(final PlanId planId) {
       return null;
+    }
+
+    @Override
+    public Map<String, List<ExternalEvent>> getExternalEvents(final PlanId planId, final Instant horizonStart)
+    throws MerlinServiceException, IOException
+    {
+      return Map.of();
     }
 
     @Override


### PR DESCRIPTION
* **Tickets addressed:** MPS-124
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Following the introduction of External Events in [#1513](https://github.com/NASA-AMMOS/aerie/pull/1513), this PR introduces the ability to schedule Activities based off of External Event occurrences, using the procedural scheduler.

This PR introduces 4 new types which users can use in their definition of scheduling procedures to narrow down the external events they would like to schedule off of and which properties they would like to access:
- an `ExternalEvent` type, which contains event-specific properties,
- an `ExternalEvents` type, which represents a filterable collection of said events,
- an `EventQuery` type, which can be used to filter the set of all `ExternalEvent`s associated with a given plan by their `ExternalSource`, derivation group, or event type.
- and an `ExternalSource` type, which can be used by `EventQuery`s to narrow down the set of events being examined by a procedure to those contained in specific sources.

To make this more explicitly clear, we will illustrate an example,  based on the tests in `ExternalEventsTests.java` under the `e2e-tests` directory.

Consider this set of events:
<img width="1096" alt="image" src="https://github.com/user-attachments/assets/c2b9158a-7493-4201-a183-370e5bee5021">

Consider scheduling the Banananation activity `BiteBanana` off of these events. 
This can mean a variety of different things, depending on the exact behavior we desire:
- schedule the activity coincident with all events
- schedule the activity coincident with events belonging to derivation group `"TestGroup"`
- schedule the activity coincident with events belonging to the second source
- schedule the activity based on events of type `"Test_Type"`
- schedule the activity based on events with the substring `"01"` in their key.

For the sake of brevity, we will explore just one case - events belonging to the second source with the substring `"01"` in their key. This case makes use of all of the types described above.

```
@SchedulingProcedure
public record ExternalEventsSourceQueryGoal() implements Goal {
  @Override
  public void run(@NotNull final EditablePlan plan) {

    // extract events belonging to the second source
    EventQuery eventQuery = new EventQuery(
        null,
        null,
        List.of(new ExternalSource("NewTest.json", "TestGroup_2"))
    );

    for (final var e: plan.events(eventQuery)) {
      // filter events that we schedule off of by key
      if (e.key.contains("01")) {
        plan.create(
            "BiteBanana",
            // place the directive such that it is coincident with the event's start
            new DirectiveStart.Absolute(e.getInterval().start),
            Map.of("biteSize", SerializedValue.of(1)));
      }
    }
    plan.commit();
  }
}
```

This goal does the following:
1. create an `EventQuery` to select events belonging to the second source. To specify that selector, we create an `ExternalSource` object, whose properties are the two properties necessary to uniquely identify two `ExternalSource`s in AERIE: a `key` and a `derivation_group_name`. 
2. Call `plan.events(eventQuery)`. This returns all external events associated with a plan (based on the associated derivation groups), and filters them according to the passed-in query.
3. Filter by key. We directly access the properties of each event (namely, `key`) now to further match our requirements.
4. Create the activity, placing it coincident with the event's start, accessed via `getInterval().start`.

After running it, we get the following result in AERIE:
<img width="902" alt="image" src="https://github.com/user-attachments/assets/3339bc55-793a-4813-8f93-5552b39c3bcc">

As expected, there is a single activity, scheduled off of an `Event_01` from the second source.

## Verification
The changes were verified both by testing with our own models, and subsequent testing of the 4 new types listed above in a few end-to-end tests (see `ExternalEventsTests.java` under the `e2e-tests` directory).

## Documentation
Documentation will need to be added to [aerie-docs](https://vcs.ssmo.gsfc.nasa.gov/SSMO-MPS/aerie-docs/tree/master/docs) to describe how scheduling using external events work. As this feature is solely an addition, no existing documentation is invalidated; the documentation is simply expanded.

## Future work
The next steps for External Event work are:
- additional cleanup and optimization of External Events in the front and backend
- adding properties to events and sources, and exposing those to the scheduler
- integration with the procedural constraint system
- introduction of a formal JSON schema for events and sources and support of said schema in the database
