### PR TITLE
Remove foreign key between sequence_template and activity_type

### DIFF
--- a/deployment/hasura/migrations/Aerie/14_sequence_templates/up.sql
+++ b/deployment/hasura/migrations/Aerie/14_sequence_templates/up.sql
@@ -6,15 +6,11 @@ create table sequencing.sequence_template (
   model_id integer null,
   parcel_id integer null,
   template_definition text not null,
-  activity_type text null,
+  activity_type text not null,
   language text not null,
   owner text,
 
   constraint sequence_template_pkey primary key (id),
-  constraint activity_type foreign key (activity_type, model_id)
-    references merlin.activity_type (name, model_id)
-    on update cascade
-    on delete set null,
   constraint seq_template_mission_model_exists foreign key (model_id)
     references merlin.mission_model (id)
     on update cascade

--- a/deployment/postgres-init-db/sql/tables/sequencing/sequence_template.sql
+++ b/deployment/postgres-init-db/sql/tables/sequencing/sequence_template.sql
@@ -5,15 +5,11 @@ create table sequencing.sequence_template (
   model_id integer null,
   parcel_id integer null,
   template_definition text not null,
-  activity_type text null,
+  activity_type text not null,
   language text not null,
   owner text,
 
   constraint sequence_template_pkey primary key (id),
-  constraint activity_type foreign key (activity_type, model_id)
-    references merlin.activity_type (name, model_id)
-    on update cascade
-    on delete set null,
   constraint seq_template_mission_model_exists foreign key (model_id)
     references merlin.mission_model (id)
     on update cascade


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
After discussion with @Mythicaeda and the sequence templates team, we decided to remove the foreign key between `sequence_template` and `activity_type`, the rationale being that neither `on delete cascade` nor `on delete set null` is appropriate. The name of the activity type with which a sequence template is associated is an important piece of context to preserve if a mission model is deleted.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Waiting to see if e2e tests pass. The only issue I'm expecting is we may need to update hasura metadata.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A
