### PR TITLE
Fix publish name for action server (aerie-action) to match dockerfiles

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
           - image: aerie-sequencing
             context: sequencing-server
             file: sequencing-server/Dockerfile
-          - image: aerie-actions
+          - image: aerie-action
             context: action-server
             file: action-server/Dockerfile
           - image: aerie-hasura


### PR DESCRIPTION
## Description
The image on our packages page for action server is called `aerie-actions`:
https://github.com/NASA-AMMOS/aerie/packages

However the docker compose files are looking for `aerie-action`:
https://github.com/NASA-AMMOS/aerie/blob/develop/deployment/docker-compose.yml#L18

this change to the publish step should fix it. I believe this is what is causing `aerie-dev` deployment to fail.