### PR TITLE
Ignore generated sequencing parsers

### DIFF
--- a/sequencing-server/plugins/.gitignore
+++ b/sequencing-server/plugins/.gitignore
@@ -1,0 +1,2 @@
+fprime-dictionary-parser/fprime-parser.js
+ampcs-dictionary-parser/ampcs-parser.js


### PR DESCRIPTION
This PR adds the generated fprime and ampcs parsers to a local gitignore.