### PR TITLE
ignore DoS vulnerability CVE-2023-7272 in Trivy scans 

### DIFF
--- a/.github/config/.trivyignore
+++ b/.github/config/.trivyignore
@@ -9,3 +9,8 @@
 CVE-2023-24538
 CVE-2023-24540
 CVE-2024-24790
+
+# Not relevant to Aerie, as it requires an attacker to craft a malicious JSON string to perform a Denial of Service attack
+# https://access.redhat.com/security/cve/CVE-2023-7272
+# This is not part of our threat model, we intentionally allow users to perform many long-running actions that could cause DoS
+CVE-2023-7272


### PR DESCRIPTION
## Description
[Vulnerability CVE-2023-7272](https://access.redhat.com/security/cve/CVE-2023-7272) is [causing our Publish workflows to fail](https://github.com/NASA-AMMOS/aerie/actions/runs/14390780843/job/40357249281). This PR adds it to the list of ignored vulnerabilities.

## Justification
The nature of this vuln makes it not relevant to Aerie, as it requires an attacker to craft a malicious JSON string to perform a Denial of Service attack. (see https://access.redhat.com/security/cve/CVE-2023-7272 for details).
This is not part of our threat model, we intentionally allow users to perform many long-running actions that could cause DoS if they are not careful. It does not allow arbitrary code execution or breaking out of sandboxes, it just allows users to make the system very slow, which they can trivially do already.

## Verification
The Publish workflow should successfully run on this branch/after merge.