### PR TITLE
Switch semantics of filterLongerThan and filterShorterThan

### DIFF
--- a/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/ops/GeneralOps.kt
+++ b/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/ops/GeneralOps.kt
@@ -247,10 +247,10 @@ interface GeneralOps<V: IntervalLike<V>, THIS: GeneralOps<V, THIS>>: Timeline<V,
    */
   fun filterByDuration(validInterval: Interval) = filter(true) { validInterval.contains(it.interval.duration()) }
 
-  /** [(DOC)][filterShorterThan] Removes objects whose duration is shorter than a given duration. */
-  fun filterShorterThan(dur: Duration) = filter(true) { it.interval.duration() >= dur }
-  /** [(DOC)][filterLongerThan] Removes objects whose duration is longer than a given duration. */
-  fun filterLongerThan(dur: Duration) = filter(true) { it.interval.duration() <= dur }
+  /** [(DOC)][filterShorterThan] Removes objects whose duration is longer than a given duration. */
+  fun filterShorterThan(dur: Duration) = filter(true) { it.interval.duration() <= dur }
+  /** [(DOC)][filterLongerThan] Removes objects whose duration is shorter than a given duration. */
+  fun filterLongerThan(dur: Duration) = filter(true) { it.interval.duration() >= dur }
 
   /**
    * [(DOC)][filterByWindows] Filters out payload objects whose intervals are not contained in the


### PR DESCRIPTION
When I made the `filterShortThan` and `filterLongerThan` methods in the timeline library, I had a choice of semantics, either "filterShorterThan filters OUT intervals shorter than" or "filterShorterThan filters SUCH THAT all intervals are shorter than". I chose the first, but in practice I get confused every time I use these functions. This is because with all other filter-like functions such as `highlightEqualTo` or `isolateTrue`, I named them in the pattern `<operation><predicate>`. So in `highlightEqualTo("x")`, if the segment is equal to `"x"`, it is highlighted. Unfortunately I broke that pattern with `filterLonger/ShorterThan`; in `filterShorterThan` the object is retained if it *doesn't* match the shorter-than predicate.

I understand that this is the absolute worst kind of breaking change. It doesn't just invalidate existing code, it completely reverses what it does. But I can't think of another way that isn't more work than it's worth. I'm hoping the impact is pretty small since procedural scheduling is still a new feature.
