### PR TITLE
enforce strict version 0.1.7 for aerie-actions dependency

### DIFF
--- a/action-server/package-lock.json
+++ b/action-server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@nasa-jpl/aerie-actions": "^0.1.7",
+        "@nasa-jpl/aerie-actions": "0.1.7",
         "express": "^5.0.1",
         "pg": "^8.13.3",
         "piscina": "^5.0.0-alpha.0",

--- a/action-server/package.json
+++ b/action-server/package.json
@@ -26,7 +26,7 @@
     "ts-node": "^10.9.2"
   },
   "dependencies": {
-    "@nasa-jpl/aerie-actions": "^0.1.7",
+    "@nasa-jpl/aerie-actions": "0.1.7",
     "express": "^5.0.1",
     "pg": "^8.13.3",
     "piscina": "^5.0.0-alpha.0",


### PR DESCRIPTION
By default, `npm` installs this as a with a loose [caret version range](https://github.com/npm/node-semver?tab=readme-ov-file#caret-ranges-123-025-004), as a result older versions installed in local environments (eg. `0.1.6`) will be considered matching/resolved and not updated.

We should make a bigger push at some point to pin more dependencies, but this is a hotfix to resolve local issues with Actions