### PR TITLE
HOTFIX: Fix sequence templates time helper functions

### DIFF
--- a/sequencing-server/src/lib/mustache/util/index.ts
+++ b/sequencing-server/src/lib/mustache/util/index.ts
@@ -1,22 +1,12 @@
 /* A wrapper for Handlebars, so that `sequencing-server` isn't polluted with helper registration and the like. */
 import Handlebars from "handlebars";
-import { addTime as addTimeFull, subtractTime as subtractTimeFull, InstanttoSTOL, STOLToInstant, SeqNToInstant, InstanttoSeqN, TextToISO8601 } from "./time.js";
+import { addTime, subtractTime, formatTime } from "./time.js";
 import { getEnv } from "../../../env.js";
 import { SequencingLanguage } from "../enums/language.js";
 
 // initialized to environment variable, but this can be changed at runtime.
 const environment = {
     language: getEnv().SEQUENCING_LANGUAGE
-}
-
-/////////////// AERIE HELPERS ///////////////
-// wrappers for helpers
-function addTime(startTime: string, duration: string) {
-    return addTimeFull(startTime, duration, environment)
-}
-
-function subtractTime(startTime: string, duration: string) {
-    return subtractTimeFull(startTime, duration, environment)
 }
 
 // helper to flatten out array
@@ -29,24 +19,11 @@ function flatten(array: any[]): string {
     }
 }
 
-// helper to clean dates. must be manually invoked by the user, just in case. here, Text and SeqN are handled the same.
-function formatAsDate(date: string): string {
-    if (environment.language === SequencingLanguage.STOL) {
-        return InstanttoSTOL(STOLToInstant(date))
-    }
-    else if (environment.language === SequencingLanguage.TEXT) {
-        return TextToISO8601(date)
-    }
-    else {
-        return InstanttoSeqN(SeqNToInstant(date))
-    }
-}
-
 /////////////// AERIE HELPER REGISTRATION ///////////////
-Handlebars.registerHelper("add-time", addTime)
-Handlebars.registerHelper("subtract-time", subtractTime)
+Handlebars.registerHelper("add-time", (t, d) => addTime(t, d, environment.language))
+Handlebars.registerHelper("subtract-time", (t, d) => subtractTime(t, d, environment.language))
 Handlebars.registerHelper("flatten", flatten)
-Handlebars.registerHelper("format-as-date", formatAsDate)
+Handlebars.registerHelper("format-as-date", t => formatTime(t, environment.language))
 
 
 /////////////// EXPOSE TO SEQUENCING-SERVER ///////////////

--- a/sequencing-server/src/lib/mustache/util/time.ts
+++ b/sequencing-server/src/lib/mustache/util/time.ts
@@ -2,92 +2,75 @@ import { ParsedDoyString, ParsedDurationString, ParsedYmdString, TimeTypes } fro
 import { Temporal } from '@js-temporal/polyfill';
 import { SequencingLanguage } from '../enums/language.js';
 
+/**
+ * Time Helpers
+ */
+export function addTime(startTime: string, duration: string, language: SequencingLanguage): string {
+  return serializeInstant(parseInstant(startTime, language).add(parseDuration(duration)), language);
+}
 
