### PR TITLE
Fix "before delete" trigger on Scheduling Specification Conditions

### DIFF
--- a/deployment/hasura/migrations/Aerie/13_before_delete_trigger_fix/down.sql
+++ b/deployment/hasura/migrations/Aerie/13_before_delete_trigger_fix/down.sql
@@ -1,0 +1,12 @@
+create or replace function scheduler.increment_spec_revision_on_conditions_spec_delete()
+  returns trigger
+  security definer
+language plpgsql as $$
+begin
+  update scheduler.scheduling_specification
+  set revision = revision + 1
+  where id = new.specification_id;
+  return new;
+end;
+$$;
+call migrations.mark_migration_rolled_back('13');

--- a/deployment/hasura/migrations/Aerie/13_before_delete_trigger_fix/up.sql
+++ b/deployment/hasura/migrations/Aerie/13_before_delete_trigger_fix/up.sql
@@ -1,0 +1,12 @@
+create or replace function scheduler.increment_spec_revision_on_conditions_spec_delete()
+  returns trigger
+  security definer
+language plpgsql as $$
+begin
+  update scheduler.scheduling_specification
+  set revision = revision + 1
+  where id = new.specification_id;
+  return old;
+end;
+$$;
+call migrations.mark_migration_applied('13');

--- a/deployment/postgres-init-db/sql/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/applied_migrations.sql
@@ -15,3 +15,4 @@ call migrations.mark_migration_applied('9');
 call migrations.mark_migration_applied('10');
 call migrations.mark_migration_applied('11');
 call migrations.mark_migration_applied('12');
+call migrations.mark_migration_applied('13');

--- a/deployment/postgres-init-db/sql/tables/scheduler/scheduling_specification/scheduling_specification_conditions.sql
+++ b/deployment/postgres-init-db/sql/tables/scheduler/scheduling_specification/scheduling_specification_conditions.sql
@@ -59,7 +59,7 @@ begin
   update scheduler.scheduling_specification
   set revision = revision + 1
   where id = new.specification_id;
-  return new;
+  return old;
 end;
 $$;
 


### PR DESCRIPTION
* **Tickets addressed:** AERIE-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
If a "before" trigger returns `NULL`, the operation is cancelled, as per the [Postgres Documentation](https://www.postgresql.org/docs/16/trigger-definition.html).

Since `new` is not defined in a `delete` trigger, the trigger would always return `null`, cancelling the deletion. This made it impossible to remove scheduling conditions from a plan's specification.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Bryan tested the new code and proved that it fixed the bug.

Additionally, I searched for all instances of "before delete" triggers, since this is not an issue with "after" triggers (from the docs "The return value is ignored for row-level triggers fired after an operation, and so they can return NULL."). The regex search I used was `before .*delete`.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Nowhere near the scope of this ticket, but the fact that it took just over a year for this bug to be observed gives the impression that Scheduling Conditions aren't used that often. Given the current work to increase the power of goals and constraints, I think they may end up obsoleting conditions entirely.