### PR TITLE
Remove merlin-server as a dependency of orchestration-utils

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/json/Parsers.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/json/Parsers.java
@@ -1,0 +1,80 @@
+package gov.nasa.jpl.aerie.merlin.driver.json;
+
+import gov.nasa.jpl.aerie.json.JsonParseResult;
+import gov.nasa.jpl.aerie.json.JsonParser;
+import gov.nasa.jpl.aerie.json.SchemaCache;
+import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.types.Timestamp;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.util.Map;
+
+import static gov.nasa.jpl.aerie.json.BasicParsers.doubleP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.mapP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
+import static gov.nasa.jpl.aerie.json.BasicParsers.stringP;
+import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
+import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
+import static gov.nasa.jpl.aerie.merlin.driver.json.SerializedValueJsonParser.serializedValueP;
+
+public class Parsers {
+  public static final JsonParser<Timestamp> pgTimestampP = new JsonParser<>() {
+    private static final DateTimeFormatter format =
+        new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+            .toFormatter();
+
+    @Override
+    public JsonObject getSchema(final SchemaCache anchors) {
+      return Json
+          .createObjectBuilder(stringP.getSchema())
+          .add("format", "date-time")
+          .build();
+    }
+
+    @Override
+    public JsonParseResult<Timestamp> parse(final JsonValue json) {
+      final var result = stringP.parse(json);
+      if (result instanceof final JsonParseResult.Success<String> s) {
+        try {
+          final var instant = LocalDateTime.parse(s.result(), format).atZone(ZoneOffset.UTC);
+          return JsonParseResult.success(new Timestamp(instant));
+        } catch (final DateTimeParseException e) {
+          return JsonParseResult.failure("invalid timestamp format "+e);
+        }
+      } else if (result instanceof final JsonParseResult.Failure<?> f) {
+        return f.cast();
+      } else {
+        throw new Error("Unexpected subtype of " + JsonParseResult.class + ": " + result);
+      }
+    }
+
+    @Override
+    public JsonValue unparse(final Timestamp value) {
+      final var s = format.format(value.toInstant().atZone(ZoneOffset.UTC));
+      return stringP.unparse(s);
+    }
+  };
+
+  public static final JsonParser<Map<String, SerializedValue>> activityArgumentsP = mapP(serializedValueP);
+
+  public static final JsonParser<Map<String, SerializedValue>> simulationArgumentsP = mapP(serializedValueP);
+
+  public static final JsonParser<RealDynamics> realDynamicsP
+      = productP
+      . field("initial", doubleP)
+      . field("rate", doubleP)
+      . map(
+          untuple(RealDynamics::linear),
+          $ -> tuple($.initial, $.rate));
+}

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/timeline/EventGraphFlattener.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/timeline/EventGraphFlattener.java
@@ -1,6 +1,5 @@
-package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+package gov.nasa.jpl.aerie.merlin.driver.timeline;
 
-import gov.nasa.jpl.aerie.merlin.driver.timeline.EventGraph;
 import gov.nasa.jpl.aerie.merlin.protocol.model.EffectTrait;
 import org.apache.commons.lang3.tuple.Pair;
 

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/timeline/EventGraphUnflattener.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/timeline/EventGraphUnflattener.java
@@ -1,6 +1,5 @@
-package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+package gov.nasa.jpl.aerie.merlin.driver.timeline;
 
-import gov.nasa.jpl.aerie.merlin.driver.timeline.EventGraph;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;

--- a/merlin-driver/src/test/java/gov/nasa/jpl/aerie/merlin/driver/timeline/EventGraphFlattenerTest.java
+++ b/merlin-driver/src/test/java/gov/nasa/jpl/aerie/merlin/driver/timeline/EventGraphFlattenerTest.java
@@ -1,6 +1,5 @@
-package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+package gov.nasa.jpl.aerie.merlin.driver.timeline;
 