-/////////////// SEQUENCING-SERVER-SPECIFIC HELPERS ///////////////
-export function addTime(startTime: string, duration: string, environment: { language: SequencingLanguage }): string {
-  let date: Temporal.Instant
-  if (environment.language === SequencingLanguage.STOL) {
-    date = STOLToInstant(startTime)
-  }
-  else if (environment.language === SequencingLanguage.TEXT) {
-    date = Temporal.Instant.from(TextToISO8601(startTime))
-  }
-  else {
-    date = SeqNToInstant(startTime)
-  }
+export function subtractTime(startTime: string, duration: string, language: SequencingLanguage): string {
+  return serializeInstant(parseInstant(startTime, language).subtract(parseDuration(duration)), language);
+}
 
-  let dur: Temporal.Duration;
-  if (duration.includes(":")) {
-    dur = Temporal.Duration.from(AERIEDurationToISO8601(duration))
-  }
-  else {
-    dur = Temporal.Duration.from(duration)
-  }
-  date = date.add(dur)
+export function formatTime(time: string, language: SequencingLanguage): string {
+  return serializeInstant(parseInstant(time, language), language);
+}
 
-  if (environment.language === SequencingLanguage.STOL) {
-    return InstanttoSTOL(date)
-  }
-  else if (environment.language === SequencingLanguage.TEXT) {
-    return InstantToText(date)
-  }
-  else { 
-    return InstanttoSeqN(date)
+/**
+ * Utilities for parsing and serializing times used in sequence templates
+ */
+
+function parseInstant(instant: string, language: SequencingLanguage): Temporal.Instant {
+  if (language === SequencingLanguage.STOL) {
+    return STOLToInstant(instant);
+  } else if (language === SequencingLanguage.TEXT) {
+    return Temporal.Instant.from(TextToISO8601(instant));
+  } else if (language === SequencingLanguage.SEQN) {
+    return SeqNToInstant(instant);
+  } else {
+    throw new Error('Unknown language: ' + language)
   }
 }
 
-export function subtractTime(startTime: string, duration: string, environment: { language: SequencingLanguage }): string {
-  let date: Temporal.Instant
-  if (environment.language === SequencingLanguage.STOL) {
-    date = STOLToInstant(startTime)
+function serializeInstant(instant: Temporal.Instant, language: SequencingLanguage): string {
+  if (language === SequencingLanguage.STOL) {
+    return InstanttoSTOL(instant);
+  } else if (language === SequencingLanguage.TEXT) {
+    return InstantToText(instant);
+  } else if (language === SequencingLanguage.SEQN) {
+    return InstanttoSeqN(instant);
+  } else {
+    throw new Error('Unknown language: ' + language)
   }
-  else if (environment.language === SequencingLanguage.TEXT) {
-    date = Temporal.Instant.from(TextToISO8601(startTime))
-  }
-  else {
-    date = SeqNToInstant(startTime)
-  }
-
-  let dur: Temporal.Duration;
-  if (duration.includes(":")) {
-    dur = Temporal.Duration.from(AERIEDurationToISO8601(duration))
-  }
-  else {
-    dur = Temporal.Duration.from(duration)
-  }
-  date = date.subtract(dur)
-
-  if (environment.language === SequencingLanguage.STOL) {
-    return InstanttoSTOL(date)
-  }
-  else if (environment.language === SequencingLanguage.TEXT) {
-    return InstantToText(date)
-  }
-  else { // Text and SeqN are handled the same.
-    return InstanttoSeqN(date)
-  }
-
 }
 
-// TIME PARSING
+function parseDuration(duration: string): Temporal.Duration {
+  if (duration.includes(':')) {
+    return Temporal.Duration.from(AERIEDurationToISO8601(duration));
+  } else {
+    return Temporal.Duration.from(duration);
+  }
+}
+
 export function SeqNToInstant(date: string): Temporal.Instant {
-  return Temporal.Instant.from(convertDoyToYmd(date))
+  return Temporal.Instant.from(convertDoyToYmd(date));
 }
 
 export function STOLToInstant(date: string): Temporal.Instant {
-  return Temporal.Instant.from(convertDoyToYmd(date))
+  return Temporal.Instant.from(convertDoyToYmd(date));
 }
 
 export function TextToISO8601(date: string): string {
   // https://stackoverflow.com/questions/881085/count-the-number-of-occurrences-of-a-character-in-a-string-in-javascript
-  if ((date.match(/-/g) || []).length === 2) { // YYYY-MM-DD string
-    const result = new Date(date).toISOString()
-    return result + (result.includes("Z") ? "" : "Z")
-  }
-  else { // doy string
-    const result = new Date(convertDoyToYmd(date)).toISOString()
-    console.log('result doy', result)
-    return result + (result.includes("Z") ? "" : "Z")
+  if ((date.match(/-/g) || []).length === 2) {
+    // YYYY-MM-DD string
+    const result = new Date(date).toISOString();
+    return result + (result.includes('Z') ? '' : 'Z');
+  } else {
+    // doy string
+    const result = new Date(convertDoyToYmd(date)).toISOString();
+    return result + (result.includes('Z') ? '' : 'Z');
   }
 }
 
@@ -97,93 +80,107 @@ function checkNumDurationComponents(split: string[]): split is [string, string, 
 
 export function AERIEDurationToISO8601(duration: string): string {
   // HHHHHH...:MM:SS.mmmuuu -> PHHMMSS.mmmuuuS
-  duration = duration.replace("Z", "");
-  let split = duration.split(":")
-  let isNegative = duration.includes("-")
+  duration = duration.replace('Z', '');
+  let split = duration.split(':');
+  let isNegative = duration.includes('-');
 
-  if (!checkNumDurationComponents(split)) { // required so editor wouldn't flag a type error
+  if (!checkNumDurationComponents(split)) {
+    // required so editor wouldn't flag a type error
     throw new Error(`Invalid duration string: ${duration}`);
   }
 
-  let hours = parseInt(split[0].replace("-", ""))
-  let minutes = parseInt(split[1])
-  let split2 = (split[2]).split(".")
-  let seconds = parseInt(split2[0] as string)
+  let hours = parseInt(split[0].replace('-', ''));
+  let minutes = parseInt(split[1]);
+  let split2 = split[2].split('.');
+  let seconds = parseInt(split2[0] as string);
   if (split2.length > 1) {
-    let microseconds = parseInt(split2[1]?.padEnd(6, "0") as string)
-    let microsecondsString = `${microseconds}`.padStart(6, "0")
-    return `${isNegative ? "-" : ""}PT${hours > 0 ? `${hours}H` : ""}${minutes > 0 ? `${minutes}M` : ""}${seconds > 0 && microseconds > 0 ? `${seconds}.${microsecondsString}S` : (seconds > 0) ? `${seconds}$` : (microseconds > 0) ? `0.${microsecondsString}S` : ""}`
-  }
-  else {
-    return `${isNegative ? "-" : ""}PT${hours > 0 ? `${hours}H` : ""}${minutes > 0 ? `${minutes}M` : ""}${seconds > 0 ? `${seconds}S` : ""}`
+    let microseconds = parseInt(split2[1]?.padEnd(6, '0') as string);
+    let microsecondsString = `${microseconds}`.padStart(6, '0');
+    return `${isNegative ? '-' : ''}PT${hours > 0 ? `${hours}H` : ''}${minutes > 0 ? `${minutes}M` : ''}${
+      seconds > 0 && microseconds > 0
+        ? `${seconds}.${microsecondsString}S`
+        : seconds > 0
+        ? `${seconds}$`
+        : microseconds > 0
+        ? `0.${microsecondsString}S`
+        : ''
+    }`;
+  } else {
+    return `${isNegative ? '-' : ''}PT${hours > 0 ? `${hours}H` : ''}${minutes > 0 ? `${minutes}M` : ''}${
+      seconds > 0 ? `${seconds}S` : ''
+    }`;
   }
 }
 
-// CONVERSION BACK TO STRINGS
 export function InstanttoSTOL(date: Temporal.Instant): string {
-  const stringFormat = date.toString()
+  const stringFormat = date.toString();
 
   // change to DOY
-  let split = stringFormat.split("T")
-  let day = new Date(split[0]!)
-  let doy = getDoy(day)
-  let time = split[1]!
+  let split = stringFormat.split('T');
+  let day = new Date(split[0]!);
+  let doy = getDoy(day);
+  let time = split[1]!;
 
   // extract decimal seconds, if any, and pad by length (ms -> 3 automatically, us -> 6 automatically)
-  if (!time.includes(".")) {
-    return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}/${time}`
-  }
-  else {
-    const secondSplit = time.split(".")
-    const hms = secondSplit[0]
-    const decimal = (secondSplit[1]!).replace("Z", "")
+  if (!time.includes('.')) {
+    return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}/${time}`.replace('Z', '');
+  } else {
+    const secondSplit = time.split('.');
+    const hms = secondSplit[0];
+    const decimal = secondSplit[1]!.replace('Z', '');
 
-    // if the Z is present at the end; it may not be and we don't want to extraneously add it
-    const zString = time.includes("Z") ? "Z" : ""
     if (decimal.length <= 3) {
-      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}/${hms}.${decimal.padEnd(3, '0')}${zString}`
-    }
-    else {
-      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}/${hms}.${decimal.padEnd(6, '0')}${zString}`
+      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}/${hms}.${decimal.padEnd(3, '0')}`;
+    } else {
+      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}/${hms}.${decimal.substring(0, 3)}`;
     }
   }
-
 }
 
-export function InstanttoSeqN(date: Temporal.Instant): string { // presently, cannot extract fields from Temporal by saying obj.days or anything like that
-  const stringFormat = date.toString()
+export function InstanttoSeqN(date: Temporal.Instant): string {
+  // presently, cannot extract fields from Temporal by saying obj.days or anything like that
+  const stringFormat = date.toString();
 
   // change to DOY
-  let split = stringFormat.split("T")
-  let day = new Date(split[0]!)
-  let doy = getDoy(day)
-  let time = split[1]!
+  let split = stringFormat.split('T');
+  let day = new Date(split[0]!);
+  let doy = getDoy(day);
+  let time = split[1]!;
 
   // extract decimal seconds, if any, and pad by length (ms -> 3 automatically, us -> 6 automatically)
-  if (!time.includes(".")) {
-    return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}T${time.replace("Z", "")}`
-  }
-  else {
-    const secondSplit = time.split(".")
-    const hms = secondSplit[0]
-    const decimal = (secondSplit[1] ?? "000Z").replace("Z", "")
+  if (!time.includes('.')) {
+    return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}T${time.replace('Z', '')}`;
+  } else {
+    const secondSplit = time.split('.');
+    const hms = secondSplit[0];
+    const decimal = (secondSplit[1] ?? '000Z').replace('Z', '');
 
     // seqN doesn't include "Z" in its strings.
     if (decimal.length <= 3) {
-      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}T${hms}.${decimal.padEnd(3, '0')}`
-    }
-    else {
-      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}T${hms}.${decimal.padEnd(6, '0')}`
+      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}T${hms}.${decimal.padEnd(3, '0')}`;
+    } else {
+      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}T${hms}.${decimal.padEnd(6, '0')}`;
     }
   }
 }
 
 export function InstantToText(date: Temporal.Instant): string {
   const result = date.toString();
-  return result + (result.includes("Z") ? "" : "Z");
+  if (result.includes('.') && result.split('.').length == 2) {
+    let split = result.split('.');
+    let rest = split[0];
+    let micros = split[1]?.replace('Z', '');
+    micros = micros?.padEnd(6, '0');
+    return rest + '.' + micros + 'Z';
+  } else {
+    return result + (result.includes('Z') ? '' : 'Z');
+  }
 }
 
-/////////////// AERIE-UI HELPERS ///////////////
+/**
+ * Time converters borrowed from Aerie-UI
+ * Consider replacing with implementations in aerie-time-utils: https://github.com/NASA-AMMOS/aerie-time-utils
+ */
 const ABSOLUTE_TIME = /^(\d{4})-(\d{3})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?$/;
 const RELATIVE_TIME =
   /^(?<doy>([0-9]{3}))?(T)?(?<hr>([0-9]{2})):(?<mins>([0-9]{2})):(?<secs>[0-9]{2})?(\.)?(?<ms>([0-9]+))?$/;
@@ -207,18 +204,18 @@ export function convertDoyToYmd(doyString: string, includeMsecs = true): string 
         `${date.getUTCDate()}`.padStart(2, '0'),
       ].join('-')}T${parsedDoy.time}`;
       if (includeMsecs) {
-        return `${ymdString}${ymdString.charAt(ymdString.length - 1) !== "Z" ? "Z" : ""}`;
+        return `${ymdString}${ymdString.charAt(ymdString.length - 1) !== 'Z' ? 'Z' : ''}`;
       }
-      const replaced = ymdString.replace(/(\.\d+)/, '')
-      return `${replaced}${replaced.charAt(replaced.length - 1) !== "Z" ? "Z" : ""}`;
+      const replaced = ymdString.replace(/(\.\d+)/, '');
+      return `${replaced}${replaced.charAt(replaced.length - 1) !== 'Z' ? 'Z' : ''}`;
     } else {
       // doyString is already in ymd format
       //    just in case - correct and "/" in lieu of a T, i.e. 2025-001/time vs 2025-001Ttime
-      return `${doyString.replace("/", "T")}${doyString.charAt(doyString.length - 1) !== "Z" ? "Z" : ""}`;
+      return `${doyString.replace('/', 'T')}${doyString.charAt(doyString.length - 1) !== 'Z' ? 'Z' : ''}`;
     }
   }
 
-  throw Error(`Given date: ${doyString} is an invalid DOY (or YMD) string.`)
+  throw Error(`Given date: ${doyString} is an invalid DOY (or YMD) string.`);
 }
 
 /**

--- a/sequencing-server/src/routes/command-expansion.ts
+++ b/sequencing-server/src/routes/command-expansion.ts
@@ -548,17 +548,17 @@ commandExpansionRouter.post('/expand-all-sequence-templates', async (req, res, n
     catch (e) {
       if (e instanceof Error) {
         throw new Error(
-          `POST /command-expansion/expand-all-sequence-templates: Databse insertion failed with "${e.message}"`
+          `POST /command-expansion/expand-all-sequence-templates: Database insertion failed with "${e.message}"`
         )
       }
       else if (e instanceof String) {
         throw new Error(
-          `POST /command-expansion/expand-all-sequence-templates: Databse insertion failed with "${e}"`
+          `POST /command-expansion/expand-all-sequence-templates: Database insertion failed with "${e}"`
         )
       }
       else {
         throw new Error(
-          `POST /command-expansion/expand-all-sequence-templates: Databse insertion failed with "${JSON.stringify(e)}"`
+          `POST /command-expansion/expand-all-sequence-templates: Database insertion failed with "${JSON.stringify(e)}"`
         )
       }
     }

--- a/sequencing-server/test/command-expansion.spec.ts
+++ b/sequencing-server/test/command-expansion.spec.ts
@@ -770,7 +770,7 @@ describe('template expansion', () => {
     expect(expandedTemplates).not.toBeNull();
 
     const result = expandedTemplates[seqId]
-    expect(result).toEqual('CMD ENDTIME=2020-001/01:00:30Z SETUP=2019-365/23:00:30Z\nCMD TEMPERATURE=350')
+    expect(result).toEqual('CMD ENDTIME=2020-001/01:00:30 SETUP=2019-365/23:00:30\nCMD TEMPERATURE=350')
 
     // Cleanup
     // remove sequence
@@ -821,7 +821,7 @@ describe('template expansion', () => {
     expect(expandedTemplates).not.toBeNull();
 
     const result = expandedTemplates[seqId]
-    expect(result).toEqual('CMD SETUP=2019-365/23:00:30Z') // only 1 activity. rest filtered by type and time!
+    expect(result).toEqual('CMD SETUP=2019-365/23:00:30') // only 1 activity. rest filtered by type and time!
 
     // Cleanup
     // remove sequence
@@ -880,7 +880,6 @@ describe('template expansion', () => {
     await removeActivitySequenceAssignments(graphqlClient, seqId)
   });
 
-  // TODO: test that fails because multiple languages were used in templates for the same model
   it('should fail correctly when multiple languages are used for the same model', async () => {
     let seqId = "SequenceFailMultiLang"
 
@@ -1214,10 +1213,10 @@ CMD SEQUENCE=FINAL_B AT={{ format-as-date (add-time startTime attributes.argumen
       expect(expandedTemplates).not.toBeNull();
 
       const result = expandedTemplates[seqId]
-      expect(result).toInclude(`CMD SEQUENCE=START_A AT=2020-001/00:00:00Z
-CMD SEQUENCE=FINAL_A AT=2020-001/01:00:00Z
-CMD SEQUENCE=START_B AT=2020-001/00:00:30Z
-CMD SEQUENCE=FINAL_B AT=2020-001/00:00:30.030Z`) // expect interleaving!
+      expect(result).toInclude(`CMD SEQUENCE=START_A AT=2020-001/00:00:00
+CMD SEQUENCE=FINAL_A AT=2020-001/01:00:00
+CMD SEQUENCE=START_B AT=2020-001/00:00:30
+CMD SEQUENCE=FINAL_B AT=2020-001/00:00:30.030`) // expect interleaving!
 
       // Cleanup
       // remove sequence
@@ -1229,5 +1228,87 @@ CMD SEQUENCE=FINAL_B AT=2020-001/00:00:30.030Z`) // expect interleaving!
     });
   });
 
