### PR TITLE
Update to sequence template time fixes

### DIFF
--- a/sequencing-server/src/lib/mustache/util/index.ts
+++ b/sequencing-server/src/lib/mustache/util/index.ts
@@ -1,22 +1,12 @@
 /* A wrapper for Handlebars, so that `sequencing-server` isn't polluted with helper registration and the like. */
 import Handlebars from "handlebars";
-import { addTime as addTimeFull, subtractTime as subtractTimeFull, InstanttoSTOL, STOLToInstant, SeqNToInstant, InstanttoSeqN, TextToISO8601 } from "./time.js";
+import { addTime, subtractTime, formatTime } from "./time.js";
 import { getEnv } from "../../../env.js";
 import { SequencingLanguage } from "../enums/language.js";
 
 // initialized to environment variable, but this can be changed at runtime.
 const environment = {
     language: getEnv().SEQUENCING_LANGUAGE
-}
-
-/////////////// AERIE HELPERS ///////////////
-// wrappers for helpers
-function addTime(startTime: string, duration: string) {
-    return addTimeFull(startTime, duration, environment)
-}
-
-function subtractTime(startTime: string, duration: string) {
-    return subtractTimeFull(startTime, duration, environment)
 }
 
 // helper to flatten out array
@@ -29,24 +19,11 @@ function flatten(array: any[]): string {
     }
 }
 
-// helper to clean dates. must be manually invoked by the user, just in case. here, Text and SeqN are handled the same.
-function formatAsDate(date: string): string {
-    if (environment.language === SequencingLanguage.STOL) {
-        return InstanttoSTOL(STOLToInstant(date))
-    }
-    else if (environment.language === SequencingLanguage.TEXT) {
-        return TextToISO8601(date)
-    }
-    else {
-        return InstanttoSeqN(SeqNToInstant(date))
-    }
-}
-
 /////////////// AERIE HELPER REGISTRATION ///////////////
-Handlebars.registerHelper("add-time", addTime)
-Handlebars.registerHelper("subtract-time", subtractTime)
+Handlebars.registerHelper("add-time", (t, d) => addTime(t, d, environment.language))
+Handlebars.registerHelper("subtract-time", (t, d) => subtractTime(t, d, environment.language))
 Handlebars.registerHelper("flatten", flatten)
-Handlebars.registerHelper("format-as-date", formatAsDate)
+Handlebars.registerHelper("format-as-date", t => formatTime(t, environment.language))
 
 
 /////////////// EXPOSE TO SEQUENCING-SERVER ///////////////

--- a/sequencing-server/src/lib/mustache/util/time.ts
+++ b/sequencing-server/src/lib/mustache/util/time.ts
@@ -2,74 +2,57 @@ import { ParsedDoyString, ParsedDurationString, ParsedYmdString, TimeTypes } fro
 import { Temporal } from '@js-temporal/polyfill';
 import { SequencingLanguage } from '../enums/language.js';
 
+/**
+ * Time Helpers
+ */
+export function addTime(startTime: string, duration: string, language: SequencingLanguage): string {
+  return serializeInstant(parseInstant(startTime, language).add(parseDuration(duration)), language);
+}
 
