### PR TITLE
Access resources from mission model in procedures

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/Accumulator.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/Accumulator.java
@@ -7,7 +7,7 @@ import gov.nasa.jpl.aerie.merlin.framework.CellRef;
 import gov.nasa.jpl.aerie.merlin.framework.resources.real.RealResource;
 import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics;
 
-public final class Accumulator implements RealResource {
+public final class Accumulator extends NamedResource<RealDynamics> implements RealResource {
   private final CellRef<LinearAccumulationEvent, LinearIntegrationCell> ref;
 
   public final Rate rate = new Rate();

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/NamedResource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/NamedResource.java
@@ -1,0 +1,17 @@
+package gov.nasa.jpl.aerie.contrib.models;
+
+import gov.nasa.jpl.aerie.merlin.framework.resources.NameableResource;
+
+public abstract class NamedResource<D> implements NameableResource<D> {
+  private String name = "";
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public void setName(final String name) {
+    this.name = name;
+  }
+}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/NamedResource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/NamedResource.java
@@ -2,6 +2,9 @@ package gov.nasa.jpl.aerie.contrib.models;
 
 import gov.nasa.jpl.aerie.merlin.framework.resources.NameableResource;
 
+/**
+ * Provides a field for setting the string name of the resource.
+ */
 public abstract class NamedResource<D> implements NameableResource<D> {
   private String name = "ERROR: Name was not set during model construction";
 

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/NamedResource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/NamedResource.java
@@ -3,7 +3,7 @@ package gov.nasa.jpl.aerie.contrib.models;
 import gov.nasa.jpl.aerie.merlin.framework.resources.NameableResource;
 
 public abstract class NamedResource<D> implements NameableResource<D> {
-  private String name = "";
+  private String name = "ERROR: Name was not set during model construction";
 
   @Override
   public String getName() {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/Pointing.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/Pointing.java
@@ -54,7 +54,7 @@ public final class Pointing {
     addRate(previousRate);         // Reset rate to previous rate
   }
 
-  public static final class Component implements RealResource {
+  public static final class Component extends NamedResource<RealDynamics> implements RealResource {
     private final Accumulator acc;
     public final Accumulator.Rate rate;
 

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/Register.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/Register.java
@@ -7,7 +7,7 @@ import gov.nasa.jpl.aerie.merlin.framework.resources.discrete.DiscreteResource;
 
 import java.util.function.UnaryOperator;
 
-public final class Register<Value> implements DiscreteResource<Value> {
+public final class Register<Value> extends NamedResource<Value> implements DiscreteResource<Value> {
   public final CellRef<Value, RegisterCell<Value>> ref;
 
   private Register(final UnaryOperator<Value> duplicator, final Value initialValue) {

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/SampledResource.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/SampledResource.java
@@ -13,7 +13,7 @@ import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.*;
  * Simple resource that samples arbitrarily many existing resources/values at a specified period (default period is once
  * per second).
  */
-public class SampledResource<T> implements DiscreteResource<T> {
+public class SampledResource<T> extends NamedResource<T> implements DiscreteResource<T> {
   private final Register<T> result;
   private final Supplier<T> sampler;
   private final Register<Double> period;

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/ValidationResult.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/ValidationResult.java
@@ -1,5 +1,3 @@
 package gov.nasa.jpl.aerie.contrib.models;
 
-import java.util.Optional;
-
 public record ValidationResult(boolean success, String subject, String message) {}

--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/counters/Counter.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/models/counters/Counter.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.contrib.models.counters;
 
 import gov.nasa.jpl.aerie.contrib.cells.counters.CounterCell;
+import gov.nasa.jpl.aerie.contrib.models.NamedResource;
 import gov.nasa.jpl.aerie.merlin.framework.CellRef;
 import gov.nasa.jpl.aerie.merlin.framework.resources.discrete.DiscreteResource;
 
@@ -8,7 +9,7 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
-public final class Counter<T> implements DiscreteResource<T> {
+public final class Counter<T> extends NamedResource<T> implements DiscreteResource<T> {
   private final CellRef<T, CounterCell<T>> ref;
 
   public Counter(final T initialValue, final T zero, final BinaryOperator<T> adder, final UnaryOperator<T> duplicator) {

--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -60,6 +60,7 @@ dependencies {
   annotationProcessor project(':procedural:processor')
 
   implementation project(":procedural:scheduling")
+  implementation project(":procedural:constraints")
   implementation project(":procedural:timeline")
   implementation project(':merlin-sdk')
   implementation project(':type-utils')

--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -64,6 +64,7 @@ dependencies {
   implementation project(':merlin-sdk')
   implementation project(':type-utils')
   implementation project(':contrib')
+  compileOnly project(':examples:banananation')
 
   testImplementation "com.zaxxer:HikariCP:5.1.0"
   testImplementation("org.postgresql:postgresql:42.6.0")

--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -65,7 +65,7 @@ dependencies {
   implementation project(':merlin-sdk')
   implementation project(':type-utils')
   implementation project(':contrib')
-  compileOnly project(':examples:banananation')
+  implementation project(':examples:banananation')
 
   testImplementation "com.zaxxer:HikariCP:5.1.0"
   testImplementation("org.postgresql:postgresql:42.6.0")
@@ -119,6 +119,9 @@ tasks.create("generateProcedureJarTasks") {
       archiveClassifier.set(nameWithoutExtension) // set output jar name
       manifest {
         attributes 'Main-Class': getMainClassFromGeneratedFile(file)
+      }
+      dependencies {
+        exclude(project(":examples:banananation"))
       }
       minimize()
     }

--- a/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/constraints/procedures/ModelIntegrationConstraint.java
+++ b/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/constraints/procedures/ModelIntegrationConstraint.java
@@ -1,0 +1,30 @@
+package gov.nasa.jpl.aerie.e2e.procedural.constraints.procedures;
+
+import gov.nasa.ammos.aerie.procedural.constraints.Constraint;
+import gov.nasa.ammos.aerie.procedural.constraints.Violations;
+import gov.nasa.ammos.aerie.procedural.constraints.annotations.ConstraintProcedure;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.Plan;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults;
+import gov.nasa.ammos.aerie.procedural.timeline.util.WithModel;
+import gov.nasa.jpl.aerie.banananation.Mission;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * A simple constraint that verifies access to the mission model through the WithModel interface
+ */
+@ConstraintProcedure
+public record ModelIntegrationConstraint() implements Constraint, WithModel<Mission> {
+  @Override
+  public @NotNull Violations run(@NotNull Plan plan, @NotNull SimulationResults simResults) {
+    // Access the mission model through the WithModel interface
+    // This should work without ClassCastException if the class loader fix is working
+    final var mission = model();
+
+    // Simple constraint: fruit should never go below 2.0
+    final var lowFruit = simResults.resource(mission.fruit).lessThan(2.0);
+
+    return Violations.inside(lowFruit.highlightTrue());
+  }
+}

--- a/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/package-info.java
+++ b/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/package-info.java
@@ -1,5 +1,5 @@
 @WithMappers(BasicValueMappers.class)
-package gov.nasa.jpl.aerie.e2e.procedural.scheduling;
+package gov.nasa.jpl.aerie.e2e.procedural;
 
 import gov.nasa.jpl.aerie.contrib.serialization.rulesets.BasicValueMappers;
 import gov.nasa.ammos.aerie.procedural.scheduling.annotations.WithMappers;

--- a/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ModelIntegrationGoal.java
+++ b/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ModelIntegrationGoal.java
@@ -1,0 +1,27 @@
+package gov.nasa.jpl.aerie.e2e.procedural.scheduling.procedures;
+
+import gov.nasa.ammos.aerie.procedural.scheduling.Goal;
+import gov.nasa.ammos.aerie.procedural.scheduling.annotations.SchedulingProcedure;
+import gov.nasa.ammos.aerie.procedural.scheduling.plan.EditablePlan;
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.DirectiveStart;
+import gov.nasa.ammos.aerie.procedural.timeline.util.WithModel;
+import gov.nasa.jpl.aerie.banananation.Mission;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+/**
+ * Creates a bite banana every time /producer changes
+ */
+@SchedulingProcedure
+public record ModelIntegrationGoal() implements Goal, WithModel<Mission> {
+  @Override
+  public void run(@NotNull final EditablePlan plan) {
+    final var changes = plan.simulate().resource(model().producer).changes().highlightTrue();
+    for (final var interval: changes) {
+      plan.create("BiteBanana", new DirectiveStart.Absolute(interval.start), Map.of("biteSize", SerializedValue.of(1)));
+    }
+    plan.commit();
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/ProceduralSetup.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/ProceduralSetup.java
@@ -1,4 +1,4 @@
-package gov.nasa.jpl.aerie.e2e.procedural.scheduling;
+package gov.nasa.jpl.aerie.e2e.procedural;
 
 import com.microsoft.playwright.Playwright;
 import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.TestInstance;
 import java.io.IOException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public abstract class ProceduralSchedulingSetup {
+public abstract class ProceduralSetup {
 
   // Requests
   protected Playwright playwright;

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/constraints/ModelIntegrationConstraintTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/constraints/ModelIntegrationConstraintTests.java
@@ -1,0 +1,64 @@
+package gov.nasa.jpl.aerie.e2e.procedural.constraints;
+
+import gov.nasa.jpl.aerie.e2e.procedural.ProceduralSetup;
+import gov.nasa.jpl.aerie.e2e.types.ConstraintInvocationId;
+import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.json.Json;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ModelIntegrationConstraintTests extends ProceduralSetup {
+  private int constraintJarId;
+  private ConstraintInvocationId constraintId;
+
+  @BeforeEach
+  void localBeforeEach() throws IOException {
+    try (final var gateway = new GatewayRequests(playwright)) {
+      constraintJarId = gateway.uploadJarFile("build/libs/ModelIntegrationConstraint.jar");
+      // Add Constraint Procedure
+      constraintId = hasura.insertPlanConstraintJar(
+          "Test Model Integration Constraint",
+          planId,
+          constraintJarId
+      );
+    }
+  }
+
+  @AfterEach
+  void localAfterEach() throws IOException {
+    hasura.deleteConstraint(constraintId.id());
+  }
+
+  @Test
+  void testModelIntegrationConstraint() throws IOException {
+    // Add an activity that will cause fruit to go below 2.0
+    hasura.insertActivityDirective(
+        planId,
+        "BiteBanana",
+        "1h",
+        Json.createObjectBuilder().add("biteSize", Json.createValue(4)).build()
+    );
+
+    // Simulate the plan
+    hasura.awaitSimulation(planId);
+
+    // Run constraints and check that our constraint can access the mission model
+    final var results = hasura.checkConstraints(planId);
+    final var run = results.constraintsRun().getFirst();
+
+    assertEquals("Test Model Integration Constraint", run.constraintName());
+
+    // The constraint should run without ClassCastException and detect violations
+    assertTrue(run.success());
+    assertEquals(1, run.result().get().violations().size());
+
+    assertEquals(Duration.hours(1), Duration.microseconds(run.result().get().violations().getFirst().windows().getFirst().start()));
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/AutoDeletionTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/AutoDeletionTests.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.e2e.procedural.scheduling;
 
+import gov.nasa.jpl.aerie.e2e.procedural.ProceduralSetup;
 import gov.nasa.jpl.aerie.e2e.types.GoalInvocationId;
 import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
 import org.junit.jupiter.api.AfterEach;
@@ -10,13 +11,12 @@ import javax.json.Json;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AutoDeletionTests extends ProceduralSchedulingSetup {
+public class AutoDeletionTests extends ProceduralSetup {
   private GoalInvocationId edslId;
   private GoalInvocationId procedureId;
 

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/BasicTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/BasicTests.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.e2e.procedural.scheduling;
 
+import gov.nasa.jpl.aerie.e2e.procedural.ProceduralSetup;
 import gov.nasa.jpl.aerie.e2e.types.GoalInvocationId;
 import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
 import org.junit.jupiter.api.AfterEach;
@@ -13,7 +14,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BasicTests extends ProceduralSchedulingSetup {
+public class BasicTests extends ProceduralSetup {
   private int procedureJarId;
   private GoalInvocationId procedureId;
 

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/DatabaseDeletionTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/DatabaseDeletionTests.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.e2e.procedural.scheduling;
 
+import gov.nasa.jpl.aerie.e2e.procedural.ProceduralSetup;
 import gov.nasa.jpl.aerie.e2e.types.GoalInvocationId;
 import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
 import org.junit.jupiter.api.AfterEach;
@@ -16,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DatabaseDeletionTests extends ProceduralSchedulingSetup {
+public class DatabaseDeletionTests extends ProceduralSetup {
   private GoalInvocationId procedureId;
 
   @BeforeEach

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/DeletionTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/DeletionTests.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.e2e.procedural.scheduling;
 
+import gov.nasa.jpl.aerie.e2e.procedural.ProceduralSetup;
 import gov.nasa.jpl.aerie.e2e.types.GoalInvocationId;
 import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
 import org.junit.jupiter.api.AfterEach;
@@ -14,7 +15,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DeletionTests extends ProceduralSchedulingSetup {
+public class DeletionTests extends ProceduralSetup {
   private GoalInvocationId procedureId;
 
   @BeforeEach

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalEventsSchedulingTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalEventsSchedulingTests.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.e2e.procedural.scheduling;
 
+import gov.nasa.jpl.aerie.e2e.procedural.ProceduralSetup;
 import gov.nasa.jpl.aerie.e2e.types.GoalInvocationId;
 import gov.nasa.jpl.aerie.e2e.types.Plan;
 import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
@@ -17,7 +18,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ExternalEventsSchedulingTests extends ProceduralSchedulingSetup {
+public class ExternalEventsSchedulingTests extends ProceduralSetup {
   private GoalInvocationId procedureId;
   private final static String SOURCE_TYPE = "TestType";
   private final static String EVENT_TYPE = "TestType";

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalProfilesTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalProfilesTests.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.e2e.procedural.scheduling;
 
 import gov.nasa.jpl.aerie.e2e.ExternalDatasetsTest;
+import gov.nasa.jpl.aerie.e2e.procedural.ProceduralSetup;
 import gov.nasa.jpl.aerie.e2e.types.GoalInvocationId;
 import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
 import org.junit.jupiter.api.AfterEach;
@@ -14,7 +15,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ExternalProfilesTests extends ProceduralSchedulingSetup {
+public class ExternalProfilesTests extends ProceduralSetup {
   private GoalInvocationId procedureId;
   private int datasetId;
 

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ModelIntegrationTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ModelIntegrationTests.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.e2e.procedural.scheduling;
 
+import gov.nasa.jpl.aerie.e2e.procedural.ProceduralSetup;
 import gov.nasa.jpl.aerie.e2e.types.GoalInvocationId;
 import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
 import org.junit.jupiter.api.AfterEach;
@@ -14,7 +15,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ModelIntegrationTests extends ProceduralSchedulingSetup {
+public class ModelIntegrationTests extends ProceduralSetup {
   private int procedureJarId;
   private GoalInvocationId procedureId;
 

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ModelIntegrationTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ModelIntegrationTests.java
@@ -1,0 +1,57 @@
+package gov.nasa.jpl.aerie.e2e.procedural.scheduling;
+
+import gov.nasa.jpl.aerie.e2e.types.GoalInvocationId;
+import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.json.Json;
+import javax.json.JsonValue;
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ModelIntegrationTests extends ProceduralSchedulingSetup {
+  private int procedureJarId;
+  private GoalInvocationId procedureId;
+
+  @BeforeEach
+  void localBeforeEach() throws IOException {
+    try (final var gateway = new GatewayRequests(playwright)) {
+      procedureJarId = gateway.uploadJarFile("build/libs/ModelIntegrationGoal.jar");
+      // Add Scheduling Procedure
+      procedureId = hasura.createSchedulingSpecProcedure(
+          "Test Scheduling Procedure",
+          procedureJarId,
+          specId,
+          0
+      );
+    }
+  }
+
+  @AfterEach
+  void localAfterEach() throws IOException {
+    hasura.deleteSchedulingGoal(procedureId.goalId());
+  }
+
+  @Test
+  void testModelIntegration() throws IOException {
+    hasura.insertActivityDirective(
+        planId,
+        "ChangeProducer",
+        "1h",
+        Json.createObjectBuilder().add("producer", Json.createValue("p")).build()
+    );
+    hasura.updatePlanRevisionSchedulingSpec(planId);
+
+    hasura.awaitScheduling(specId);
+
+    final var plan = hasura.getPlan(planId);
+    final var activities = plan.activityDirectives();
+
+    assertEquals(2, activities.size());
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ConstraintError.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ConstraintError.java
@@ -5,7 +5,8 @@ import javax.json.JsonObject;
 public record ConstraintError(String message, String stack, Location location ){
   record Location(int column, int line){
     public static Location fromJSON(JsonObject json){
-      return new Location(json.getJsonNumber("column").intValue(), json.getJsonNumber("line").intValue());
+      if (!json.containsKey("column") || !json.containsKey("line") || json.isNull("column") || json.isNull("line")) return null;
+      else return new Location(json.getJsonNumber("column").intValue(), json.getJsonNumber("line").intValue());
     }
   };
 

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/HasuraRequests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/HasuraRequests.java
@@ -1272,6 +1272,32 @@ public class HasuraRequests implements AutoCloseable {
     );
   }
 
+  public ConstraintInvocationId insertPlanConstraintJar(
+      String name,
+      int planId,
+      int jarId
+  ) throws IOException {
+    final var constraintInsertBuilder = Json.createObjectBuilder()
+                                            .add("plan_id", planId)
+                                            .add("constraint_metadata",
+                                                 Json.createObjectBuilder()
+                                                     .add("data",
+                                                          Json.createObjectBuilder()
+                                                              .add("name", name)
+                                                              .add("versions",
+                                                                   Json.createObjectBuilder()
+                                                                       .add("data",
+                                                                            Json.createObjectBuilder()
+                                                                                .add("type", "JAR")
+                                                                                .add("uploaded_jar_id", jarId)))));
+    final var variables = Json.createObjectBuilder().add("constraint", constraintInsertBuilder).build();
+    final var resp = makeRequest(GQL.INSERT_PLAN_SPEC_CONSTRAINT, variables).getJsonObject("constraint");
+    return new ConstraintInvocationId(
+        resp.getInt("constraint_id"),
+        resp.getInt("invocation_id")
+    );
+  }
+
   public void updatePlanConstraintSpecVersion(int invocationId, int constraintRevision) throws IOException {
     final var variables = Json.createObjectBuilder()
                               .add("invocation_id", invocationId)

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelLoader.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/MissionModelLoader.java
@@ -66,7 +66,8 @@ public final class MissionModelLoader {
         final var className = getImplementingClassName(path, name, version);
 
         // Construct a ClassLoader with access to classes in the mission model location.
-        final var classLoader = new URLClassLoader(new URL[] {missionModelPathToUrl(path)});
+        final var parentClassLoader = Thread.currentThread().getContextClassLoader();
+        final var classLoader = new URLClassLoader(new URL[] {missionModelPathToUrl(path)}, parentClassLoader);
 
         try {
             final var pluginClass$ = classLoader.loadClass(className);

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Registrar.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Registrar.java
@@ -26,7 +26,7 @@ public final class Registrar {
 
   public <Value> void discrete(final String name, final Resource<Value> resource, final ValueMapper<Value> mapper) {
     if (resource instanceof NameableResource) {
-      ((NameableResource) resource).setName(name);
+      ((NameableResource<?>) resource).setName(name);
     }
 
     this.builder.resource(name, makeResource("discrete", resource, mapper.getValueSchema(), mapper::serializeValue));
@@ -42,7 +42,7 @@ public final class Registrar {
 
   private void real(final String name, final Resource<RealDynamics> resource, UnaryOperator<ValueSchema> schemaModifier) {
     if (resource instanceof NameableResource) {
-      ((NameableResource) resource).setName(name);
+      ((NameableResource<?>) resource).setName(name);
     }
 
     this.builder.resource(

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Registrar.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Registrar.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.framework;
 
+import gov.nasa.jpl.aerie.merlin.framework.resources.NameableResource;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Initializer;
 import gov.nasa.jpl.aerie.merlin.protocol.driver.Querier;
 import gov.nasa.jpl.aerie.merlin.protocol.model.OutputType;
@@ -24,6 +25,10 @@ public final class Registrar {
   }
 
   public <Value> void discrete(final String name, final Resource<Value> resource, final ValueMapper<Value> mapper) {
+    if (resource instanceof NameableResource) {
+      ((NameableResource) resource).setName(name);
+    }
+
     this.builder.resource(name, makeResource("discrete", resource, mapper.getValueSchema(), mapper::serializeValue));
   }
 
@@ -36,6 +41,10 @@ public final class Registrar {
   }
 
   private void real(final String name, final Resource<RealDynamics> resource, UnaryOperator<ValueSchema> schemaModifier) {
+    if (resource instanceof NameableResource) {
+      ((NameableResource) resource).setName(name);
+    }
+
     this.builder.resource(
         name,
         makeResource(

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/resources/NameableResource.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/resources/NameableResource.java
@@ -1,0 +1,8 @@
+package gov.nasa.jpl.aerie.merlin.framework.resources;
+
+import gov.nasa.jpl.aerie.merlin.framework.Resource;
+
+public interface NameableResource<D> extends Resource<D> {
+  String getName();
+  void setName(String name);
+}

--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/resources/NameableResource.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/resources/NameableResource.java
@@ -2,6 +2,10 @@ package gov.nasa.jpl.aerie.merlin.framework.resources;
 
 import gov.nasa.jpl.aerie.merlin.framework.Resource;
 
+/**
+ * A resource that can be given a string name. Used by scheduling and constraints
+ * to access resources through the mission model rather than with name+deserializer.
+ */
 public interface NameableResource<D> extends Resource<D> {
   String getName();
   void setName(String name);

--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -82,6 +82,7 @@ application {
 dependencies {
   implementation project(':type-utils')
   implementation project(':merlin-driver')
+  implementation project(':merlin-framework')
   implementation project(':parsing-utilities')
   implementation project(':constraints')
   implementation project(':permissions')

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/AerieAppDriver.java
@@ -90,7 +90,8 @@ public final class AerieAppDriver {
       constraintsDSLCompilationService,
       constraintService,
       planController,
-      simulationController
+      simulationController,
+      missionModelController
     );
     final var generateConstraintsLibAction = new GenerateConstraintsLibAction(typescriptCodeGenerationService);
     final var permissionsService = new PermissionsService(

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ExecutableConstraint.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ExecutableConstraint.java
@@ -76,10 +76,19 @@ public sealed interface ExecutableConstraint extends Comparable<ExecutableConstr
         ReadonlyProceduralSimResults simResults,
         gov.nasa.jpl.aerie.merlin.driver.SimulationResults merlinResults
     ) {
+      return run(plan, simResults, merlinResults, Thread.currentThread().getContextClassLoader());
+    }
+
+    public ProceduralConstraintResult run(
+        ReadonlyPlan plan,
+        ReadonlyProceduralSimResults simResults,
+        gov.nasa.jpl.aerie.merlin.driver.SimulationResults merlinResults,
+        ClassLoader missionModelClassLoader
+    ) {
       final ProcedureMapper<?> procedureMapper;
       try {
         final var jar = (ConstraintType.JAR) record.type();
-        procedureMapper = ProcedureLoader.loadProcedure(jar.path());
+        procedureMapper = ProcedureLoader.loadProcedure(jar.path(), missionModelClassLoader);
       } catch (ProcedureLoader.ProcedureLoadException e) {
         throw new RuntimeException(e);
       }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ProcedureLoader.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ProcedureLoader.java
@@ -15,7 +15,8 @@ public final class ProcedureLoader {
   throws ProcedureLoadException
   {
     final var className = getImplementingClassName(path);
-    final var classLoader = new URLClassLoader(new URL[] {pathToUrl(path)});
+    final var parentClassLoader = Thread.currentThread().getContextClassLoader();
+    final var classLoader = new URLClassLoader(new URL[] {pathToUrl(path)}, parentClassLoader);
 
     try {
       final var pluginClass$ = classLoader.loadClass(className);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ProcedureLoader.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ProcedureLoader.java
@@ -11,11 +11,14 @@ import java.util.Objects;
 import java.util.jar.JarFile;
 
 public final class ProcedureLoader {
-  public static ProcedureMapper<?> loadProcedure(final Path path)
+  public static ProcedureMapper<?> loadProcedure(final Path path) throws ProcedureLoadException {
+    return loadProcedure(path, Thread.currentThread().getContextClassLoader());
+  }
+
+  public static ProcedureMapper<?> loadProcedure(final Path path, final ClassLoader parentClassLoader)
   throws ProcedureLoadException
   {
     final var className = getImplementingClassName(path);
-    final var parentClassLoader = Thread.currentThread().getContextClassLoader();
     final var classLoader = new URLClassLoader(new URL[] {pathToUrl(path)}, parentClassLoader);
 
     try {

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintAction.java
@@ -10,6 +10,7 @@ import gov.nasa.jpl.aerie.merlin.server.http.Fallible;
 import gov.nasa.jpl.aerie.merlin.server.models.*;
 import gov.nasa.jpl.aerie.types.MissionModelId;
 import org.apache.commons.lang3.tuple.Pair;
+import gov.nasa.ammos.aerie.procedural.timeline.util.WithModel;
 
 import java.util.*;
 
@@ -18,17 +19,20 @@ public class ConstraintAction {
   private final ConstraintService constraintService;
   private final PlanService planService;
   private final SimulationService simulationService;
+  private final MissionModelService missionModelService;
 
   public ConstraintAction(
       final ConstraintsDSLCompilationService constraintsDSLCompilationService,
       final ConstraintService constraintService,
       final PlanService planService,
-      final SimulationService simulationService
+      final SimulationService simulationService,
+      final MissionModelService missionModelService
   ) {
     this.constraintsDSLCompilationService = constraintsDSLCompilationService;
     this.constraintService = constraintService;
     this.planService = planService;
     this.simulationService = simulationService;
+    this.missionModelService = missionModelService;
   }
 
   /**
@@ -160,6 +164,9 @@ public class ConstraintAction {
       final var timelinePlan = new ReadonlyPlan(plan, environment);
       final var timelineSimResults = new ReadonlyProceduralSimResults(merlinSimResults, timelinePlan);
 
+      // Load mission model for constraint procedures that use WithModel interface
+      final var missionModel = this.missionModelService.loadAndInstantiateMissionModel(plan.missionModelId());
+      WithModel.setModelSingleton(missionModel.getModel());
 
       // run constraints
       for(final var constraint : compiledConstraints) {
@@ -171,7 +178,7 @@ public class ConstraintAction {
               break;
             }
             case ExecutableConstraint.JARConstraint jar: {
-              constraintResultMap.put(record, Fallible.of(jar.run(timelinePlan, timelineSimResults, merlinSimResults)));
+              constraintResultMap.put(record, Fallible.of(jar.run(timelinePlan, timelineSimResults, merlinSimResults, missionModel.getModel().getClass().getClassLoader())));
               break;
             }
           }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalMissionModelService.java
@@ -381,7 +381,8 @@ public final class LocalMissionModelService implements MissionModelService {
    * it contains may not abide by the expected contract at load time.
    * @throws NoSuchMissionModelException If no mission model is known by the given ID.
    */
-  private MissionModel<?> loadAndInstantiateMissionModel(final MissionModelId missionModelId)
+  @Override
+  public MissionModel<?> loadAndInstantiateMissionModel(final MissionModelId missionModelId)
   throws NoSuchMissionModelException, MissionModelLoadException
   {
     return loadAndInstantiateMissionModel(missionModelId, untruePlanStart, SerializedValue.of(Map.of()));
@@ -418,7 +419,4 @@ public final class LocalMissionModelService implements MissionModelService {
     }
   }
 
-  public static class MissionModelLoadException extends RuntimeException {
-    public MissionModelLoadException(final Throwable cause) { super(cause); }
-  }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/MissionModelService.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelLoader;
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.types.MissionModelId;
@@ -71,6 +72,9 @@ public interface MissionModelService {
       final SimulationResourceManager resourceManager
   ) throws NoSuchMissionModelException, MissionModelService.NoSuchActivityTypeException;
 
+  MissionModel<?> loadAndInstantiateMissionModel(final MissionModelId missionModelId)
+  throws NoSuchMissionModelException, MissionModelLoadException;
+
   void refreshModelParameters(MissionModelId missionModelId) throws NoSuchMissionModelException;
   void refreshActivityTypes(MissionModelId missionModelId) throws NoSuchMissionModelException;
   void refreshResourceTypes(MissionModelId missionModelId) throws NoSuchMissionModelException;
@@ -114,5 +118,9 @@ public interface MissionModelService {
     record NoSuchMissionModelError(NoSuchMissionModelException ex) implements BulkArgumentValidationResponse { }
     record NoSuchActivityError(NoSuchActivityTypeException ex) implements BulkArgumentValidationResponse { }
     record InstantiationError(InstantiationException ex) implements BulkArgumentValidationResponse { }
+  }
+
+  class MissionModelLoadException extends RuntimeException {
+    public MissionModelLoadException(final Throwable cause) { super(cause); }
   }
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubMissionModelService.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.mocks;
 
+import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.types.MissionModelId;
 import gov.nasa.jpl.aerie.types.Plan;
@@ -205,6 +206,16 @@ public final class StubMissionModelService implements MissionModelService {
     }
 
     return SUCCESSFUL_SIMULATION_RESULTS;
+  }
+
+  @Override
+  public MissionModel<?> loadAndInstantiateMissionModel(final MissionModelId missionModelId)
+  throws NoSuchMissionModelException, MissionModelLoadException
+  {
+    if (!Objects.equals(missionModelId, EXISTENT_MISSION_MODEL_ID)) {
+      throw new NoSuchMissionModelException(missionModelId);
+    }
+    return null;
   }
 
   @Override

--- a/procedural/examples/banana-procedures/build.gradle
+++ b/procedural/examples/banana-procedures/build.gradle
@@ -24,6 +24,8 @@ dependencies {
   implementation project(':type-utils')
   implementation project(':contrib')
 
+  implementation project(":examples:banananation")
+
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
   testImplementation project(':procedural:utils')
   testImplementation project(':orchestration-utils')

--- a/procedural/examples/banana-procedures/src/main/java/gov/nasa/ammos/aerie/procedural/examples/bananaprocedures/procedures/SimulationDemo.java
+++ b/procedural/examples/banana-procedures/src/main/java/gov/nasa/ammos/aerie/procedural/examples/bananaprocedures/procedures/SimulationDemo.java
@@ -1,25 +1,26 @@
 package gov.nasa.ammos.aerie.procedural.examples.bananaprocedures.procedures;
 
+import gov.nasa.ammos.aerie.procedural.timeline.util.WithModel;
+import gov.nasa.jpl.aerie.banananation.Mission;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.ammos.aerie.procedural.scheduling.Goal;
 import gov.nasa.ammos.aerie.procedural.scheduling.annotations.SchedulingProcedure;
 import gov.nasa.ammos.aerie.procedural.scheduling.plan.EditablePlan;
-import gov.nasa.ammos.aerie.procedural.timeline.collections.profiles.Real;
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.DirectiveStart;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
 @SchedulingProcedure
-public record SimulationDemo(int quantity) implements Goal {
+public record SimulationDemo(int quantity) implements Goal, WithModel<Mission> {
   @Override
   public void run(@NotNull final EditablePlan plan) {
 
     var simResults = plan.latestResults();
     if (simResults == null) simResults = plan.simulate();
 
-    final var lowFruit = simResults.resource("/fruit", Real.deserializer()).lessThan(3.5).isolateTrue();
+    final var lowFruit = simResults.resource(model().fruit).lessThan(3.5).isolateTrue();
     final var bites = simResults.instances("BiteBanana");
 
     final var connections = lowFruit.starts().shift(Duration.MINUTE.negate())

--- a/procedural/timeline/build.gradle
+++ b/procedural/timeline/build.gradle
@@ -14,6 +14,7 @@ repositories {
 
 dependencies {
   implementation project(':merlin-driver')
+  implementation project(':merlin-framework')
   implementation project(':type-utils')
 
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'

--- a/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/collections/profiles/Numbers.kt
+++ b/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/collections/profiles/Numbers.kt
@@ -223,5 +223,38 @@ data class Numbers<N: Number>(private val timeline: Timeline<Segment<N>, Numbers
       }
       seg.withNewValue(number)
     }) }
+
+    /**
+     * Converts a list of serialized value segments into an integer [Numbers] profile;
+     * for use with [gov.nasa.ammos.aerie.procedural.timeline.plan.Plan.resource].
+     *
+     * @throws ArithmeticException if any of the segment values are not integers
+     */
+    @JvmStatic fun intDeserializer() = { list: List<Segment<SerializedValue>> -> Numbers(list.map { seg ->
+      val bigDecimal = seg.value.asNumeric().orElseThrow { Exception("value was not numeric: $seg") }
+      seg.withNewValue(bigDecimal.intValueExact())
+    }) }
+
+    /**
+     * Converts a list of serialized value segments into a double [Numbers] profile;
+     * for use with [gov.nasa.ammos.aerie.procedural.timeline.plan.Plan.resource].
+     *
+     * @throws ArithmeticException if any of the segment values are not doubles
+     */
+    @JvmStatic fun doubleDeserializer() = { list: List<Segment<SerializedValue>> -> Numbers(list.map { seg ->
+      val bigDecimal = seg.value.asNumeric().orElseThrow { Exception("value was not numeric: $seg") }
+      seg.withNewValue(bigDecimal.toDouble())
+    }) }
+
+    /**
+     * Converts a list of serialized value segments into a long [Numbers] profile;
+     * for use with [gov.nasa.ammos.aerie.procedural.timeline.plan.Plan.resource].
+     *
+     * @throws ArithmeticException if any of the segment values are not longs
+     */
+    @JvmStatic fun longDeserializer() = { list: List<Segment<SerializedValue>> -> Numbers(list.map { seg ->
+      val bigDecimal = seg.value.asNumeric().orElseThrow { Exception("value was not numeric: $seg") }
+      seg.withNewValue(bigDecimal.longValueExact())
+    }) }
   }
 }

--- a/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/plan/SimulationResults.kt
+++ b/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/plan/SimulationResults.kt
@@ -6,8 +6,11 @@ import gov.nasa.ammos.aerie.procedural.timeline.collections.Directives
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.Segment
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.AnyInstance
 import gov.nasa.ammos.aerie.procedural.timeline.collections.Instances
+import gov.nasa.ammos.aerie.procedural.timeline.collections.profiles.*
 import gov.nasa.ammos.aerie.procedural.timeline.ops.SerialSegmentOps
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.AnyDirective
+import gov.nasa.jpl.aerie.merlin.framework.resources.NameableResource
+import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics
 
 /** An interface for querying plan information and simulation results. */
 interface SimulationResults {
@@ -24,6 +27,13 @@ interface SimulationResults {
    * @param name string name of the resource
    */
   fun <V: Any, TL: SerialSegmentOps<V, TL>> resource(name: String, deserializer: (List<Segment<SerializedValue>>) -> TL): TL
+
+  fun resource(instance: NameableResource<RealDynamics>) = resource(instance.name, Real.deserializer())
+  fun resource(instance: NameableResource<Boolean>) = resource(instance.name, Booleans.deserializer())
+  fun resource(instance: NameableResource<String>) = resource(instance.name, Strings.deserializer())
+  fun resource(instance: NameableResource<Number>) = resource(instance.name, Numbers.deserializer())
+  fun <V: Any> resource(instance: NameableResource<V>, mapper: (Segment<SerializedValue>) -> V)
+    = resource(instance.name, Constants.deserializer(mapper))
 
   /**
    * Query activity instances.

--- a/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/util/WithModel.kt
+++ b/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/util/WithModel.kt
@@ -1,0 +1,16 @@
+package gov.nasa.ammos.aerie.procedural.timeline.util
+
+interface WithModel<M> {
+  @Suppress("unchecked_cast")
+  fun model(): M {
+    if (modelSingleton == null) {
+      throw IllegalStateException("modelSingleton was not initialized.")
+    }
+
+    return modelSingleton as M
+  }
+
+  companion object {
+    @JvmStatic var modelSingleton: Any? = null
+  }
+}

--- a/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/util/WithModel.kt
+++ b/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/util/WithModel.kt
@@ -1,5 +1,18 @@
 package gov.nasa.ammos.aerie.procedural.timeline.util
 
+/**
+ * A mixin for accessing a singleton instance of the mission model object.
+ *
+ * Just make your goal or constraint `implements WithModel<MyModel>`. You can
+ * then access the mission model with `this.model()`. This interface makes no
+ * guarantees about the simulation configuration the model was instantiated with.
+ * It will most likely be the default config, but that is not a formal
+ * requirement. The only guarantee is that it will be a valid instance of the class.
+ *
+ * The type `M` provided to `WithModel<M>` is not checked at compile time.
+ * Giving the wrong type will result in a runtime class cast exception when
+ * `model()` is called.
+ */
 interface WithModel<M> {
   @Suppress("unchecked_cast")
   fun model(): M {

--- a/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/PerishableSimResultsWrapper.kt
+++ b/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/PerishableSimResultsWrapper.kt
@@ -1,7 +1,15 @@
 package gov.nasa.ammos.aerie.procedural.utils
 
 import gov.nasa.ammos.aerie.procedural.scheduling.utils.PerishableSimulationResults
+import gov.nasa.ammos.aerie.procedural.timeline.Interval
+import gov.nasa.ammos.aerie.procedural.timeline.collections.Directives
+import gov.nasa.ammos.aerie.procedural.timeline.collections.Instances
+import gov.nasa.ammos.aerie.procedural.timeline.collections.profiles.*
+import gov.nasa.ammos.aerie.procedural.timeline.ops.SerialSegmentOps
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.Segment
 import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults
+import gov.nasa.jpl.aerie.merlin.protocol.types.RealDynamics
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue
 
 /**
  * A wrapper around [SimulationResults] objects to make them implement
@@ -10,10 +18,24 @@ import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults
 class PerishableSimResultsWrapper(
   private val simulationResults: SimulationResults,
   private var stale: Boolean = false
-): PerishableSimulationResults, SimulationResults by simulationResults {
+): PerishableSimulationResults {
   override fun setStale(stale: Boolean) {
     this.stale = stale
   }
 
   override fun isStale() = this.stale
+
+
+  // Delegation for SimulationResults
+  // Cannot use the `by` keyword due to multiple inheritance of the default overloaded resource methods
+
+  override fun simBounds() = simulationResults.simBounds()
+
+  override fun <V: Any, TL: SerialSegmentOps<V, TL>> resource(name: String, deserializer: (List<Segment<SerializedValue>>) -> TL)
+    = simulationResults.resource(name, deserializer)
+
+  override fun <A : Any> instances(type: String?, deserializer: (SerializedValue) -> A) = simulationResults.instances(type, deserializer)
+
+  override fun <A : Any> inputDirectives(deserializer: (SerializedValue) -> A) = simulationResults.inputDirectives(deserializer)
+
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/ProcedureLoader.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/ProcedureLoader.java
@@ -14,8 +14,13 @@ public final class ProcedureLoader {
   public static ProcedureMapper<?> loadProcedure(final Path path)
   throws ProcedureLoadException
   {
+    return loadProcedure(path, Thread.currentThread().getContextClassLoader());
+  }
+
+  public static ProcedureMapper<?> loadProcedure(final Path path, final ClassLoader parentClassLoader)
+  throws ProcedureLoadException
+  {
     final var className = getImplementingClassName(path);
-    final var parentClassLoader = Thread.currentThread().getContextClassLoader();
     final var classLoader = new URLClassLoader(new URL[] {pathToUrl(path)}, parentClassLoader);
 
     try {

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/ProcedureLoader.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/ProcedureLoader.java
@@ -15,7 +15,8 @@ public final class ProcedureLoader {
   throws ProcedureLoadException
   {
     final var className = getImplementingClassName(path);
-    final var classLoader = new URLClassLoader(new URL[] {pathToUrl(path)});
+    final var parentClassLoader = Thread.currentThread().getContextClassLoader();
+    final var classLoader = new URLClassLoader(new URL[] {pathToUrl(path)}, parentClassLoader);
 
     try {
       final var pluginClass$ = classLoader.loadClass(className);

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Procedure.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Procedure.java
@@ -82,7 +82,7 @@ public class Procedure extends Goal {
 
     final var simResults = editablePlan.latestResults();
 
-    instantiateGoal();
+    instantiateGoal(missionModel.getModel().getClass().getClassLoader());
 
     this.shouldDelete = this.goal.shouldDeletePastCreations(editablePlan, simResults);
 
@@ -103,7 +103,7 @@ public class Procedure extends Goal {
       final DirectiveIdGenerator idGenerator,
       Map<String, List<ExternalEvent>> eventsByDerivationGroup
   ) {
-    instantiateGoal();
+    instantiateGoal(missionModel.getModel().getClass().getClassLoader());
 
     List<SchedulingActivity> newActivities = new ArrayList<>();
 
@@ -150,10 +150,14 @@ public class Procedure extends Goal {
   }
 
   private void instantiateGoal() {
+    instantiateGoal(Thread.currentThread().getContextClassLoader());
+  }
+
+  private void instantiateGoal(final ClassLoader missionModelClassLoader) {
     if (this.goal == null) {
       final ProcedureMapper<?> procedureMapper;
       try {
-        procedureMapper = ProcedureLoader.loadProcedure(jarPath);
+        procedureMapper = ProcedureLoader.loadProcedure(jarPath, missionModelClassLoader);
       } catch (ProcedureLoader.ProcedureLoadException e) {
         throw new RuntimeException(e);
       }

--- a/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/services/SynchronousSchedulerAgent.java
+++ b/scheduler-worker/src/main/java/gov/nasa/jpl/aerie/scheduler/worker/services/SynchronousSchedulerAgent.java
@@ -22,6 +22,7 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
+import gov.nasa.ammos.aerie.procedural.timeline.util.WithModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModel;
 import gov.nasa.jpl.aerie.merlin.driver.MissionModelLoader;
 import gov.nasa.jpl.aerie.merlin.driver.SimulationEngineConfiguration;
@@ -129,6 +130,7 @@ public record SynchronousSchedulerAgent(
       ensureRequestIsCurrent(specification, request);
       //create scheduler problem seeded with initial plan
       final var schedulerMissionModel = loadMissionModel(planMetadata);
+      WithModel.setModelSingleton(schedulerMissionModel.missionModel.getModel());
       final var planningHorizon = new PlanningHorizon(
           specification.horizonStartTimestamp().toInstant(),
           specification.horizonEndTimestamp().toInstant()

--- a/stateless-aerie/build.gradle
+++ b/stateless-aerie/build.gradle
@@ -20,6 +20,7 @@ jar {
   dependsOn(':orchestration-utils:jar')
   dependsOn(':constraints:jar')
   dependsOn(':merlin-driver:jar')
+  dependsOn(':merlin-framework:jar')
   dependsOn(':merlin-sdk:jar')
   dependsOn(':procedural:timeline:jar')
   dependsOn(':procedural:constraints:jar')


### PR DESCRIPTION
* **Tickets addressed:** AERIE-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
This PR lets goals and constraints query resources by referencing them through the mission model. Meaning you can write `simResults.resource(model.fruit)` instead of `simResults.resource("/fruit", Real.deserializer())`, where `mission` is a valid instance of the mission model.

- **Vile hack No. 1**: The goal/constraint gets the instance of the model through the `WithModel<M>` interface, which has a mutable static field `modelSingleton`. The scheduler or constraint action creates an instance of the model with the default sim config and sets the sim config at the beginning of the action. Goals/constraints that inherit from `WithModel<M>` can then get that instance with `this.model()`.
- **Vile Hack No. 2**: The only code this adds to the mission model is a `NameableResource` interface and `NamedResource` abstract implementor of that interface for convenience. Concrete resource types can inherit from `NamedResource`, which just lets the `Registrar` call `NameableResource.setName(string)`. This happens during the model constructor, so it happens both during simulation (which is useless) and during scheduling/constraint actions. The timeline library `SimulationResults` then provides a few `resource(...)` overloads that look for things like `NameableResource<RealDynamics>`, `NameableResource<Boolean>`, etc. It calls `NameableResource.getName()` and associates the payload type with a timeline type like `Real`, `Booleans`, etc.

This required some fiddling with ClassLoaders to make sure that the mission model was not loaded twice by different loaders (which isn't just a waste, it also causes a class cast exception).

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I've made two integration tests, one for scheduling and one for constraints. I've also manually verified that the constraint/goal jars don't include the mission model. (`unzip -l <jar> | grep banana`)

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
I swear I'll update the guide docs this time.

## Future work
<!-- What next steps can we anticipate from here, if any? -->

Because Vile Hack No. 1 creates the model with the default sim config, this could cause some issues when we support other configs during scheduling. I'm assuming that the default config corresponds to the full model with no resources left out.
