### PR TITLE
Streamline incons

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.contrib.streamline.core;
 
 import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ErrorCatchingMonad;
+import gov.nasa.jpl.aerie.contrib.streamline.utils.InvertibleFunction;
 import gov.nasa.jpl.aerie.merlin.framework.CellRef;
 import gov.nasa.jpl.aerie.merlin.protocol.model.CellType;
 import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
@@ -23,37 +24,47 @@ public final class CellRefV2 {
   /**
    * Allocate a new resource with an explicitly given effect type and effect trait.
    */
-  public static <D extends Dynamics<?, D>, E extends DynamicsEffect<D>> CellRef<E, Cell<D>> allocate(ErrorCatching<Expiring<D>> initialDynamics, EffectTrait<E> effectTrait) {
-    return CellRef.allocate(new Cell<>(initialDynamics), new CellType<>() {
-      @Override
-      public EffectTrait<E> getEffectType() {
-        return effectTrait;
-      }
+  public static <D extends Dynamics<?, D>, E extends DynamicsEffect<D>> CellRef<E, Cell<D>> allocate(
+          InconBehavior<ErrorCatching<Expiring<D>>> inconBehavior,
+          EffectTrait<E> effectTrait) {
+    // Building the invertible function below ties together two key functions as de-facto inverses:
+    // 1. Reading the incon and using it to initialize the cell.
+    // 2. Reading the cell and using it to write the fincon.
+    // Registering that mapped incon behavior here then ensures that we always register the incon behavior,
+    // without the modeler needing to manage incons as a separate step, which they may forget / mismanage.
+    return InitialConditionManager.register(inconBehavior.map(InvertibleFunction.of(
+            initialDynamics -> CellRef.allocate(new Cell<>(initialDynamics), new CellType<>() {
+              @Override
+              public EffectTrait<E> getEffectType() {
+                return effectTrait;
+              }
 
-      @Override
-      public Cell<D> duplicate(Cell<D> cell) {
-        return new Cell<>(cell.initialDynamics, cell.dynamics, cell.elapsedTime);
-      }
+              @Override
+              public Cell<D> duplicate(Cell<D> cell) {
+                return new Cell<>(cell.initialDynamics, cell.dynamics, cell.elapsedTime);
+              }
 
-      @Override
-      public void apply(Cell<D> cell, E effect) {
-        cell.initialDynamics = effect.apply(cell.dynamics).match(
-            ErrorCatching::success,
-                error -> failure(new RuntimeException(
-                    "Applying effect '%s' failed.".formatted(getName(effect, null)), error)));
-        cell.dynamics = cell.initialDynamics;
-        cell.elapsedTime = ZERO;
-      }
+              @Override
+              public void apply(Cell<D> cell, E effect) {
+                cell.initialDynamics = effect.apply(cell.dynamics).match(
+                        ErrorCatching::success,
+                        error -> failure(new RuntimeException(
+                                "Applying effect '%s' failed.".formatted(getName(effect, null)), error)));
+                cell.dynamics = cell.initialDynamics;
+                cell.elapsedTime = ZERO;
+              }
 
-      @Override
-      public void step(Cell<D> cell, Duration duration) {
-        // Avoid accumulated round-off error in imperfect stepping
-        // by always stepping up from the initial dynamics
-        cell.elapsedTime = cell.elapsedTime.plus(duration);
-        cell.dynamics = ErrorCatchingMonad.map(cell.initialDynamics, d ->
-            expiring(d.data().step(cell.elapsedTime), d.expiry().minus(cell.elapsedTime)));
-      }
-    });
+              @Override
+              public void step(Cell<D> cell, Duration duration) {
+                // Avoid accumulated round-off error in imperfect stepping
+                // by always stepping up from the initial dynamics
+                cell.elapsedTime = cell.elapsedTime.plus(duration);
+                cell.dynamics = ErrorCatchingMonad.map(cell.initialDynamics, d ->
+                        expiring(d.data().step(cell.elapsedTime), d.expiry().minus(cell.elapsedTime)));
+              }
+            }),
+            cellRef -> cellRef.get().dynamics
+    )));
   }
 
   public static <D extends Dynamics<?, D>> EffectTrait<DynamicsEffect<D>> noncommutingEffects() {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/InconBehavior.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/InconBehavior.java
@@ -1,51 +1,33 @@
 package gov.nasa.jpl.aerie.contrib.streamline.core;
 
 import gov.nasa.jpl.aerie.contrib.streamline.utils.InvertibleFunction;
-import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
-import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.InitialConditionManager.*;
 
 /**
  * Combines the operations of getting initial state and saving final state,
  * since these operations are intentionally closely coupled.
  */
 public interface InconBehavior<T> {
-    T getIncon(InitialConditionManager.InitialConditions initialConditions);
+    T getIncon(InitialConditions initialConditions);
 
-    void writeFincon(T state, InitialConditionManager.FinalConditions finalConditions);
+    void writeFincon(T state, FinalConditions finalConditions);
 
-    static <T> InconBehavior<T> of(Function<InitialConditionManager.InitialConditions, T> getIncon, BiConsumer<T, InitialConditionManager.FinalConditions> writeFincon) {
-        return new InconBehavior<T>() {
+    static <T> InconBehavior<T> of(Function<InitialConditions, T> getIncon, BiConsumer<T, FinalConditions> writeFincon) {
+        return new InconBehavior<>() {
             @Override
-            public T getIncon(InitialConditionManager.InitialConditions initialConditions) {
+            public T getIncon(InitialConditions initialConditions) {
                 return getIncon.apply(initialConditions);
             }
 
             @Override
-            public void writeFincon(T state, InitialConditionManager.FinalConditions finalConditions) {
+            public void writeFincon(T state, FinalConditions finalConditions) {
                 writeFincon.accept(state, finalConditions);
             }
         };
-    }
-
-    /**
-     * The null case of incon behavior, when in fact the state does not get saved out.
-     */
-    static <T> InconBehavior<T> constant(T value) {
-        return InconBehavior.of($ -> value, (s, f) -> {});
-    }
-
-    /**
-     * The standard case of incon behavior, where the state is serialized out under a single key.
-     */
-    static <T> InconBehavior<T> serialized(String key, Function<Optional<SerializedValue>, T> constructor, Function<T, SerializedValue> serializer) {
-        return InconBehavior.of(
-                incons -> constructor.apply(incons.get(key)),
-                (state, fincons) -> fincons.put(key, serializer.apply(state)));
     }
 
     /**

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/InconBehavior.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/InconBehavior.java
@@ -1,0 +1,62 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core;
+
+import gov.nasa.jpl.aerie.contrib.streamline.utils.InvertibleFunction;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Combines the operations of getting initial state and saving final state,
+ * since these operations are intentionally closely coupled.
+ */
+public interface InconBehavior<T> {
+    T getIncon(InitialConditionManager.InitialConditions initialConditions);
+
+    void writeFincon(T state, InitialConditionManager.FinalConditions finalConditions);
+
+    static <T> InconBehavior<T> of(Function<InitialConditionManager.InitialConditions, T> getIncon, BiConsumer<T, InitialConditionManager.FinalConditions> writeFincon) {
+        return new InconBehavior<T>() {
+            @Override
+            public T getIncon(InitialConditionManager.InitialConditions initialConditions) {
+                return getIncon.apply(initialConditions);
+            }
+
+            @Override
+            public void writeFincon(T state, InitialConditionManager.FinalConditions finalConditions) {
+                writeFincon.accept(state, finalConditions);
+            }
+        };
+    }
+
+    /**
+     * The null case of incon behavior, when in fact the state does not get saved out.
+     */
+    static <T> InconBehavior<T> constant(T value) {
+        return InconBehavior.of($ -> value, (s, f) -> {});
+    }
+
+    /**
+     * The standard case of incon behavior, where the state is serialized out under a single key.
+     */
+    static <T> InconBehavior<T> serialized(String key, Function<Optional<SerializedValue>, T> constructor, Function<T, SerializedValue> serializer) {
+        return InconBehavior.of(
+                incons -> constructor.apply(incons.get(key)),
+                (state, fincons) -> fincons.put(key, serializer.apply(state)));
+    }
+
+    /**
+     * Extend this {@link InconBehavior} with an invertible function.
+     * <p>
+     *     In particular, this can be used to apply {@link Resource} wrappers around the initial state.
+     * </p>
+     */
+    default <U> InconBehavior<U> map(InvertibleFunction<T, U> f) {
+        return InconBehavior.of(
+                f.compose(this::getIncon),
+                (state, fincons) -> this.writeFincon(f.inverse().apply(state), fincons));
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/InitialConditionManager.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/InitialConditionManager.java
@@ -1,0 +1,76 @@
+package gov.nasa.jpl.aerie.contrib.streamline.core;
+
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+public final class InitialConditionManager {
+    private InitialConditionManager() {}
+
+    private static boolean initialized = false;
+    private static InitialConditions initialConditions;
+    private static Consumer<Map<String, SerializedValue>> finconHandler;
+    private static List<Consumer<FinalConditions>> finconHooks;
+
+    public static void init(InitialConditions initialConditions, Consumer<Map<String, SerializedValue>> finconHandler) {
+        if (initialized) {
+            throw new IllegalStateException("InitialConditionManager has already been initialized");
+        }
+
+        InitialConditionManager.initialConditions = initialConditions;
+        InitialConditionManager.finconHandler = finconHandler;
+        InitialConditionManager.finconHooks = new ArrayList<>();
+        initialized = true;
+    }
+
+    // The "correct" way to get an initial value also registers a way to write the final value.
+    // This is intended to remind the modeler that these operations are closely coupled.
+    public static <T> T register(InconBehavior<T> behavior) {
+        if (!initialized) {
+            throw new IllegalStateException("InitialConditionManager has not been initialized");
+        }
+
+        var result =  behavior.getIncon(initialConditions);
+        // This looks admittedly strange, but the intent is for result to be something like a resource,
+        // which is a stable handle for a state that changes over the course of the simulation.
+        // This closure captures that stable handle, with the intent of querying it later to capture the final state.
+        finconHooks.add($ -> behavior.writeFincon(result, $));
+        return result;
+    }
+
+    public static void writeFincon() {
+        var transparentFincons = new HashMap<String, SerializedValue>();
+        // opaqueFincons is a write-only view of transparentFincons
+        var opaqueFincons = FinalConditions.of(transparentFincons);
+        // Each fincon hook appends its portion of the fincons
+        for (var finconHook : finconHooks) {
+            finconHook.accept(opaqueFincons);
+        }
+        // Finally we write the full object out
+        finconHandler.accept(transparentFincons);
+    }
+
+
+    public interface InitialConditions {
+        Optional<SerializedValue> get(String key);
+
+        static InitialConditions of(Map<String, SerializedValue> map) {
+            return key -> Optional.ofNullable(map.get(key));
+        }
+    }
+
+    public interface FinalConditions {
+        void put(String key, SerializedValue value);
+
+        static FinalConditions of(Map<String, SerializedValue> map) {
+            return (key, value) -> {
+                if (map.putIfAbsent(key, value) != null) {
+                    throw new IllegalStateException(String.format(
+                            "Final condition has already been written for %s", key));
+                }
+            };
+        }
+    }
+
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/MutableResource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/MutableResource.java
@@ -88,7 +88,7 @@ public interface MutableResource<D extends Dynamics<?, D>> extends Resource<D> {
     return serializing(key, pure(defaultValue), standardDynamicsMapper(mapper));
   }
 
-  private static <D> ValueMapper<ErrorCatching<Expiring<D>>> standardDynamicsMapper(ValueMapper<D> baseMapper) {
+  static <D> ValueMapper<ErrorCatching<Expiring<D>>> standardDynamicsMapper(ValueMapper<D> baseMapper) {
     return new ValueMapper<>() {
       @Override
       public ValueSchema getValueSchema() {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/MutableResource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/MutableResource.java
@@ -76,12 +76,14 @@ public interface MutableResource<D extends Dynamics<?, D>> extends Resource<D> {
   }
 
   static <D> InconBehavior<ErrorCatching<Expiring<D>>> notSaving(ErrorCatching<Expiring<D>> initialValue) {
-    return InconBehavior.constant(initialValue);
+    return InconBehavior.of($ -> initialValue, (s, f) -> {});
   }
 
   // TODO - It would be nice if the name we set here could somehow auto-populate the name of the resource,
   //  and also be the name we register the resource as. Same for the value mapper, it would be nice to just use that for registration too.
   // Alternatively, we could demand a name for every MutableResource, and combine that with the other info here later...?
+  // On reflection, I think the discrete resource and linear resource constructors are the place to combine all this info.
+  // Those would know which registrar method to call, and what value mapper to use.
   static <D> InconBehavior<ErrorCatching<Expiring<D>>> serializing(String key, D defaultValue, ValueMapper<D> mapper) {
     return serializing(key, pure(defaultValue), standardDynamicsMapper(mapper));
   }
@@ -131,10 +133,9 @@ public interface MutableResource<D extends Dynamics<?, D>> extends Resource<D> {
   }
 
   static <D> InconBehavior<ErrorCatching<Expiring<D>>> serializing(String key, ErrorCatching<Expiring<D>> defaultValue, ValueMapper<ErrorCatching<Expiring<D>>> mapper) {
-    return InconBehavior.serialized(
-            key,
-            serializedValue -> serializedValue.map($ -> mapper.deserializeValue($).getSuccessOrThrow()).orElse(defaultValue),
-            mapper::serializeValue);
+    return InconBehavior.of(
+            incons -> incons.get(key).map($ -> mapper.deserializeValue($).getSuccessOrThrow()).orElse(defaultValue),
+            (state, fincons) -> fincons.put(key, mapper.serializeValue(state)));
   }
 
   static <D extends Dynamics<?, D>> void set(MutableResource<D> resource, D newDynamics) {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/MutableResource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/MutableResource.java
@@ -6,10 +6,19 @@ import gov.nasa.jpl.aerie.contrib.streamline.debugging.Context;
 import gov.nasa.jpl.aerie.contrib.streamline.debugging.Profiling;
 import gov.nasa.jpl.aerie.merlin.framework.CellRef;
 import gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.Cell;
+import gov.nasa.jpl.aerie.merlin.framework.Result;
+import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
 import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
+import java.util.Map;
+import java.util.Optional;
+
+import static gov.nasa.jpl.aerie.contrib.serialization.rulesets.BasicValueMappers.duration;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.allocate;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.autoEffects;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiry.expiry;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.DynamicsMonad.pure;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Profiling.profile;
@@ -25,24 +34,18 @@ public interface MutableResource<D extends Dynamics<?, D>> extends Resource<D> {
     emit(name(effect, effectName));
   }
 
-  static <D extends Dynamics<?, D>> MutableResource<D> resource(D initial) {
-    return resource(pure(initial));
-  }
-
-  static <D extends Dynamics<?, D>> MutableResource<D> resource(D initial, EffectTrait<DynamicsEffect<D>> effectTrait) {
-    return resource(pure(initial), effectTrait);
-  }
-
-  static <D extends Dynamics<?, D>> MutableResource<D> resource(ErrorCatching<Expiring<D>> initial) {
+  static <D extends Dynamics<?, D>> MutableResource<D> resource(InconBehavior<ErrorCatching<Expiring<D>>> inconBehavior) {
     // Use autoEffects for a generic CellResource, on the theory that most resources
     // have relatively few effects, and even fewer concurrent effects, so this is performant enough.
     // If that doesn't hold, a more specialized solution can be constructed directly.
-    return resource(initial, autoEffects());
+    return resource(inconBehavior, autoEffects());
   }
 
-  static <D extends Dynamics<?, D>> MutableResource<D> resource(ErrorCatching<Expiring<D>> initial, EffectTrait<DynamicsEffect<D>> effectTrait) {
+  static <D extends Dynamics<?, D>> MutableResource<D> resource(
+          InconBehavior<ErrorCatching<Expiring<D>>> inconBehavior,
+          EffectTrait<DynamicsEffect<D>> effectTrait) {
     MutableResource<D> result = new MutableResource<>() {
-      private final CellRef<DynamicsEffect<D>, Cell<D>> cell = allocate(initial, effectTrait);
+      private final CellRef<DynamicsEffect<D>, Cell<D>> cell = allocate(inconBehavior, effectTrait);
 
       @Override
       public void emit(final DynamicsEffect<D> effect) {
@@ -66,6 +69,72 @@ public interface MutableResource<D extends Dynamics<?, D>> extends Resource<D> {
       result = profile(result);
     }
     return result;
+  }
+
+  static <D> InconBehavior<ErrorCatching<Expiring<D>>> notSaving(D initialValue) {
+    return notSaving(pure(initialValue));
+  }
+
+  static <D> InconBehavior<ErrorCatching<Expiring<D>>> notSaving(ErrorCatching<Expiring<D>> initialValue) {
+    return InconBehavior.constant(initialValue);
+  }
+
+  // TODO - It would be nice if the name we set here could somehow auto-populate the name of the resource,
+  //  and also be the name we register the resource as. Same for the value mapper, it would be nice to just use that for registration too.
+  // Alternatively, we could demand a name for every MutableResource, and combine that with the other info here later...?
+  static <D> InconBehavior<ErrorCatching<Expiring<D>>> serializing(String key, D defaultValue, ValueMapper<D> mapper) {
+    return serializing(key, pure(defaultValue), standardDynamicsMapper(mapper));
+  }
+
+  private static <D> ValueMapper<ErrorCatching<Expiring<D>>> standardDynamicsMapper(ValueMapper<D> baseMapper) {
+    return new ValueMapper<>() {
+      @Override
+      public ValueSchema getValueSchema() {
+        // Note: Both errorMessage and expiry are nullable.
+        return ValueSchema.ofStruct(Map.of(
+                "error", ValueSchema.STRING,
+                "expiry", ValueSchema.DURATION,
+                "dynamics", baseMapper.getValueSchema()));
+      }
+
+      @Override
+      public SerializedValue serializeValue(ErrorCatching<Expiring<D>> value) {
+        return value.match(
+                success -> SerializedValue.of(Map.of(
+                        "expiry", success.expiry().value().map(duration()::serializeValue).orElse(SerializedValue.NULL),
+                        "dynamics", baseMapper.serializeValue(success.data())
+                )),
+                error -> SerializedValue.of(Map.of(
+                        "error", SerializedValue.of(error.getMessage())
+                ))
+        );
+      }
+
+      @Override
+      public Result<ErrorCatching<Expiring<D>>, String> deserializeValue(SerializedValue serializedValue) {
+        try {
+          var map = serializedValue.asMap().orElseThrow();
+          if (map.containsKey("error")) {
+            return Result.success(ErrorCatching.failure(new Exception(map.get("error").asString().orElseThrow())));
+          } else {
+            var expiry = expiry(Optional.ofNullable(map.get("expiry"))
+                    .map($ -> duration().deserializeValue($).getSuccessOrThrow()));
+            var dynamics = baseMapper.deserializeValue(map.get("dynamics")).getSuccessOrThrow();
+            return Result.success(ErrorCatching.success(Expiring.expiring(dynamics, expiry)));
+          }
+        } catch (Throwable e) {
+          // TODO - we need *way* better error reporting here, but I just can't be bothered tonight.
+          return Result.failure("Failed to deserialize value as a standard wrapped dynamics object.");
+        }
+      }
+    };
+  }
+
+  static <D> InconBehavior<ErrorCatching<Expiring<D>>> serializing(String key, ErrorCatching<Expiring<D>> defaultValue, ValueMapper<ErrorCatching<Expiring<D>>> mapper) {
+    return InconBehavior.serialized(
+            key,
+            serializedValue -> serializedValue.map($ -> mapper.deserializeValue($).getSuccessOrThrow()).orElse(defaultValue),
+            mapper::serializeValue);
   }
 
   static <D extends Dynamics<?, D>> void set(MutableResource<D> resource, D newDynamics) {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Demo.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Demo.java
@@ -17,6 +17,7 @@ import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 import java.util.Optional;
 
+import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.notSaving;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.black_box.Approximation.approximate;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.black_box.DifferentiableResources.asDifferentiable;
@@ -130,7 +131,7 @@ public final class Demo {
   Resource<Linear> approxQuotient = approximate(quotient, secantApproximation(IntervalFunctions.<Unstructured<Double>>byBoundingError(
       1e-6, Duration.SECOND, Duration.HOUR.times(24), errorByOptimization())));
 
-  Resource<Unstructured<Pair<Vector3D, Vector3D>>> positionAndVelocity = resource(Unstructured.timeBased(t -> /* some spice call */ null));
+  Resource<Unstructured<Pair<Vector3D, Vector3D>>> positionAndVelocity = resource(notSaving(Unstructured.timeBased(t -> /* some spice call */ null)));
   Resource<Discrete<Pair<Vector3D, Vector3D>>> approxPosVel = approximate(
       positionAndVelocity,
       DiscreteApproximation.<Pair<Vector3D, Vector3D>, Unstructured<Pair<Vector3D, Vector3D>>>discreteApproximation(

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
@@ -15,6 +15,8 @@ import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.whenever;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentData;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
@@ -54,8 +56,8 @@ public class Registrar {
     Throw
   }
 
-  public Registrar(final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar, final ErrorBehavior errorBehavior) {
-    Resources.init();
+  public Registrar(final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar, final Instant planStart, final ErrorBehavior errorBehavior) {
+    Resources.init(planStart);
     Logging.init(baseRegistrar);
     this.baseRegistrar = baseRegistrar;
     this.errorBehavior = errorBehavior;

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/black_box/Approximation.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/black_box/Approximation.java
@@ -10,6 +10,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.notSaving;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.expiring;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.whenever;
@@ -32,7 +33,9 @@ public final class Approximation {
    */
   public static <D extends Dynamics<?, D>, E extends Dynamics<?, E>> Resource<E> approximate(
       Resource<D> resource, Function<Expiring<D>, Expiring<E>> approximation) {
-    var result = resource(resource.getDynamics().map(approximation));
+    // We should, in general, not care about saving the state of an approximation.
+    // Instead, we should restore the underlying resource and re-approximate
+    var result = resource(notSaving(resource.getDynamics().map(approximation)));
     // Register the "updates" and "expires" conditions separately
     // so that the "updates" condition isn't triggered spuriously.
     wheneverUpdates(resource, newResourceDynamics -> updateApproximation(newResourceDynamics, approximation, result));

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/Clock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/Clock.java
@@ -1,8 +1,10 @@
 package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
 
 import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.AutoValueMapper;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
+@AutoValueMapper.Record
 public record Clock(Duration extract) implements Dynamics<Duration, Clock> {
   @Override
   public Clock step(Duration t) {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/ClockResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/ClockResources.java
@@ -7,24 +7,15 @@ import gov.nasa.jpl.aerie.contrib.streamline.modeling.linear.Linear;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.*;
-import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.signalling;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.bind;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete.discrete;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.not;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteResourceMonad.map;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.EPSILON;
-import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.ZERO;
 
 public final class ClockResources {
   private ClockResources() {}
-
-  /**
-   * Create a clock starting at zero time.
-   */
-  public static Resource<Clock> clock(String name) {
-    return resource(serializing(name, Clock.clock(ZERO), null /* TODO - get auto value mapper for Clock type */));
-  }
 
   public static Resource<Discrete<Boolean>> lessThan(Resource<Clock> clock, Resource<Discrete<Duration>> threshold) {
     return signalling(bind(clock, threshold, (Clock c, Discrete<Duration> t) -> {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/ClockResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/ClockResources.java
@@ -1,14 +1,13 @@
 package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
 
-import gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.linear.Linear;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
-import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.*;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.signalling;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.bind;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete.discrete;
@@ -23,8 +22,8 @@ public final class ClockResources {
   /**
    * Create a clock starting at zero time.
    */
-  public static Resource<Clock> clock() {
-    return resource(Clock.clock(ZERO));
+  public static Resource<Clock> clock(String name) {
+    return resource(serializing(name, Clock.clock(ZERO), null /* TODO - get auto value mapper for Clock type */));
   }
 
   public static Resource<Discrete<Boolean>> lessThan(Resource<Clock> clock, Resource<Discrete<Duration>> threshold) {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
@@ -1,0 +1,24 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.addToInstant;
+
+/**
+ * A variation on {@link Clock} that represents an absolute {@link Instant}
+ * instead of a relative {@link Duration}.
+ */
+public record InstantClock(Instant extract) implements Dynamics<Instant, InstantClock> {
+    @Override
+    public InstantClock step(Duration t) {
+        return new InstantClock(addToInstant(extract, t));
+    }
+
+    static Duration durationBetween(Instant start, Instant end) {
+        return Duration.of(ChronoUnit.MICROS.between(start, end), Duration.MICROSECONDS);
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
 
 import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.AutoValueMapper;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
 import java.time.Instant;
@@ -12,6 +13,7 @@ import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.addToInstant;
  * A variation on {@link Clock} that represents an absolute {@link Instant}
  * instead of a relative {@link Duration}.
  */
+@AutoValueMapper.Record
 public record InstantClock(Instant extract) implements Dynamics<Instant, InstantClock> {
     @Override
     public InstantClock step(Duration t) {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
@@ -18,6 +18,8 @@ public record InstantClock(Instant extract) implements Dynamics<Instant, Instant
         return new InstantClock(addToInstant(extract, t));
     }
 
+    // TODO - this method belongs somewhere else...
+    //  Making it package-private at least lets us move it later without dependency issues outside the library.
     static Duration durationBetween(Instant start, Instant end) {
         return Duration.of(ChronoUnit.MICROS.between(start, end), Duration.MICROSECONDS);
     }

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClockResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClockResources.java
@@ -1,0 +1,56 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.*;
+import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.time.Instant;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.map;
+import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.name;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.constant;
+
+public class InstantClockResources {
+    /**
+     * Create an absolute clock that starts now at the given start time.
+     */
+    public static MutableResource<InstantClock> absoluteClock(Instant startTime) {
+        return resource(new InstantClock(startTime));
+    }
+
+    public static Resource<InstantClock> addToInstant(Instant zeroTime, Resource<Clock> relativeClock) {
+        return addToInstant(constant(zeroTime), relativeClock);
+    }
+
+    public static Resource<InstantClock> addToInstant(Resource<Discrete<Instant>> zeroTime, Resource<Clock> relativeClock) {
+        return name(
+                map(zeroTime, relativeClock, (zero, clock) ->
+                        new InstantClock(Duration.addToInstant(zero.extract(), clock.extract()))),
+                "%s + %s",
+                zeroTime,
+                relativeClock);
+    }
+
+    public static Resource<Clock> relativeTo(Resource<InstantClock> clock, Resource<Discrete<Instant>> zeroTime) {
+        return name(ResourceMonad.map(clock, zeroTime, (c, t) -> new Clock(InstantClock.durationBetween(t.extract(), c.extract()))),
+                "%s relative to %s", clock, zeroTime);
+    }
+
+    public static Resource<Discrete<Boolean>> lessThan(Resource<InstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return ClockResources.lessThan(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> lessThanOrEquals(Resource<InstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return ClockResources.lessThanOrEquals(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> greaterThan(Resource<InstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return ClockResources.greaterThan(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> greaterThanOrEquals(Resource<InstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return ClockResources.greaterThanOrEquals(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClockResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClockResources.java
@@ -13,13 +13,6 @@ import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.name;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.constant;
 
 public class InstantClockResources {
-    /**
-     * Create an absolute clock that starts now at the given start time.
-     */
-    public static MutableResource<InstantClock> absoluteClock(Instant startTime) {
-        return resource(new InstantClock(startTime));
-    }
-
     public static Resource<InstantClock> addToInstant(Instant zeroTime, Resource<Clock> relativeClock) {
         return addToInstant(constant(zeroTime), relativeClock);
     }

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableClock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableClock.java
@@ -1,10 +1,12 @@
 package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
 
 import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.AutoValueMapper;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.ZERO;
 
+@AutoValueMapper.Record
 public record VariableClock(Duration extract, int multiplier) implements Dynamics<Duration, VariableClock> {
   @Override
   public VariableClock step(final Duration t) {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClock.java
@@ -1,0 +1,19 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.time.Instant;
+
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.addToInstant;
+
+/**
+ * A variation on {@link VariableClock} that represents an absolute {@link Instant}
+ * instead of a relative {@link Duration}.
+ */
+public record VariableInstantClock(Instant extract, int multiplier) implements Dynamics<Instant, VariableInstantClock> {
+    @Override
+    public VariableInstantClock step(Duration t) {
+        return new VariableInstantClock(addToInstant(extract, t.times(multiplier)), multiplier);
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClock.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
 
 import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
+import gov.nasa.jpl.aerie.merlin.framework.annotations.AutoValueMapper;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
 import java.time.Instant;
@@ -11,6 +12,7 @@ import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.addToInstant;
  * A variation on {@link VariableClock} that represents an absolute {@link Instant}
  * instead of a relative {@link Duration}.
  */
+@AutoValueMapper.Record
 public record VariableInstantClock(Instant extract, int multiplier) implements Dynamics<Instant, VariableInstantClock> {
     @Override
     public VariableInstantClock step(Duration t) {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockEffects.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockEffects.java
@@ -1,0 +1,33 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource;
+
+import java.time.Instant;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.DynamicsMonad.effect;
+import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.name;
+
+public final class VariableInstantClockEffects {
+    private VariableInstantClockEffects() {}
+
+    /**
+     * Stop the clock without affecting the current time.
+     */
+    public static void pause(MutableResource<VariableInstantClock> clock) {
+        clock.emit("Pause", effect($ -> new VariableInstantClock($.extract(), 0)));
+    }
+
+    /**
+     * Start the clock without affecting the current time.
+     */
+    public static void start(MutableResource<VariableInstantClock> clock) {
+        clock.emit("Start", effect($ -> new VariableInstantClock($.extract(), 1)));
+    }
+
+    /**
+     * Reset the clock to the given time, without affecting how fast it's running.
+     */
+    public static void reset(MutableResource<VariableInstantClock> clock, Instant newTime) {
+        clock.emit(name(effect($ -> new VariableInstantClock(newTime, $.multiplier())), "Reset to %s", newTime));
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockResources.java
@@ -1,0 +1,42 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.time.Instant;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.map;
+import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.name;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.InstantClock.durationBetween;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.constant;
+
+public final class VariableInstantClockResources {
+    private VariableInstantClockResources() {}
+
+    public static Resource<VariableClock> relativeTo(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> zeroTime) {
+        return name(map(clock, zeroTime, (c, t) ->
+                        new VariableClock(durationBetween(c.extract(), t.extract()), c.multiplier())),
+                "%s relative to %s", clock, zeroTime);
+    }
+
+    public static Resource<Discrete<Boolean>> lessThan(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return VariableClockResources.lessThan(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> lessThanOrEquals(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return VariableClockResources.lessThanOrEquals(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> greaterThan(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return VariableClockResources.greaterThan(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> greaterThanOrEquals(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return VariableClockResources.greaterThanOrEquals(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<VariableClock> between(Resource<VariableInstantClock> start, Resource<VariableInstantClock> end) {
+        return map(start, end, (s, e) -> new VariableClock(durationBetween(s.extract(), e.extract()), e.multiplier() - s.multiplier()));
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteResources.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete;
 
 import gov.nasa.jpl.aerie.contrib.streamline.core.*;
 import gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.CommutativityTestInput;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteDynamicsMonad;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteMonad;
@@ -11,6 +12,8 @@ import gov.nasa.jpl.aerie.merlin.framework.Condition;
 import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.Unit;
 import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAware;
 import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAwareResources;
+import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
+import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
 import java.time.Instant;
@@ -24,6 +27,7 @@ import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.testing;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.expiring;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiry.expiry;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.serializing;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.every;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.whenever;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.*;
@@ -46,6 +50,68 @@ public final class DiscreteResources {
     return result;
   }
 
+  public static <T> DiscreteResourceBuilder<T> discreteResource(T initialValue) {
+
+  }
+
+  public class DiscreteResourceBuilder<T> {
+    private ErrorCatching<Expiring<Discrete<T>>> defaultValue;
+    private String name;
+    private ValueMapper<T> valueMapper;
+    private InconBehavior<ErrorCatching<Expiring<Discrete<T>>>> inconBehavior;
+    private EffectTrait<DynamicsEffect<Discrete<T>>> effectTrait = autoEffects();
+
+    public DiscreteResourceBuilder<T> defaultValue(T defaultValue) {
+      return defaultValue(DiscreteDynamicsMonad.pure(defaultValue));
+    }
+
+    public DiscreteResourceBuilder<T> defaultValue(ErrorCatching<Expiring<Discrete<T>>> defaultValue) {
+      assertNotSet("default value", this.defaultValue);
+      this.defaultValue = defaultValue;
+      return this;
+    }
+
+    public DiscreteResourceBuilder<T> name(String name) {
+      assertNotSet("name", this.name);
+      this.name = name;
+      return this;
+    }
+
+    public DiscreteResourceBuilder<T> valueMapper(ValueMapper<T> valueMapper) {
+      assertNotSet("value mapper", this.valueMapper);
+      this.valueMapper = valueMapper;
+      return this;
+    }
+
+    public DiscreteResourceBuilder<T> inconBehavior(InconBehavior<ErrorCatching<Expiring<Discrete<T>>>> inconBehavior) {
+      assertNotSet("incon behavior", this.inconBehavior);
+      this.inconBehavior = inconBehavior;
+      return this;
+    }
+
+    private void assertNotSet(String name, Object thing) {
+      if (thing != null)
+        throw new IllegalStateException(String.format("%s has already been set on this builder!", name));
+    }
+
+    // Terminal methods - these build and return the resource
+
+    // TODO - would it be more convenient to make Registrar a singleton, like the incon manager?
+    // Then it wouldn't have to be passed around just to give to these builders.
+    // We already assume you have exactly one registrar, because building it initializes all the singletons...
+    public Resource<Discrete<T>> registered(Registrar registrar) {
+      var result = notRegistered();
+      registrar.discrete(name, result, valueMapper);
+      return result;
+    }
+
+    public Resource<Discrete<T>> notRegistered() {
+      return resource(inconBehavior, effectTrait);
+    }
+  }
+
+  // --- REWRITE START ---
+
   // General discrete cell resource constructor
   public static <T> MutableResource<Discrete<T>> discreteResource(T initialValue) {
     return resource(discrete(initialValue));
@@ -65,6 +131,8 @@ public final class DiscreteResources {
             input.leftResult().extract(),
             input.rightResult().extract()))));
   }
+
+  // --- REWRITE END ---
 
   /**
    * Returns a condition that's satisfied whenever this resource is true.

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteResources.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete;
 
 import gov.nasa.jpl.aerie.contrib.streamline.core.*;
 import gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.CommutativityTestInput;
+import gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteDynamicsMonad;
@@ -12,9 +13,12 @@ import gov.nasa.jpl.aerie.merlin.framework.Condition;
 import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.Unit;
 import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAware;
 import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAwareResources;
+import gov.nasa.jpl.aerie.merlin.framework.Result;
 import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
 import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -22,12 +26,12 @@ import java.util.*;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 
+import static gov.nasa.jpl.aerie.contrib.serialization.rulesets.BasicValueMappers.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.autoEffects;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.testing;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.expiring;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiry.expiry;
-import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
-import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.serializing;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.every;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.whenever;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.*;
@@ -35,7 +39,6 @@ import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.bi
 import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.pure;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Dependencies.addDependency;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.*;
-import static gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.ClockResources.clock;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete.discrete;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteEffects.set;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteResourceMonad.*;
@@ -50,11 +53,40 @@ public final class DiscreteResources {
     return result;
   }
 
+  // General discrete resource constructor
   public static <T> DiscreteResourceBuilder<T> discreteResource(T initialValue) {
-
+    return new DiscreteResourceBuilder<T>().defaultValue(initialValue);
   }
 
-  public class DiscreteResourceBuilder<T> {
+  // Special cases for primitives, which (a) need a little special handling for double's effect trait,
+  // and (b) we can bake in the value mapper for them by default.
+  public static DiscreteResourceBuilder<Boolean> discreteResource(boolean initialValue) {
+    return new DiscreteResourceBuilder<Boolean>().defaultValue(initialValue).valueMapper($boolean());
+  }
+  public static DiscreteResourceBuilder<Integer> discreteResource(int initialValue) {
+    return new DiscreteResourceBuilder<Integer>().defaultValue(initialValue).valueMapper($int());
+  }
+  // Doubles are special, as they get a toleranced equality check by default for their effect trait.
+  public static DiscreteResourceBuilder<Double> discreteResource(double initialValue) {
+    return new DiscreteResourceBuilder<Double>()
+            .defaultValue(initialValue)
+            .valueMapper($double())
+            .effectTrait(autoEffects(testing(
+                    (CommutativityTestInput<Discrete<Double>> input) -> DoubleUtils.areEqualResults(
+                            input.original().extract(),
+                            input.leftResult().extract(),
+                            input.rightResult().extract()))));
+  }
+  public static DiscreteResourceBuilder<String> discreteResource(String initialValue) {
+    return new DiscreteResourceBuilder<String>().defaultValue(initialValue).valueMapper(string());
+  }
+  // SAFETY - Enums are final, so initialValue.getClass() equals E, hence this assignment is guaranteed correct.
+  @SuppressWarnings("unchecked")
+  public static <E extends Enum<E>> DiscreteResourceBuilder<E> discreteResource(E initialValue) {
+    return new DiscreteResourceBuilder<E>().defaultValue(initialValue).valueMapper($enum(initialValue.getClass()));
+  }
+
+  public static class DiscreteResourceBuilder<T> {
     private ErrorCatching<Expiring<Discrete<T>>> defaultValue;
     private String name;
     private ValueMapper<T> valueMapper;
@@ -66,32 +98,64 @@ public final class DiscreteResources {
     }
 
     public DiscreteResourceBuilder<T> defaultValue(ErrorCatching<Expiring<Discrete<T>>> defaultValue) {
-      assertNotSet("default value", this.defaultValue);
       this.defaultValue = defaultValue;
       return this;
     }
 
     public DiscreteResourceBuilder<T> name(String name) {
-      assertNotSet("name", this.name);
       this.name = name;
       return this;
     }
 
     public DiscreteResourceBuilder<T> valueMapper(ValueMapper<T> valueMapper) {
-      assertNotSet("value mapper", this.valueMapper);
       this.valueMapper = valueMapper;
       return this;
     }
 
+    public DiscreteResourceBuilder<T> notSaved() {
+      assertSet("default value", defaultValue);
+      return inconBehavior(notSaving(defaultValue));
+    }
+
+    public DiscreteResourceBuilder<T> serialized() {
+      assertSet("name", name);
+      assertSet("default value", defaultValue);
+      assertSet("value mapper", valueMapper);
+      return inconBehavior(serializing(name, defaultValue, standardDynamicsMapper(standardDiscreteMapper(valueMapper))));
+    }
+
+    public static <T> ValueMapper<Discrete<T>> standardDiscreteMapper(ValueMapper<T> mapper) {
+      return new ValueMapper<>() {
+        @Override
+        public ValueSchema getValueSchema() {
+          return mapper.getValueSchema();
+        }
+
+        @Override
+        public Result<Discrete<T>, String> deserializeValue(SerializedValue serializedValue) {
+          return mapper.deserializeValue(serializedValue).mapSuccess(Discrete::discrete);
+        }
+
+        @Override
+        public SerializedValue serializeValue(Discrete<T> value) {
+          return mapper.serializeValue(value.extract());
+        }
+      };
+    }
+
     public DiscreteResourceBuilder<T> inconBehavior(InconBehavior<ErrorCatching<Expiring<Discrete<T>>>> inconBehavior) {
-      assertNotSet("incon behavior", this.inconBehavior);
       this.inconBehavior = inconBehavior;
       return this;
     }
 
-    private void assertNotSet(String name, Object thing) {
-      if (thing != null)
-        throw new IllegalStateException(String.format("%s has already been set on this builder!", name));
+    public DiscreteResourceBuilder<T> effectTrait(EffectTrait<DynamicsEffect<Discrete<T>>> effectTrait) {
+      this.effectTrait = effectTrait;
+      return this;
+    }
+
+    private void assertSet(String name, Object thing) {
+      if (thing == null)
+        throw new IllegalStateException(String.format("%s has not been set on this builder!", name));
     }
 
     // Terminal methods - these build and return the resource
@@ -99,40 +163,23 @@ public final class DiscreteResources {
     // TODO - would it be more convenient to make Registrar a singleton, like the incon manager?
     // Then it wouldn't have to be passed around just to give to these builders.
     // We already assume you have exactly one registrar, because building it initializes all the singletons...
-    public Resource<Discrete<T>> registered(Registrar registrar) {
+    public MutableResource<Discrete<T>> registered(Registrar registrar) {
       var result = notRegistered();
+      assertSet("name", name);
+      assertSet("value mapper", valueMapper);
       registrar.discrete(name, result, valueMapper);
       return result;
     }
 
-    public Resource<Discrete<T>> notRegistered() {
-      return resource(inconBehavior, effectTrait);
+    public MutableResource<Discrete<T>> notRegistered() {
+      // If no incon behavior is set, default to serializing the value in the default way.
+      if (inconBehavior == null) serialized();
+      assertSet("effect trait", effectTrait);
+      var result = resource(inconBehavior, effectTrait);
+      if (name != null) Naming.name(result, name);
+      return result;
     }
   }
-
-  // --- REWRITE START ---
-
-  // General discrete cell resource constructor
-  public static <T> MutableResource<Discrete<T>> discreteResource(T initialValue) {
-    return resource(discrete(initialValue));
-  }
-
-  // Annoyingly, we need to repeat the specialization for integer resources, so that
-  // discreteMutableResource(42) doesn't become a double resource, due to the next overload
-  public static MutableResource<Discrete<Integer>> discreteResource(int initialValue) {
-    return resource(discrete(initialValue));
-  }
-
-  // specialized constructor for doubles, because they require a toleranced equality comparison
-  public static MutableResource<Discrete<Double>> discreteResource(double initialValue) {
-    return resource(discrete(initialValue), autoEffects(testing(
-        (CommutativityTestInput<Discrete<Double>> input) -> DoubleUtils.areEqualResults(
-            input.original().extract(),
-            input.leftResult().extract(),
-            input.rightResult().extract()))));
-  }
-
-  // --- REWRITE END ---
 
   /**
    * Returns a condition that's satisfied whenever this resource is true.
@@ -150,7 +197,9 @@ public final class DiscreteResources {
    * Cache resource, updating the cache when updatePredicate(cached value, resource value) is true.
    */
   public static <V> Resource<Discrete<V>> cache(Resource<Discrete<V>> resource, BiPredicate<V, V> updatePredicate) {
-    final var cell = resource(resource.getDynamics());
+    // Caches are logically derived from the resource they're caching, so should not be directly saved.
+    // Instead, the resource(s) feeding this cache should be saved, and used to reinitialize this.
+    final var cell = resource(notSaving(resource.getDynamics()));
     // TODO: Does the update predicate need to propagate expiry information?
     BiPredicate<ErrorCatching<Expiring<Discrete<V>>>, ErrorCatching<Expiring<Discrete<V>>>> liftedUpdatePredicate = (eCurrent, eNew) ->
         eCurrent.match(
@@ -178,7 +227,7 @@ public final class DiscreteResources {
    * Sample valueSupplier once every samplePeriod.
    */
   public static <V, T extends Dynamics<Duration, T>> Resource<Discrete<V>> sampled(Supplier<V> valueSupplier, Resource<T> samplePeriod) {
-    var result = discreteResource(valueSupplier.get());
+    var result = discreteResource(valueSupplier.get()).notSaved().notRegistered();
     every(() -> currentValue(samplePeriod, Duration.MAX_VALUE),
           () -> set(result, valueSupplier.get()));
     return result;
@@ -191,8 +240,7 @@ public final class DiscreteResources {
    */
   public static <V> Resource<Discrete<V>> precomputed(
       final V valueBeforeFirstEntry, final NavigableMap<Duration, V> segments) {
-    var clock = clock();
-    return signalling(bind(clock, (Clock clock$) -> {
+    return signalling(bind(simulationClock(), (Clock clock$) -> {
       var t = clock$.extract();
       var entry = segments.floorEntry(t);
       var value = entry == null ? valueBeforeFirstEntry : entry.getValue();

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialResources.java
@@ -5,6 +5,7 @@ import gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.CommutativityTestInp
 import gov.nasa.jpl.aerie.contrib.streamline.core.monads.DynamicsMonad;
 import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ErrorCatchingMonad;
 import gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.black_box.*;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
@@ -17,6 +18,8 @@ import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAwareOperations;
 import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAwareResources;
 import gov.nasa.jpl.aerie.contrib.streamline.utils.DoubleUtils;
 import gov.nasa.jpl.aerie.merlin.framework.Condition;
+import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
+import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.apache.commons.lang3.mutable.MutableObject;
 
@@ -30,10 +33,10 @@ import java.util.stream.Stream;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.autoEffects;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.testing;
-import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.expiring;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.neverExpiring;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiry.NEVER;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.wheneverDynamicsChange;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.DynamicsMonad.bindEffect;
@@ -47,7 +50,6 @@ import static gov.nasa.jpl.aerie.contrib.streamline.modeling.black_box.Different
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.black_box.IntervalFunctions.byBoundingError;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.black_box.SecantApproximation.ErrorEstimates.errorByQuadraticApproximation;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.black_box.SecantApproximation.secantApproximation;
-import static gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.ClockResources.clock;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete.discrete;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.assertThat;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial.Polynomial.polynomial;
@@ -87,6 +89,75 @@ public final class PolynomialResources {
                          left.getCoefficient(i),
                          right.getCoefficient(i)));
         })));
+  }
+
+  public class PolynomialResourceBuilder {
+    private ErrorCatching<Expiring<Polynomial>> defaultValue;
+    private String name;
+    private InconBehavior<ErrorCatching<Expiring<Polynomial>>> inconBehavior;
+    private EffectTrait<DynamicsEffect<Polynomial>> effectTrait = autoEffects(testing(
+        (CommutativityTestInput<Polynomial> input) -> {
+          Polynomial original = input.original();
+          Polynomial left = input.leftResult();
+          Polynomial right = input.rightResult();
+          return left.degree() == right.degree() &&
+                 IntStream.rangeClosed(0, left.degree()).allMatch(
+                     i -> DoubleUtils.areEqualResults(
+                         original.getCoefficient(i),
+                         left.getCoefficient(i),
+                         right.getCoefficient(i)));
+        }));
+
+    public PolynomialResourceBuilder defaultValue(Polynomial defaultValue) {
+      return defaultValue(DynamicsMonad.pure(defaultValue));
+    }
+
+    public PolynomialResourceBuilder defaultValue(ErrorCatching<Expiring<Polynomial>> defaultValue) {
+      this.defaultValue = defaultValue;
+      return this;
+    }
+
+    public PolynomialResourceBuilder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public PolynomialResourceBuilder notSaved() {
+      assertSet("default value", defaultValue);
+      return inconBehavior(notSaving(defaultValue));
+    }
+
+    public PolynomialResourceBuilder serialized() {
+      assertSet("name", name);
+      assertSet("default value", defaultValue);
+      return inconBehavior(serializing(name, defaultValue, standardDynamicsMapper(null /* TODO - get auto value mapper for polynomial */)));
+    }
+
+    public PolynomialResourceBuilder inconBehavior(InconBehavior<ErrorCatching<Expiring<Polynomial>>> inconBehavior) {
+      this.inconBehavior = inconBehavior;
+      return this;
+    }
+
+    public PolynomialResourceBuilder effectTrait(EffectTrait<DynamicsEffect<Polynomial>> effectTrait) {
+      this.effectTrait = effectTrait;
+      return this;
+    }
+
+    private void assertSet(String name, Object thing) {
+      if (thing == null)
+        throw new IllegalStateException(String.format("%s has not been set on this builder!", name));
+    }
+
+    // Terminal methods - these build and return the resource
+
+    public MutableResource<Polynomial> notRegistered() {
+      // If no incon behavior is set, default to serializing the value in the default way.
+      if (inconBehavior == null) serialized();
+      assertSet("effect trait", effectTrait);
+      var result = resource(inconBehavior, effectTrait);
+      if (name != null) Naming.name(result, name);
+      return result;
+    }
   }
 
   /**
@@ -207,8 +278,7 @@ public final class PolynomialResources {
     if (segments.isEmpty()) {
       throw new IllegalArgumentException("Segments map must have at least one segment");
     }
-    var clock = clock();
-    return signalling(bind(clock, (Clock clock$) -> {
+    return signalling(bind(simulationClock(), (Clock clock$) -> {
       var t = clock$.extract();
       var start = segments.floorEntry(t);
       var end = segments.higherEntry(t);

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/utils/InvertibleFunction.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/utils/InvertibleFunction.java
@@ -1,0 +1,39 @@
+package gov.nasa.jpl.aerie.contrib.streamline.utils;
+
+import java.util.function.Function;
+
+public interface InvertibleFunction<A, B> extends Function<A, B> {
+    InvertibleFunction<B, A> inverse();
+
+    default <C> InvertibleFunction<C, B> compose(InvertibleFunction<C, A> before) {
+        return new InvertibleFunction<>() {
+            @Override
+            public InvertibleFunction<B, C> inverse() {
+                return before.inverse().<B>compose(InvertibleFunction.this.inverse());
+            }
+
+            @Override
+            public B apply(C c) {
+                return InvertibleFunction.this.apply(before.apply(c));
+            }
+        };
+    }
+
+    default <C> InvertibleFunction<A, C> andThen(InvertibleFunction<B, C> after) {
+        return after.compose(this);
+    }
+
+    static <A, B> InvertibleFunction<A, B> of(Function<A, B> map, Function<B, A> inverse) {
+        return new InvertibleFunction<>() {
+            @Override
+            public B apply(A a) {
+                return map.apply(a);
+            }
+
+            @Override
+            public InvertibleFunction<B, A> inverse() {
+                return InvertibleFunction.of(inverse, map);
+            }
+        };
+    }
+}

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2Test.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2Test.java
@@ -9,10 +9,11 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.autoEffects;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.commutingEffects;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.noncommutingEffects;
-import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete.discrete;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteDynamicsMonad.effect;
@@ -27,10 +28,11 @@ class MutableResourceTest {
   @TestInstance(Lifecycle.PER_CLASS)
   class NonCommutingEffects {
     public NonCommutingEffects(final Registrar registrar) {
-      Resources.init();
+      Resources.init(Instant.EPOCH);
+      cell = MutableResource.resource(discrete(42), noncommutingEffects());
     }
 
-    private final MutableResource<Discrete<Integer>> cell = MutableResource.resource(discrete(42), noncommutingEffects());
+    private final MutableResource<Discrete<Integer>> cell;
 
     @Test
     void gets_initial_value_if_no_effects_are_emitted() {
@@ -66,10 +68,11 @@ class MutableResourceTest {
   @TestInstance(Lifecycle.PER_CLASS)
   class CommutingEffects {
     public CommutingEffects(final Registrar registrar) {
-      Resources.init();
+      Resources.init(Instant.EPOCH);
+      cell = MutableResource.resource(discrete(42), commutingEffects());
     }
 
-    private final MutableResource<Discrete<Integer>> cell = MutableResource.resource(discrete(42), commutingEffects());
+    private final MutableResource<Discrete<Integer>> cell;
 
     @Test
     void gets_initial_value_if_no_effects_are_emitted() {
@@ -108,11 +111,12 @@ class MutableResourceTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class AutoEffects {
-    public AutoEffects(final Registrar registrar) {
-      Resources.init();
+    public AutoEffects() {
+      Resources.init(Instant.EPOCH);
+      cell = MutableResource.resource(discrete(42), autoEffects());
     }
 
-    private final MutableResource<Discrete<Integer>> cell = MutableResource.resource(discrete(42), autoEffects());
+    private final MutableResource<Discrete<Integer>> cell;
 
     @Test
     void gets_initial_value_if_no_effects_are_emitted() {

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/DependenciesTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/DependenciesTest.java
@@ -1,7 +1,7 @@
 package gov.nasa.jpl.aerie.contrib.streamline.debugging;
 
-import gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial.Polynomial;
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.*;
@@ -21,12 +23,22 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DependenciesTest {
-  Resource<Discrete<Boolean>> constantTrue = DiscreteResources.constant(true);
-  Resource<Polynomial> constant1234 = constant(1234);
-  Resource<Polynomial> constant5678 = constant(5678);
-  Resource<Polynomial> polynomialCell = resource(polynomial(1));
-  Resource<Polynomial> derived = map(constantTrue, constant1234, constant5678,
-                                     (b, x, y) -> b.extract() ? x : y);
+  public DependenciesTest() {
+    Resources.init(Instant.EPOCH);
+
+    constantTrue = DiscreteResources.constant(true);
+    constant1234 = constant(1234);
+    constant5678 = constant(5678);
+    polynomialCell = resource(polynomial(1));
+    derived = map(constantTrue, constant1234, constant5678,
+                                       (b, x, y) -> b.extract() ? x : y);
+  }
+
+  Resource<Discrete<Boolean>> constantTrue;
+  Resource<Polynomial> constant1234;
+  Resource<Polynomial> constant5678;
+  Resource<Polynomial> polynomialCell;
+  Resource<Polynomial> derived;
 
   @Test
   void constants_are_named_by_their_value() {

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/SimulationClockTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/SimulationClockTest.java
@@ -1,0 +1,66 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
+import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.*;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.HOUR;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.ZERO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MerlinExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SimulationClockTest {
+    // This time is unlikely to be a hard-coded default anywhere
+    public static final Instant PLAN_START = Instant.parse("2020-01-02T03:04:05Z");
+
+    public SimulationClockTest() {
+        Resources.init(PLAN_START);
+    }
+
+    @Test
+    public void relative_clock_starts_at_zero() {
+        assertEquals(ZERO, currentTime());
+        assertEquals(ZERO, currentValue(simulationClock()));
+    }
+
+    @Test
+    public void absolute_clock_starts_at_plan_start() {
+        assertEquals(PLAN_START, currentInstant());
+        assertEquals(PLAN_START, currentValue(absoluteClock()));
+    }
+
+    @Test
+    public void relative_clock_advances_at_unit_rate() {
+        delay(1, HOUR);
+        assertEquals(Duration.of(1, HOUR), currentTime());
+        assertEquals(Duration.of(1, HOUR), currentValue(simulationClock()));
+        delay(1, HOUR);
+        assertEquals(Duration.of(2, HOUR), currentTime());
+        assertEquals(Duration.of(2, HOUR), currentValue(simulationClock()));
+        delay(1, HOUR);
+        assertEquals(Duration.of(3, HOUR), currentTime());
+        assertEquals(Duration.of(3, HOUR), currentValue(simulationClock()));
+    }
+
+    @Test
+    public void absolute_clock_advances_at_unit_rate() {
+        delay(1, HOUR);
+        assertEquals(PLAN_START.plus(1, ChronoUnit.HOURS), currentInstant());
+        assertEquals(PLAN_START.plus(1, ChronoUnit.HOURS), currentValue(absoluteClock()));
+        delay(1, HOUR);
+        assertEquals(PLAN_START.plus(2, ChronoUnit.HOURS), currentInstant());
+        assertEquals(PLAN_START.plus(2, ChronoUnit.HOURS), currentValue(absoluteClock()));
+        delay(1, HOUR);
+        assertEquals(PLAN_START.plus(3, ChronoUnit.HOURS), currentInstant());
+        assertEquals(PLAN_START.plus(3, ChronoUnit.HOURS), currentValue(absoluteClock()));
+    }
+}

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffectsTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffectsTest.java
@@ -5,13 +5,14 @@ import gov.nasa.jpl.aerie.contrib.streamline.core.ErrorCatching;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock;
 import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAware;
-import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentTime;
@@ -40,8 +41,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 class DiscreteEffectsTest {
-  public DiscreteEffectsTest(final Registrar registrar) {
-    Resources.init();
+  {
+    // We need to initialize this up front, so we can use in-line initializers for other resources after.
+    // I think in-line initializers for the other resources make the tests easier to read.
+    Resources.init(Instant.EPOCH);
   }
 
   private final MutableResource<Discrete<Integer>> settable = resource(discrete(42));

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/PrecomputedTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/PrecomputedTest.java
@@ -2,7 +2,6 @@ package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete;
 
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
-import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.junit.jupiter.api.Test;
@@ -26,8 +25,10 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class PrecomputedTest {
-    public PrecomputedTest(final Registrar registrar) {
-        Resources.init();
+    {
+        // We need to initialize this up front, so we can use in-line initializers for other resources after.
+        // I think in-line initializers for the other resources make the tests easier to read.
+        Resources.init(Instant.EPOCH);
     }
 
     final Resource<Discrete<Integer>> precomputedAsAConstant =

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/ComparisonsTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/ComparisonsTest.java
@@ -5,13 +5,14 @@ import gov.nasa.jpl.aerie.contrib.streamline.core.Expiry;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
-import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.set;
@@ -28,22 +29,26 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class ComparisonsTest {
-  public ComparisonsTest(final Registrar registrar) {
-    Resources.init();
+  public ComparisonsTest() {
+    Resources.init(Instant.EPOCH);
+
+    p = resource(polynomial(0));
+    q = resource(polynomial(0));
+
+    p_lt_q = lessThan(p, q);
+    p_lte_q = lessThanOrEquals(p, q);
+    p_gt_q = greaterThan(p, q);
+    p_gte_q = greaterThanOrEquals(p, q);
+
+    min_p_q = min(p, q);
+    min_q_p = min(q, p);
+    max_p_q = max(p, q);
+    max_q_p = max(q, p);
   }
 
-  private final MutableResource<Polynomial> p = resource(polynomial(0));
-  private final MutableResource<Polynomial> q = resource(polynomial(0));
-
-  private final Resource<Discrete<Boolean>> p_lt_q = lessThan(p, q);
-  private final Resource<Discrete<Boolean>> p_lte_q = lessThanOrEquals(p, q);
-  private final Resource<Discrete<Boolean>> p_gt_q = greaterThan(p, q);
-  private final Resource<Discrete<Boolean>> p_gte_q = greaterThanOrEquals(p, q);
-
-  private final Resource<Polynomial> min_p_q = min(p, q);
-  private final Resource<Polynomial> min_q_p = min(q, p);
-  private final Resource<Polynomial> max_p_q = max(p, q);
-  private final Resource<Polynomial> max_q_p = max(q, p);
+  private final MutableResource<Polynomial> p, q;
+  private final Resource<Discrete<Boolean>> p_lt_q, p_lte_q, p_gt_q, p_gte_q;
+  private final Resource<Polynomial> min_p_q, min_q_p, max_p_q, max_q_p;
 
   @Test
   void comparing_distinct_constants() {

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/LinearBoundaryConsistencySolverTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/LinearBoundaryConsistencySolverTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentData;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial.LinearBoundaryConsistencySolver.Comparison.*;
@@ -25,11 +27,13 @@ class LinearBoundaryConsistencySolverTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class SingleVariableSingleConstraint {
-    MutableResource<Polynomial> driver = resource(polynomial(10));
+    MutableResource<Polynomial> driver;
     Resource<Polynomial> result;
 
-    public SingleVariableSingleConstraint() {
-      Resources.init();
+    SingleVariableSingleConstraint() {
+      Resources.init(Instant.EPOCH);
+
+      driver = resource(polynomial(10));
 
       var solver = new LinearBoundaryConsistencySolver("SingleVariableSingleConstraint");
       var v = solver.variable("v", Domain::upperBound);
@@ -65,13 +69,15 @@ class LinearBoundaryConsistencySolverTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class SingleVariableMultipleConstraint {
-    MutableResource<Polynomial> lowerBound1 = resource(polynomial(10));
-    MutableResource<Polynomial> lowerBound2 = resource(polynomial(20));
-    MutableResource<Polynomial> upperBound = resource(polynomial(30));
+    MutableResource<Polynomial> lowerBound1, lowerBound2, upperBound;
     Resource<Polynomial> result;
 
-    public SingleVariableMultipleConstraint() {
-      Resources.init();
+    SingleVariableMultipleConstraint() {
+      Resources.init(Instant.EPOCH);
+
+      lowerBound1 = resource(polynomial(10));
+      lowerBound2 = resource(polynomial(20));
+      upperBound = resource(polynomial(30));
 
       var solver = new LinearBoundaryConsistencySolver("SingleVariableMultipleConstraint");
       var v = solver.variable("v", Domain::lowerBound);
@@ -141,11 +147,13 @@ class LinearBoundaryConsistencySolverTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class ScalingConstraint {
-    MutableResource<Polynomial> driver = resource(polynomial(10));
+    MutableResource<Polynomial> driver;
     Resource<Polynomial> result;
 
-    public ScalingConstraint() {
-      Resources.init();
+    ScalingConstraint() {
+      Resources.init(Instant.EPOCH);
+
+      driver = resource(polynomial(10));
 
       var solver = new LinearBoundaryConsistencySolver("ScalingConstraint");
       var v = solver.variable("v", Domain::upperBound);
@@ -171,12 +179,14 @@ class LinearBoundaryConsistencySolverTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class MultipleVariables {
-    MutableResource<Polynomial> upperBound = resource(polynomial(10));
-    MutableResource<Polynomial> upperBoundOnC = resource(polynomial(5));
+    MutableResource<Polynomial> upperBound, upperBoundOnC;
     Resource<Polynomial> a, b, c;
 
-    public MultipleVariables() {
-      Resources.init();
+    MultipleVariables() {
+      Resources.init(Instant.EPOCH);
+
+      upperBound = resource(polynomial(10));
+      upperBoundOnC = resource(polynomial(5));
 
       var solver = new LinearBoundaryConsistencySolver("MultipleVariablesSingleConstraint");
       var a = solver.variable("a", Domain::upperBound);

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PrecomputedTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PrecomputedTest.java
@@ -2,13 +2,13 @@ package gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial;
 
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
-import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -24,8 +24,10 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class PrecomputedTest {
-    public PrecomputedTest(final Registrar registrar) {
-        Resources.init();
+    {
+        // We need to initialize this up front, so we can use in-line initializers for other resources after.
+        // I think in-line initializers for the other resources make the tests easier to read.
+        Resources.init(Instant.EPOCH);
     }
 
     final Resource<Polynomial> precomputedAsConstantInPast =

--- a/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
+++ b/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
@@ -5,13 +5,15 @@ import gov.nasa.jpl.aerie.contrib.streamline.debugging.Profiling;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.ModelActions;
 
+import java.time.Instant;
+
 public final class Mission {
   public final DataModel dataModel;
   public final ErrorTestingModel errorTestingModel;
   public final ApproximationModel approximationModel;
 
-  public Mission(final gov.nasa.jpl.aerie.merlin.framework.Registrar registrar$, final Configuration config) {
-    var registrar = new Registrar(registrar$, Registrar.ErrorBehavior.Log);
+  public Mission(final gov.nasa.jpl.aerie.merlin.framework.Registrar registrar$, Instant planStart, final Configuration config) {
+    var registrar = new Registrar(registrar$, planStart, Registrar.ErrorBehavior.Log);
     if (config.traceResources) registrar.setTrace();
     if (config.profileResources) Resource.profileAllResources();
     dataModel = new DataModel(registrar, config);


### PR DESCRIPTION
DO NOT MERGE - this PR is for displaying this prototype code only, and is not meant to be merged.

This is a prototype of adding incon/fincon machinery to streamline, rather than writing it into core. Credit to Alex Greer for a lot of the ideas in here, especially the idea that streamline's particular implementation of a cell would be a good place to mix in incon/fincon functionality.

Since the "read incon" behavior and "write fincon" behavior should be tightly coupled, I've created an InconBehavior interface to package them together. The signatures on these methods allow them to be extended (see InconBehavior.map), which is important for allowing users to write an InconBehavior for simple types, that we can automatically extend to more complex or "wrapped" types. Otherwise, the InconBehavior is left highly general, treating incons as String-SerializedValue key-value pairs, which can be freely queried for incons and freely written for fincons.

The key principle in this design is "_Every_ cell has an incon behavior." There are some cells where that behavior is degenerate, i.e., "For incons, use this constant value, and for fincons, write nothing out." However, this is an opt-out system, where the modeler needs to choose _not_ to save the cell's value, rather than needing to remember everywhere else that they _should_ save the cell's value.

To that end, I've modified streamline's cell allocation function to take an InconBehavior instead of an initial value. This interacts with a static incon manager to retrieve the initial value for the cell and register the fincon behavior, simultaneously. Doing the two operations simultaneously, I hope, will contribute to keeping the two halves of this behavior tightly coupled.

On top of this, I'm modifying the MutableResource constructors to add more user-friendly support for common use cases, namely
1. mapping the dynamics directly to a single key in the incon/fincon, and
2. not saving the dynamics at all.
There will still be a more general constructor for MutableResource which allows any incon/fincon behavior, to support edge cases.

Finally, that static incon manager is initialized and loaded with a set of incons when building the registrar, since building the registrar has evolved into the natural place to initialize all the streamline singletons, like the simulation clock and the global logger. That static incon manager then exposes a method to write a fincon, which the model may call at any time to invoke all the registered fincon behaviors, compose a full system fincon, and save that fincon. Note that this will mean it's up to the mission model to define something like a simulation config parameter and model task, or a "Fincon" activity, to actually save the fincon.