-/////////////// SEQUENCING-SERVER-SPECIFIC HELPERS ///////////////
-export function addTime(startTime: string, duration: string, environment: { language: SequencingLanguage }): string {
-  let date: Temporal.Instant
-  if (environment.language === SequencingLanguage.STOL) {
-    date = STOLToInstant(startTime)
-  }
-  else if (environment.language === SequencingLanguage.TEXT) {
-    date = Temporal.Instant.from(TextToISO8601(startTime))
-  }
-  else {
-    date = SeqNToInstant(startTime)
-  }
+export function subtractTime(startTime: string, duration: string, language: SequencingLanguage): string {
+  return serializeInstant(parseInstant(startTime, language).subtract(parseDuration(duration)), language);
+}
 
-  let dur: Temporal.Duration;
-  if (duration.includes(":")) {
-    dur = Temporal.Duration.from(AERIEDurationToISO8601(duration))
-  }
-  else {
-    dur = Temporal.Duration.from(duration)
-  }
-  date = date.add(dur)
+export function formatTime(time: string, language: SequencingLanguage): string {
+  return serializeInstant(parseInstant(time, language), language);
+}
 
-  if (environment.language === SequencingLanguage.STOL) {
-    return InstanttoSTOL(date)
-  }
-  else if (environment.language === SequencingLanguage.TEXT) {
-    return InstantToText(date)
-  }
-  else { 
-    return InstanttoSeqN(date)
+/**
+ * Utilities for parsing and serializing times used in sequence templates
+ */
+
+function parseInstant(instant: string, language: SequencingLanguage): Temporal.Instant {
+  if (language === SequencingLanguage.STOL) {
+    return STOLToInstant(instant);
+  } else if (language === SequencingLanguage.TEXT) {
+    return Temporal.Instant.from(TextToISO8601(instant));
+  } else if (language === SequencingLanguage.SEQN) {
+    return SeqNToInstant(instant);
+  } else {
+    throw new Error('Unknown language: ' + language)
   }
 }
 
-export function subtractTime(startTime: string, duration: string, environment: { language: SequencingLanguage }): string {
-  let date: Temporal.Instant
-  if (environment.language === SequencingLanguage.STOL) {
-    date = STOLToInstant(startTime)
+function serializeInstant(instant: Temporal.Instant, language: SequencingLanguage): string {
+  if (language === SequencingLanguage.STOL) {
+    return InstanttoSTOL(instant);
+  } else if (language === SequencingLanguage.TEXT) {
+    return InstantToText(instant);
+  } else if (language === SequencingLanguage.SEQN) {
+    return InstanttoSeqN(instant);
+  } else {
+    throw new Error('Unknown language: ' + language)
   }
-  else if (environment.language === SequencingLanguage.TEXT) {
-    date = Temporal.Instant.from(TextToISO8601(startTime))
-  }
-  else {
-    date = SeqNToInstant(startTime)
-  }
-
-  let dur: Temporal.Duration;
-  if (duration.includes(":")) {
-    dur = Temporal.Duration.from(AERIEDurationToISO8601(duration))
-  }
-  else {
-    dur = Temporal.Duration.from(duration)
-  }
-  date = date.subtract(dur)
-
-  if (environment.language === SequencingLanguage.STOL) {
-    return InstanttoSTOL(date)
-  }
-  else if (environment.language === SequencingLanguage.TEXT) {
-    return InstantToText(date)
-  }
-  else { 
-    return InstanttoSeqN(date)
-  }
-
 }
 
-// TIME PARSING
+function parseDuration(duration: string): Temporal.Duration {
+  if (duration.includes(':')) {
+    return Temporal.Duration.from(AERIEDurationToISO8601(duration));
+  } else {
+    return Temporal.Duration.from(duration);
+  }
+}
+
 export function SeqNToInstant(date: string): Temporal.Instant {
   return Temporal.Instant.from(convertDoyToYmd(date));
 }
@@ -129,7 +112,6 @@ export function AERIEDurationToISO8601(duration: string): string {
   }
 }
 
-// CONVERSION BACK TO STRINGS
 export function InstanttoSTOL(date: Temporal.Instant): string {
   const stringFormat = date.toString();
 
@@ -195,7 +177,6 @@ export function InstantToText(date: Temporal.Instant): string {
   }
 }
 
-/////////////// AERIE-UI HELPERS ///////////////
 const ABSOLUTE_TIME = /^(\d{4})-(\d{3})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?$/;
 const RELATIVE_TIME =
   /^(?<doy>([0-9]{3}))?(T)?(?<hr>([0-9]{2})):(?<mins>([0-9]{2})):(?<secs>[0-9]{2})?(\.)?(?<ms>([0-9]+))?$/;

--- a/sequencing-server/src/lib/mustache/util/time.ts
+++ b/sequencing-server/src/lib/mustache/util/time.ts
@@ -177,6 +177,10 @@ export function InstantToText(date: Temporal.Instant): string {
   }
 }
 
+/**
+ * Time converters borrowed from Aerie-UI
+ * Consider replacing with implementations in aerie-time-utils: https://github.com/NASA-AMMOS/aerie-time-utils
+ */
 const ABSOLUTE_TIME = /^(\d{4})-(\d{3})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?$/;
 const RELATIVE_TIME =
   /^(?<doy>([0-9]{3}))?(T)?(?<hr>([0-9]{2})):(?<mins>([0-9]{2})):(?<secs>[0-9]{2})?(\.)?(?<ms>([0-9]+))?$/;

--- a/sequencing-server/src/lib/mustache/util/time.ts
+++ b/sequencing-server/src/lib/mustache/util/time.ts
@@ -71,22 +71,23 @@ export function subtractTime(startTime: string, duration: string, environment: {
 
 // TIME PARSING
 export function SeqNToInstant(date: string): Temporal.Instant {
-  return Temporal.Instant.from(convertDoyToYmd(date))
+  return Temporal.Instant.from(convertDoyToYmd(date));
 }
 
 export function STOLToInstant(date: string): Temporal.Instant {
-  return Temporal.Instant.from(convertDoyToYmd(date))
+  return Temporal.Instant.from(convertDoyToYmd(date));
 }
 
 export function TextToISO8601(date: string): string {
   // https://stackoverflow.com/questions/881085/count-the-number-of-occurrences-of-a-character-in-a-string-in-javascript
-  if ((date.match(/-/g) || []).length === 2) { // YYYY-MM-DD string
-    const result = new Date(date).toISOString()
-    return result + (result.includes("Z") ? "" : "Z")
-  }
-  else { // doy string
-    const result = new Date(convertDoyToYmd(date)).toISOString()
-    return result + (result.includes("Z") ? "" : "Z")
+  if ((date.match(/-/g) || []).length === 2) {
+    // YYYY-MM-DD string
+    const result = new Date(date).toISOString();
+    return result + (result.includes('Z') ? '' : 'Z');
+  } else {
+    // doy string
+    const result = new Date(convertDoyToYmd(date)).toISOString();
+    return result + (result.includes('Z') ? '' : 'Z');
   }
 }
 
@@ -96,96 +97,101 @@ function checkNumDurationComponents(split: string[]): split is [string, string, 
 
 export function AERIEDurationToISO8601(duration: string): string {
   // HHHHHH...:MM:SS.mmmuuu -> PHHMMSS.mmmuuuS
-  duration = duration.replace("Z", "");
-  let split = duration.split(":")
-  let isNegative = duration.includes("-")
+  duration = duration.replace('Z', '');
+  let split = duration.split(':');
+  let isNegative = duration.includes('-');
 
-  if (!checkNumDurationComponents(split)) { // required so editor wouldn't flag a type error
+  if (!checkNumDurationComponents(split)) {
+    // required so editor wouldn't flag a type error
     throw new Error(`Invalid duration string: ${duration}`);
   }
 
-  let hours = parseInt(split[0].replace("-", ""))
-  let minutes = parseInt(split[1])
-  let split2 = (split[2]).split(".")
-  let seconds = parseInt(split2[0] as string)
+  let hours = parseInt(split[0].replace('-', ''));
+  let minutes = parseInt(split[1]);
+  let split2 = split[2].split('.');
+  let seconds = parseInt(split2[0] as string);
   if (split2.length > 1) {
-    let microseconds = parseInt(split2[1]?.padEnd(6, "0") as string)
-    let microsecondsString = `${microseconds}`.padStart(6, "0")
-    return `${isNegative ? "-" : ""}PT${hours > 0 ? `${hours}H` : ""}${minutes > 0 ? `${minutes}M` : ""}${seconds > 0 && microseconds > 0 ? `${seconds}.${microsecondsString}S` : (seconds > 0) ? `${seconds}$` : (microseconds > 0) ? `0.${microsecondsString}S` : ""}`
-  }
-  else {
-    return `${isNegative ? "-" : ""}PT${hours > 0 ? `${hours}H` : ""}${minutes > 0 ? `${minutes}M` : ""}${seconds > 0 ? `${seconds}S` : ""}`
+    let microseconds = parseInt(split2[1]?.padEnd(6, '0') as string);
+    let microsecondsString = `${microseconds}`.padStart(6, '0');
+    return `${isNegative ? '-' : ''}PT${hours > 0 ? `${hours}H` : ''}${minutes > 0 ? `${minutes}M` : ''}${
+      seconds > 0 && microseconds > 0
+        ? `${seconds}.${microsecondsString}S`
+        : seconds > 0
+        ? `${seconds}$`
+        : microseconds > 0
+        ? `0.${microsecondsString}S`
+        : ''
+    }`;
+  } else {
+    return `${isNegative ? '-' : ''}PT${hours > 0 ? `${hours}H` : ''}${minutes > 0 ? `${minutes}M` : ''}${
+      seconds > 0 ? `${seconds}S` : ''
+    }`;
   }
 }
 
 // CONVERSION BACK TO STRINGS
 export function InstanttoSTOL(date: Temporal.Instant): string {
-  const stringFormat = date.toString()
+  const stringFormat = date.toString();
 
   // change to DOY
-  let split = stringFormat.split("T")
-  let day = new Date(split[0]!)
-  let doy = getDoy(day)
-  let time = split[1]!
+  let split = stringFormat.split('T');
+  let day = new Date(split[0]!);
+  let doy = getDoy(day);
+  let time = split[1]!;
 
   // extract decimal seconds, if any, and pad by length (ms -> 3 automatically, us -> 6 automatically)
-  if (!time.includes(".")) {
-    return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}/${time}`.replace("Z", "")
-  }
-  else {
-    const secondSplit = time.split(".")
-    const hms = secondSplit[0]
-    const decimal = (secondSplit[1]!).replace("Z", "")
+  if (!time.includes('.')) {
+    return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}/${time}`.replace('Z', '');
+  } else {
+    const secondSplit = time.split('.');
+    const hms = secondSplit[0];
+    const decimal = secondSplit[1]!.replace('Z', '');
 
     if (decimal.length <= 3) {
-      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}/${hms}.${decimal.padEnd(3, '0')}`
-    }
-    else {
-      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}/${hms}.${decimal.substring(0, 3)}`
+      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}/${hms}.${decimal.padEnd(3, '0')}`;
+    } else {
+      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}/${hms}.${decimal.substring(0, 3)}`;
     }
   }
-
 }
 
-export function InstanttoSeqN(date: Temporal.Instant): string { // presently, cannot extract fields from Temporal by saying obj.days or anything like that
-  const stringFormat = date.toString()
+export function InstanttoSeqN(date: Temporal.Instant): string {
+  // presently, cannot extract fields from Temporal by saying obj.days or anything like that
+  const stringFormat = date.toString();
 
   // change to DOY
-  let split = stringFormat.split("T")
-  let day = new Date(split[0]!)
-  let doy = getDoy(day)
-  let time = split[1]!
+  let split = stringFormat.split('T');
+  let day = new Date(split[0]!);
+  let doy = getDoy(day);
+  let time = split[1]!;
 
   // extract decimal seconds, if any, and pad by length (ms -> 3 automatically, us -> 6 automatically)
-  if (!time.includes(".")) {
-    return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}T${time.replace("Z", "")}`
-  }
-  else {
-    const secondSplit = time.split(".")
-    const hms = secondSplit[0]
-    const decimal = (secondSplit[1] ?? "000Z").replace("Z", "")
+  if (!time.includes('.')) {
+    return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}T${time.replace('Z', '')}`;
+  } else {
+    const secondSplit = time.split('.');
+    const hms = secondSplit[0];
+    const decimal = (secondSplit[1] ?? '000Z').replace('Z', '');
 
     // seqN doesn't include "Z" in its strings.
     if (decimal.length <= 3) {
-      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}T${hms}.${decimal.padEnd(3, '0')}`
-    }
-    else {
-      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}T${hms}.${decimal.padEnd(6, '0')}`
+      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}T${hms}.${decimal.padEnd(3, '0')}`;
+    } else {
+      return `${day.getUTCFullYear()}-${new String(doy).padStart(3, '0')}T${hms}.${decimal.padEnd(6, '0')}`;
     }
   }
 }
 
 export function InstantToText(date: Temporal.Instant): string {
   const result = date.toString();
-  if (result.includes(".") && result.split(".").length == 2) {
-    let split = result.split(".")
-    let rest = split[0]
-    let micros = split[1]?.replace("Z", "")
-    micros = micros?.padEnd(6, "0")
-    return rest + "." + micros + "Z"
-  }
-  else {
-    return result + (result.includes("Z") ? "" : "Z");
+  if (result.includes('.') && result.split('.').length == 2) {
+    let split = result.split('.');
+    let rest = split[0];
+    let micros = split[1]?.replace('Z', '');
+    micros = micros?.padEnd(6, '0');
+    return rest + '.' + micros + 'Z';
+  } else {
+    return result + (result.includes('Z') ? '' : 'Z');
   }
 }
 
@@ -213,18 +219,18 @@ export function convertDoyToYmd(doyString: string, includeMsecs = true): string 
         `${date.getUTCDate()}`.padStart(2, '0'),
       ].join('-')}T${parsedDoy.time}`;
       if (includeMsecs) {
-        return `${ymdString}${ymdString.charAt(ymdString.length - 1) !== "Z" ? "Z" : ""}`;
+        return `${ymdString}${ymdString.charAt(ymdString.length - 1) !== 'Z' ? 'Z' : ''}`;
       }
-      const replaced = ymdString.replace(/(\.\d+)/, '')
-      return `${replaced}${replaced.charAt(replaced.length - 1) !== "Z" ? "Z" : ""}`;
+      const replaced = ymdString.replace(/(\.\d+)/, '');
+      return `${replaced}${replaced.charAt(replaced.length - 1) !== 'Z' ? 'Z' : ''}`;
     } else {
       // doyString is already in ymd format
       //    just in case - correct and "/" in lieu of a T, i.e. 2025-001/time vs 2025-001Ttime
-      return `${doyString.replace("/", "T")}${doyString.charAt(doyString.length - 1) !== "Z" ? "Z" : ""}`;
+      return `${doyString.replace('/', 'T')}${doyString.charAt(doyString.length - 1) !== 'Z' ? 'Z' : ''}`;
     }
   }
 
-  throw Error(`Given date: ${doyString} is an invalid DOY (or YMD) string.`)
+  throw Error(`Given date: ${doyString} is an invalid DOY (or YMD) string.`);
 }
 
 /**

--- a/sequencing-server/src/routes/command-expansion.ts
+++ b/sequencing-server/src/routes/command-expansion.ts
@@ -548,17 +548,17 @@ commandExpansionRouter.post('/expand-all-sequence-templates', async (req, res, n
     catch (e) {
       if (e instanceof Error) {
         throw new Error(
-          `POST /command-expansion/expand-all-sequence-templates: Databse insertion failed with "${e.message}"`
+          `POST /command-expansion/expand-all-sequence-templates: Database insertion failed with "${e.message}"`
         )
       }
       else if (e instanceof String) {
         throw new Error(
-          `POST /command-expansion/expand-all-sequence-templates: Databse insertion failed with "${e}"`
+          `POST /command-expansion/expand-all-sequence-templates: Database insertion failed with "${e}"`
         )
       }
       else {
         throw new Error(
-          `POST /command-expansion/expand-all-sequence-templates: Databse insertion failed with "${JSON.stringify(e)}"`
+          `POST /command-expansion/expand-all-sequence-templates: Database insertion failed with "${JSON.stringify(e)}"`
         )
       }
     }

--- a/sequencing-server/test/command-expansion.spec.ts
+++ b/sequencing-server/test/command-expansion.spec.ts
@@ -1229,5 +1229,89 @@ CMD SEQUENCE=FINAL_B AT=2020-001/00:00:30.030`) // expect interleaving!
     });
   });
 
+  // STOL/plaintext-specific tests
+  describe('Plaintext sequences', () => {
+    let language = 'TEXT';
+
+    it.only('should format dates and simply concatenate strings', async () => {
+      let seqId = 'TextSequenceMerge';
+
+      await insertSequenceTemplate(
+        graphqlClient,
+        `GrowBanana.tpl`,
+        parcelId,
+        missionModelId,
+        `GrowBanana`,
+        language,
+        [
+          `A{{ format-as-date startTime }} GROW_BANANA_1`,
+          `A{{ format-as-date (add-time startTime attributes.arguments.growingDuration) }} GROW_BANANA_2`,
+        ].join(`\n`),
+      );
+
+      await insertSequenceTemplate(
+        graphqlClient,
+        `DurationParameterActivity.tpl`,
+        parcelId,
+        missionModelId,
+        `DurationParameterActivity`,
+        language,
+        [
+          `A{{ format-as-date startTime }} DURATION_ACTIVITY_1`,
+          `A{{ format-as-date (add-time startTime attributes.arguments.duration) }} DURATION_ACTIVITY_2`,
+        ].join(`\n`),
+      );
+
+      const activityId_A = await insertActivityDirective(graphqlClient, planId, 'GrowBanana', '0 milliseconds');
+      const activityId_B = await insertActivityDirective(
+        graphqlClient,
+        planId,
+        'DurationParameterActivity',
+        '30 seconds',
+        { duration: 30000 },
+      );
+
+      // Simulate Plan
+      const simulationArtifactPk = await executeSimulation(graphqlClient, planId);
+
+      // Create Sequence
+      const sequenceId = await createSequence(graphqlClient, seqId, simulationArtifactPk.simulationDatasetId);
+
+      // Assign Activities Manually
+      await assignActivityToSequence(graphqlClient, simulationArtifactPk.simulationDatasetId, activityId_A, seqId);
+      await assignActivityToSequence(graphqlClient, simulationArtifactPk.simulationDatasetId, activityId_B, seqId);
+
+      // Expand Plan
+      const expandedTemplates: { [seqId: string]: string } = await expandTemplates(
+        graphqlClient,
+        missionModelId,
+        [seqId],
+        simulationArtifactPk.simulationDatasetId,
+      );
+
+      // verify results
+      expect(sequenceId).toEqual(seqId);
+      expect(expandedTemplates).not.toBeNull();
+
+      const result = expandedTemplates[seqId];
+      expect(result).toInclude(
+        [
+          `A2020-01-01T00:00:00Z GROW_BANANA_1`,
+          `A2020-01-01T01:00:00Z GROW_BANANA_2`,
+          `A2020-01-01T00:00:30Z DURATION_ACTIVITY_1`,
+          `A2020-01-01T00:00:30.030000Z DURATION_ACTIVITY_2`,
+        ].join(`\n`),
+      );
+
+      // Cleanup
+      // remove sequence
+      await removeSequence(graphqlClient, seqId);
+      // remove simulation artifact pk
+      await removeSimulationArtifacts(graphqlClient, simulationArtifactPk);
+      // remove associations
+      await removeActivitySequenceAssignments(graphqlClient, seqId);
+    });
+  });
+
   // TODO: DAVID'S EDGE CASES
 })

--- a/sequencing-server/test/templating/mustache.spec.ts
+++ b/sequencing-server/test/templating/mustache.spec.ts
@@ -85,19 +85,19 @@ describe('Test built-in helpers', () => {
     it('should reformat text/non-language-specific dates correctly', () => {
         // doy
         let templateRawDoy = 'Uncleaned: {{ date }}; Cleaned: {{ format-as-date date }}; Chained {{ format-as-date (add-time (format-as-date date) duration) }}'
-        let inputDoy = { date: "2025-001T00:00:00.00", duration: "00:05:00" }
+        let inputDoy = { date: "2025-001T00:00:00.00", duration: "00:05:00.250" }
 
         let templateDoy = new Mustache(templateRawDoy, SequencingLanguage.TEXT)
         expect(templateDoy.execute(inputDoy))
-            .toEqual('Uncleaned: 2025-001T00:00:00.00; Cleaned: 2025-01-01T00:00:00.000Z; Chained 2025-01-01T00:05:00.000Z')
+            .toEqual('Uncleaned: 2025-001T00:00:00.00; Cleaned: 2025-01-01T00:00:00Z; Chained 2025-01-01T00:05:00.250000Z')
 
 
         // ymd
         let templateRawYmd = 'Uncleaned: {{ date }}; Cleaned: {{ format-as-date date }}; Chained {{ format-as-date (add-time (format-as-date date) duration) }}'
-        let inputYmd = { date: "2025-01-01T00:00:00.00Z", duration: "00:05:00" } // excluding the Z with ymd leads to time zone conversions...
+        let inputYmd = { date: "2025-01-01T00:00:00.00Z", duration: "00:05:00.250" } // excluding the Z with ymd leads to time zone conversions...
 
         let templateYmd = new Mustache(templateRawYmd, SequencingLanguage.TEXT)
         expect(templateYmd.execute(inputYmd))
-            .toEqual('Uncleaned: 2025-01-01T00:00:00.00Z; Cleaned: 2025-01-01T00:00:00.000Z; Chained 2025-01-01T00:05:00.000Z')
+            .toEqual('Uncleaned: 2025-01-01T00:00:00.00Z; Cleaned: 2025-01-01T00:00:00Z; Chained 2025-01-01T00:05:00.250000Z')
     });
 });

--- a/sequencing-server/test/templating/time.spec.ts
+++ b/sequencing-server/test/templating/time.spec.ts
@@ -1,4 +1,4 @@
-import type { SequencingLanguage } from '../../src/lib/mustache/enums/language.js';
+import { SequencingLanguage } from '../../src/lib/mustache/enums/language.js';
 import {
     addTime,
     AERIEDurationToISO8601,
@@ -7,6 +7,7 @@ import {
     InstanttoSeqN,
     InstanttoSTOL,
     SeqNToInstant,
+    STOLToInstant,
     subtractTime
 } from '../../src/lib/mustache/util/time.js';
 import { Temporal } from '@js-temporal/polyfill';
@@ -17,7 +18,7 @@ describe('Time vector functions', () => {
         let inputTime = '2025-001/12:00:01.0002' // removed Z
         let inputDuration = '1000:00:01.01234Z'
 
-        let result = addTime(inputTime, inputDuration, { language: 'STOL' as SequencingLanguage })
+        let result = addTime(inputTime, inputDuration, SequencingLanguage.STOL)
         expect(result).toEqual('2025-043/04:00:02.012') // truncates, no Z either
     });
 
@@ -26,7 +27,7 @@ describe('Time vector functions', () => {
         let inputTime = '2025-001/12:00:01.0002Z'
         let inputDuration = '1000:00:01.01234' // removed Z
 
-        let result = subtractTime(inputTime, inputDuration, { language: 'STOL' as SequencingLanguage })
+        let result = subtractTime(inputTime, inputDuration, SequencingLanguage.STOL)
         expect(result).toEqual('2024-325/19:59:59.987') // truncates, no Z either
     });
 
@@ -35,7 +36,7 @@ describe('Time vector functions', () => {
         let inputTime = '2025-001T12:00:01.0002Z'
         let inputDuration = '1000:00:01.01234' // removed Z
 
-        let result = subtractTime(inputTime, inputDuration, { language: 'Text' as SequencingLanguage })
+        let result = subtractTime(inputTime, inputDuration, SequencingLanguage.TEXT)
         expect(result).toEqual('2024-11-20T19:59:59.987660Z')
     });
 
@@ -44,7 +45,7 @@ describe('Time vector functions', () => {
         let inputTime = '2025-001/12:00:01.0002Z'
         let inputDuration = '-1000:00:01.01234' // removed Z
 
-        let result = addTime(inputTime, inputDuration, { language: 'STOL' as SequencingLanguage })
+        let result = addTime(inputTime, inputDuration, SequencingLanguage.STOL)
         expect(result).toEqual('2024-325/19:59:59.987') // truncates, no Z either
 
     });
@@ -54,14 +55,14 @@ describe('Time vector functions', () => {
         let inputTime = '2025-001/12:00:01.0002Z'
         let inputDuration = '-1000:00:01.01234' // removed Z
 
-        let result = subtractTime(inputTime, inputDuration, { language: 'STOL' as SequencingLanguage })
+        let result = subtractTime(inputTime, inputDuration, SequencingLanguage.STOL)
         expect(result).toEqual('2025-043/04:00:02.012') // truncates, no Z either
     });
 });
 
 describe('Parsing times', () => {
     it('should parse from SeqN', () => {
-        let seqNstring = '2025-001T12:00:01.0002Z'
+        let seqNstring = '2025-001T12:00:01.0002'
         let instant: Temporal.Instant = SeqNToInstant(seqNstring)
 
         expect(instant.toString()).toEqual('2025-01-01T12:00:01.0002Z')
@@ -69,8 +70,8 @@ describe('Parsing times', () => {
 
 
     it('should parse from STOL', () => {
-        let seqNstring = '2025-001/12:00:01.0002Z'
-        let instant: Temporal.Instant = SeqNToInstant(seqNstring)
+        let stolString = '2025-001/12:00:01.0002Z'
+        let instant: Temporal.Instant = STOLToInstant(stolString)
 
         expect(instant.toString()).toEqual('2025-01-01T12:00:01.0002Z')
     });


### PR DESCRIPTION
- Cleans up/unifies logic for parsing and serializing times in templates
- Makes the behavior consistent, where previously the behavior of the `add-time` and `subtract-time` helpers was different than the `format-as-date` helper
- Adds/improves some tests
- Ran the formatter (oops, my IDE did it)