### PR TITLE
Permissions for sequence templates

### DIFF
--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PermissionsTest.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PermissionsTest.java
@@ -981,6 +981,8 @@ public class PermissionsTest {
             "create_expansion_rule": "NO_CHECK",
             "create_expansion_set": "NO_CHECK",
             "expand_all_activities": "NO_CHECK",
+            "expand_all_templates": "NO_CHECK",
+            "assign_activities_by_filter": "NO_CHECK",
             "insert_ext_dataset": "PLAN_OWNER",
             "resource_samples": "NO_CHECK",
             "schedule":"PLAN_OWNER_COLLABORATOR",

--- a/deployment/hasura/migrations/Aerie/22_template_permissions/down.sql
+++ b/deployment/hasura/migrations/Aerie/22_template_permissions/down.sql
@@ -1,0 +1,19 @@
+update permissions.user_role_permission
+set action_permissions = action_permissions - 'expand_all_templates' - 'assign_activities_by_filter';
+
+drop type permissions.action_permission_key;
+
+create type permissions.action_permission_key
+  as enum (
+    'check_constraints',
+    'create_expansion_rule',
+    'create_expansion_set',
+    'expand_all_activities',
+    'insert_ext_dataset',
+    'resource_samples',
+    'schedule',
+    'sequence_seq_json_bulk',
+    'simulate'
+  );
+
+call migrations.mark_migration_rolled_back('22');

--- a/deployment/hasura/migrations/Aerie/22_template_permissions/up.sql
+++ b/deployment/hasura/migrations/Aerie/22_template_permissions/up.sql
@@ -1,0 +1,24 @@
+drop type permissions.action_permission_key;
+
+create type permissions.action_permission_key
+  as enum (
+    'assign_activities_by_filter',
+    'check_constraints',
+    'create_expansion_rule',
+    'create_expansion_set',
+    'expand_all_activities',
+    'expand_all_templates',
+    'insert_ext_dataset',
+    'resource_samples',
+    'schedule',
+    'sequence_seq_json_bulk',
+    'simulate'
+  );
+
+update permissions.user_role_permission
+set action_permissions = action_permissions
+    || jsonb_build_object('expand_all_templates', 'NO_CHECK')
+    || jsonb_build_object('assign_activities_by_filter', 'NO_CHECK')
+where role = 'user';
+
+call migrations.mark_migration_applied('22');

--- a/deployment/postgres-init-db/sql/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/applied_migrations.sql
@@ -23,4 +23,5 @@ call migrations.mark_migration_applied('18');
 call migrations.mark_migration_applied('19');
 call migrations.mark_migration_applied('20');
 call migrations.mark_migration_applied('21');
+call migrations.mark_migration_applied('22');
 

--- a/deployment/postgres-init-db/sql/default_user_roles.sql
+++ b/deployment/postgres-init-db/sql/default_user_roles.sql
@@ -14,6 +14,8 @@ set action_permissions = '{
       "create_expansion_rule": "NO_CHECK",
       "create_expansion_set": "NO_CHECK",
       "expand_all_activities": "NO_CHECK",
+      "expand_all_templates": "NO_CHECK",
+      "assign_activities_by_filter": "NO_CHECK",
       "insert_ext_dataset": "PLAN_OWNER",
       "resource_samples": "NO_CHECK",
       "schedule":"PLAN_OWNER_COLLABORATOR",

--- a/deployment/postgres-init-db/sql/types/permissions/permissions.sql
+++ b/deployment/postgres-init-db/sql/types/permissions/permissions.sql
@@ -18,10 +18,12 @@ create type permissions.permission
 
 create type permissions.action_permission_key
   as enum (
+    'assign_activities_by_filter',
     'check_constraints',
     'create_expansion_rule',
     'create_expansion_set',
     'expand_all_activities',
+    'expand_all_templates',
     'insert_ext_dataset',
     'resource_samples',
     'schedule',

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ActionPermissionsSet.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ActionPermissionsSet.java
@@ -11,6 +11,8 @@ public record ActionPermissionsSet(Map<ActionKey, Permission> permissions){
       create_expansion_rule,
       create_expansion_set,
       expand_all_activities,
+      expand_all_templates,
+      assign_activities_by_filter,
       insert_ext_dataset,
       resource_samples,
       schedule,

--- a/sequencing-server/src/routes/command-expansion.ts
+++ b/sequencing-server/src/routes/command-expansion.ts
@@ -141,9 +141,7 @@ commandExpansionRouter.post('/assign-activities-by-filter', async (req, res, nex
       `POST /command-expansion/assign-activities-by-filter: Entries failed to be created for filtered activities.`,
     );
   }
-  logger.info(
-    `POST /command-expansion/expand-all-activity-instances: Inserted entries for filtered activities.`,
-  );
+  logger.info(`POST /command-expansion/assign-activities-by-filter: Inserted entries for filtered activities.`);
 
   //    3c. Return
   res.status(200).json({

--- a/sequencing-server/src/utils/hasura.ts
+++ b/sequencing-server/src/utils/hasura.ts
@@ -43,6 +43,8 @@ const ENDPOINTS_TO_ACTION_KEY: Record<string, string> = {
   '/command-expansion/put-expansion-set': 'create_expansion_set',
   '/command-expansion/put-expansion': 'create_expansion_rule',
   '/command-expansion/expand-all-activity-instances': 'expand_all_activities',
+  '/command-expansion/expand-all-sequence-templates': 'expand_all_templates',
+  '/command-expansion/assign-activities-by-filter': 'assign_activities_by_filter',
   '/seqjson/bulk-get-seqjson-for-seqid-and-simulation-dataset': 'sequence_seq_json_bulk',
 };
 


### PR DESCRIPTION
Closes #1686 

## Description

Creates permissions for expanding templates and applying sequence filters and specifies those permissions for the corresponding routes.

See matching aerie-ui PR: NASA-AMMOS/aerie-ui#1700

## Verification

Updated automated tests using my best pattern recognition skills. Also tested manually by applying sequence filters and expanding templates in a local deployment with the `user` role selected. Ran migrations and checked contents in pgAdmin were as expected.

## Documentation

https://github.com/NASA-AMMOS/aerie-docs/pull/234
