### PR TITLE
Update SeqJson Schema v1.3.1

### DIFF
--- a/sequencing-server/package-lock.json
+++ b/sequencing-server/package-lock.json
@@ -15,7 +15,7 @@
         "@js-temporal/polyfill": "~0.4.3",
         "@nasa-jpl/aerie-ampcs": "~1.0.6",
         "@nasa-jpl/aerie-ts-user-code-runner": "~0.7.0",
-        "@nasa-jpl/seq-json-schema": "1.0.20",
+        "@nasa-jpl/seq-json-schema": "1.3.1",
         "body-parser": "~1.20.1",
         "dataloader": "~2.2.0",
         "express": "~5.0.0-beta.1",
@@ -1288,9 +1288,10 @@
       }
     },
     "node_modules/@nasa-jpl/seq-json-schema": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/seq-json-schema/-/seq-json-schema-1.0.20.tgz",
-      "integrity": "sha512-fEIxZ7xlV8y+ybCN5yd2bhgEXLx4gbysa5W6KfXSBq9hY2gpYlYJ1PTNr0JA+N7KRK36Wh1lQnFtYpHfI/Owxw=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/seq-json-schema/-/seq-json-schema-1.3.1.tgz",
+      "integrity": "sha512-0WC75kGX9RCsYi6Ajpf9CgxR5wadR81GntznWZgWZQedbgRjORueaVmxVagLZFaR2a2L3ShIPJs2TjlRZH2PhA==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4666,6 +4667,10 @@
         "node-gyp-build": "^4.2.2"
       }
     },
+    "node_modules/nisar-dictionary-parser": {
+      "resolved": "plugins/nisar-dictionary-parser",
+      "link": true
+    },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
@@ -6343,6 +6348,26 @@
         "xml-js": "bin/cli.js"
       }
     },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -6463,7 +6488,6 @@
     },
     "plugins/nisar-dictionary-parser": {
       "version": "1.0.0",
-      "extraneous": true,
       "license": "ISC",
       "dependencies": {
         "@nasa-jpl/aerie-ampcs": "^1.0.6",
@@ -6475,6 +6499,27 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@types/node": "^22.4.1",
         "rollup": "^4.21.0"
+      }
+    },
+    "plugins/nisar-dictionary-parser/node_modules/@types/node": {
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.19.8"
+      }
+    },
+    "plugins/nisar-dictionary-parser/node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     }
   },
@@ -7430,9 +7475,9 @@
       }
     },
     "@nasa-jpl/seq-json-schema": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/seq-json-schema/-/seq-json-schema-1.0.20.tgz",
-      "integrity": "sha512-fEIxZ7xlV8y+ybCN5yd2bhgEXLx4gbysa5W6KfXSBq9hY2gpYlYJ1PTNr0JA+N7KRK36Wh1lQnFtYpHfI/Owxw=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/seq-json-schema/-/seq-json-schema-1.3.1.tgz",
+      "integrity": "sha512-0WC75kGX9RCsYi6Ajpf9CgxR5wadR81GntznWZgWZQedbgRjORueaVmxVagLZFaR2a2L3ShIPJs2TjlRZH2PhA=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -10016,6 +10061,34 @@
         "node-gyp-build": "^4.2.2"
       }
     },
+    "nisar-dictionary-parser": {
+      "version": "file:plugins/nisar-dictionary-parser",
+      "requires": {
+        "@nasa-jpl/aerie-ampcs": "^1.0.6",
+        "@rollup/plugin-commonjs": "^26.0.1",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "@types/node": "^22.4.1",
+        "rollup": "^4.21.0",
+        "typescript": "^5.6.2",
+        "xml2js": "^0.6.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "22.9.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+          "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~6.19.8"
+          }
+        },
+        "typescript": {
+          "version": "5.6.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+          "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="
+        }
+      }
+    },
     "node-addon-api": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
@@ -11209,6 +11282,20 @@
       "requires": {
         "sax": "^1.2.4"
       }
+    },
+    "xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/sequencing-server/package.json
+++ b/sequencing-server/package.json
@@ -29,7 +29,7 @@
     "@js-temporal/polyfill": "~0.4.3",
     "@nasa-jpl/aerie-ampcs": "~1.0.6",
     "@nasa-jpl/aerie-ts-user-code-runner": "~0.7.0",