-  // TODO: DAVID'S EDGE CASES
+  // STOL/plaintext-specific tests
+  describe('Plaintext sequences', () => {
+    let language = 'TEXT';
+
+    it.only('should format dates and simply concatenate strings', async () => {
+      let seqId = 'TextSequenceMerge';
+
+      await insertSequenceTemplate(
+        graphqlClient,
+        `GrowBanana.tpl`,
+        parcelId,
+        missionModelId,
+        `GrowBanana`,
+        language,
+        [
+          `A{{ format-as-date startTime }} GROW_BANANA_1`,
+          `A{{ format-as-date (add-time startTime attributes.arguments.growingDuration) }} GROW_BANANA_2`,
+        ].join(`\n`),
+      );
+
+      await insertSequenceTemplate(
+        graphqlClient,
+        `DurationParameterActivity.tpl`,
+        parcelId,
+        missionModelId,
+        `DurationParameterActivity`,
+        language,
+        [
+          `A{{ format-as-date startTime }} DURATION_ACTIVITY_1`,
+          `A{{ format-as-date (add-time startTime attributes.arguments.duration) }} DURATION_ACTIVITY_2`,
+        ].join(`\n`),
+      );
+
+      const activityId_A = await insertActivityDirective(graphqlClient, planId, 'GrowBanana', '0 milliseconds');
+      const activityId_B = await insertActivityDirective(
+        graphqlClient,
+        planId,
+        'DurationParameterActivity',
+        '30 seconds',
+        { duration: 30000 },
+      );
+
+      // Simulate Plan
+      const simulationArtifactPk = await executeSimulation(graphqlClient, planId);
+
+      // Create Sequence
+      const sequenceId = await createSequence(graphqlClient, seqId, simulationArtifactPk.simulationDatasetId);
+
+      // Assign Activities Manually
+      await assignActivityToSequence(graphqlClient, simulationArtifactPk.simulationDatasetId, activityId_A, seqId);
+      await assignActivityToSequence(graphqlClient, simulationArtifactPk.simulationDatasetId, activityId_B, seqId);
+
+      // Expand Plan
+      const expandedTemplates: { [seqId: string]: string } = await expandTemplates(
+        graphqlClient,
+        missionModelId,
+        [seqId],
+        simulationArtifactPk.simulationDatasetId,
+      );
+
+      // verify results
+      expect(sequenceId).toEqual(seqId);
+      expect(expandedTemplates).not.toBeNull();
+
+      const result = expandedTemplates[seqId];
+      expect(result).toInclude(
+        [
+          `A2020-01-01T00:00:00Z GROW_BANANA_1`,
+          `A2020-01-01T01:00:00Z GROW_BANANA_2`,
+          `A2020-01-01T00:00:30Z DURATION_ACTIVITY_1`,
+          `A2020-01-01T00:00:30.030000Z DURATION_ACTIVITY_2`,
+        ].join(`\n`),
+      );
+
+      // Cleanup
+      // remove sequence
+      await removeSequence(graphqlClient, seqId);
+      // remove simulation artifact pk
+      await removeSimulationArtifacts(graphqlClient, simulationArtifactPk);
+      // remove associations
+      await removeActivitySequenceAssignments(graphqlClient, seqId);
+    });
+  });
 })

