### PR TITLE
Bugfix: Allow resource streaming jobs to finish before closing connections

### DIFF
--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/postgres/PostgresProfileStreamer.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/postgres/PostgresProfileStreamer.java
@@ -27,7 +27,7 @@ public class PostgresProfileStreamer implements Consumer<ResourceProfiles>, Auto
 
   @Override
   public void close() {
-    queryQueue.shutdown();
+    queryQueue.close();  // This waits for all submitted jobs to complete before returning
     try {
         queryHandler.close();
     } catch (SQLException e) {

--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/postgres/PostgresProfileStreamer.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/postgres/PostgresProfileStreamer.java
@@ -28,11 +28,11 @@ public class PostgresProfileStreamer implements Consumer<ResourceProfiles>, Auto
   @Override
   public void close() {
     queryQueue.shutdown();
-      try {
-          queryHandler.close();
-      } catch (SQLException e) {
-          throw new DatabaseException("Error occurred while attempting to close PostgresProfileQueryHandler", e);
-      }
+    try {
+        queryHandler.close();
+    } catch (SQLException e) {
+        throw new DatabaseException("Error occurred while attempting to close PostgresProfileQueryHandler", e);
+    }
   }
 
 }


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

### The symptoms
@ewferg ran into an issue developing a mission model on Aerie 3.3.0. After running a simulation, he noticed that the resource profiles displayed in the UI seemed to end too early; i.e. after a certain point in the profile, data seemed to be missing. The point at which this happened varied from resource to resource:

![image](https://github.com/user-attachments/assets/5ebe7cc2-0328-4316-bef1-316197304309)

### The hypothesis

Our hypothesis is that the issue is related to #1630 , which introduces a separate thread to work on inserting profile segments into the database without blocking the simulation thread.

I did not see this behavior using Banananation, so to test the hypothesis I introduced some lag into the resource streaming thread like so:

```diff
queryQueue.submit(() -> {
+  for (int i = 0; i < <big number>; i++) {}
  queryHandler.uploadResourceProfiles(resourceProfiles);
});
```

After running a simulation with this change, I observed empty profiles, which I believe is consistent with our hypothesis.

### The most likely root cause

We believe the root cause stems from the `PostgresProfileStreamer::close` method, which is called automatically by this try-with-resources expression after the `simulate` method completes: https://github.com/NASA-AMMOS/aerie/blob/b1fac9b277ab1cead226cf6e0a95a43e7d555470/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/MerlinWorkerAppDriver.java#L96-L103

Here is the `close` method. `queryQueue.shutdown()` notifies the executor that it should stop accepting jobs, finish the ones that have already been submitted, and then stop the worker thread.
https://github.com/NASA-AMMOS/aerie/blob/24221cb51036a46a1dc8b4a7774a9e033073279e/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/postgres/PostgresProfileStreamer.java#L29-L36

The trouble is that `shutdown` is non-blocking; i.e. it allows the calling thread to proceed while the remaining jobs in the queue are run. This means that `queryHandler.close` can be called before all the jobs have finished. `queryHandler.close` closes all of the SQL Statements used by the resource streamer, which means it effectively prevents the remaining jobs in the queue (read: "the remaining profile segments") from completing successfully.

This issue is hard to spot because it's a race condition: if the profile segments are inserted to the database very quickly, all or most of them will complete successfully before `queryHandler.close` gets called. This is the case when we test with banananation. However, if we have a mission model and plan that produce a larger volume of profile segments, it causes the resource streamer to lose the race, and some profile segments don't make it into the database.

### The Fix

We need to block the main thread so that `queryHandler.close` doesn't get called until all of the profile segments have successfully been inserted. The `ExecutorService::close` method does just that: it calls `shutdown`, along with `awaitTermination` and has some logic to handle interrupts and timeouts. Source code is [here](https://github.com/openjdk/jdk/blob/4e67ac41365ecd0c7e919d77e359f77ea602feb9/src/java.base/share/classes/java/util/concurrent/ExecutorService.java#L368-L407).

From our perspective, that means we can replace `queryQueue.shutdown()` with `queryQueue.close()`.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I used the same hack in the "Hypothesis" section above and verified that all profiles were inserted in their entirety.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A