### PR TITLE
Add InstantClock and VariableInstantClock support

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
@@ -15,6 +15,8 @@ import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.whenever;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentData;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
@@ -54,8 +56,8 @@ public class Registrar {
     Throw
   }
 
-  public Registrar(final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar, final ErrorBehavior errorBehavior) {
-    Resources.init();
+  public Registrar(final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar, final Instant planStart, final ErrorBehavior errorBehavior) {
+    Resources.init(planStart);
     Logging.init(baseRegistrar);
     this.baseRegistrar = baseRegistrar;
     this.errorBehavior = errorBehavior;

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
@@ -1,0 +1,24 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.addToInstant;
+
+/**
+ * A variation on {@link Clock} that represents an absolute {@link Instant}
+ * instead of a relative {@link Duration}.
+ */
+public record InstantClock(Instant extract) implements Dynamics<Instant, InstantClock> {
+    @Override
+    public InstantClock step(Duration t) {
+        return new InstantClock(addToInstant(extract, t));
+    }
+
+    static Duration durationBetween(Instant start, Instant end) {
+        return Duration.of(ChronoUnit.MICROS.between(start, end), Duration.MICROSECONDS);
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
@@ -4,7 +4,6 @@ import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.addToInstant;
 
@@ -16,11 +15,5 @@ public record InstantClock(Instant extract) implements Dynamics<Instant, Instant
     @Override
     public InstantClock step(Duration t) {
         return new InstantClock(addToInstant(extract, t));
-    }
-
-    // TODO - this method belongs somewhere else...
-    //  Making it package-private at least lets us move it later without dependency issues outside the library.
-    static Duration durationBetween(Instant start, Instant end) {
-        return Duration.of(ChronoUnit.MICROS.between(start, end), Duration.MICROSECONDS);
     }
 }

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
@@ -18,6 +18,8 @@ public record InstantClock(Instant extract) implements Dynamics<Instant, Instant
         return new InstantClock(addToInstant(extract, t));
     }
 
+    // TODO - this method belongs somewhere else...
+    //  Making it package-private at least lets us move it later without dependency issues outside the library.
     static Duration durationBetween(Instant start, Instant end) {
         return Duration.of(ChronoUnit.MICROS.between(start, end), Duration.MICROSECONDS);
     }

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClockResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClockResources.java
@@ -34,7 +34,7 @@ public class InstantClockResources {
     }
 
     public static Resource<Clock> relativeTo(Resource<InstantClock> clock, Resource<Discrete<Instant>> zeroTime) {
-        return name(ResourceMonad.map(clock, zeroTime, (c, t) -> new Clock(InstantClock.durationBetween(t.extract(), c.extract()))),
+        return name(ResourceMonad.map(clock, zeroTime, (c, t) -> new Clock(Duration.between(t.extract(), c.extract()))),
                 "%s relative to %s", clock, zeroTime);
     }
 

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClockResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClockResources.java
@@ -1,0 +1,56 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.*;
+import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.time.Instant;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.map;
+import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.name;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.constant;
+
+public class InstantClockResources {
+    /**
+     * Create an absolute clock that starts now at the given start time.
+     */
+    public static MutableResource<InstantClock> absoluteClock(Instant startTime) {
+        return resource(new InstantClock(startTime));
+    }
+
+    public static Resource<InstantClock> addToInstant(Instant zeroTime, Resource<Clock> relativeClock) {
+        return addToInstant(constant(zeroTime), relativeClock);
+    }
+
+    public static Resource<InstantClock> addToInstant(Resource<Discrete<Instant>> zeroTime, Resource<Clock> relativeClock) {
+        return name(
+                map(zeroTime, relativeClock, (zero, clock) ->
+                        new InstantClock(Duration.addToInstant(zero.extract(), clock.extract()))),
+                "%s + %s",
+                zeroTime,
+                relativeClock);
+    }
+
+    public static Resource<Clock> relativeTo(Resource<InstantClock> clock, Resource<Discrete<Instant>> zeroTime) {
+        return name(ResourceMonad.map(clock, zeroTime, (c, t) -> new Clock(InstantClock.durationBetween(t.extract(), c.extract()))),
+                "%s relative to %s", clock, zeroTime);
+    }
+
+    public static Resource<Discrete<Boolean>> lessThan(Resource<InstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return ClockResources.lessThan(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> lessThanOrEquals(Resource<InstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return ClockResources.lessThanOrEquals(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> greaterThan(Resource<InstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return ClockResources.greaterThan(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> greaterThanOrEquals(Resource<InstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return ClockResources.greaterThanOrEquals(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClock.java
@@ -1,0 +1,19 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.time.Instant;
+
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.addToInstant;
+
+/**
+ * A variation on {@link VariableClock} that represents an absolute {@link Instant}
+ * instead of a relative {@link Duration}.
+ */
+public record VariableInstantClock(Instant extract, int multiplier) implements Dynamics<Instant, VariableInstantClock> {
+    @Override
+    public VariableInstantClock step(Duration t) {
+        return new VariableInstantClock(addToInstant(extract, t.times(multiplier)), multiplier);
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockEffects.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockEffects.java
@@ -1,0 +1,33 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource;
+
+import java.time.Instant;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.DynamicsMonad.effect;
+import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.name;
+
+public final class VariableInstantClockEffects {
+    private VariableInstantClockEffects() {}
+
+    /**
+     * Stop the clock without affecting the current time.
+     */
+    public static void pause(MutableResource<VariableInstantClock> clock) {
+        clock.emit("Pause", effect($ -> new VariableInstantClock($.extract(), 0)));
+    }
+
+    /**
+     * Start the clock without affecting the current time.
+     */
+    public static void start(MutableResource<VariableInstantClock> clock) {
+        clock.emit("Start", effect($ -> new VariableInstantClock($.extract(), 1)));
+    }
+
+    /**
+     * Reset the clock to the given time, without affecting how fast it's running.
+     */
+    public static void reset(MutableResource<VariableInstantClock> clock, Instant newTime) {
+        clock.emit(name(effect($ -> new VariableInstantClock(newTime, $.multiplier())), "Reset to %s", newTime));
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockResources.java
@@ -1,0 +1,42 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.time.Instant;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.map;
+import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.name;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.InstantClock.durationBetween;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.constant;
+
+public final class VariableInstantClockResources {
+    private VariableInstantClockResources() {}
+
+    public static Resource<VariableClock> relativeTo(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> zeroTime) {
+        return name(map(clock, zeroTime, (c, t) ->
+                        new VariableClock(durationBetween(c.extract(), t.extract()), c.multiplier())),
+                "%s relative to %s", clock, zeroTime);
+    }
+
+    public static Resource<Discrete<Boolean>> lessThan(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return VariableClockResources.lessThan(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> lessThanOrEquals(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return VariableClockResources.lessThanOrEquals(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> greaterThan(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return VariableClockResources.greaterThan(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> greaterThanOrEquals(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return VariableClockResources.greaterThanOrEquals(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<VariableClock> between(Resource<VariableInstantClock> start, Resource<VariableInstantClock> end) {
+        return map(start, end, (s, e) -> new VariableClock(durationBetween(s.extract(), e.extract()), e.multiplier() - s.multiplier()));
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockResources.java
@@ -8,7 +8,6 @@ import java.time.Instant;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.map;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.name;
-import static gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.InstantClock.durationBetween;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.constant;
 
 public final class VariableInstantClockResources {
@@ -16,7 +15,7 @@ public final class VariableInstantClockResources {
 
     public static Resource<VariableClock> relativeTo(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> zeroTime) {
         return name(map(clock, zeroTime, (c, t) ->
-                        new VariableClock(durationBetween(c.extract(), t.extract()), c.multiplier())),
+                        new VariableClock(Duration.between(c.extract(), t.extract()), c.multiplier())),
                 "%s relative to %s", clock, zeroTime);
     }
 
@@ -37,6 +36,6 @@ public final class VariableInstantClockResources {
     }
 
     public static Resource<VariableClock> between(Resource<VariableInstantClock> start, Resource<VariableInstantClock> end) {
-        return map(start, end, (s, e) -> new VariableClock(durationBetween(s.extract(), e.extract()), e.multiplier() - s.multiplier()));
+        return map(start, end, (s, e) -> new VariableClock(Duration.between(s.extract(), e.extract()), e.multiplier() - s.multiplier()));
     }
 }

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2Test.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2Test.java
@@ -9,10 +9,11 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.autoEffects;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.commutingEffects;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.noncommutingEffects;
-import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete.discrete;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteDynamicsMonad.effect;
@@ -27,10 +28,11 @@ class MutableResourceTest {
   @TestInstance(Lifecycle.PER_CLASS)
   class NonCommutingEffects {
     public NonCommutingEffects(final Registrar registrar) {
-      Resources.init();
+      Resources.init(Instant.EPOCH);
+      cell = MutableResource.resource(discrete(42), noncommutingEffects());
     }
 
-    private final MutableResource<Discrete<Integer>> cell = MutableResource.resource(discrete(42), noncommutingEffects());
+    private final MutableResource<Discrete<Integer>> cell;
 
     @Test
     void gets_initial_value_if_no_effects_are_emitted() {
@@ -66,10 +68,11 @@ class MutableResourceTest {
   @TestInstance(Lifecycle.PER_CLASS)
   class CommutingEffects {
     public CommutingEffects(final Registrar registrar) {
-      Resources.init();
+      Resources.init(Instant.EPOCH);
+      cell = MutableResource.resource(discrete(42), commutingEffects());
     }
 
-    private final MutableResource<Discrete<Integer>> cell = MutableResource.resource(discrete(42), commutingEffects());
+    private final MutableResource<Discrete<Integer>> cell;
 
     @Test
     void gets_initial_value_if_no_effects_are_emitted() {
@@ -108,11 +111,12 @@ class MutableResourceTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class AutoEffects {
-    public AutoEffects(final Registrar registrar) {
-      Resources.init();
+    public AutoEffects() {
+      Resources.init(Instant.EPOCH);
+      cell = MutableResource.resource(discrete(42), autoEffects());
     }
 
-    private final MutableResource<Discrete<Integer>> cell = MutableResource.resource(discrete(42), autoEffects());
+    private final MutableResource<Discrete<Integer>> cell;
 
     @Test
     void gets_initial_value_if_no_effects_are_emitted() {

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/DependenciesTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/DependenciesTest.java
@@ -1,7 +1,7 @@
 package gov.nasa.jpl.aerie.contrib.streamline.debugging;
 
-import gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial.Polynomial;
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.*;
@@ -21,12 +23,22 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DependenciesTest {
-  Resource<Discrete<Boolean>> constantTrue = DiscreteResources.constant(true);
-  Resource<Polynomial> constant1234 = constant(1234);
-  Resource<Polynomial> constant5678 = constant(5678);
-  Resource<Polynomial> polynomialCell = resource(polynomial(1));
-  Resource<Polynomial> derived = map(constantTrue, constant1234, constant5678,
-                                     (b, x, y) -> b.extract() ? x : y);
+  public DependenciesTest() {
+    Resources.init(Instant.EPOCH);
+
+    constantTrue = DiscreteResources.constant(true);
+    constant1234 = constant(1234);
+    constant5678 = constant(5678);
+    polynomialCell = resource(polynomial(1));
+    derived = map(constantTrue, constant1234, constant5678,
+                                       (b, x, y) -> b.extract() ? x : y);
+  }
+
+  Resource<Discrete<Boolean>> constantTrue;
+  Resource<Polynomial> constant1234;
+  Resource<Polynomial> constant5678;
+  Resource<Polynomial> polynomialCell;
+  Resource<Polynomial> derived;
 
   @Test
   void constants_are_named_by_their_value() {

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/SimulationClockTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/SimulationClockTest.java
@@ -1,0 +1,66 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
+import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.*;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.HOUR;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.ZERO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MerlinExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SimulationClockTest {
+    // This time is unlikely to be a hard-coded default anywhere
+    public static final Instant PLAN_START = Instant.parse("2020-01-02T03:04:05Z");
+
+    public SimulationClockTest() {
+        Resources.init(PLAN_START);
+    }
+
+    @Test
+    public void relative_clock_starts_at_zero() {
+        assertEquals(ZERO, currentTime());
+        assertEquals(ZERO, currentValue(simulationClock()));
+    }
+
+    @Test
+    public void absolute_clock_starts_at_plan_start() {
+        assertEquals(PLAN_START, currentInstant());
+        assertEquals(PLAN_START, currentValue(absoluteClock()));
+    }
+
+    @Test
+    public void relative_clock_advances_at_unit_rate() {
+        delay(1, HOUR);
+        assertEquals(Duration.of(1, HOUR), currentTime());
+        assertEquals(Duration.of(1, HOUR), currentValue(simulationClock()));
+        delay(1, HOUR);
+        assertEquals(Duration.of(2, HOUR), currentTime());
+        assertEquals(Duration.of(2, HOUR), currentValue(simulationClock()));
+        delay(1, HOUR);
+        assertEquals(Duration.of(3, HOUR), currentTime());
+        assertEquals(Duration.of(3, HOUR), currentValue(simulationClock()));
+    }
+
+    @Test
+    public void absolute_clock_advances_at_unit_rate() {
+        delay(1, HOUR);
+        assertEquals(PLAN_START.plus(1, ChronoUnit.HOURS), currentInstant());
+        assertEquals(PLAN_START.plus(1, ChronoUnit.HOURS), currentValue(absoluteClock()));
+        delay(1, HOUR);
+        assertEquals(PLAN_START.plus(2, ChronoUnit.HOURS), currentInstant());
+        assertEquals(PLAN_START.plus(2, ChronoUnit.HOURS), currentValue(absoluteClock()));
+        delay(1, HOUR);
+        assertEquals(PLAN_START.plus(3, ChronoUnit.HOURS), currentInstant());
+        assertEquals(PLAN_START.plus(3, ChronoUnit.HOURS), currentValue(absoluteClock()));
+    }
+}

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffectsTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffectsTest.java
@@ -5,13 +5,14 @@ import gov.nasa.jpl.aerie.contrib.streamline.core.ErrorCatching;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock;
 import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAware;
-import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentTime;
@@ -40,8 +41,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 class DiscreteEffectsTest {
-  public DiscreteEffectsTest(final Registrar registrar) {
-    Resources.init();
+  {
+    // We need to initialize this up front, so we can use in-line initializers for other resources after.
+    // I think in-line initializers for the other resources make the tests easier to read.
+    Resources.init(Instant.EPOCH);
   }
 
   private final MutableResource<Discrete<Integer>> settable = resource(discrete(42));

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/PrecomputedTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/PrecomputedTest.java
@@ -2,7 +2,6 @@ package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete;
 
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
-import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.junit.jupiter.api.Test;
@@ -26,8 +25,10 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class PrecomputedTest {
-    public PrecomputedTest(final Registrar registrar) {
-        Resources.init();
+    {
+        // We need to initialize this up front, so we can use in-line initializers for other resources after.
+        // I think in-line initializers for the other resources make the tests easier to read.
+        Resources.init(Instant.EPOCH);
     }
 
     final Resource<Discrete<Integer>> precomputedAsAConstant =

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/ComparisonsTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/ComparisonsTest.java
@@ -5,13 +5,14 @@ import gov.nasa.jpl.aerie.contrib.streamline.core.Expiry;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
-import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.set;
@@ -28,22 +29,26 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class ComparisonsTest {
-  public ComparisonsTest(final Registrar registrar) {
-    Resources.init();
+  public ComparisonsTest() {
+    Resources.init(Instant.EPOCH);
+
+    p = resource(polynomial(0));
+    q = resource(polynomial(0));
+
+    p_lt_q = lessThan(p, q);
+    p_lte_q = lessThanOrEquals(p, q);
+    p_gt_q = greaterThan(p, q);
+    p_gte_q = greaterThanOrEquals(p, q);
+
+    min_p_q = min(p, q);
+    min_q_p = min(q, p);
+    max_p_q = max(p, q);
+    max_q_p = max(q, p);
   }
 
-  private final MutableResource<Polynomial> p = resource(polynomial(0));
-  private final MutableResource<Polynomial> q = resource(polynomial(0));
-
-  private final Resource<Discrete<Boolean>> p_lt_q = lessThan(p, q);
-  private final Resource<Discrete<Boolean>> p_lte_q = lessThanOrEquals(p, q);
-  private final Resource<Discrete<Boolean>> p_gt_q = greaterThan(p, q);
-  private final Resource<Discrete<Boolean>> p_gte_q = greaterThanOrEquals(p, q);
-
-  private final Resource<Polynomial> min_p_q = min(p, q);
-  private final Resource<Polynomial> min_q_p = min(q, p);
-  private final Resource<Polynomial> max_p_q = max(p, q);
-  private final Resource<Polynomial> max_q_p = max(q, p);
+  private final MutableResource<Polynomial> p, q;
+  private final Resource<Discrete<Boolean>> p_lt_q, p_lte_q, p_gt_q, p_gte_q;
+  private final Resource<Polynomial> min_p_q, min_q_p, max_p_q, max_q_p;
 
   @Test
   void comparing_distinct_constants() {

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/LinearBoundaryConsistencySolverTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/LinearBoundaryConsistencySolverTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentData;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial.LinearBoundaryConsistencySolver.Comparison.*;
@@ -25,11 +27,13 @@ class LinearBoundaryConsistencySolverTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class SingleVariableSingleConstraint {
-    MutableResource<Polynomial> driver = resource(polynomial(10));
+    MutableResource<Polynomial> driver;
     Resource<Polynomial> result;
 
-    public SingleVariableSingleConstraint() {
-      Resources.init();
+    SingleVariableSingleConstraint() {
+      Resources.init(Instant.EPOCH);
+
+      driver = resource(polynomial(10));
 
       var solver = new LinearBoundaryConsistencySolver("SingleVariableSingleConstraint");
       var v = solver.variable("v", Domain::upperBound);
@@ -65,13 +69,15 @@ class LinearBoundaryConsistencySolverTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class SingleVariableMultipleConstraint {
-    MutableResource<Polynomial> lowerBound1 = resource(polynomial(10));
-    MutableResource<Polynomial> lowerBound2 = resource(polynomial(20));
-    MutableResource<Polynomial> upperBound = resource(polynomial(30));
+    MutableResource<Polynomial> lowerBound1, lowerBound2, upperBound;
     Resource<Polynomial> result;
 
-    public SingleVariableMultipleConstraint() {
-      Resources.init();
+    SingleVariableMultipleConstraint() {
+      Resources.init(Instant.EPOCH);
+
+      lowerBound1 = resource(polynomial(10));
+      lowerBound2 = resource(polynomial(20));
+      upperBound = resource(polynomial(30));
 
       var solver = new LinearBoundaryConsistencySolver("SingleVariableMultipleConstraint");
       var v = solver.variable("v", Domain::lowerBound);
@@ -141,11 +147,13 @@ class LinearBoundaryConsistencySolverTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class ScalingConstraint {
-    MutableResource<Polynomial> driver = resource(polynomial(10));
+    MutableResource<Polynomial> driver;
     Resource<Polynomial> result;
 
-    public ScalingConstraint() {
-      Resources.init();
+    ScalingConstraint() {
+      Resources.init(Instant.EPOCH);
+
+      driver = resource(polynomial(10));
 
       var solver = new LinearBoundaryConsistencySolver("ScalingConstraint");
       var v = solver.variable("v", Domain::upperBound);
@@ -171,12 +179,14 @@ class LinearBoundaryConsistencySolverTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class MultipleVariables {
-    MutableResource<Polynomial> upperBound = resource(polynomial(10));
-    MutableResource<Polynomial> upperBoundOnC = resource(polynomial(5));
+    MutableResource<Polynomial> upperBound, upperBoundOnC;
     Resource<Polynomial> a, b, c;
 
-    public MultipleVariables() {
-      Resources.init();
+    MultipleVariables() {
+      Resources.init(Instant.EPOCH);
+
+      upperBound = resource(polynomial(10));
+      upperBoundOnC = resource(polynomial(5));
 
       var solver = new LinearBoundaryConsistencySolver("MultipleVariablesSingleConstraint");
       var a = solver.variable("a", Domain::upperBound);

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PrecomputedTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PrecomputedTest.java
@@ -2,13 +2,13 @@ package gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial;
 
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
-import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -24,8 +24,10 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class PrecomputedTest {
-    public PrecomputedTest(final Registrar registrar) {
-        Resources.init();
+    {
+        // We need to initialize this up front, so we can use in-line initializers for other resources after.
+        // I think in-line initializers for the other resources make the tests easier to read.
+        Resources.init(Instant.EPOCH);
     }
 
     final Resource<Polynomial> precomputedAsConstantInPast =

--- a/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
+++ b/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
@@ -5,13 +5,15 @@ import gov.nasa.jpl.aerie.contrib.streamline.debugging.Profiling;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.ModelActions;
 
+import java.time.Instant;
+
 public final class Mission {
   public final DataModel dataModel;
   public final ErrorTestingModel errorTestingModel;
   public final ApproximationModel approximationModel;
 
-  public Mission(final gov.nasa.jpl.aerie.merlin.framework.Registrar registrar$, final Configuration config) {
-    var registrar = new Registrar(registrar$, Registrar.ErrorBehavior.Log);
+  public Mission(final gov.nasa.jpl.aerie.merlin.framework.Registrar registrar$, Instant planStart, final Configuration config) {
+    var registrar = new Registrar(registrar$, planStart, Registrar.ErrorBehavior.Log);
     if (config.traceResources) registrar.setTrace();
     if (config.profileResources) Resource.profileAllResources();
     dataModel = new DataModel(registrar, config);

--- a/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/Duration.java
+++ b/merlin-sdk/src/main/java/gov/nasa/jpl/aerie/merlin/protocol/types/Duration.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.protocol.types;
 
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
@@ -453,6 +454,11 @@ public record Duration(long micros) implements Comparable<Duration> {
     return instant
         .plusMillis(duration.dividedBy(Duration.MILLISECONDS))
         .plusNanos(1000 * duration.remainderOf(Duration.MILLISECONDS).dividedBy(Duration.MICROSECONDS));
+  }
+
+  /** Compute the duration between two {@link Instant}s. */
+  public static Duration between(Instant start, Instant end) {
+    return Duration.of(ChronoUnit.MICROS.between(start, end), Duration.MICROSECONDS);
   }
 
   /** @see Duration#add(Duration, Duration) */


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds "Instant" counterparts to Clock and VariableClock, which report absolute times as Java instants, but still step time according to an Aerie duration. Also adds some minimal interoperability between absolute and relative clocks, and some useful derivations including comparisons.

Using these, also adds a global Instant-based clock to Resources, along with exposing both the duration- and instant-based clocks as resources.

In doing so, we add a new parameter for the plan's start time to Resources.init(). This in turn required refactoring some unit tests, and I took the opportunity to clean up the test construction a little bit as well. This revealed a way to correctly initialize Resources, i.e., to call Resources.init() exactly once per initialization of each test model. As a result, I refactored the clock handling to remove the awkward reinitialization pattern, since that pattern was added to handle test code.

## Verification
Simple tests added for simulationClock() and absoluteClock() added to Resources, which are likely to be the most-used parts of this PR. I'll test other types and functions in this PR incidentally as I prototype some other ideas, and update this PR with those results..

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Ideally these should be mentioned in the streamline users' guide.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Although absolute clocks are often useful in their own right, this is specifically in support of command expansion and incon/fincon prototypes I'm working on.