--- a/sequencing-server/test/templating/mustache.spec.ts
+++ b/sequencing-server/test/templating/mustache.spec.ts
@@ -52,14 +52,14 @@ describe('Test built-in helpers', () => {
             let templateRaw = 'Adding dates: {{ add-time date duration }}'
             let template = new Mustache(templateRaw, SequencingLanguage.STOL)
             expect(template.execute(input))
-                .toEqual('Adding dates: 2025-001/01:07:04.124600Z')
+                .toEqual('Adding dates: 2025-001/01:07:04.124') // truncated, no Z
         })
 
         it('should decrement correctly', () => {
             let templateRaw = 'Subtracting dates: {{ subtract-time date duration }}'
             let template = new Mustache(templateRaw, SequencingLanguage.STOL)
             expect(template.execute(input))
-                .toEqual('Subtracting dates: 2025-001/00:57:01.877800Z')
+                .toEqual('Subtracting dates: 2025-001/00:57:01.877') // truncated, no Z
         })
     });
 
@@ -79,25 +79,25 @@ describe('Test built-in helpers', () => {
 
         let template = new Mustache(templateRaw, SequencingLanguage.STOL)
         expect(template.execute(input))
-            .toEqual('Uncleaned: 2025-001T00:00:00.00; Cleaned: 2025-001/00:00:00Z; Chained 2025-001/00:05:00Z')
+            .toEqual('Uncleaned: 2025-001T00:00:00.00; Cleaned: 2025-001/00:00:00; Chained 2025-001/00:05:00') // no Z
     });
 
     it('should reformat text/non-language-specific dates correctly', () => {
         // doy
         let templateRawDoy = 'Uncleaned: {{ date }}; Cleaned: {{ format-as-date date }}; Chained {{ format-as-date (add-time (format-as-date date) duration) }}'
-        let inputDoy = { date: "2025-001T00:00:00.00", duration: "00:05:00" }
+        let inputDoy = { date: "2025-001T00:00:00.00", duration: "00:05:00.250" }
 
         let templateDoy = new Mustache(templateRawDoy, SequencingLanguage.TEXT)
         expect(templateDoy.execute(inputDoy))
-            .toEqual('Uncleaned: 2025-001T00:00:00.00; Cleaned: 2025-01-01T00:00:00.000Z; Chained 2025-01-01T00:05:00.000Z')
+            .toEqual('Uncleaned: 2025-001T00:00:00.00; Cleaned: 2025-01-01T00:00:00Z; Chained 2025-01-01T00:05:00.250000Z')
 
 
         // ymd
         let templateRawYmd = 'Uncleaned: {{ date }}; Cleaned: {{ format-as-date date }}; Chained {{ format-as-date (add-time (format-as-date date) duration) }}'
-        let inputYmd = { date: "2025-01-01T00:00:00.00Z", duration: "00:05:00" } // excluding the Z with ymd leads to time zone conversions...
+        let inputYmd = { date: "2025-01-01T00:00:00.00Z", duration: "00:05:00.250" } // excluding the Z with ymd leads to time zone conversions...
 
         let templateYmd = new Mustache(templateRawYmd, SequencingLanguage.TEXT)
         expect(templateYmd.execute(inputYmd))
-            .toEqual('Uncleaned: 2025-01-01T00:00:00.00Z; Cleaned: 2025-01-01T00:00:00.000Z; Chained 2025-01-01T00:05:00.000Z')
+            .toEqual('Uncleaned: 2025-01-01T00:00:00.00Z; Cleaned: 2025-01-01T00:00:00Z; Chained 2025-01-01T00:05:00.250000Z')
     });
 });

