### PR TITLE
use alternate repository for trivy vulnerabilities DB in Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -151,6 +151,9 @@ jobs:
 
       - name: Scan ${{ matrix.image }} for vulnerabilities
         uses: aquasecurity/trivy-action@0.24.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:develop
           ignore-unfixed: true


### PR DESCRIPTION
Fixes #1597 (hopefully)

See comments here:
https://github.com/NASA-AMMOS/aerie/issues/1597#issuecomment-2489885810