### PR TITLE
Use a different username for sequencing e2e tests to avoid issues running in parallel

### DIFF
--- a/sequencing-server/test/testUtils/MissionModel.ts
+++ b/sequencing-server/test/testUtils/MissionModel.ts
@@ -69,7 +69,7 @@ export async function uploadMissionModel(graphqlClient: GraphQLClient): Promise<
 async function login() {
   const response = await fetch(`${process.env['MERLIN_GATEWAY_URL']}/auth/login`, {
     method: 'POST',
-    body: `{"username": "AerieE2ETests", "password": "password"}`,
+    body: `{"username": "AerieE2ESequencingTests", "password": "password"}`,
     headers: { 'Content-Type': 'application/json' },
   });
   if (!response.ok) {


### PR DESCRIPTION
## Description
There have been a bunch of flaky backend e2e test failures recently, for example:
https://github.com/NASA-AMMOS/aerie/actions/runs/14180266488/attempts/1
^this succeeds on the 2nd attempt proving it was flakiness & not real failure… I also got it 3 times in a row on develop on Friday:
https://github.com/NASA-AMMOS/aerie/actions/runs/14132769498

This run has some clues under Print Logs for Services:
https://github.com/NASA-AMMOS/aerie/actions/runs/14132769498/job/39608198626

Gateway runs for awhile and then this happens and it restarts:
```
***_gateway     | 2025-03-28T19:19:46.945624839Z /app/node_modules/pg-pool/index.js:45
***_gateway     | 2025-03-28T19:19:46.945640779Z     Error.captureStackTrace(err);
***_gateway     | 2025-03-28T19:19:46.945646830Z           ^
***_gateway     | 2025-03-28T19:19:46.945652090Z 
***_gateway     | 2025-03-28T19:19:46.945675844Z error: duplicate key value violates unique constraint "users_allowed_roles_pkey"
***_gateway     | 2025-03-28T19:19:46.945684651Z     at /app/node_modules/pg-pool/index.js:45:11
***_gateway     | 2025-03-28T19:19:46.945701682Z     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
***_gateway     | 2025-03-28T19:19:46.945705730Z     at async upsertUserRoles (file:///app/dist/packages/auth/functions.js:60:9) {
***_gateway     | 2025-03-28T19:19:46.945709547Z   length: 272,
***_gateway     | 2025-03-28T19:19:46.945713254Z   severity: 'ERROR',
***_gateway     | 2025-03-28T19:19:46.945716941Z   code: '23505',
***_gateway     | 2025-03-28T19:19:46.945720708Z   detail: 'Key (username, allowed_role)=(AerieE2ETests, ***_admin) already exists.',
```

@Mythicaeda noted this error may occur because the sequencing e2e tests run in their own gradle tasks, potentially in parallel with the other `aerie` tests, & they both use this same username ("AerieE2ETests") which may be causing collisions.