--- a/sequencing-server/test/templating/time.spec.ts
+++ b/sequencing-server/test/templating/time.spec.ts
@@ -1,4 +1,4 @@
-import type { SequencingLanguage } from '../../src/lib/mustache/enums/language.js';
+import { SequencingLanguage } from '../../src/lib/mustache/enums/language.js';
 import {
     addTime,
     AERIEDurationToISO8601,
@@ -7,6 +7,7 @@ import {
     InstanttoSeqN,
     InstanttoSTOL,
     SeqNToInstant,
+    STOLToInstant,
     subtractTime
 } from '../../src/lib/mustache/util/time.js';
 import { Temporal } from '@js-temporal/polyfill';
@@ -17,8 +18,8 @@ describe('Time vector functions', () => {
         let inputTime = '2025-001/12:00:01.0002' // removed Z
         let inputDuration = '1000:00:01.01234Z'
 
-        let result = addTime(inputTime, inputDuration, { language: 'STOL' as SequencingLanguage })
-        expect(result).toEqual('2025-043/04:00:02.012540Z')
+        let result = addTime(inputTime, inputDuration, SequencingLanguage.STOL)
+        expect(result).toEqual('2025-043/04:00:02.012') // truncates, no Z either
     });
 
     it('should decrement correctly', () => {
@@ -26,17 +27,17 @@ describe('Time vector functions', () => {
         let inputTime = '2025-001/12:00:01.0002Z'
         let inputDuration = '1000:00:01.01234' // removed Z
 
-        let result = subtractTime(inputTime, inputDuration, { language: 'STOL' as SequencingLanguage })
-        expect(result).toEqual('2024-325/19:59:59.987860Z')
+        let result = subtractTime(inputTime, inputDuration, SequencingLanguage.STOL)
+        expect(result).toEqual('2024-325/19:59:59.987') // truncates, no Z either
     });
 
-    it('should handle TEXT correctly', () => {
+    it('should handle Text correctly', () => {
         // arbitrarily formatted as STOL
         let inputTime = '2025-001T12:00:01.0002Z'
         let inputDuration = '1000:00:01.01234' // removed Z
 
-        let result = subtractTime(inputTime, inputDuration, { language: 'TEXT' as SequencingLanguage })
-        expect(result).toEqual('2024-325T19:59:59.987860')
+        let result = subtractTime(inputTime, inputDuration, SequencingLanguage.TEXT)
+        expect(result).toEqual('2024-11-20T19:59:59.987660Z')
     });
 
     it('should add negative durations correctly', () => {
@@ -44,8 +45,8 @@ describe('Time vector functions', () => {
         let inputTime = '2025-001/12:00:01.0002Z'
         let inputDuration = '-1000:00:01.01234' // removed Z
 
-        let result = addTime(inputTime, inputDuration, { language: 'STOL' as SequencingLanguage })
-        expect(result).toEqual('2024-325/19:59:59.987860Z')
+        let result = addTime(inputTime, inputDuration, SequencingLanguage.STOL)
+        expect(result).toEqual('2024-325/19:59:59.987') // truncates, no Z either
 
     });
 
@@ -54,14 +55,14 @@ describe('Time vector functions', () => {
         let inputTime = '2025-001/12:00:01.0002Z'
         let inputDuration = '-1000:00:01.01234' // removed Z
 
-        let result = subtractTime(inputTime, inputDuration, { language: 'STOL' as SequencingLanguage })
-        expect(result).toEqual('2025-043/04:00:02.012540Z')
+        let result = subtractTime(inputTime, inputDuration, SequencingLanguage.STOL)
+        expect(result).toEqual('2025-043/04:00:02.012') // truncates, no Z either
     });
 });
 
 describe('Parsing times', () => {
     it('should parse from SeqN', () => {
-        let seqNstring = '2025-001T12:00:01.0002Z'
+        let seqNstring = '2025-001T12:00:01.0002'
         let instant: Temporal.Instant = SeqNToInstant(seqNstring)
 
         expect(instant.toString()).toEqual('2025-01-01T12:00:01.0002Z')
@@ -69,8 +70,8 @@ describe('Parsing times', () => {
 
 
     it('should parse from STOL', () => {
-        let seqNstring = '2025-001/12:00:01.0002Z'
-        let instant: Temporal.Instant = SeqNToInstant(seqNstring)
+        let stolString = '2025-001/12:00:01.0002Z'
+        let instant: Temporal.Instant = STOLToInstant(stolString)
 
         expect(instant.toString()).toEqual('2025-01-01T12:00:01.0002Z')
     });
@@ -137,24 +138,24 @@ describe('String conversion', () => {
             let instant: Temporal.Instant = Temporal.Instant.from('2025-01-01T12:01:23.000123Z');
             let stolString = InstanttoSTOL(instant)
 
-            expect(stolString).toEqual('2025-001/12:01:23.000123Z')
+            expect(stolString).toEqual('2025-001/12:01:23.000') // truncates, no Z either
         });
 
         it('should handle padding correctly', () => {
             let normalInstant: Temporal.Instant = Temporal.Instant.from('2025-01-01T12:01:23.0Z');
             let normalStolString = InstanttoSTOL(normalInstant)
 
-            expect(normalStolString).toEqual('2025-001/12:01:23Z')
+            expect(normalStolString).toEqual('2025-001/12:01:23') // no Z
 
             let msInstant: Temporal.Instant = Temporal.Instant.from('2025-01-01T12:01:23.010Z');
             let msStolString = InstanttoSTOL(msInstant)
 
-            expect(msStolString).toEqual('2025-001/12:01:23.010Z')
+            expect(msStolString).toEqual('2025-001/12:01:23.010') // truncates, no Z either
 
             let usInstant: Temporal.Instant = Temporal.Instant.from('2025-01-01T12:01:23.000010Z');
             let usStolString = InstanttoSTOL(usInstant)
 
-            expect(usStolString).toEqual('2025-001/12:01:23.000010Z')
+            expect(usStolString).toEqual('2025-001/12:01:23.000') // truncates, no Z either
         });
     });
 });


### PR DESCRIPTION
`___REQUIRES_GATEWAY_PR___="132"`

* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
There are a few minor fixes required in `InstantToSTOL`/`InstantToText` conversion. These primarily have to do with the presence of milliseconds versus microseconds, and the presence of a Zulu time indicator being required versus not. This gets its own PR, separate from the Sequence Template work, because the functionality here _does_ affect other parts of the code and isn't exclusively related to Sequence Templates. That being said, the changes are pretty minimal.

## Verification
All tests are updated! It's one of the 4 commits in this hotfix.

## Documentation
NASA-AMMOS/aerie-docs#243

## Future work
N/A