-    "@nasa-jpl/seq-json-schema": "1.0.20",
+    "@nasa-jpl/seq-json-schema": "1.3.1",
     "body-parser": "~1.20.1",
     "dataloader": "~2.2.0",
     "express": "~5.0.0-beta.1",

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -3927,7 +3927,7 @@ export type Request = {
  * Description. Can be attached to any sequence step.
  */
 export type Description = string;
-export type Step = Activate | Command | GroundBlock | GroundEvent | Load;
+export type Step = Activate | Command | GroundBlock | GroundEvent | Load | Note;
 /**
  * Array of command arguments
  */
@@ -3939,6 +3939,26 @@ export type Args = (
   | HexArgument
   | RepeatArgument
 )[];
+/**
+ * Time object
+ */
+export type Time =
+  | {
+      /**
+       * Allowed time types without a tag: COMMAND_COMPLETE
+       */
+      type: 'COMMAND_COMPLETE';
+    }
+  | {
+      /**
+       * Allowed time types with a tag: ABSOLUTE, BLOCK_RELATIVE, COMMAND_RELATIVE, EPOCH_RELATIVE.
+       */
+      type: 'ABSOLUTE' | 'BLOCK_RELATIVE' | 'COMMAND_RELATIVE' | 'EPOCH_RELATIVE';
+      /**
+       * Relative or absolute time. Required for ABSOLUTE, BLOCK_RELATIVE, COMMAND_RELATIVE, and EPOCH_RELATIVE time types but not COMMAND_COMPLETE.
+       */
+      tag: string;
+    };
 
 export interface SeqJson {
   /**
@@ -3969,7 +3989,7 @@ export interface SeqJson {
   /**
    * Immediate commands which are interpreted by FSW and not part of any sequence.
    */
-  immediate_commands?: ImmediateCommand[];
+  immediate_commands?: (ImmediateFswCommand | ImmediateLoad | ImmediateActivate)[];
   /**
    * Hardware commands which are not interpreted by FSW and not part of any sequence.
    */
@@ -4151,19 +4171,6 @@ export interface Model {
   variable: string;
 }
 /**
- * Time object
- */
-export interface Time {
-  /**
-   * Relative or absolute time. Required for ABSOLUTE, COMMAND_RELATIVE, and EPOCH_RELATIVE time tags but not COMMAND_COMPLETE.
-   */
-  tag?: string;
-  /**
-   * Allowed time types: ABSOLUTE, COMMAND_RELATIVE, EPOCH_RELATIVE, or COMMAND_COMPLETE.
-   */
-  type: 'ABSOLUTE' | 'COMMAND_RELATIVE' | 'EPOCH_RELATIVE' | 'COMMAND_COMPLETE';
-}
-/**
  * Command object
  */
 export interface Command {
@@ -4236,16 +4243,76 @@ export interface Load {
   type: 'load';
 }
 /**
+ * Used to add a note within a sequence at a specific instant. Can be used by command & sequence simulator tools to print the string argument at the relevant instant within simulations.
+ */
+export interface Note {
+  /**
+   * Note string arg.
+   */
+  string_arg: string;
+  description?: Description;
+  metadata?: Metadata;
+  models?: Model[];
+  time: Time;
+  type: 'note';
+}
+/**
  * Object representing a single Immediate Command
  */
-export interface ImmediateCommand {
+export interface ImmediateFswCommand {
   args: Args;
   description?: Description;
   metadata?: Metadata;
+  models?: Model[];
   /**
    * Command stem
    */
   stem: string;
+  type?: 'immediate_command';
+}
+/**
+ * Untimed load object
+ */
+export interface ImmediateLoad {
+  args?: Args;
+  description?: Description;
+  /**
+   * Sequence target engine.
+   */
+  engine?: number;
+  /**
+   * Onboard epoch to pass to the sequence for derivation of epoch-relative timetags
+   */
+  epoch?: string;
+  metadata?: Metadata;
+  models?: Model[];
+  /**
+   * Onboard path and filename of sequence to be loaded.
+   */
+  sequence: string;
+  type: 'immediate_load';
+}
+/**
+ * Untimed activate object
+ */
+export interface ImmediateActivate {
+  args?: Args;
+  description?: Description;
+  /**
+   * Sequence target engine.
+   */
+  engine?: number;
+  /**
+   * Onboard epoch to pass to the sequence for derivation of epoch-relative timetags
+   */
+  epoch?: string;
+  metadata?: Metadata;
+  models?: Model[];
+  /**
+   * Onboard path and filename of sequence to be loaded.
+   */
+  sequence: string;
+  type: 'immediate_activate';
 }
 /**
  * Object representing a single Hardware Command


### PR DESCRIPTION
## Description
Added `immediate_activate` `immediate_load` `notes` and `block time` to the seqJson schema. The sequencing server is not using that as the Sequence eDSL has been phased out with SeqN. 

This is to address https://github.com/NASA-AMMOS/aerie-ui/issues/1527

## Verification
Update the e2e snapshot and test

