### PR TITLE
Refine migration script

### DIFF
--- a/.github/workflows/pgcmp.yml
+++ b/.github/workflows/pgcmp.yml
@@ -111,7 +111,7 @@ jobs:
           AERIE_PASSWORD=${AERIE_PASSWORD}
           EOF
           python -m pip install -r requirements.txt
-          python aerie_db_migration.py --apply --all
+          python aerie_db_migration.py migrate --apply --all
           cd ..
       - name: Clone PGCMP
         uses: actions/checkout@v4
@@ -204,7 +204,7 @@ jobs:
           AERIE_PASSWORD=${AERIE_PASSWORD}
           EOF
           python -m pip install -r requirements.txt
-          python aerie_db_migration.py --revert --all
+          python aerie_db_migration.py migrate --revert --all
           cd ..
       - name: Dump Migrated Database
         run: |

--- a/deployment/aerie_db_migration.py
+++ b/deployment/aerie_db_migration.py
@@ -167,11 +167,12 @@ def mark_current_version(username, password, netloc):
 
   return current_schema
 
-def main():
+def createArgsParser() -> argparse.ArgumentParser:
   # Create a cli parser
   parser = argparse.ArgumentParser(description=__doc__)
+
   # Applying and Reverting are exclusive arguments
-  exclusive_args = parser.add_mutually_exclusive_group(required='true')
+  exclusive_args = parser.add_mutually_exclusive_group(required=True)
 
   # Add arguments
   exclusive_args.add_argument(
@@ -202,8 +203,10 @@ def main():
     help="the network location of the database. defaults to localhost",
     default='localhost')
 
+  return parser
+def main():
   # Generate arguments
-  args = parser.parse_args()
+  args = migrateArgsParser().parse_args()
 
   HASURA_PATH = "./hasura"
   if args.hasura_path:

--- a/deployment/aerie_db_migration.py
+++ b/deployment/aerie_db_migration.py
@@ -11,6 +11,17 @@ import psycopg
 def clear_screen():
   os.system('cls' if os.name == 'nt' else 'clear')
 
+
+def exit_with_error(message: str, exit_code=1):
+  """
+  Exit the program with the specified error message and exit code.
+
+  :param message: Error message to display before exiting.
+  :param exit_code: Error code to exit with. Defaults to 1.
+  """
+  print("\033[91mError\033[0m: "+message)
+  sys.exit(exit_code)
+
 # internal class
 class DB_Migration:
   steps = []

--- a/deployment/aerie_db_migration.py
+++ b/deployment/aerie_db_migration.py
@@ -509,4 +509,7 @@ def createArgsParser() -> argparse.ArgumentParser:
 if __name__ == "__main__":
   # Generate arguments and kick off correct subfunction
   arguments = createArgsParser().parse_args()
-  arguments.func(arguments)
+  try:
+    arguments.func(arguments)
+  except AttributeError:
+    createArgsParser().print_help()

--- a/deployment/aerie_db_migration.py
+++ b/deployment/aerie_db_migration.py
@@ -408,7 +408,8 @@ def main():
   clear_screen()
   print(f'\n###############################'
         f'\nAERIE DATABASE MIGRATION HELPER'
-        f'\n###############################')
+        f'\n###############################'
+        f'\n\nMigrating database at {hasura.endpoint}')
   # Enter step-by-step mode if not otherwise specified
   if not args.all:
     # Find all migration folders for the database

