### PR TITLE
Procedural scheduling migration fix patch

### DIFF
--- a/deployment/hasura/migrations/Aerie/10_procedural_scheduling/up.sql
+++ b/deployment/hasura/migrations/Aerie/10_procedural_scheduling/up.sql
@@ -29,6 +29,11 @@ from scheduler.scheduling_request as sr
 where sr.analysis_id = sga.analysis_id
   and sga.goal_id = ssg.goal_id;
 
+-- v3.1.1 migration patch addition
+update scheduler.scheduling_goal_analysis
+set goal_invocation_id = -1 * goal_id
+where goal_invocation_id is null;
+
 alter table scheduler.scheduling_goal_analysis
   -- explictly set not null before PKing
   alter column goal_invocation_id set not null,
@@ -52,6 +57,11 @@ from scheduler.scheduling_request as sr
             on sr.specification_id = ssg.specification_id
 where sr.analysis_id = sgaca.analysis_id
   and sgaca.goal_id = ssg.goal_id;
+
+-- v3.1.1 migration patch addition
+update scheduler.scheduling_goal_analysis_created_activities
+set goal_invocation_id = -1 * goal_id
+where goal_invocation_id is null;
 
 alter table scheduler.scheduling_goal_analysis_created_activities
   drop column goal_id,
@@ -84,6 +94,11 @@ from scheduler.scheduling_request as sr
             on sr.specification_id = ssg.specification_id
 where sr.analysis_id = sgasa.analysis_id
   and sgasa.goal_id = ssg.goal_id;
+
+-- v3.1.1 migration patch addition
+update scheduler.scheduling_goal_analysis_satisfying_activities
+set goal_invocation_id = -1 * goal_id
+where goal_invocation_id is null;
 
 alter table scheduler.scheduling_goal_analysis_satisfying_activities
   drop column goal_id,


### PR DESCRIPTION
Fixes an issue discovered by @parkerabercrombie during database migration while upgrading from Aerie `2.11.2` to `3.1.0`:

* While on `2.11.2`, there was a plan that had some scheduling goals which were run, and produced scheduling goal analysis rows in the database.
* Some of these goals were removed from the plan after the scheduling run, which caused the scheduling analysis rows to refer to a `goal_id` which was no longer in the plan spec (didn't cause any issues yet).
* The `up.sql` migration `10` assigns `goal_invocation_id`s to all goal invocations in the plan spec, and propagates these IDs to the corresponding entries in the goal analysis tables.
* This process expected that all analysis rows would refer to goals that still existed in the plan spec, but since some goals were removed from the spec, the associated analysis rows were assigned `null` as their `goal_invocation_id`, which is not legal to be used as part of a primary key
* This caused the migration to fail when trying to set the primary key to include this column

This PR fixes the issue by assigning a "dummy value" to any goal analysis rows which would have suffered from this problem - instead of setting the `goal_invocation_id` to null, we (somewhat arbitrarily) set it to the negative of the goal id which instantiated it. This could have been any valid integer, but we decided to use this as the value since it gives us a bit more information about where the analysis came from.

(summarized by @dandelany )