### PR TITLE
Fix analysis mode of scheduling engine

### DIFF
--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -491,8 +491,8 @@ public class PrioritySolver implements Solver {
       assert missing != null;
       logger.info("Processing conflict " + (++i));
       logger.info(missing.toString());
-      //determine the best activities to satisfy the conflict
-      ConflictSolverResult conflictSolverReturn = null;
+      //initialize conflict result to unsatisfied + no activities created
+      var conflictSolverReturn = new ConflictSolverResult();
       if (!analysisOnly && (missing instanceof MissingActivityInstanceConflict missingActivityInstanceConflict)) {
         conflictSolverReturn = solveActivityInstanceConflict(missingActivityInstanceConflict, goal);
       } else if (!analysisOnly && (missing instanceof MissingActivityTemplateConflict missingActivityTemplateConflict)) {


### PR DESCRIPTION
* **Tickets addressed:** Resolves #1583 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The issue arose in this case
- `conflictSolverReturn` was not initialized 
- the analysis mode was ON
- the type of the conflict was something else than an association conflict so the variable kept being `null`

Initializing the `conflictSolverReturn` variable to its default state (unsatisfied, no activities created) fixes that issue and no other logic is impacted.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
None.  

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
None.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None. 