### PR TITLE
Disable on-update triggers much more aggressively during Proc Constraints Migration

### DIFF
--- a/deployment/hasura/migrations/Aerie/16_procedural_constraints/up.sql
+++ b/deployment/hasura/migrations/Aerie/16_procedural_constraints/up.sql
@@ -129,9 +129,8 @@ drop trigger update_scheduling_model_specification_goal on scheduler.scheduling_
 with priorities as (
   select
     goal_invocation_id,
-    row_number() over (partition by model_id) as new_prio
+    row_number() over (partition by model_id order by priority) as new_prio
   from scheduler.scheduling_model_specification_goals smg
-  order by priority
 )
 update scheduler.scheduling_model_specification_goals smg
 set priority = p.new_prio - 1 -- -1, as priority starts at 0
@@ -149,9 +148,8 @@ drop trigger update_scheduling_specification_goal on scheduler.scheduling_specif
 with priorities as (
   select
     goal_invocation_id,
-    row_number() over (partition by specification_id) as new_prio
+    row_number() over (partition by specification_id order by priority) as new_prio
   from scheduler.scheduling_specification_goals ssg
-  order by priority
 )
 update scheduler.scheduling_specification_goals ssg
 set priority = p.new_prio - 1 -- -1, as priority starts at 0


### PR DESCRIPTION
## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Within a single transaction, just disabling the trigger will still cause it to gather up events to fire on, causing issues when it is reenabled in the same transaction. Rather than include a `commit` in a migration (which would break the fact that our migrations are atomic), I decided to just drop and recreate the trigger rather than disable and reenable it. The only difference in effect is that a dropped trigger cannot gather events like a disabled trigger.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I wrapped the up migration in a transaction (with a `rollback` at the end) when I tested this time, to mirror how the migration is wrapped. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
