### PR TITLE
Streamline system initialization refactor

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/StreamlineSystem.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/StreamlineSystem.java
@@ -1,0 +1,52 @@
+package gov.nasa.jpl.aerie.contrib.streamline;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
+import gov.nasa.jpl.aerie.contrib.streamline.debugging.Logging;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registration;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock.clock;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.ZERO;
+
+public final class StreamlineSystem {
+    private static Resource<Clock> CLOCK;
+
+    private StreamlineSystem() {}
+
+    /**
+     * Initialize all streamline singletons.
+     * This method should be called once as the first step of creating a model.
+     * <p>
+     *     This will call the following subordinate initialization methods:
+     *     <ul>
+     *         <li>{@link Logging#init}</li>
+     *         <li>{@link Registration#init}</li>
+     *     </ul>
+     *     as well as initialize the singletons contained within this class.
+     * </p>
+     */
+    public static void init(
+            final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar,
+            final Registrar.ErrorBehavior errorBehavior) {
+        CLOCK = resource(clock(ZERO));
+        Logging.init(baseRegistrar);
+        Registration.init(baseRegistrar, errorBehavior);
+    }
+
+    /**
+     * Variation on {@link StreamlineSystem#init} for unit testing.
+     * Fills in most arguments with defaults suitable for testing.
+     */
+    public static void testInit(
+            final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar) {
+        init(baseRegistrar, Registrar.ErrorBehavior.Throw);
+    }
+
+    public static Duration currentTime() {
+        return currentValue(CLOCK);
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/StreamlineSystem.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/StreamlineSystem.java
@@ -5,17 +5,80 @@ import gov.nasa.jpl.aerie.contrib.streamline.debugging.Logging;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registration;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.ClockResources;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.InstantClock;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.InstantClockResources;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
-import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
+import java.time.Instant;
+import java.util.Objects;
+
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
-import static gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock.clock;
-import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.ZERO;
 
 public final class StreamlineSystem {
     private static Resource<Clock> CLOCK;
+    private static Resource<InstantClock> ABSOLUTE_CLOCK;
 
     private StreamlineSystem() {}
+
+    /**
+     * Arguments required for {@link StreamlineSystem#init}, packaged into an object for easier handling.
+     * <p>
+     *     Can be constructed directly, or through {@link InitArgs#builder}.
+     * </p>
+     */
+    public record InitArgs(
+            gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar,
+            Registrar.ErrorBehavior errorBehavior,
+            Instant planStart) {
+        /**
+         * Returns a blank {@link Builder}.
+         */
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        /**
+         * Returns a {@link Builder} with some fields set to defaults generally appropriate for testing.
+         */
+        public static Builder testBuilder() {
+            return builder()
+                    .errorBehavior(Registrar.ErrorBehavior.Throw)
+                    .planStart(Instant.EPOCH);
+        }
+
+        public static class Builder {
+            private gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar;
+            private Registrar.ErrorBehavior errorBehavior;
+            private Instant planStart;
+
+            private Builder() {}
+
+            public Builder baseRegistrar(final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar) {
+                this.baseRegistrar = baseRegistrar;
+                return this;
+            }
+
+            public Builder errorBehavior(final Registrar.ErrorBehavior errorBehavior) {
+                this.errorBehavior = errorBehavior;
+                return this;
+            }
+
+            public Builder planStart(final Instant planStart) {
+                this.planStart = planStart;
+                return this;
+            }
+
+            public InitArgs build() {
+                return new InitArgs(
+                        Objects.requireNonNull(baseRegistrar, "baseRegistrar must be set"),
+                        Objects.requireNonNull(errorBehavior, "errorBehavior must be set"),
+                        Objects.requireNonNull(planStart, "planStart must be set")
+                );
+            }
+        }
+
+    }
 
     /**
      * Initialize all streamline singletons.
@@ -29,24 +92,26 @@ public final class StreamlineSystem {
      *     as well as initialize the singletons contained within this class.
      * </p>
      */
-    public static void init(
-            final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar,
-            final Registrar.ErrorBehavior errorBehavior) {
-        CLOCK = resource(clock(ZERO));
-        Logging.init(baseRegistrar);
-        Registration.init(baseRegistrar, errorBehavior);
-    }
-
-    /**
-     * Variation on {@link StreamlineSystem#init} for unit testing.
-     * Fills in most arguments with defaults suitable for testing.
-     */
-    public static void testInit(
-            final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar) {
-        init(baseRegistrar, Registrar.ErrorBehavior.Throw);
+    public static void init(InitArgs args) {
+        CLOCK = ClockResources.clock();
+        ABSOLUTE_CLOCK = InstantClockResources.absoluteClock(args.planStart);
+        Logging.init(args.baseRegistrar);
+        Registration.init(args.baseRegistrar, args.errorBehavior);
     }
 
     public static Duration currentTime() {
         return currentValue(CLOCK);
+    }
+
+    public static Resource<Clock> simulationClock() {
+        return CLOCK;
+    }
+
+    public static Instant currentInstant() {
+        return currentValue(ABSOLUTE_CLOCK);
+    }
+
+    public static Resource<InstantClock> absoluteClock() {
+        return ABSOLUTE_CLOCK;
     }
 }

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Resources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/core/Resources.java
@@ -1,8 +1,7 @@
 package gov.nasa.jpl.aerie.contrib.streamline.core;
 
-import gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock;
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem;
 import gov.nasa.jpl.aerie.merlin.framework.Condition;
-import gov.nasa.jpl.aerie.merlin.framework.Scoped;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
 
@@ -19,7 +18,6 @@ import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiry.NEVER;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.wheneverDynamicsChange;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Dependencies.addDependency;
 import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.*;
-import static gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock.clock;
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.*;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.ZERO;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete.discrete;
@@ -29,32 +27,6 @@ import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete.d
  */
 public final class Resources {
   private Resources() {}
-
-  /**
-   * Ensure that Resources are initialized.
-   *
-   * <p>
-   *   This method needs to be called during simulation initialization.
-   *   This method is idempotent; calling it multiple times is the same as calling it once.
-   * </p>
-   */
-  public static void init() {
-    currentTime();
-  }
-
-  // TODO if Aerie provides either a `getElapsedTime` method or dynamic allocation of Cells, we can avoid this mutable static variable
-  private static Resource<Clock> CLOCK = resource(clock(ZERO));
-  public static Duration currentTime() {
-    try {
-      return currentValue(CLOCK);
-    } catch (Scoped.EmptyDynamicCellException | IllegalArgumentException e) {
-      // If we're running unit tests, several simulations can happen without reloading the Resources class.
-      // In that case, we'll have discarded the clock resource we were using, and get the above exception.
-      // REVIEW: Is there a cleaner way to make sure this resource gets (re-)initialized?
-      CLOCK = resource(clock(ZERO));
-      return currentValue(CLOCK);
-    }
-  }
 
   public static <D> D currentData(Resource<D> resource) {
     return data(resource.getDynamics());
@@ -96,10 +68,10 @@ public final class Resources {
    */
   public static <D extends Dynamics<?, D>> Condition dynamicsChange(Resource<D> resource) {
     final var startingDynamics = resource.getDynamics();
-    final Duration startTime = currentTime();
+    final Duration startTime = StreamlineSystem.currentTime();
     Condition result = (positive, atEarliest, atLatest) -> {
       var currentDynamics = resource.getDynamics();
-      var elapsedTime = currentTime().minus(startTime);
+      var elapsedTime = StreamlineSystem.currentTime().minus(startTime);
       boolean haveChanged = startingDynamics.match(
           start -> currentDynamics.match(
               current -> !current.data().equals(start.data().step(elapsedTime)) ||

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Logging.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Logging.java
@@ -14,14 +14,10 @@ public final class Logging {
 
     /**
      * Initialize the primary logger.
-     * This is called when constructing a {@link gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar},
-     * and does not need to be called directly by the model.
+     * This is called by {@link gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem#init}
+     * and should not be called by the model directly.
      */
     public static void init(final Registrar registrar) {
-        if (LOGGER == null) {
-            LOGGER = new Logger(registrar);
-        } else {
-            LOGGER.warning("Attempting to re-initialize primary logger. This attempt is being ignored.");
-        }
+        LOGGER = new Logger(registrar);
     }
 }

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Tracing.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/Tracing.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.contrib.streamline.debugging;
 
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem;
 import gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
 import gov.nasa.jpl.aerie.contrib.streamline.core.DynamicsEffect;
@@ -11,8 +12,6 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
 
 import java.util.Stack;
 import java.util.function.Supplier;
-
-import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentTime;
 
 /**
  * Functions for debugging resources by tracing their calculation.
@@ -90,9 +89,9 @@ public final class Tracing {
 
   private static <T> T traceAction(Supplier<String> name, Supplier<T> action) {
     activeTracePoints.push(name.get());
-    System.out.printf("TRACE: %s - %s start...%n", currentTime(), formatStack());
+      System.out.printf("TRACE: %s - %s start...%n", StreamlineSystem.currentTime(), formatStack());
     T result = action.get();
-    System.out.printf("TRACE: %s - %s: %s%n", currentTime(), formatStack(), result);
+      System.out.printf("TRACE: %s - %s: %s%n", StreamlineSystem.currentTime(), formatStack(), result);
     activeTracePoints.pop();
     return result;
   }

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
@@ -55,8 +55,6 @@ public class Registrar {
   }
 
   public Registrar(final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar, final ErrorBehavior errorBehavior) {
-    Resources.init();
-    Logging.init(baseRegistrar);
     this.baseRegistrar = baseRegistrar;
     this.errorBehavior = errorBehavior;
 

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registrar.java
@@ -15,6 +15,8 @@ import gov.nasa.jpl.aerie.merlin.framework.ValueMapper;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Unit;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Reactions.whenever;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentData;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
@@ -54,8 +56,8 @@ public class Registrar {
     Throw
   }
 
-  public Registrar(final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar, final ErrorBehavior errorBehavior) {
-    Resources.init();
+  public Registrar(final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar, final Instant planStart, final ErrorBehavior errorBehavior) {
+    Resources.init(planStart);
     Logging.init(baseRegistrar);
     this.baseRegistrar = baseRegistrar;
     this.errorBehavior = errorBehavior;

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registration.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/Registration.java
@@ -1,0 +1,18 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling;
+
+public final class Registration {
+    private Registration() {}
+
+    public static Registrar REGISTRAR;
+
+    /**
+     * Initialize the primary registrar.
+     * This is called by {@link gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem#init}
+     * and should not be called by the model directly.
+     */
+    public static void init(
+            final gov.nasa.jpl.aerie.merlin.framework.Registrar baseRegistrar,
+            final Registrar.ErrorBehavior errorBehavior) {
+        REGISTRAR = new Registrar(baseRegistrar, errorBehavior);
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
@@ -1,0 +1,24 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.addToInstant;
+
+/**
+ * A variation on {@link Clock} that represents an absolute {@link Instant}
+ * instead of a relative {@link Duration}.
+ */
+public record InstantClock(Instant extract) implements Dynamics<Instant, InstantClock> {
+    @Override
+    public InstantClock step(Duration t) {
+        return new InstantClock(addToInstant(extract, t));
+    }
+
+    static Duration durationBetween(Instant start, Instant end) {
+        return Duration.of(ChronoUnit.MICROS.between(start, end), Duration.MICROSECONDS);
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClock.java
@@ -18,6 +18,8 @@ public record InstantClock(Instant extract) implements Dynamics<Instant, Instant
         return new InstantClock(addToInstant(extract, t));
     }
 
+    // TODO - this method belongs somewhere else...
+    //  Making it package-private at least lets us move it later without dependency issues outside the library.
     static Duration durationBetween(Instant start, Instant end) {
         return Duration.of(ChronoUnit.MICROS.between(start, end), Duration.MICROSECONDS);
     }

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClockResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/InstantClockResources.java
@@ -1,0 +1,56 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.*;
+import gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.time.Instant;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.map;
+import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.name;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.constant;
+
+public class InstantClockResources {
+    /**
+     * Create an absolute clock that starts now at the given start time.
+     */
+    public static MutableResource<InstantClock> absoluteClock(Instant startTime) {
+        return resource(new InstantClock(startTime));
+    }
+
+    public static Resource<InstantClock> addToInstant(Instant zeroTime, Resource<Clock> relativeClock) {
+        return addToInstant(constant(zeroTime), relativeClock);
+    }
+
+    public static Resource<InstantClock> addToInstant(Resource<Discrete<Instant>> zeroTime, Resource<Clock> relativeClock) {
+        return name(
+                map(zeroTime, relativeClock, (zero, clock) ->
+                        new InstantClock(Duration.addToInstant(zero.extract(), clock.extract()))),
+                "%s + %s",
+                zeroTime,
+                relativeClock);
+    }
+
+    public static Resource<Clock> relativeTo(Resource<InstantClock> clock, Resource<Discrete<Instant>> zeroTime) {
+        return name(ResourceMonad.map(clock, zeroTime, (c, t) -> new Clock(InstantClock.durationBetween(t.extract(), c.extract()))),
+                "%s relative to %s", clock, zeroTime);
+    }
+
+    public static Resource<Discrete<Boolean>> lessThan(Resource<InstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return ClockResources.lessThan(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> lessThanOrEquals(Resource<InstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return ClockResources.lessThanOrEquals(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> greaterThan(Resource<InstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return ClockResources.greaterThan(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> greaterThanOrEquals(Resource<InstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return ClockResources.greaterThanOrEquals(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClock.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClock.java
@@ -1,0 +1,19 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Dynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.time.Instant;
+
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.addToInstant;
+
+/**
+ * A variation on {@link VariableClock} that represents an absolute {@link Instant}
+ * instead of a relative {@link Duration}.
+ */
+public record VariableInstantClock(Instant extract, int multiplier) implements Dynamics<Instant, VariableInstantClock> {
+    @Override
+    public VariableInstantClock step(Duration t) {
+        return new VariableInstantClock(addToInstant(extract, t.times(multiplier)), multiplier);
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockEffects.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockEffects.java
@@ -1,0 +1,33 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource;
+
+import java.time.Instant;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.DynamicsMonad.effect;
+import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.name;
+
+public final class VariableInstantClockEffects {
+    private VariableInstantClockEffects() {}
+
+    /**
+     * Stop the clock without affecting the current time.
+     */
+    public static void pause(MutableResource<VariableInstantClock> clock) {
+        clock.emit("Pause", effect($ -> new VariableInstantClock($.extract(), 0)));
+    }
+
+    /**
+     * Start the clock without affecting the current time.
+     */
+    public static void start(MutableResource<VariableInstantClock> clock) {
+        clock.emit("Start", effect($ -> new VariableInstantClock($.extract(), 1)));
+    }
+
+    /**
+     * Reset the clock to the given time, without affecting how fast it's running.
+     */
+    public static void reset(MutableResource<VariableInstantClock> clock, Instant newTime) {
+        clock.emit(name(effect($ -> new VariableInstantClock(newTime, $.multiplier())), "Reset to %s", newTime));
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/VariableInstantClockResources.java
@@ -1,0 +1,42 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+
+import java.time.Instant;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.map;
+import static gov.nasa.jpl.aerie.contrib.streamline.debugging.Naming.name;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.InstantClock.durationBetween;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.constant;
+
+public final class VariableInstantClockResources {
+    private VariableInstantClockResources() {}
+
+    public static Resource<VariableClock> relativeTo(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> zeroTime) {
+        return name(map(clock, zeroTime, (c, t) ->
+                        new VariableClock(durationBetween(c.extract(), t.extract()), c.multiplier())),
+                "%s relative to %s", clock, zeroTime);
+    }
+
+    public static Resource<Discrete<Boolean>> lessThan(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return VariableClockResources.lessThan(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> lessThanOrEquals(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return VariableClockResources.lessThanOrEquals(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> greaterThan(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return VariableClockResources.greaterThan(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<Discrete<Boolean>> greaterThanOrEquals(Resource<VariableInstantClock> clock, Resource<Discrete<Instant>> threshold) {
+        return VariableClockResources.greaterThanOrEquals(relativeTo(clock, threshold), constant(Duration.ZERO));
+    }
+
+    public static Resource<VariableClock> between(Resource<VariableInstantClock> start, Resource<VariableInstantClock> end) {
+        return map(start, end, (s, e) -> new VariableClock(durationBetween(s.extract(), e.extract()), e.multiplier() - s.multiplier()));
+    }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteResources.java
@@ -19,6 +19,8 @@ import java.util.*;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 
+import static gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem.currentInstant;
+import static gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem.simulationClock;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.autoEffects;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.testing;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Expiring.expiring;
@@ -121,10 +123,9 @@ public final class DiscreteResources {
    * Resource value is the value associated with the greatest key in segments not exceeding
    * the current simulation time, or valueBeforeFirstEntry if every key exceeds current simulation time.
    */
-  public static <V> Resource<Discrete<V>> precomputed(
+  public static <V> Resource<Discrete<V>> precomputed$(
       final V valueBeforeFirstEntry, final NavigableMap<Duration, V> segments) {
-    var clock = clock();
-    return signalling(bind(clock, (Clock clock$) -> {
+    return signalling(bind(simulationClock(), (Clock clock$) -> {
       var t = clock$.extract();
       var entry = segments.floorEntry(t);
       var value = entry == null ? valueBeforeFirstEntry : entry.getValue();
@@ -139,14 +140,15 @@ public final class DiscreteResources {
    * the current simulation time, or valueBeforeFirstEntry if every key exceeds current simulation time.
    */
   public static <V> Resource<Discrete<V>> precomputed(
-      final V valueBeforeFirstEntry, final NavigableMap<Instant, V> segments, final Instant simulationStartTime) {
+      final V valueBeforeFirstEntry, final NavigableMap<Instant, V> segments) {
+    var simulationStartTime = currentInstant();
     var segmentsUsingDurationKeys = new TreeMap<Duration, V>();
     for (var entry : segments.entrySet()) {
       segmentsUsingDurationKeys.put(
           Duration.of(ChronoUnit.MICROS.between(simulationStartTime, entry.getKey()), Duration.MICROSECONDS),
           entry.getValue());
     }
-    return precomputed(valueBeforeFirstEntry, segmentsUsingDurationKeys);
+    return precomputed$(valueBeforeFirstEntry, segmentsUsingDurationKeys);
   }
 
   /**

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialEffects.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialEffects.java
@@ -1,6 +1,6 @@
 package gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial;
 
-import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem;
 import gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource;
 import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.StandardUnits;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
@@ -94,9 +94,9 @@ public final class PolynomialEffects {
   private static void withConsumableEffects(String verb, MutableResource<Polynomial> resource, Polynomial profile, Runnable action) {
     resource.emit(name(effect($ -> $.subtract(profile)),
             "Start %s according to profile %s", verb, profile));
-    final Duration start = Resources.currentTime();
+      final Duration start = StreamlineSystem.currentTime();
     action.run();
-    final Duration elapsedTime = Resources.currentTime().minus(start);
+      final Duration elapsedTime = StreamlineSystem.currentTime().minus(start);
     // Nullify ongoing effects by adding a profile with the same behavior,
     // but with an initial value of 0
     final Polynomial steppedProfile = profile.step(elapsedTime);
@@ -158,9 +158,9 @@ public final class PolynomialEffects {
   private static void withNonConsumableEffect(String verb, MutableResource<Polynomial> resource, Polynomial profile, Runnable action) {
     resource.emit(name(effect($ -> $.subtract(profile)),
             "Start %s profile %s", verb, profile));
-    final Duration start = Resources.currentTime();
+      final Duration start = StreamlineSystem.currentTime();
     action.run();
-    final Duration elapsedTime = Resources.currentTime().minus(start);
+      final Duration elapsedTime = StreamlineSystem.currentTime().minus(start);
     // Reset by adding a counteracting profile
     final Polynomial counteractingProfile = profile.step(elapsedTime);
     resource.emit(name(effect($ -> $.add(counteractingProfile)),

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2Test.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2Test.java
@@ -9,10 +9,11 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.autoEffects;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.commutingEffects;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.CellRefV2.noncommutingEffects;
-import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete.discrete;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.monads.DiscreteDynamicsMonad.effect;
@@ -27,10 +28,11 @@ class MutableResourceTest {
   @TestInstance(Lifecycle.PER_CLASS)
   class NonCommutingEffects {
     public NonCommutingEffects(final Registrar registrar) {
-      Resources.init();
+      Resources.init(Instant.EPOCH);
+      cell = MutableResource.resource(discrete(42), noncommutingEffects());
     }
 
-    private final MutableResource<Discrete<Integer>> cell = MutableResource.resource(discrete(42), noncommutingEffects());
+    private final MutableResource<Discrete<Integer>> cell;
 
     @Test
     void gets_initial_value_if_no_effects_are_emitted() {
@@ -66,10 +68,11 @@ class MutableResourceTest {
   @TestInstance(Lifecycle.PER_CLASS)
   class CommutingEffects {
     public CommutingEffects(final Registrar registrar) {
-      Resources.init();
+      Resources.init(Instant.EPOCH);
+      cell = MutableResource.resource(discrete(42), commutingEffects());
     }
 
-    private final MutableResource<Discrete<Integer>> cell = MutableResource.resource(discrete(42), commutingEffects());
+    private final MutableResource<Discrete<Integer>> cell;
 
     @Test
     void gets_initial_value_if_no_effects_are_emitted() {
@@ -108,11 +111,12 @@ class MutableResourceTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class AutoEffects {
-    public AutoEffects(final Registrar registrar) {
-      Resources.init();
+    public AutoEffects() {
+      Resources.init(Instant.EPOCH);
+      cell = MutableResource.resource(discrete(42), autoEffects());
     }
 
-    private final MutableResource<Discrete<Integer>> cell = MutableResource.resource(discrete(42), autoEffects());
+    private final MutableResource<Discrete<Integer>> cell;
 
     @Test
     void gets_initial_value_if_no_effects_are_emitted() {

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2Test.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2Test.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.contrib.streamline.core;
 
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
 import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
@@ -27,7 +28,7 @@ class MutableResourceTest {
   @TestInstance(Lifecycle.PER_CLASS)
   class NonCommutingEffects {
     public NonCommutingEffects(final Registrar registrar) {
-      Resources.init();
+      StreamlineSystem.testInit(registrar);
     }
 
     private final MutableResource<Discrete<Integer>> cell = MutableResource.resource(discrete(42), noncommutingEffects());
@@ -66,7 +67,7 @@ class MutableResourceTest {
   @TestInstance(Lifecycle.PER_CLASS)
   class CommutingEffects {
     public CommutingEffects(final Registrar registrar) {
-      Resources.init();
+      StreamlineSystem.testInit(registrar);
     }
 
     private final MutableResource<Discrete<Integer>> cell = MutableResource.resource(discrete(42), commutingEffects());
@@ -109,7 +110,7 @@ class MutableResourceTest {
   @TestInstance(Lifecycle.PER_CLASS)
   class AutoEffects {
     public AutoEffects(final Registrar registrar) {
-      Resources.init();
+      StreamlineSystem.testInit(registrar);
     }
 
     private final MutableResource<Discrete<Integer>> cell = MutableResource.resource(discrete(42), autoEffects());

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2Test.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/core/CellRefV2Test.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.contrib.streamline.core;
 
 import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem;
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem.InitArgs;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
 import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
@@ -28,7 +29,7 @@ class MutableResourceTest {
   @TestInstance(Lifecycle.PER_CLASS)
   class NonCommutingEffects {
     public NonCommutingEffects(final Registrar registrar) {
-      StreamlineSystem.testInit(registrar);
+      StreamlineSystem.init(InitArgs.testBuilder().baseRegistrar(registrar).build());
 
       cell = MutableResource.resource(discrete(42), noncommutingEffects());
     }
@@ -69,7 +70,7 @@ class MutableResourceTest {
   @TestInstance(Lifecycle.PER_CLASS)
   class CommutingEffects {
     public CommutingEffects(final Registrar registrar) {
-      StreamlineSystem.testInit(registrar);
+      StreamlineSystem.init(InitArgs.testBuilder().baseRegistrar(registrar).build());
 
       cell = MutableResource.resource(discrete(42), commutingEffects());
     }
@@ -114,7 +115,7 @@ class MutableResourceTest {
   @TestInstance(Lifecycle.PER_CLASS)
   class AutoEffects {
     public AutoEffects(final Registrar registrar) {
-      StreamlineSystem.testInit(registrar);
+      StreamlineSystem.init(InitArgs.testBuilder().baseRegistrar(registrar).build());
 
       cell = MutableResource.resource(discrete(42), autoEffects());
     }

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/DependenciesTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/DependenciesTest.java
@@ -1,10 +1,12 @@
 package gov.nasa.jpl.aerie.contrib.streamline.debugging;
 
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial.Polynomial;
+import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,8 +25,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DependenciesTest {
-  public DependenciesTest() {
-    Resources.init(Instant.EPOCH);
+  public DependenciesTest(final Registrar registrar) {
+    StreamlineSystem.init(StreamlineSystem.InitArgs.testBuilder().baseRegistrar(registrar).build());
 
     constantTrue = DiscreteResources.constant(true);
     constant1234 = constant(1234);

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/DependenciesTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/debugging/DependenciesTest.java
@@ -1,7 +1,7 @@
 package gov.nasa.jpl.aerie.contrib.streamline.debugging;
 
-import gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial.Polynomial;
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.monads.ResourceMonad.*;
@@ -21,12 +23,22 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DependenciesTest {
-  Resource<Discrete<Boolean>> constantTrue = DiscreteResources.constant(true);
-  Resource<Polynomial> constant1234 = constant(1234);
-  Resource<Polynomial> constant5678 = constant(5678);
-  Resource<Polynomial> polynomialCell = resource(polynomial(1));
-  Resource<Polynomial> derived = map(constantTrue, constant1234, constant5678,
-                                     (b, x, y) -> b.extract() ? x : y);
+  public DependenciesTest() {
+    Resources.init(Instant.EPOCH);
+
+    constantTrue = DiscreteResources.constant(true);
+    constant1234 = constant(1234);
+    constant5678 = constant(5678);
+    polynomialCell = resource(polynomial(1));
+    derived = map(constantTrue, constant1234, constant5678,
+                                       (b, x, y) -> b.extract() ? x : y);
+  }
+
+  Resource<Discrete<Boolean>> constantTrue;
+  Resource<Polynomial> constant1234;
+  Resource<Polynomial> constant5678;
+  Resource<Polynomial> polynomialCell;
+  Resource<Polynomial> derived;
 
   @Test
   void constants_are_named_by_their_value() {

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/SimulationClockTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/SimulationClockTest.java
@@ -1,0 +1,66 @@
+package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
+
+import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
+import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.*;
+import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.HOUR;
+import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.ZERO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MerlinExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SimulationClockTest {
+    // This time is unlikely to be a hard-coded default anywhere
+    public static final Instant PLAN_START = Instant.parse("2020-01-02T03:04:05Z");
+
+    public SimulationClockTest() {
+        Resources.init(PLAN_START);
+    }
+
+    @Test
+    public void relative_clock_starts_at_zero() {
+        assertEquals(ZERO, currentTime());
+        assertEquals(ZERO, currentValue(simulationClock()));
+    }
+
+    @Test
+    public void absolute_clock_starts_at_plan_start() {
+        assertEquals(PLAN_START, currentInstant());
+        assertEquals(PLAN_START, currentValue(absoluteClock()));
+    }
+
+    @Test
+    public void relative_clock_advances_at_unit_rate() {
+        delay(1, HOUR);
+        assertEquals(Duration.of(1, HOUR), currentTime());
+        assertEquals(Duration.of(1, HOUR), currentValue(simulationClock()));
+        delay(1, HOUR);
+        assertEquals(Duration.of(2, HOUR), currentTime());
+        assertEquals(Duration.of(2, HOUR), currentValue(simulationClock()));
+        delay(1, HOUR);
+        assertEquals(Duration.of(3, HOUR), currentTime());
+        assertEquals(Duration.of(3, HOUR), currentValue(simulationClock()));
+    }
+
+    @Test
+    public void absolute_clock_advances_at_unit_rate() {
+        delay(1, HOUR);
+        assertEquals(PLAN_START.plus(1, ChronoUnit.HOURS), currentInstant());
+        assertEquals(PLAN_START.plus(1, ChronoUnit.HOURS), currentValue(absoluteClock()));
+        delay(1, HOUR);
+        assertEquals(PLAN_START.plus(2, ChronoUnit.HOURS), currentInstant());
+        assertEquals(PLAN_START.plus(2, ChronoUnit.HOURS), currentValue(absoluteClock()));
+        delay(1, HOUR);
+        assertEquals(PLAN_START.plus(3, ChronoUnit.HOURS), currentInstant());
+        assertEquals(PLAN_START.plus(3, ChronoUnit.HOURS), currentValue(absoluteClock()));
+    }
+}

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/SimulationClockTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/clocks/SimulationClockTest.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks;
 
-import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem;
+import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.junit.jupiter.api.Test;
@@ -10,7 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
-import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.*;
+import static gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem.*;
+import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.HOUR;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.ZERO;
@@ -22,8 +24,11 @@ public class SimulationClockTest {
     // This time is unlikely to be a hard-coded default anywhere
     public static final Instant PLAN_START = Instant.parse("2020-01-02T03:04:05Z");
 
-    public SimulationClockTest() {
-        Resources.init(PLAN_START);
+    public SimulationClockTest(final Registrar registrar) {
+        StreamlineSystem.init(InitArgs.testBuilder()
+                .baseRegistrar(registrar)
+                .planStart(PLAN_START)
+                .build());
     }
 
     @Test

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffectsTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffectsTest.java
@@ -5,13 +5,14 @@ import gov.nasa.jpl.aerie.contrib.streamline.core.ErrorCatching;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.clocks.Clock;
 import gov.nasa.jpl.aerie.contrib.streamline.unit_aware.UnitAware;
-import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentTime;
@@ -40,8 +41,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 class DiscreteEffectsTest {
-  public DiscreteEffectsTest(final Registrar registrar) {
-    Resources.init();
+  {
+    // We need to initialize this up front, so we can use in-line initializers for other resources after.
+    // I think in-line initializers for the other resources make the tests easier to read.
+    Resources.init(Instant.EPOCH);
   }
 
   private final MutableResource<Discrete<Integer>> settable = resource(discrete(42));

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffectsTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffectsTest.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete;
 
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem;
 import gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.ErrorCatching;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
@@ -14,7 +15,6 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
-import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentTime;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete.discrete;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteEffects.*;
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestInstance(Lifecycle.PER_CLASS)
 class DiscreteEffectsTest {
   public DiscreteEffectsTest(final Registrar registrar) {
-    Resources.init();
+    StreamlineSystem.testInit(registrar);
   }
 
   private final MutableResource<Discrete<Integer>> settable = resource(discrete(42));
@@ -162,12 +162,12 @@ class DiscreteEffectsTest {
 
   @Test
   void using_runs_synchronously() {
-    Duration start = currentTime();
+      Duration start = StreamlineSystem.currentTime();
     using(nonconsumable, 3.14, () -> {
-      assertEquals(start, currentTime());
+        assertEquals(start, StreamlineSystem.currentTime());
       delay(MINUTE);
     });
-    assertEquals(start.plus(MINUTE), currentTime());
+      assertEquals(start.plus(MINUTE), StreamlineSystem.currentTime());
   }
 
   @Test

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffectsTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/DiscreteEffectsTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestInstance(Lifecycle.PER_CLASS)
 class DiscreteEffectsTest {
   public DiscreteEffectsTest(final Registrar registrar) {
-    StreamlineSystem.testInit(registrar);
+    StreamlineSystem.init(StreamlineSystem.InitArgs.testBuilder().baseRegistrar(registrar).build());
   }
 
   private final MutableResource<Discrete<Integer>> settable = resource(discrete(42));

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/PrecomputedTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/PrecomputedTest.java
@@ -2,7 +2,6 @@ package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete;
 
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
-import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.junit.jupiter.api.Test;
@@ -26,8 +25,10 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class PrecomputedTest {
-    public PrecomputedTest(final Registrar registrar) {
-        Resources.init();
+    {
+        // We need to initialize this up front, so we can use in-line initializers for other resources after.
+        // I think in-line initializers for the other resources make the tests easier to read.
+        Resources.init(Instant.EPOCH);
     }
 
     final Resource<Discrete<Integer>> precomputedAsAConstant =

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/PrecomputedTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/PrecomputedTest.java
@@ -17,6 +17,7 @@ import java.util.TreeMap;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentValue;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.precomputed;
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.DiscreteResources.precomputed$;
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -28,19 +29,22 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestInstance(Lifecycle.PER_CLASS)
 public class PrecomputedTest {
     public PrecomputedTest(final Registrar registrar) {
-        StreamlineSystem.testInit(registrar);
-        precomputedAsAConstant = precomputed(4, new TreeMap<>());
-        precomputedWithOneTransitionInFuture = precomputed(0, new TreeMap<>(Map.of(MINUTE, 10)));
-        precomputedWithOneTransitionInPast = precomputed(0, new TreeMap<>(Map.of(duration(-1, MINUTE), 10)));
-        precomputedWithMultipleTransitionsInFuture = precomputed(0, new TreeMap<>(Map.of(
+        StreamlineSystem.init(StreamlineSystem.InitArgs.testBuilder()
+                .baseRegistrar(registrar)
+                .planStart(Instant.parse("2023-10-18T00:00:00Z"))
+                .build());
+        precomputedAsAConstant = precomputed$(4, new TreeMap<>());
+        precomputedWithOneTransitionInFuture = precomputed$(0, new TreeMap<>(Map.of(MINUTE, 10)));
+        precomputedWithOneTransitionInPast = precomputed$(0, new TreeMap<>(Map.of(duration(-1, MINUTE), 10)));
+        precomputedWithMultipleTransitionsInFuture = precomputed$(0, new TreeMap<>(Map.of(
                 duration(2, MINUTE), 5,
                 duration(5, MINUTE), 10,
                 duration(6, MINUTE), 15)));
-        precomputedWithMultipleTransitionsInPast = precomputed(0, new TreeMap<>(Map.of(
+        precomputedWithMultipleTransitionsInPast = precomputed$(0, new TreeMap<>(Map.of(
                 duration(-2, MINUTE), 5,
                 duration(-5, MINUTE), 10,
                 duration(-6, MINUTE), 15)));
-        precomputedWithTransitionsInPastAndFuture = precomputed(0, new TreeMap<>(Map.of(
+        precomputedWithTransitionsInPastAndFuture = precomputed$(0, new TreeMap<>(Map.of(
                 duration(-5, MINUTE), 25,
                 duration(-2, MINUTE), 5,
                 duration(5, MINUTE), 10,
@@ -49,8 +53,7 @@ public class PrecomputedTest {
                 Instant.parse("2023-10-17T23:55:00Z"), 25,
                 Instant.parse("2023-10-17T23:58:00Z"), 5,
                 Instant.parse("2023-10-18T00:05:00Z"), 10,
-                Instant.parse("2023-10-18T00:06:00Z"), 15)),
-                Instant.parse("2023-10-18T00:00:00Z"));
+                Instant.parse("2023-10-18T00:06:00Z"), 15)));
     }
 
     final Resource<Discrete<Integer>> precomputedAsAConstant;

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/PrecomputedTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/discrete/PrecomputedTest.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete;
 
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.merlin.framework.Registrar;
@@ -27,11 +28,32 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestInstance(Lifecycle.PER_CLASS)
 public class PrecomputedTest {
     public PrecomputedTest(final Registrar registrar) {
-        Resources.init();
+        StreamlineSystem.testInit(registrar);
+        precomputedAsAConstant = precomputed(4, new TreeMap<>());
+        precomputedWithOneTransitionInFuture = precomputed(0, new TreeMap<>(Map.of(MINUTE, 10)));
+        precomputedWithOneTransitionInPast = precomputed(0, new TreeMap<>(Map.of(duration(-1, MINUTE), 10)));
+        precomputedWithMultipleTransitionsInFuture = precomputed(0, new TreeMap<>(Map.of(
+                duration(2, MINUTE), 5,
+                duration(5, MINUTE), 10,
+                duration(6, MINUTE), 15)));
+        precomputedWithMultipleTransitionsInPast = precomputed(0, new TreeMap<>(Map.of(
+                duration(-2, MINUTE), 5,
+                duration(-5, MINUTE), 10,
+                duration(-6, MINUTE), 15)));
+        precomputedWithTransitionsInPastAndFuture = precomputed(0, new TreeMap<>(Map.of(
+                duration(-5, MINUTE), 25,
+                duration(-2, MINUTE), 5,
+                duration(5, MINUTE), 10,
+                duration(6, MINUTE), 15)));
+        precomputedWithInstantKeys = precomputed(0, new TreeMap<>(Map.of(
+                Instant.parse("2023-10-17T23:55:00Z"), 25,
+                Instant.parse("2023-10-17T23:58:00Z"), 5,
+                Instant.parse("2023-10-18T00:05:00Z"), 10,
+                Instant.parse("2023-10-18T00:06:00Z"), 15)),
+                Instant.parse("2023-10-18T00:00:00Z"));
     }
 
-    final Resource<Discrete<Integer>> precomputedAsAConstant =
-            precomputed(4, new TreeMap<>());
+    final Resource<Discrete<Integer>> precomputedAsAConstant;
     @Test
     void precomputed_with_no_transitions_uses_default_value_forever() {
         assertEquals(4, currentValue(precomputedAsAConstant));
@@ -41,8 +63,7 @@ public class PrecomputedTest {
         assertEquals(4, currentValue(precomputedAsAConstant));
     }
 
-    final Resource<Discrete<Integer>> precomputedWithOneTransitionInFuture =
-            precomputed(0, new TreeMap<>(Map.of(MINUTE, 10)));
+    final Resource<Discrete<Integer>> precomputedWithOneTransitionInFuture;
     @Test
     void precomputed_with_transition_in_future_changes_at_that_time() {
         assertEquals(0, currentValue(precomputedWithOneTransitionInFuture));
@@ -53,8 +74,7 @@ public class PrecomputedTest {
         assertEquals(10, currentValue(precomputedWithOneTransitionInFuture));
     }
 
-    final Resource<Discrete<Integer>> precomputedWithOneTransitionInPast =
-            precomputed(0, new TreeMap<>(Map.of(duration(-1, MINUTE), 10)));
+    final Resource<Discrete<Integer>> precomputedWithOneTransitionInPast;
     @Test
     void precomputed_with_transition_in_past_uses_that_value_forever() {
         assertEquals(10, currentValue(precomputedWithOneTransitionInPast));
@@ -64,11 +84,7 @@ public class PrecomputedTest {
         assertEquals(10, currentValue(precomputedWithOneTransitionInPast));
     }
 
-    final Resource<Discrete<Integer>> precomputedWithMultipleTransitionsInFuture =
-            precomputed(0, new TreeMap<>(Map.of(
-                    duration(2, MINUTE), 5,
-                    duration(5, MINUTE), 10,
-                    duration(6, MINUTE), 15)));
+    final Resource<Discrete<Integer>> precomputedWithMultipleTransitionsInFuture;
     @Test
     void precomputed_with_multiple_transitions_in_future_goes_through_each_in_turn() {
         assertEquals(0, currentValue(precomputedWithMultipleTransitionsInFuture));
@@ -81,11 +97,7 @@ public class PrecomputedTest {
         assertEquals(15, currentValue(precomputedWithMultipleTransitionsInFuture));
     }
 
-    final Resource<Discrete<Integer>> precomputedWithMultipleTransitionsInPast =
-            precomputed(0, new TreeMap<>(Map.of(
-                    duration(-2, MINUTE), 5,
-                    duration(-5, MINUTE), 10,
-                    duration(-6, MINUTE), 15)));
+    final Resource<Discrete<Integer>> precomputedWithMultipleTransitionsInPast;
     @Test
     void precomputed_with_multiple_transition_in_past_uses_last_value_forever() {
         assertEquals(5, currentValue(precomputedWithMultipleTransitionsInPast));
@@ -95,12 +107,7 @@ public class PrecomputedTest {
         assertEquals(5, currentValue(precomputedWithMultipleTransitionsInPast));
     }
 
-    final Resource<Discrete<Integer>> precomputedWithTransitionsInPastAndFuture =
-            precomputed(0, new TreeMap<>(Map.of(
-                    duration(-5, MINUTE), 25,
-                    duration(-2, MINUTE), 5,
-                    duration(5, MINUTE), 10,
-                    duration(6, MINUTE), 15)));
+    final Resource<Discrete<Integer>> precomputedWithTransitionsInPastAndFuture;
     @Test
     void precomputed_with_transitions_in_past_and_future_chooses_starting_value_and_changes_later() {
         assertEquals(5, currentValue(precomputedWithTransitionsInPastAndFuture));
@@ -112,13 +119,7 @@ public class PrecomputedTest {
         assertEquals(15, currentValue(precomputedWithTransitionsInPastAndFuture));
     }
 
-    final Resource<Discrete<Integer>> precomputedWithInstantKeys =
-            precomputed(0, new TreeMap<>(Map.of(
-                    Instant.parse("2023-10-17T23:55:00Z"), 25,
-                    Instant.parse("2023-10-17T23:58:00Z"), 5,
-                    Instant.parse("2023-10-18T00:05:00Z"), 10,
-                    Instant.parse("2023-10-18T00:06:00Z"), 15)),
-                    Instant.parse("2023-10-18T00:00:00Z"));
+    final Resource<Discrete<Integer>> precomputedWithInstantKeys;
     @Test
     void precomputed_with_instant_keys_behaves_identically_to_equivalent_duration_offsets() {
         assertEquals(5, currentValue(precomputedWithInstantKeys));

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/ComparisonsTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/ComparisonsTest.java
@@ -5,13 +5,14 @@ import gov.nasa.jpl.aerie.contrib.streamline.core.Expiry;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.discrete.Discrete;
-import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
 
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.resource;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.set;
@@ -28,22 +29,26 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class ComparisonsTest {
-  public ComparisonsTest(final Registrar registrar) {
-    Resources.init();
+  public ComparisonsTest() {
+    Resources.init(Instant.EPOCH);
+
+    p = resource(polynomial(0));
+    q = resource(polynomial(0));
+
+    p_lt_q = lessThan(p, q);
+    p_lte_q = lessThanOrEquals(p, q);
+    p_gt_q = greaterThan(p, q);
+    p_gte_q = greaterThanOrEquals(p, q);
+
+    min_p_q = min(p, q);
+    min_q_p = min(q, p);
+    max_p_q = max(p, q);
+    max_q_p = max(q, p);
   }
 
-  private final MutableResource<Polynomial> p = resource(polynomial(0));
-  private final MutableResource<Polynomial> q = resource(polynomial(0));
-
-  private final Resource<Discrete<Boolean>> p_lt_q = lessThan(p, q);
-  private final Resource<Discrete<Boolean>> p_lte_q = lessThanOrEquals(p, q);
-  private final Resource<Discrete<Boolean>> p_gt_q = greaterThan(p, q);
-  private final Resource<Discrete<Boolean>> p_gte_q = greaterThanOrEquals(p, q);
-
-  private final Resource<Polynomial> min_p_q = min(p, q);
-  private final Resource<Polynomial> min_q_p = min(q, p);
-  private final Resource<Polynomial> max_p_q = max(p, q);
-  private final Resource<Polynomial> max_q_p = max(q, p);
+  private final MutableResource<Polynomial> p, q;
+  private final Resource<Discrete<Boolean>> p_lt_q, p_lte_q, p_gt_q, p_gte_q;
+  private final Resource<Polynomial> min_p_q, min_q_p, max_p_q, max_q_p;
 
   @Test
   void comparing_distinct_constants() {

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/ComparisonsTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/ComparisonsTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestInstance(Lifecycle.PER_CLASS)
 public class ComparisonsTest {
   public ComparisonsTest(final Registrar registrar) {
-    StreamlineSystem.testInit(registrar);
+    StreamlineSystem.init(StreamlineSystem.InitArgs.testBuilder().baseRegistrar(registrar).build());
 
     p = resource(polynomial(0));
     q = resource(polynomial(0));

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/ComparisonsTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/ComparisonsTest.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial;
 
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem;
 import gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Expiry;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
@@ -29,21 +30,23 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestInstance(Lifecycle.PER_CLASS)
 public class ComparisonsTest {
   public ComparisonsTest(final Registrar registrar) {
-    Resources.init();
+    StreamlineSystem.testInit(registrar);
+
+    p = resource(polynomial(0));
+    q = resource(polynomial(0));
+    p_lt_q = lessThan(p, q);
+    p_lte_q = lessThanOrEquals(p, q);
+    p_gt_q = greaterThan(p, q);
+    p_gte_q = greaterThanOrEquals(p, q);
+    min_p_q = min(p, q);
+    min_q_p = min(q, p);
+    max_p_q = max(p, q);
+    max_q_p = max(q, p);
   }
 
-  private final MutableResource<Polynomial> p = resource(polynomial(0));
-  private final MutableResource<Polynomial> q = resource(polynomial(0));
-
-  private final Resource<Discrete<Boolean>> p_lt_q = lessThan(p, q);
-  private final Resource<Discrete<Boolean>> p_lte_q = lessThanOrEquals(p, q);
-  private final Resource<Discrete<Boolean>> p_gt_q = greaterThan(p, q);
-  private final Resource<Discrete<Boolean>> p_gte_q = greaterThanOrEquals(p, q);
-
-  private final Resource<Polynomial> min_p_q = min(p, q);
-  private final Resource<Polynomial> min_q_p = min(q, p);
-  private final Resource<Polynomial> max_p_q = max(p, q);
-  private final Resource<Polynomial> max_q_p = max(q, p);
+  private final MutableResource<Polynomial> p, q;
+  private final Resource<Discrete<Boolean>> p_lt_q, p_lte_q, p_gt_q, p_gte_q;
+  private final Resource<Polynomial> min_p_q, min_q_p, max_p_q, max_q_p;
 
   @Test
   void comparing_distinct_constants() {

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/LinearBoundaryConsistencySolverTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/LinearBoundaryConsistencySolverTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.contrib.streamline.core.MutableResource.*;
 import static gov.nasa.jpl.aerie.contrib.streamline.core.Resources.currentData;
 import static gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial.LinearBoundaryConsistencySolver.Comparison.*;
@@ -25,11 +27,13 @@ class LinearBoundaryConsistencySolverTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class SingleVariableSingleConstraint {
-    MutableResource<Polynomial> driver = resource(polynomial(10));
+    MutableResource<Polynomial> driver;
     Resource<Polynomial> result;
 
-    public SingleVariableSingleConstraint() {
-      Resources.init();
+    SingleVariableSingleConstraint() {
+      Resources.init(Instant.EPOCH);
+
+      driver = resource(polynomial(10));
 
       var solver = new LinearBoundaryConsistencySolver("SingleVariableSingleConstraint");
       var v = solver.variable("v", Domain::upperBound);
@@ -65,13 +69,15 @@ class LinearBoundaryConsistencySolverTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class SingleVariableMultipleConstraint {
-    MutableResource<Polynomial> lowerBound1 = resource(polynomial(10));
-    MutableResource<Polynomial> lowerBound2 = resource(polynomial(20));
-    MutableResource<Polynomial> upperBound = resource(polynomial(30));
+    MutableResource<Polynomial> lowerBound1, lowerBound2, upperBound;
     Resource<Polynomial> result;
 
-    public SingleVariableMultipleConstraint() {
-      Resources.init();
+    SingleVariableMultipleConstraint() {
+      Resources.init(Instant.EPOCH);
+
+      lowerBound1 = resource(polynomial(10));
+      lowerBound2 = resource(polynomial(20));
+      upperBound = resource(polynomial(30));
 
       var solver = new LinearBoundaryConsistencySolver("SingleVariableMultipleConstraint");
       var v = solver.variable("v", Domain::lowerBound);
@@ -141,11 +147,13 @@ class LinearBoundaryConsistencySolverTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class ScalingConstraint {
-    MutableResource<Polynomial> driver = resource(polynomial(10));
+    MutableResource<Polynomial> driver;
     Resource<Polynomial> result;
 
-    public ScalingConstraint() {
-      Resources.init();
+    ScalingConstraint() {
+      Resources.init(Instant.EPOCH);
+
+      driver = resource(polynomial(10));
 
       var solver = new LinearBoundaryConsistencySolver("ScalingConstraint");
       var v = solver.variable("v", Domain::upperBound);
@@ -171,12 +179,14 @@ class LinearBoundaryConsistencySolverTest {
   @ExtendWith(MerlinExtension.class)
   @TestInstance(Lifecycle.PER_CLASS)
   class MultipleVariables {
-    MutableResource<Polynomial> upperBound = resource(polynomial(10));
-    MutableResource<Polynomial> upperBoundOnC = resource(polynomial(5));
+    MutableResource<Polynomial> upperBound, upperBoundOnC;
     Resource<Polynomial> a, b, c;
 
-    public MultipleVariables() {
-      Resources.init();
+    MultipleVariables() {
+      Resources.init(Instant.EPOCH);
+
+      upperBound = resource(polynomial(10));
+      upperBoundOnC = resource(polynomial(5));
 
       var solver = new LinearBoundaryConsistencySolver("MultipleVariablesSingleConstraint");
       var a = solver.variable("a", Domain::upperBound);

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/LinearBoundaryConsistencySolverTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/LinearBoundaryConsistencySolverTest.java
@@ -1,7 +1,9 @@
 package gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial;
 
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem;
 import gov.nasa.jpl.aerie.contrib.streamline.core.*;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial.LinearBoundaryConsistencySolver.Domain;
+import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import org.junit.jupiter.api.Nested;
@@ -28,8 +30,8 @@ class LinearBoundaryConsistencySolverTest {
     MutableResource<Polynomial> driver = resource(polynomial(10));
     Resource<Polynomial> result;
 
-    public SingleVariableSingleConstraint() {
-      Resources.init();
+    public SingleVariableSingleConstraint(final Registrar registrar) {
+      StreamlineSystem.testInit(registrar);
 
       var solver = new LinearBoundaryConsistencySolver("SingleVariableSingleConstraint");
       var v = solver.variable("v", Domain::upperBound);
@@ -70,8 +72,8 @@ class LinearBoundaryConsistencySolverTest {
     MutableResource<Polynomial> upperBound = resource(polynomial(30));
     Resource<Polynomial> result;
 
-    public SingleVariableMultipleConstraint() {
-      Resources.init();
+    public SingleVariableMultipleConstraint(final Registrar registrar) {
+      StreamlineSystem.testInit(registrar);
 
       var solver = new LinearBoundaryConsistencySolver("SingleVariableMultipleConstraint");
       var v = solver.variable("v", Domain::lowerBound);
@@ -144,8 +146,8 @@ class LinearBoundaryConsistencySolverTest {
     MutableResource<Polynomial> driver = resource(polynomial(10));
     Resource<Polynomial> result;
 
-    public ScalingConstraint() {
-      Resources.init();
+    public ScalingConstraint(final Registrar registrar) {
+      StreamlineSystem.testInit(registrar);
 
       var solver = new LinearBoundaryConsistencySolver("ScalingConstraint");
       var v = solver.variable("v", Domain::upperBound);
@@ -175,8 +177,8 @@ class LinearBoundaryConsistencySolverTest {
     MutableResource<Polynomial> upperBoundOnC = resource(polynomial(5));
     Resource<Polynomial> a, b, c;
 
-    public MultipleVariables() {
-      Resources.init();
+    public MultipleVariables(final Registrar registrar) {
+      StreamlineSystem.testInit(registrar);
 
       var solver = new LinearBoundaryConsistencySolver("MultipleVariablesSingleConstraint");
       var a = solver.variable("a", Domain::upperBound);

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/LinearBoundaryConsistencySolverTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/LinearBoundaryConsistencySolverTest.java
@@ -31,7 +31,7 @@ class LinearBoundaryConsistencySolverTest {
     Resource<Polynomial> result;
 
     public SingleVariableSingleConstraint(final Registrar registrar) {
-      StreamlineSystem.testInit(registrar);
+      StreamlineSystem.init(StreamlineSystem.InitArgs.testBuilder().baseRegistrar(registrar).build());
 
       driver = resource(polynomial(10));
 
@@ -73,7 +73,7 @@ class LinearBoundaryConsistencySolverTest {
     Resource<Polynomial> result;
 
     public SingleVariableMultipleConstraint(final Registrar registrar) {
-      StreamlineSystem.testInit(registrar);
+      StreamlineSystem.init(StreamlineSystem.InitArgs.testBuilder().baseRegistrar(registrar).build());
 
       lowerBound1 = resource(polynomial(10));
       lowerBound2 = resource(polynomial(20));
@@ -151,7 +151,7 @@ class LinearBoundaryConsistencySolverTest {
     Resource<Polynomial> result;
 
     public ScalingConstraint(final Registrar registrar) {
-      StreamlineSystem.testInit(registrar);
+      StreamlineSystem.init(StreamlineSystem.InitArgs.testBuilder().baseRegistrar(registrar).build());
 
       driver = resource(polynomial(10));
 
@@ -183,7 +183,7 @@ class LinearBoundaryConsistencySolverTest {
     Resource<Polynomial> a, b, c;
 
     public MultipleVariables(final Registrar registrar) {
-      StreamlineSystem.testInit(registrar);
+      StreamlineSystem.init(StreamlineSystem.InitArgs.testBuilder().baseRegistrar(registrar).build());
 
       upperBound = resource(polynomial(10));
       upperBoundOnC = resource(polynomial(5));

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PrecomputedTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PrecomputedTest.java
@@ -2,13 +2,13 @@ package gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial;
 
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
-import gov.nasa.jpl.aerie.merlin.framework.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.junit.MerlinExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -24,8 +24,10 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MerlinExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class PrecomputedTest {
-    public PrecomputedTest(final Registrar registrar) {
-        Resources.init();
+    {
+        // We need to initialize this up front, so we can use in-line initializers for other resources after.
+        // I think in-line initializers for the other resources make the tests easier to read.
+        Resources.init(Instant.EPOCH);
     }
 
     final Resource<Polynomial> precomputedAsConstantInPast =

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PrecomputedTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PrecomputedTest.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.contrib.streamline.modeling.polynomial;
 
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resources;
 import gov.nasa.jpl.aerie.merlin.framework.Registrar;
@@ -25,11 +26,27 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestInstance(Lifecycle.PER_CLASS)
 public class PrecomputedTest {
     public PrecomputedTest(final Registrar registrar) {
-        Resources.init();
+        StreamlineSystem.testInit(registrar);
+
+        precomputedAsConstantInPast = precomputed(new TreeMap<>(Map.of(duration(-1, MINUTE), 4.0)));
+        precomputedAsConstantInFuture = precomputed(new TreeMap<>(Map.of(duration(2, HOUR), 4.0)));
+        precomputedWithSingleInteriorSegmentInPast = precomputed(new TreeMap<>(Map.of(
+                duration(-100, SECOND), 0.0,
+                duration(-50, SECOND), 5.0)));
+        precomputedWithSingleInteriorSegmentInFuture = precomputed(new TreeMap<>(Map.of(
+                duration(50, SECOND), 0.0,
+                duration(100, SECOND), 5.0)));
+        precomputedStartingInInterior = precomputed(new TreeMap<>(Map.of(
+                duration(-50, SECOND), 0.0,
+                duration(50, SECOND), 10.0)));
+        precomputedWithMultipleSegments = precomputed(new TreeMap<>(Map.of(
+                duration(-50, SECOND), 0.0,
+                duration(50, SECOND), 10.0,
+                duration(60, SECOND), 30.0,
+                duration(90, SECOND), -30.0)));
     }
 
-    final Resource<Polynomial> precomputedAsConstantInPast =
-            precomputed(new TreeMap<>(Map.of(duration(-1, MINUTE), 4.0)));
+    final Resource<Polynomial> precomputedAsConstantInPast;
     @Test
     void precomputed_with_single_point_in_past_extrapolates_that_value_forever() {
         assertValueEquals(4.0, precomputedAsConstantInPast);
@@ -39,8 +56,7 @@ public class PrecomputedTest {
         assertValueEquals(4.0, precomputedAsConstantInPast);
     }
 
-    final Resource<Polynomial> precomputedAsConstantInFuture =
-            precomputed(new TreeMap<>(Map.of(duration(2, HOUR), 4.0)));
+    final Resource<Polynomial> precomputedAsConstantInFuture;
     @Test
     void precomputed_with_single_point_in_future_extrapolates_that_value_forever() {
         assertValueEquals(4.0, precomputedAsConstantInFuture);
@@ -54,10 +70,7 @@ public class PrecomputedTest {
         assertValueEquals(4.0, precomputedAsConstantInFuture);
     }
 
-    final Resource<Polynomial> precomputedWithSingleInteriorSegmentInPast =
-            precomputed(new TreeMap<>(Map.of(
-                    duration(-100, SECOND), 0.0,
-                    duration(-50, SECOND), 5.0)));
+    final Resource<Polynomial> precomputedWithSingleInteriorSegmentInPast;
     @Test
     void precomputed_with_single_interior_segment_in_past_extrapolates_final_value() {
         assertValueEquals(5.0, precomputedWithSingleInteriorSegmentInPast);
@@ -67,10 +80,7 @@ public class PrecomputedTest {
         assertValueEquals(5.0, precomputedWithSingleInteriorSegmentInPast);
     }
 
-    final Resource<Polynomial> precomputedWithSingleInteriorSegmentInFuture =
-            precomputed(new TreeMap<>(Map.of(
-                    duration(50, SECOND), 0.0,
-                    duration(100, SECOND), 5.0)));
+    final Resource<Polynomial> precomputedWithSingleInteriorSegmentInFuture;
     @Test
     void precomputed_with_single_interior_segment_in_future_interpolates_that_segment() {
         assertValueEquals(0.0, precomputedWithSingleInteriorSegmentInFuture);
@@ -90,10 +100,7 @@ public class PrecomputedTest {
         assertValueEquals(5.0, precomputedWithSingleInteriorSegmentInFuture);
     }
 
-    final Resource<Polynomial> precomputedStartingInInterior =
-            precomputed(new TreeMap<>(Map.of(
-                    duration(-50, SECOND), 0.0,
-                    duration(50, SECOND), 10.0)));
+    final Resource<Polynomial> precomputedStartingInInterior;
     void precomputed_starting_in_interior_interpolates_over_full_segment() {
         assertValueEquals(5.0, precomputedStartingInInterior);
         delay(10, SECOND);
@@ -110,12 +117,7 @@ public class PrecomputedTest {
         assertValueEquals(10.0, precomputedStartingInInterior);
     }
 
-    final Resource<Polynomial> precomputedWithMultipleSegments =
-            precomputed(new TreeMap<>(Map.of(
-                    duration(-50, SECOND), 0.0,
-                    duration(50, SECOND), 10.0,
-                    duration(60, SECOND), 30.0,
-                    duration(90, SECOND), -30.0)));
+    final Resource<Polynomial> precomputedWithMultipleSegments;
     @Test
     void precomputed_with_multiple_segments_interpolates_each_segment_independently() {
         assertValueEquals(5.0, precomputedWithMultipleSegments);

--- a/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PrecomputedTest.java
+++ b/contrib/src/test/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PrecomputedTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestInstance(Lifecycle.PER_CLASS)
 public class PrecomputedTest {
     public PrecomputedTest(final Registrar registrar) {
-        StreamlineSystem.testInit(registrar);
+        StreamlineSystem.init(StreamlineSystem.InitArgs.testBuilder().baseRegistrar(registrar).build());
 
         precomputedAsConstantInPast = precomputed(new TreeMap<>(Map.of(duration(-1, MINUTE), 4.0)));
         precomputedAsConstantInFuture = precomputed(new TreeMap<>(Map.of(duration(2, HOUR), 4.0)));

--- a/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
+++ b/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
@@ -1,11 +1,16 @@
 package gov.nasa.jpl.aerie.streamline_demo;
 
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem;
+import gov.nasa.jpl.aerie.contrib.streamline.StreamlineSystem.InitArgs;
 import gov.nasa.jpl.aerie.contrib.streamline.core.Resource;
 import gov.nasa.jpl.aerie.contrib.streamline.debugging.Profiling;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar;
+import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registration;
 import gov.nasa.jpl.aerie.merlin.framework.ModelActions;
 
 import java.time.Instant;
+
+import static gov.nasa.jpl.aerie.contrib.streamline.modeling.Registration.REGISTRAR;
 
 public final class Mission {
   public final DataModel dataModel;
@@ -13,12 +18,16 @@ public final class Mission {
   public final ApproximationModel approximationModel;
 
   public Mission(final gov.nasa.jpl.aerie.merlin.framework.Registrar registrar$, Instant planStart, final Configuration config) {
-    var registrar = new Registrar(registrar$, planStart, Registrar.ErrorBehavior.Log);
-    if (config.traceResources) registrar.setTrace();
+    StreamlineSystem.init(InitArgs.builder()
+            .baseRegistrar(registrar$)
+            .planStart(planStart)
+            .errorBehavior(Registrar.ErrorBehavior.Log)
+            .build());
+      if (config.traceResources) REGISTRAR.setTrace();
     if (config.profileResources) Resource.profileAllResources();
-    dataModel = new DataModel(registrar, config);
-    errorTestingModel = new ErrorTestingModel(registrar, config);
-    approximationModel = new ApproximationModel(registrar, config);
+    dataModel = new DataModel(REGISTRAR, config);
+    errorTestingModel = new ErrorTestingModel(REGISTRAR, config);
+    approximationModel = new ApproximationModel(REGISTRAR, config);
     if (config.profilingDumpTime.isPositive()) {
       ModelActions.defer(config.profilingDumpTime, Profiling::dump);
     }

--- a/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
+++ b/examples/streamline-demo/src/main/java/gov/nasa/jpl/aerie/streamline_demo/Mission.java
@@ -5,13 +5,15 @@ import gov.nasa.jpl.aerie.contrib.streamline.debugging.Profiling;
 import gov.nasa.jpl.aerie.contrib.streamline.modeling.Registrar;
 import gov.nasa.jpl.aerie.merlin.framework.ModelActions;
 
+import java.time.Instant;
+
 public final class Mission {
   public final DataModel dataModel;
   public final ErrorTestingModel errorTestingModel;
   public final ApproximationModel approximationModel;
 
-  public Mission(final gov.nasa.jpl.aerie.merlin.framework.Registrar registrar$, final Configuration config) {
-    var registrar = new Registrar(registrar$, Registrar.ErrorBehavior.Log);
+  public Mission(final gov.nasa.jpl.aerie.merlin.framework.Registrar registrar$, Instant planStart, final Configuration config) {
+    var registrar = new Registrar(registrar$, planStart, Registrar.ErrorBehavior.Log);
     if (config.traceResources) registrar.setTrace();
     if (config.profileResources) Resource.profileAllResources();
     dataModel = new DataModel(registrar, config);


### PR DESCRIPTION
DRAFT pending #1589 , on which this PR builds.

* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Refactors the initialization of streamline to an explicit call to StreamlineSystem.init. This new method is responsible for building all the singletons used by streamline, rather than putting that responsibility on the Registrar. This promotes a better separation of concerns, especially as we add more singleton-type functionality to initialize.

This also standardizes re-initialization behavior. Re-initializing an already-initialized system will simply rebuild all the singletons. While this would be wasteful if abused in production, it supports testing scenarios where multiple models may be built and re-built as tests are run.

Finally, after merging in #1589, this adds a globally-visible absolute clock, and relatedly the `StreamlineSystem.currentInstant()` method to get the current time as an Instant.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Existing unit tests were updated to call StreamlineSystem.init, and they continue to function properly.
The streamline-demo model was also updated to call this method, and was tested manually in a local aerie deployment. It continues to function correctly as well.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

IMPORTANT: This is a breaking change!
All projects that use streamline should change
```java
var registrar = new Registrar(aerieRegistrar, errorBehavior);
```
into
```java
StreamlineSystem.init(InitArgs.builder()
    .baseRegistrar(aerieRegistrar)
    .errorBehavior(errorBehavior)
    .planStart(planStart)
    .build());
var registrar = Registration.REGISTRAR;
```
when constructing their model. This will properly initialize the full streamline system.

Additionally, `currentTime()` has moved from `Resources` to `StreamlineSystem`.

Finally, while not a breaking change, this does expose `StreamlineSystem.currentInstant()`, which returns the current absolute time as an Instant. This is something I expect many might find useful.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A
