### PR TITLE
Hotfix: add `aerie_net` network to workspace service in deployment docker-compose

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -180,6 +180,8 @@ services:
     restart: always
     volumes:
       - workspace_file_store:/usr/src/ws
+    networks:
+      - aerie_net
   aerie_ui:
     container_name: aerie_ui
     depends_on: ["postgres"]


### PR DESCRIPTION
Quick hotfix for aerie-dev deployment. Updates workspace `networks` section to match all other services in the file