### PR TITLE
Fix deployment/docker-compose for action server

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -19,8 +19,9 @@ services:
     ports: [ "27186:27186" ]
     restart: always
     volumes:
-      - ./action-server:/app:cached
       - aerie_file_store:/usr/src/app/action_file_store
+    networks:
+      - aerie_net
   aerie_gateway:
     container_name: aerie_gateway
     depends_on: ["postgres"]


### PR DESCRIPTION

## Description
Fixes issues encountered deploying action-server on `aerie-dev` by making action-server consistent with other services. Specifically:
* The `./action-server` directory shouldn't be mapped to a volume for production deployment like we do for development, this causes the error:
```
npm error code ENOENT
npm error syscall open
npm error path /app/package.json
npm error errno -2
npm error enoent Could not read package.json: Error: ENOENT: no such file or directory, open '/app/package.json'
npm error enoent This is related to npm not being able to find a file.
npm error enoent
```
* The container was missing the `aerie_net` network setting, causing:
```
Server running on port 27186
2025-04-04T00:36:42.290Z [INFO] Creating PG pool
Failed to initialize application: Error: getaddrinfo ENOTFOUND postgres
    at /app/node_modules/pg-pool/index.js:45:11
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async setupListeners (/app/build/listeners/dbListeners.js:143:20)
    at async Server.<anonymous> (/app/build/app.js:23:9) {
  errno: -3008,
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'postgres'
}
```

## Verification
I made these changes manually on `aerie-dev`, then brought the containers `down` and back `up` and confirmed these fixed the issue.

