### PR TITLE
Remove deprecated version tag from docker-compose.yml

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   aerie_action:
     container_name: aerie_action

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   aerie_action:
     build:

--- a/e2e-tests/docker-compose-many-workers.yml
+++ b/e2e-tests/docker-compose-many-workers.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   aerie_action:
     build:


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
When I run docker compose commands, I get the following warning message:

> WARN[0000] /Users/dailis/projects/aerie/worktrees/feature/external-source-event-attributes/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

This PR heeds the warning and removes the version tag from all of the docker-compose.yml files in this repository.

Docker compose docs: https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

I have not validated these changes, but my hope is that the CI checks will be sufficient to prove that at least the e2e-test docker compose file is well-formed.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

I'm not aware of any docs that talk about docker compose versions - I'm open to suggestions for whether we should document that, and if so, where to put that documentation.

## Future work
<!-- What next steps can we anticipate from here, if any? -->

Possible future documentation work.