### PR TITLE
Delay reporting simulation status until after profile segments have been written

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
@@ -109,6 +109,8 @@ public final class SimulationDriver {
           simulationExtentConsumer.accept(engine.getElapsedTime());
         }
 
+        simulationExtentConsumer.accept(engine.getElapsedTime()); // Report the final simulation time
+
       } catch (SpanException ex) {
         // Swallowing the spanException as the internal `spanId` is not user meaningful info.
         final var topics = missionModel.getTopics();

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/resources/AsyncConsumer.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/resources/AsyncConsumer.java
@@ -1,0 +1,23 @@
+package gov.nasa.jpl.aerie.merlin.driver.resources;
+
+/**
+ * Represents an asynchronous operation that accepts a single input argument and does something
+ * with it in the background
+ */
+public interface AsyncConsumer<T> {
+  /**
+   * Asynchronously performs this operation on the given argument
+   *
+   * @param t the input argument
+   *
+   * accept should not be called after the consumer has been closed
+   */
+  void accept(T t);
+
+  /**
+   * close blocks until the consumer has finished processing all inputs
+   *
+   * close should be idempotent - i.e. it should be safe to call multiple times
+   */
+  void close();
+}

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/resources/SimulationResourceManager.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/resources/SimulationResourceManager.java
@@ -14,6 +14,8 @@ public interface SimulationResourceManager {
   /**
    * Compute all ProfileSegments stored in this resource manager
    * @param elapsedDuration the amount of time elapsed since the start of simulation.
+   *
+   * This method blocks until all profile segments have finished being processed
    */
   ResourceProfiles computeProfiles(final Duration elapsedDuration);
 

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/resources/StreamingSimulationResourceManager.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/resources/StreamingSimulationResourceManager.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 
 /**
  * A variant of a SimulationResourceManager that streams resources as needed in order to conserve memory.
@@ -21,7 +20,7 @@ public class StreamingSimulationResourceManager implements SimulationResourceMan
   private final HashMap<String, ResourceSegments<RealDynamics>> realResourceSegments;
   private final HashMap<String, ResourceSegments<SerializedValue>> discreteResourceSegments;
 
-  private final Consumer<ResourceProfiles> streamer;
+  private final AsyncConsumer<ResourceProfiles> streamer;
 
   private Duration lastReceivedTime;
 
@@ -31,11 +30,11 @@ public class StreamingSimulationResourceManager implements SimulationResourceMan
   private static final int DEFAULT_THRESHOLD = 1024;
   private final int threshold;
 
-  public StreamingSimulationResourceManager(final Consumer<ResourceProfiles> streamer) {
+  public StreamingSimulationResourceManager(final AsyncConsumer<ResourceProfiles> streamer) {
     this(streamer, DEFAULT_THRESHOLD);
   }
 
-  public StreamingSimulationResourceManager(final Consumer<ResourceProfiles> streamer, int threshold) {
+  public StreamingSimulationResourceManager(final AsyncConsumer<ResourceProfiles> streamer, int threshold) {
     realResourceSegments = new HashMap<>();
     discreteResourceSegments = new HashMap<>();
     this.threshold = threshold;
@@ -82,6 +81,7 @@ public class StreamingSimulationResourceManager implements SimulationResourceMan
     }
 
     streamer.accept(profiles);
+    streamer.close(); // Wait for streamer to finish before continuing
     return profiles;
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -564,7 +564,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
         postSimulationResults(connection, datasetId, results, SimulationStateRecord.success());
         deleteSimulationExtent(connection, datasetId);
         transactionContext.commit();
-        logger.info("%s updated simulation status".formatted(Duration.microseconds(System.nanoTime() / 1000)));
+        logger.info("%s set simulation status to success".formatted(Duration.microseconds(System.nanoTime() / 1000)));
       } catch (final SQLException ex) {
         throw new DatabaseException("Failed to store simulation results", ex);
       } catch (final NoSuchSimulationDatasetException ex) {
@@ -581,6 +581,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
         failSimulation(connection, datasetId, reason);
         deleteSimulationExtent(connection, datasetId);
         transactionContext.commit();
+        logger.info("%s set simulation status to failed".formatted(Duration.microseconds(System.nanoTime() / 1000)));
       } catch (final SQLException ex) {
         throw new DatabaseException("Failed to update simulation state to failure", ex);
       } catch (final NoSuchSimulationDatasetException ex) {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresResultsCellRepository.java
@@ -564,6 +564,7 @@ public final class PostgresResultsCellRepository implements ResultsCellRepositor
         postSimulationResults(connection, datasetId, results, SimulationStateRecord.success());
         deleteSimulationExtent(connection, datasetId);
         transactionContext.commit();
+        logger.info("%s updated simulation status".formatted(Duration.microseconds(System.nanoTime() / 1000)));
       } catch (final SQLException ex) {
         throw new DatabaseException("Failed to store simulation results", ex);
       } catch (final NoSuchSimulationDatasetException ex) {

--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/postgres/PostgresProfileStreamer.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/postgres/PostgresProfileStreamer.java
@@ -2,7 +2,10 @@ package gov.nasa.jpl.aerie.merlin.worker.postgres;
 
 import gov.nasa.jpl.aerie.merlin.driver.resources.AsyncConsumer;
 import gov.nasa.jpl.aerie.merlin.driver.resources.ResourceProfiles;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.server.remotes.postgres.DatabaseException;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
@@ -10,6 +13,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class PostgresProfileStreamer implements AsyncConsumer<ResourceProfiles>, AutoCloseable {
+  public static final Logger log = LoggerFactory.getLogger(PostgresProfileStreamer.class);
   private final ExecutorService queryQueue;
   private final PostgresProfileQueryHandler queryHandler;
   private boolean closed = false;
@@ -24,6 +28,7 @@ public class PostgresProfileStreamer implements AsyncConsumer<ResourceProfiles>,
     if (closed) throw new IllegalStateException("accept cannot be called on a closed PostgresProfileStreamer");
     queryQueue.submit(() -> {
       queryHandler.uploadResourceProfiles(resourceProfiles);
+      log.info("%s : uploaded %d resource profiles".formatted(Duration.microseconds(System.nanoTime() / 1000), resourceProfiles.discreteProfiles().size() + resourceProfiles.realProfiles().size()));
     });
   }
 

--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/postgres/PostgresProfileStreamer.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/postgres/PostgresProfileStreamer.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.worker.postgres;
 
+import gov.nasa.jpl.aerie.merlin.driver.resources.AsyncConsumer;
 import gov.nasa.jpl.aerie.merlin.driver.resources.ResourceProfiles;
 import gov.nasa.jpl.aerie.merlin.server.remotes.postgres.DatabaseException;
 
@@ -7,11 +8,11 @@ import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.function.Consumer;
 
-public class PostgresProfileStreamer implements Consumer<ResourceProfiles>, AutoCloseable {
+public class PostgresProfileStreamer implements AsyncConsumer<ResourceProfiles>, AutoCloseable {
   private final ExecutorService queryQueue;
   private final PostgresProfileQueryHandler queryHandler;
+  private boolean closed = false;
 
   public PostgresProfileStreamer(DataSource dataSource, long datasetId) throws SQLException {
     this.queryQueue = Executors.newSingleThreadExecutor();
@@ -20,6 +21,7 @@ public class PostgresProfileStreamer implements Consumer<ResourceProfiles>, Auto
 
   @Override
   public void accept(final ResourceProfiles resourceProfiles) {
+    if (closed) throw new IllegalStateException("accept cannot be called on a closed PostgresProfileStreamer");
     queryQueue.submit(() -> {
       queryHandler.uploadResourceProfiles(resourceProfiles);
     });
@@ -27,6 +29,8 @@ public class PostgresProfileStreamer implements Consumer<ResourceProfiles>, Auto
 
   @Override
   public void close() {
+    if (closed) return;
+    closed = true;
     queryQueue.close();  // This waits for all submitted jobs to complete before returning
     try {
         queryHandler.close();

--- a/orchestration-utils/src/main/java/gov/nasa/jpl/aerie/orchestration/simulation/ResourceFileStreamer.java
+++ b/orchestration-utils/src/main/java/gov/nasa/jpl/aerie/orchestration/simulation/ResourceFileStreamer.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.orchestration.simulation;
 
+import gov.nasa.jpl.aerie.merlin.driver.resources.AsyncConsumer;
 import gov.nasa.jpl.aerie.merlin.driver.resources.ResourceProfiles;
 
 import javax.json.Json;
@@ -8,7 +9,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.UUID;
-import java.util.function.Consumer;
 
 import static gov.nasa.jpl.aerie.merlin.driver.json.SerializedValueJsonParser.serializedValueP;
 import static gov.nasa.jpl.aerie.merlin.server.http.ProfileParsers.realDynamicsP;
@@ -16,7 +16,7 @@ import static gov.nasa.jpl.aerie.merlin.server.http.ProfileParsers.realDynamicsP
 /**
  * A consumer that writes resource segments to the file system.
  */
-public class ResourceFileStreamer implements Consumer<ResourceProfiles> {
+public class ResourceFileStreamer implements AsyncConsumer<ResourceProfiles> {
   private final UUID uuid;
   private final HashMap<String, String> fileNames;
 
@@ -99,4 +99,10 @@ public class ResourceFileStreamer implements Consumer<ResourceProfiles> {
     return fileName;
   }
 
+  @Override
+  public void close() {
+    // No-op.
+    // ResourceFileStreamer's accept method is self-contained and
+    // doesn't leave any state that needs to be cleaned up
+  }
 }


### PR DESCRIPTION
* **Tickets addressed:** Fixes #1694 Fixes #1683
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Follow-up to https://github.com/NASA-AMMOS/aerie/pull/1640

Contract: simulation status is `success` implies that the simulation dataset is fully written and committed.

We currently violate this contract occasionally.

See more details here: https://github.com/NASA-AMMOS/aerie/issues/1694#issuecomment-3001499156 

After discussion with @Mythicaeda and @joshhaug , we decided to go with "Option 1" from the linked comment. This amounts to making the `computeResults` block until the resource streamer has finished.

This PR replaces the use of `Consumer` for resource streaming with a new `AsyncConsumer`, which is meant to reflect that the work done by the `accept` method may continue in the background after `accept` has returned. Its `close` method is intended to block until all previous calls to `accept` have finished their background processing.

`close` needs to be safe to call twice, because we call it both in the "nominal" case, as well as in the "finally" case.

### Report final simulation time
While doing the verification steps below, I noticed that the final simulation time was never reported. I added one commit to report the simulation extent one more time after exiting the main simulation loop.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

I followed a similar approach to https://github.com/NASA-AMMOS/aerie/pull/1640

I deliberately slowed down the resource streamer to guarantee that it is not done by the time the simulation status is updated.
```diff
queryQueue.submit(() -> {
+  Thread.sleep(10000); // omitting try/catch for brevity
  queryHandler.uploadResourceProfiles(resourceProfiles);
});
```

Having reproduced the problem on develop, I stashed the above change, checked out this branch, and popped the stash, and observed that simulation would spend longer in the "incomplete" status, and would only switch to "success" after the resources had finished being written.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
This is a bug fix; no documentation has been invalidated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Hopefully none 🤞 