### PR TITLE
Run backend e2e tests with given gateway docker tag when provided in PR body, add dev docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
       - dev-[0-9]+.[0-9]+.[0-9]+
+    types:
+      # defaults + 'edited', to handle changes to flags like ___REQUIRES_GATEWAY_PR___ in the PR body
+      [ opened, synchronize, reopened, edited ]
   push:
     branches:
       - develop
@@ -27,6 +30,7 @@ env:
   SCHEDULER_PASSWORD: "${{secrets.SCHEDULER_PASSWORD}}"
   SEQUENCING_USERNAME: "${{secrets.SEQUENCING_USERNAME}}"
   SEQUENCING_PASSWORD: "${{secrets.SEQUENCING_PASSWORD}}"
+  PR_BODY: "${{github.event.pull_request.body}}"
 
 jobs:
   unit-test:
@@ -62,6 +66,12 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+      - name: Extract Aerie gateway docker tag from PR body
+        # look in the PR body for the string ___REQUIRES_GATEWAY_PR___=9999, extract the number if so & save to env var
+        # if gateway PR is labeled correctly, it will publish a docker tag called 'pr-9999' to use in tests
+        if: ${{ contains(env.PR_BODY, '___REQUIRES_GATEWAY_PR___=') }}
+        run: |
+          echo "GATEWAY_IMAGE_TAG=pr-$(echo $PR_BODY | sed -n 's/.*___REQUIRES_GATEWAY_PR___=\"\([0-9]\+\)\".*/\1/p')" >> $GITHUB_ENV
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -81,9 +91,10 @@ jobs:
         run: ./gradlew e2e-tests:buildAllSchedulingProcedureJars
       - name: Start Services
         run: |
-          docker compose -f ./e2e-tests/docker-compose-test.yml up -d --build
+          echo "GATEWAY_IMAGE_TAG: $GATEWAY_IMAGE_TAG"
+          docker compose -f ./e2e-tests/docker-compose-test.yml up -d --build --quiet-pull
           docker images
-          docker ps -a
+          docker ps -a --no-trunc
       - name: Sleep for 30 Seconds
         run: sleep 30s
         shell: bash

--- a/e2e-tests/docker-compose-many-workers.yml
+++ b/e2e-tests/docker-compose-many-workers.yml
@@ -17,7 +17,7 @@ services:
       AERIE_DB_PORT: 5432
       GATEWAY_DB_USER: "${GATEWAY_USERNAME}"
       GATEWAY_DB_PASSWORD: "${GATEWAY_PASSWORD}"
-    image: "ghcr.io/nasa-ammos/aerie-gateway:develop"
+    image: 'ghcr.io/nasa-ammos/aerie-gateway:${GATEWAY_IMAGE_TAG:-develop}'
     ports: ["9000:9000"]
     restart: always
     volumes:

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -19,7 +19,7 @@ services:
       AERIE_DB_PORT: 5432
       GATEWAY_DB_USER: "${GATEWAY_USERNAME}"
       GATEWAY_DB_PASSWORD: "${GATEWAY_PASSWORD}"
-    image: 'ghcr.io/nasa-ammos/aerie-gateway:develop'
+    image: 'ghcr.io/nasa-ammos/aerie-gateway:${GATEWAY_IMAGE_TAG:-develop}'
     ports: ['9000:9000']
     restart: always
     volumes:


### PR DESCRIPTION
```___REQUIRES_GATEWAY_PR___="116"```
### Description
Closes https://github.com/NASA-AMMOS/aerie/issues/1538

For reference see https://github.com/NASA-AMMOS/aerie-ui/pull/1439

This PR contains two things:
* An update to GH workflows to allow `aerie` backend PRs to specify an `aerie-gateway` PR/image to use for e2e tests - since, as noted in [this comment from @Mythicaeda](https://github.com/NASA-AMMOS/aerie/issues/1538#issuecomment-2322105332), the backend e2e tests may rely on changes in Gateway. This is an exact copy of the approach from https://github.com/NASA-AMMOS/aerie-ui/pull/1439 applied to the `aerie` backend e2e tests
* Updates to the CONTRIBUTING.md developer docs to explain how to use this process. Also added some notes on Required Checks in general since they weren't mentioned before.

### Verification

I tested this PR both with and without the `REQUIRES_GATEWAY_PR` tag at the top, and verified that when it is present, the e2e test action correctly pulls and runs the gateway image tagged as `pr-116` (shown in the workflow run logs)