### PR TITLE
Bugfix: Sequencing Server Duration Parsing and Rebalancing

### DIFF
--- a/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
+++ b/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
@@ -315,7 +315,7 @@ function convertType(value: any, schema: Schema): any {
       return value;
     case SchemaTypes.Duration:
       if (value !== null) {
-        return Temporal.Duration.from(parse(value).toISOString());
+        return Temporal.Duration.from({ microseconds: value });
       }
       return value;
     case SchemaTypes.Boolean:

--- a/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
+++ b/sequencing-server/src/lib/codegen/CommandEDSLPreface.ts
@@ -3233,13 +3233,36 @@ export function doyToInstant(doy: DOY_STRING): Temporal.Instant {
 export function durationToHms(time: Temporal.Duration): HMS_STRING {
   let { days, hours, minutes, seconds, milliseconds } = time;
 
+  const isNegative = days < 0 || hours < 0 || minutes < 0 || seconds < 0 || milliseconds < 0;
+
+  if (isNegative) {
+    days = Math.abs(days);
+    hours = Math.abs(hours);
+    minutes = Math.abs(minutes);
+    seconds = Math.abs(seconds);
+    milliseconds = Math.abs(milliseconds);
+  }
+
+  seconds += Math.floor(milliseconds / 1000);
+  milliseconds %= 1000;
+
+  minutes += Math.floor(seconds / 60);
+  seconds %= 60;
+
+  hours += Math.floor(minutes / 60);
+  minutes %= 60;
+
+  days += Math.floor(hours / 24);
+  hours %= 24;
+
+
   const DD = days !== 0 ? `${formatNumber(days, 3)}T` : '';
   const HH = days !== 0 ? formatNumber(hours, 2).replace('-', '') : formatNumber(hours, 2);
   const MM = formatNumber(minutes, 2).replace('-', '');
   const SS = formatNumber(seconds, 2).replace('-', '');
   const sss = formatNumber(milliseconds, 3).replace('-', '');
 
-  return `${DD}${HH}:${MM}:${SS}.${sss}` as HMS_STRING;
+  return `${isNegative ? '-' : ''}${DD}${HH}:${MM}:${SS}.${sss}` as HMS_STRING;
 }
 
 export function hmsToDuration(hms: HMS_STRING, epoch: boolean = false): Temporal.Duration {

--- a/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
+++ b/sequencing-server/test/__snapshots__/command-types.spec.ts.snap
@@ -3236,13 +3236,36 @@ export function doyToInstant(doy: DOY_STRING): Temporal.Instant {
 export function durationToHms(time: Temporal.Duration): HMS_STRING {
   let { days, hours, minutes, seconds, milliseconds } = time;
 
+  const isNegative = days < 0 || hours < 0 || minutes < 0 || seconds < 0 || milliseconds < 0;
+
+  if (isNegative) {
+    days = Math.abs(days);
+    hours = Math.abs(hours);
+    minutes = Math.abs(minutes);
+    seconds = Math.abs(seconds);
+    milliseconds = Math.abs(milliseconds);
+  }
+
+  seconds += Math.floor(milliseconds / 1000);
+  milliseconds %= 1000;
+
+  minutes += Math.floor(seconds / 60);
+  seconds %= 60;
+
+  hours += Math.floor(minutes / 60);
+  minutes %= 60;
+
+  days += Math.floor(hours / 24);
+  hours %= 24;
+
+
   const DD = days !== 0 ? \`\${formatNumber(days, 3)}T\` : '';
   const HH = days !== 0 ? formatNumber(hours, 2).replace('-', '') : formatNumber(hours, 2);
   const MM = formatNumber(minutes, 2).replace('-', '');
   const SS = formatNumber(seconds, 2).replace('-', '');
   const sss = formatNumber(milliseconds, 3).replace('-', '');
 
-  return \`\${DD}\${HH}:\${MM}:\${SS}.\${sss}\` as HMS_STRING;
+  return \`\${isNegative ? '-' : ''}\${DD}\${HH}:\${MM}:\${SS}.\${sss}\` as HMS_STRING;
 }
 
 export function hmsToDuration(hms: HMS_STRING, epoch: boolean = false): Temporal.Duration {

--- a/sequencing-server/test/command-expansion.spec.ts
+++ b/sequencing-server/test/command-expansion.spec.ts
@@ -338,6 +338,7 @@ describe('expansion', () => {
       return [
         R(props.activityInstance.startOffset).PREHEAT_OVEN({temperature: 70}),
         R(props.activityInstance.duration).PREHEAT_OVEN({temperature: 70}),
+        R(props.activityInstance.attributes.arguments.growingDuration).PREHEAT_OVEN({temperature: 71}),
       ];
     }
     `,
@@ -388,6 +389,13 @@ describe('expansion', () => {
       },
       {
         args: [{ value: 70, name: 'temperature', type: 'number' }],
+        metadata: { simulatedActivityId },
+        stem: 'PREHEAT_OVEN',
+        time: { tag: '01:00:00.000', type: TimingTypes.COMMAND_RELATIVE },
+        type: 'command',
+      },
+      {
+        args: [{ value: 71, name: 'temperature', type: 'number' }],
         metadata: { simulatedActivityId },
         stem: 'PREHEAT_OVEN',
         time: { tag: '01:00:00.000', type: TimingTypes.COMMAND_RELATIVE },


### PR DESCRIPTION
* **Tickets addressed:** Fixes #1625 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Durations in the Aerie system take a few different forms. Sometimes they're postgres intervals, sometimes they're ISO8601, and yet other times they're integers representing microseconds.

The Duration Value Schema type uses the integer in microseconds representation.

Fixing this bug uncovered another: the relative-timed commands coming out of the EDSL expansion could end up with unbalanced durations. This PR also adds some code to rebalance durations in `durationToHms`. The approach I chose for rebalancing is simple, but not necessarily fast. My assumption is that the durations are likely to be _nearly_ balanced, and the while loops shouldn't need to do more than a handful of iterations.

Balancing stops at hours and does not continue on into days etc.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
An existing EDSL command expansion test was modified to hit this code path. It uses GrowBanana's "growingDuration" parameter as a relative time command offset.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A