### PR TITLE
Bugfix: Add 'simulation_dataset_id' as mapping in 'sequence_to_simulated_activity' view

### DIFF
--- a/deployment/hasura/metadata/databases/tables/sequencing/sequence_to_simulated_activity.yaml
+++ b/deployment/hasura/metadata/databases/tables/sequencing/sequence_to_simulated_activity.yaml
@@ -12,6 +12,7 @@ object_relationships:
     manual_configuration:
       column_mapping:
         simulated_activity_id: id
+        simulation_dataset_id: simulation_dataset_id
       remote_table:
         name: simulated_activity
         schema: merlin


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Encountered a bug where scheduling goals could cause a span ID to be re-used across **separate** activity directives when simulating, causing 'simulated_activity' entries to potentially point to the wrong span.

Spans do not have unique IDs globally, only within specific simulation datasets. This means if two spans are given the same ID across two separate simulation datasets, the `sequence_to_simulated_activity` view will still _only_ reference the first span as it is only referencing through `span_id` and not `span_id` + `simulation_dataset_id`. This update enforces that the reference always takes into account the `simulation_dataset_id` to find the proper span regardless of what Id alone it was given during simulation.

## Verification
The error was re-produced through:
1. Creating a new plan
2. Running multiple scheduling goals
3. Removing a single activity from the timeline and re-simulation
4. Re-running scheduling goals

This gave the 'bad' state shown below:
![image](https://github.com/user-attachments/assets/cb2ad983-5257-4d7c-8e8d-581b9f615c88)
In the image, the sequence is trying to use span `58` from dataset `2`, but the final reference to `simulated_activity` (through `sequence_to_simulated_activity`) retrieves span `58` from dataset `1`.

After the metadata changes, the proper span is retrieved even when multiple unique spans share an Id:
![image](https://github.com/user-attachments/assets/764c40ed-c69a-46e6-9cfa-353930ad1778)

![image](https://github.com/user-attachments/assets/973acb22-e64b-4121-9555-c7e11e2785a9)
(The screenshot above shows the state of the multiple span `4`s in the 'After' screenshot. This scenario would cause only the first, `DSN_2_50M_OMNI1`, to be referenced).

## Documentation
N/A

## Future work
N/A
