### PR TITLE
Adds "HASURA_API_URL" to docker-compose

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       AUTH_TYPE: none
       GQL_API_URL: http://localhost:8080/v1/graphql
+      HASURA_API_URL: http://hasura:8080/
       HASURA_GRAPHQL_JWT_SECRET: "${HASURA_GRAPHQL_JWT_SECRET}"
       LOG_FILE: console
       LOG_LEVEL: warn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       AUTH_TYPE: none
       AUTH_URL: https://atb-ocio-12b.jpl.nasa.gov:8443/cam-api
       GQL_API_URL: http://localhost:8080/v1/graphql
+      HASURA_API_URL: http://hasura:8080/
       HASURA_GRAPHQL_JWT_SECRET: "${HASURA_GRAPHQL_JWT_SECRET}"
       LOG_FILE: console
       LOG_LEVEL: debug

--- a/e2e-tests/docker-compose-many-workers.yml
+++ b/e2e-tests/docker-compose-many-workers.yml
@@ -6,6 +6,7 @@ services:
     environment:
       AUTH_TYPE: none
       AUTH_URL: https://atb-ocio-12b.jpl.nasa.gov:8443/cam-api
+      HASURA_API_URL: http://hasura:8080/
       GQL_API_URL: http://localhost:8080/v1/graphql
       HASURA_GRAPHQL_JWT_SECRET: "${HASURA_GRAPHQL_JWT_SECRET}"
       LOG_FILE: console

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -9,6 +9,7 @@ services:
     environment:
       AUTH_TYPE: none
       GQL_API_URL: http://localhost:8080/v1/graphql
+      HASURA_API_URL: http://hasura:8080/
       HASURA_GRAPHQL_JWT_SECRET: "${HASURA_GRAPHQL_JWT_SECRET}"
       LOG_FILE: console
       LOG_LEVEL: debug


### PR DESCRIPTION
* **Tickets addressed:** Closes #1619
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Explicitly adds the `HASURA_API_URL` to our docker-composes. The value used is the default value, so there is no behavior change.

This change should mitigate the usability issue brought up in #1619, where it wasn't clear that `GQL_API_URL` and `HASURA_API_URL` were separate envvars that both need to be configured.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
No verification was done, as there is no behavior change, just explicitly setting an envvar to its default value.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
[Improved the wording of this envvar in the Gateway docs.](https://github.com/NASA-AMMOS/aerie-gateway/pull/119)