-import gov.nasa.jpl.aerie.merlin.driver.timeline.EventGraph;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ForAll;
@@ -10,8 +9,8 @@ import net.jqwik.api.Provide;
 import org.junit.jupiter.api.Test;
 
 import static gov.nasa.jpl.aerie.merlin.driver.timeline.EffectExpressionDisplay.displayGraph;
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.EventGraphFlattener.flatten;
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.EventGraphUnflattener.unflatten;
+import static gov.nasa.jpl.aerie.merlin.driver.timeline.EventGraphFlattener.flatten;
+import static gov.nasa.jpl.aerie.merlin.driver.timeline.EventGraphUnflattener.unflatten;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public final class EventGraphFlattenerTest {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinParsers.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import static gov.nasa.jpl.aerie.json.BasicParsers.*;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
 import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.pgTimestampP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.pgTimestampP;
 
 public abstract class MerlinParsers {
   private MerlinParsers() {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ProfileParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ProfileParsers.java
@@ -15,26 +15,18 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 
 import static gov.nasa.jpl.aerie.json.BasicParsers.chooseP;
-import static gov.nasa.jpl.aerie.json.BasicParsers.doubleP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.listP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.literalP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.mapP;
 import static gov.nasa.jpl.aerie.json.BasicParsers.productP;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
 import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.realDynamicsP;
 import static gov.nasa.jpl.aerie.merlin.driver.json.SerializedValueJsonParser.serializedValueP;
 import static gov.nasa.jpl.aerie.merlin.driver.json.ValueSchemaJsonParser.valueSchemaP;
 import static gov.nasa.jpl.aerie.merlin.server.http.MerlinParsers.durationP;
 
 public final class ProfileParsers {
-  public static final JsonParser<RealDynamics> realDynamicsP
-      = productP
-      . field("initial", doubleP)
-      . field("rate", doubleP)
-      . map(
-          untuple(RealDynamics::linear),
-          $ -> tuple($.initial, $.rate));
-
   public static final JsonParser<ProfileSegment<Optional<RealDynamics>>> realProfileSegmentP
       = productP
       . field("duration", durationP)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateSimulationDatasetAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/CreateSimulationDatasetAction.java
@@ -10,7 +10,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Map;
 
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.simulationArgumentsP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.simulationArgumentsP;
 
 /*package local*/ final class CreateSimulationDatasetAction implements AutoCloseable {
   private static final @Language("SQL") String sql = """

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityDirectivesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityDirectivesAction.java
@@ -8,7 +8,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.activityArgumentsP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.activityArgumentsP;
 import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.getJsonColumn;
 
 /*package-local*/ final class GetActivityDirectivesAction implements AutoCloseable {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationAction.java
@@ -10,7 +10,7 @@ import java.sql.SQLException;
 import java.util.Optional;
 
 import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.getJsonColumn;
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.simulationArgumentsP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.simulationArgumentsP;
 
 /*package local*/ final class GetSimulationAction implements AutoCloseable {
   private static final @Language("SQL") String sql = """

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationEventsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationEventsAction.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.driver.engine.EventRecord;
 import gov.nasa.jpl.aerie.merlin.driver.timeline.EventGraph;
+import gov.nasa.jpl.aerie.merlin.driver.timeline.EventGraphUnflattener;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import org.apache.commons.lang3.tuple.Pair;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationTemplateAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetSimulationTemplateAction.java
@@ -9,7 +9,7 @@ import java.sql.SQLException;
 import java.util.Optional;
 
 import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.getJsonColumn;
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.simulationArgumentsP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.simulationArgumentsP;
 
 /*package local*/ final class GetSimulationTemplateAction implements AutoCloseable {
   private static final @Language("SQL") String sql = """

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetUnvalidatedDirectivesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetUnvalidatedDirectivesAction.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.activityArgumentsP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.activityArgumentsP;
 import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.getJsonColumn;
 
 public class GetUnvalidatedDirectivesAction implements AutoCloseable {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/InsertSimulationEventsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/InsertSimulationEventsAction.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import gov.nasa.jpl.aerie.merlin.driver.engine.EventRecord;
 import gov.nasa.jpl.aerie.merlin.driver.timeline.EventGraph;
+import gov.nasa.jpl.aerie.merlin.driver.timeline.EventGraphFlattener;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.types.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
@@ -28,49 +28,11 @@ import java.util.Map;
 import static gov.nasa.jpl.aerie.json.BasicParsers.*;
 import static gov.nasa.jpl.aerie.json.Uncurry.tuple;
 import static gov.nasa.jpl.aerie.json.Uncurry.untuple;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.activityArgumentsP;
 import static gov.nasa.jpl.aerie.merlin.driver.json.SerializedValueJsonParser.serializedValueP;
 import static gov.nasa.jpl.aerie.merlin.driver.json.ValueSchemaJsonParser.valueSchemaP;
 
 public final class PostgresParsers {
-
-  public static final JsonParser<Timestamp> pgTimestampP = new JsonParser<>() {
-    private static final DateTimeFormatter format =
-        new DateTimeFormatterBuilder()
-            .append(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
-            .toFormatter();
-
-    @Override
-    public JsonObject getSchema(final SchemaCache anchors) {
-      return Json
-          .createObjectBuilder(stringP.getSchema())
-          .add("format", "date-time")
-          .build();
-    }
-
-    @Override
-    public JsonParseResult<Timestamp> parse(final JsonValue json) {
-      final var result = stringP.parse(json);
-      if (result instanceof final JsonParseResult.Success<String> s) {
-        try {
-          final var instant = LocalDateTime.parse(s.result(), format).atZone(ZoneOffset.UTC);
-          return JsonParseResult.success(new Timestamp(instant));
-        } catch (final DateTimeParseException e) {
-          return JsonParseResult.failure("invalid timestamp format "+e);
-        }
-      } else if (result instanceof final JsonParseResult.Failure<?> f) {
-        return f.cast();
-      } else {
-        throw new UnexpectedSubtypeError(JsonParseResult.class, result);
-      }
-    }
-
-    @Override
-    public JsonValue unparse(final Timestamp value) {
-      final var s = format.format(value.toInstant().atZone(ZoneOffset.UTC));
-      return stringP.unparse(s);
-    }
-  };
 
   public static final JsonParser<Pair<String, ValueSchema>> discreteProfileTypeP =
       productP
@@ -117,9 +79,6 @@ public final class PostgresParsers {
   }
 
   public static final JsonParser<Map<String, SerializedValue>> constraintArgumentsP = mapP(serializedValueP);
-  public static final JsonParser<Map<String, SerializedValue>> activityArgumentsP = mapP(serializedValueP);
-
-  public static final JsonParser<Map<String, SerializedValue>> simulationArgumentsP = mapP(serializedValueP);
 
   public static final JsonParser<ActivityAttributesRecord> activityAttributesP = productP
       .optionalField("directiveId", longP)

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ProfileRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ProfileRepository.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static gov.nasa.jpl.aerie.merlin.driver.json.SerializedValueJsonParser.serializedValueP;
-import static gov.nasa.jpl.aerie.merlin.server.http.ProfileParsers.realDynamicsP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.realDynamicsP;
 
 /*package-local*/ final class ProfileRepository {
   static ProfileSet getProfiles(

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsersTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsersTest.java
@@ -1,7 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
 import javax.json.Json;
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.pgTimestampP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.pgTimestampP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import gov.nasa.jpl.aerie.types.Timestamp;

--- a/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/postgres/PostgresProfileQueryHandler.java
+++ b/merlin-worker/src/main/java/gov/nasa/jpl/aerie/merlin/worker/postgres/PostgresProfileQueryHandler.java
@@ -20,7 +20,7 @@ import java.sql.Statement;
 import java.util.HashMap;
 
 import static gov.nasa.jpl.aerie.merlin.driver.json.SerializedValueJsonParser.serializedValueP;
-import static gov.nasa.jpl.aerie.merlin.server.http.ProfileParsers.realDynamicsP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.realDynamicsP;
 import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.discreteProfileTypeP;
 import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.realProfileTypeP;
 

--- a/orchestration-utils/build.gradle
+++ b/orchestration-utils/build.gradle
@@ -34,7 +34,6 @@ jacocoTestReport {
 
 
 dependencies {
-  implementation project(':merlin-server')
   implementation project(':merlin-driver')
   implementation project(':parsing-utilities')
   implementation project(':type-utils')

--- a/orchestration-utils/src/main/java/gov/nasa/jpl/aerie/orchestration/PlanJsonParser.java
+++ b/orchestration-utils/src/main/java/gov/nasa/jpl/aerie/orchestration/PlanJsonParser.java
@@ -2,9 +2,9 @@ package gov.nasa.jpl.aerie.orchestration;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.activityArgumentsP;
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.pgTimestampP;
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.simulationArgumentsP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.activityArgumentsP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.pgTimestampP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.simulationArgumentsP;
 
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 

--- a/orchestration-utils/src/main/java/gov/nasa/jpl/aerie/orchestration/simulation/ResourceFileStreamer.java
+++ b/orchestration-utils/src/main/java/gov/nasa/jpl/aerie/orchestration/simulation/ResourceFileStreamer.java
@@ -11,7 +11,7 @@ import java.util.HashMap;
 import java.util.UUID;
 
 import static gov.nasa.jpl.aerie.merlin.driver.json.SerializedValueJsonParser.serializedValueP;
-import static gov.nasa.jpl.aerie.merlin.server.http.ProfileParsers.realDynamicsP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.realDynamicsP;
 
 /**
  * A consumer that writes resource segments to the file system.

--- a/orchestration-utils/src/main/java/gov/nasa/jpl/aerie/orchestration/simulation/SimulationResultsWriter.java
+++ b/orchestration-utils/src/main/java/gov/nasa/jpl/aerie/orchestration/simulation/SimulationResultsWriter.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.RecursiveTask;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
-import gov.nasa.jpl.aerie.merlin.server.remotes.postgres.EventGraphFlattener;
+import gov.nasa.jpl.aerie.merlin.driver.timeline.EventGraphFlattener;
 import gov.nasa.jpl.aerie.types.Plan;
 import gov.nasa.jpl.aerie.types.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;
@@ -35,9 +35,9 @@ import org.apache.commons.lang3.tuple.Triple;
 
 import static gov.nasa.jpl.aerie.merlin.driver.json.SerializedValueJsonParser.serializedValueP;
 import static gov.nasa.jpl.aerie.merlin.driver.json.ValueSchemaJsonParser.valueSchemaP;
-import static gov.nasa.jpl.aerie.merlin.server.http.ProfileParsers.realDynamicsP;
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.activityArgumentsP;
-import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.simulationArgumentsP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.realDynamicsP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.activityArgumentsP;
+import static gov.nasa.jpl.aerie.merlin.driver.json.Parsers.simulationArgumentsP;
 
 
 public class SimulationResultsWriter {


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This is a follow-up to #1700

Currently, users cannot use orchestration-utils without pulling in merlin-server. We don't typically publish merlin-server (#1700 was an exception to that). This PR removes merlin-server from the orchestration-utils dependencies.

There were four things in merlin-server that orchestration-utils needed:
- pgTimestampP
- activityArgumentsP
- simulationArgumentsP
- realDynamicsP
- EventGraphFlattener

This PR creates a new `Parsers.java` file under the `gov.nasa.jpl.aerie.merlin.driver.json` and moves the four parsers above from merlin-server to this new file.

This PR moves `EventGraphFlattener` into `gov.nasa.jpl.aerie.merlin.driver.timeline` alongside the definition of `EventGraph` itself.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
It compiles!

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
I couldn't find any docs on stateless aerie - if someone knows otherwise, let me know.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
There are a number of duplicated parsers and parsing functions across merlin-server and scheduler-server. I think we can take a careful look at them and move some of them to this new Parsers.java class. 

There are a few copy/pasted implementations of the `parseJson` function that I think can be unified by adding a static method to JsonParser in parsing-utilities. I took a stab at that, but then decided that it would be better for this PR to be minimal. That first attempt is in the branch called [`dailis/orchestration-utils-dependency-refactor-take-1`](https://github.com/NASA-AMMOS/aerie/compare/dailis/orchestration-utils-dependency-refactor-take-1)
