### PR TITLE
Bugfix: Use simulated_activity instead of span for sequence templates

### DIFF
--- a/deployment/hasura/metadata/databases/tables/sequencing/sequence_to_simulated_activity.yaml
+++ b/deployment/hasura/metadata/databases/tables/sequencing/sequence_to_simulated_activity.yaml
@@ -16,14 +16,6 @@ object_relationships:
       remote_table:
         name: simulated_activity
         schema: merlin
-- name: spans # these are treated as identically keyed, per simulatedActivityBatchLoader.ts. Doing this prevents a lot of extra hasura queries
-  using:
-    manual_configuration:
-      column_mapping:
-        simulated_activity_id: span_id
-      remote_table:
-        name: span
-        schema: merlin
 select_permissions:
   - role: aerie_admin
     permission:

--- a/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
+++ b/sequencing-server/src/lib/batchLoaders/simulatedActivityBatchLoader.ts
@@ -232,12 +232,12 @@ export const simulatedActivityInstanceBySeqIdBatchLoader: BatchLoader<
             }
           }
           sequence_to_simulated_activity(where: {_and: [{simulation_dataset_id: {_eq: $simulationDatasetId}},  {seq_id: {_eq: $seqId}}]}) {
-            spans {
-              span_id
+            spans: simulated_activity {
+              span_id: id
               attributes
               start_offset
               duration
-              activity_type_name: type
+              activity_type_name
             }
           }
         }


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This is a follow-up to #1655 . That PR had fixed the `sequence_to_simulated_activity` -> `simulated_activity` relationship. This PR makes the sequence templates feature use that relationship instead of the `sequence_to_simulated_activity` -> `span` relationship. This PR also removes that relationship, because it turned out to be unsound.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I did a quick manual test to make sure sequence template expansion worked. Existing end-to-end tests should also cover sequence template functionality.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- There are two different simulated activity batch loaders - consider consolidating