--- a/deployment/aerie_db_migration.py
+++ b/deployment/aerie_db_migration.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Migrate the Aerie Database"""
+"""Migrate the database of an Aerie venue."""
 
 import os
 import argparse
@@ -183,6 +183,13 @@ class DB_Migration:
 
 
 def step_by_step_migration(hasura: Hasura, db_migration: DB_Migration, apply: bool):
+  """
+  Migrate the database one migration at a time until there are no more migrations left or the user decides to quit.
+
+  :param hasura: Hasura object connected to the venue to be migrated
+  :param db_migration: DB_Migration containing the complete list of migrations available
+  :param apply: Whether to apply or revert migrations
+  """
   display_string = "\n\033[4mMIGRATION STEPS AVAILABLE:\033[0m\n"
   _output = hasura.get_migrate_output('status')
   del _output[0:3]
@@ -254,6 +261,12 @@ def step_by_step_migration(hasura: Hasura, db_migration: DB_Migration, apply: bo
 
 
 def bulk_migration(hasura: Hasura, apply: bool):
+  """
+  Migrate the database until there are no migrations left to be applied[reverted].
+
+  :param hasura: Hasura object connected to the venue to be migrated
+  :param apply: Whether to apply or revert migrations.
+  """
   # Migrate the database
   exit_with = 0
   if apply:
@@ -280,6 +293,11 @@ def bulk_migration(hasura: Hasura, apply: bool):
 
 
 def migrate(args: argparse.Namespace):
+  """
+  Handle the 'migrate' subcommand.
+
+  :param args: The arguments passed to the script.
+  """
   hasura = create_hasura(arguments)
 
   clear_screen()
@@ -300,6 +318,11 @@ def migrate(args: argparse.Namespace):
 
 
 def status(args: argparse.Namespace):
+  """
+  Handle the 'status' subcommand.
+
+  :param args: The arguments passed to the script.
+  """
   hasura = create_hasura(args)
 
   clear_screen()

--- a/deployment/hasura/metadata/databases/tables/migrations/applied_migrations_view.yaml
+++ b/deployment/hasura/metadata/databases/tables/migrations/applied_migrations_view.yaml
@@ -1,0 +1,11 @@
+table:
+  name: applied_migrations
+  schema: migrations
+configuration:
+  custom_name: "applied_migrations"
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true

--- a/deployment/hasura/metadata/databases/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/tables/tables.yaml
@@ -1,6 +1,11 @@
 # Would prefer to do this as one file that delegates to others, as was done with init.sql
 # but doing so currently throws an error: "parse-failed: parsing Object failed, expected Object, but encountered Array"
 
+####################
+#### MIGRATIONS ####
+####################
+- "!include migrations/applied_migrations_view.yaml"
+
 #####################
 #### PERMISSIONS ####
 #####################

--- a/deployment/hasura/migrations/Aerie/12_applied_migrations_view/down.sql
+++ b/deployment/hasura/migrations/Aerie/12_applied_migrations_view/down.sql
@@ -1,0 +1,2 @@
+drop view migrations.applied_migrations;
+call migrations.mark_migration_rolled_back('12');

--- a/deployment/hasura/migrations/Aerie/12_applied_migrations_view/up.sql
+++ b/deployment/hasura/migrations/Aerie/12_applied_migrations_view/up.sql
@@ -1,0 +1,4 @@
+create view migrations.applied_migrations as
+  select migration_id::int
+  from migrations.schema_migrations;
+call migrations.mark_migration_applied('12');

--- a/deployment/postgres-init-db/sql/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/applied_migrations.sql
@@ -14,3 +14,4 @@ call migrations.mark_migration_applied('8');
 call migrations.mark_migration_applied('9');
 call migrations.mark_migration_applied('10');
 call migrations.mark_migration_applied('11');
+call migrations.mark_migration_applied('12');

--- a/deployment/postgres-init-db/sql/init.sql
+++ b/deployment/postgres-init-db/sql/init.sql
@@ -12,6 +12,7 @@ begin;
   -- Migrations
   \ir tables/migrations/schema_migrations.sql
   \ir applied_migrations.sql
+  \ir views/migrations/applied_migrations_view.sql
 
   -- Util Functions
   \ir functions/util_functions/shared_update_functions.sql

--- a/deployment/postgres-init-db/sql/views/migrations/applied_migrations_view.sql
+++ b/deployment/postgres-init-db/sql/views/migrations/applied_migrations_view.sql
@@ -1,0 +1,3 @@
+create view migrations.applied_migrations as
+  select migration_id::int
+  from migrations.schema_migrations;

--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,3 +1,2 @@
-psycopg>=3.1.18
-psycopg-binary>=3.1.18
-typing_extensions>=4.11.0
+requests~=2.31.0
+python-dotenv~=1.0.1


### PR DESCRIPTION
* **Tickets addressed:** Closes #1353 and Closes #852 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Adds a tracked view to Hasura showing the integer contents of the `migrations.schema_migrations` table. This allows Aerie Admins on a venue to view which migrations have been applied (was formerly locked behind Hasura Admins/Postgres Admins).

Heavily refactors the Aerie DB Migration Script:
 - Adds the 'status' subcommand to view the current status of migrations without applying them
 - Moves the migration logic into the 'migrate' subcommand
 - Adds a Hasura class for communicating via the CLI or API. This ensures that all necessary flags are always passed to the CLI. Necessary flags include: the Hasura project root, the Hasura endpoint and admin secret, the location of the .env to load values from, the database to apply migrations to
 - Loads in endpoint and admin secret information the same way that the Hasura CLI does (flags, then envvars, then .env, then config.yaml)
 - Gets the current database migration status by running a [`run_sql` query against the Hasura venue](https://hasura.io/docs/2.0/api-reference/schema-api/run-sql/), removing the need to provide database connection information
 - **Fixes the bug where Hasura metadata would be reloaded but not applied, forcing the user to restart Hasura**. The new metadata is now _applied_ before it's reloaded

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Manually tested

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Added doc comments and type hints throughout the script.

The website docs were edited to reflect the changes to the command line arguments and introduction of subcommands. 
- [Docs PR can be found here](https://github.com/NASA-AMMOS/aerie-docs/pull/201).

## Future work
<!-- What next steps can we anticipate from here, if any? -->
1) Refining the output when a migration fails to run. Currently the blob JSON is printed and it's hard to parse even if you know what you're looking for.
2) Perhaps adding an "until" flag to the bulk migration (as in, "apply[revert] migrations until you reach this one"). Not sure if there's a pressing use case for this currently.
3) #1627 