### PR TITLE
Fix workspace server content-length bug

### DIFF
--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
@@ -235,12 +235,14 @@ public class WorkspaceBindings implements Plugin {
 
       try {
         final var fileStream = workspaceService.loadFile(pathInfo.workspaceId, pathInfo.filePath());
-        final var fileReader = new BufferedInputStream(fileStream.readingStream());
+//        final var fileReader = new BufferedInputStream(fileStream.readingStream());
+        logger.warn("using inputStream");
+        final var inputStream = fileStream.readingStream();
         context.header("x-render-type", workspaceService.getFileType(pathInfo.filePath).name());
         context.contentType(ContentType.OCTET_STREAM);
         context.header("Content-Disposition", "attachment; filename=\"" + pathInfo.fileName() + "\"");
         context.header("Content-Length", "" + fileStream.fileSize());
-        context.status(200).result(fileReader);
+        context.status(200).result(inputStream);
       } catch (IOException | SQLException e) {
         context.status(500).result("Could not load file " + pathInfo.fileName());
       }

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
@@ -241,7 +241,7 @@ public class WorkspaceBindings implements Plugin {
         context.header("x-render-type", workspaceService.getFileType(pathInfo.filePath).name());
         context.contentType(ContentType.OCTET_STREAM);
         context.header("Content-Disposition", "attachment; filename=\"" + pathInfo.fileName() + "\"");
-        context.header("Content-Length", "" + fileStream.fileSize());
+//        context.header("Content-Length", "" + fileStream.fileSize());
         context.status(200).result(inputStream);
       } catch (IOException | SQLException e) {
         context.status(500).result("Could not load file " + pathInfo.fileName());

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
@@ -235,13 +235,10 @@ public class WorkspaceBindings implements Plugin {
 
       try {
         final var fileStream = workspaceService.loadFile(pathInfo.workspaceId, pathInfo.filePath());
-//        final var fileReader = new BufferedInputStream(fileStream.readingStream());
-        logger.warn("using inputStream");
         final var inputStream = fileStream.readingStream();
         context.header("x-render-type", workspaceService.getFileType(pathInfo.filePath).name());
         context.contentType(ContentType.OCTET_STREAM);
         context.header("Content-Disposition", "attachment; filename=\"" + pathInfo.fileName() + "\"");
-//        context.header("Content-Length", "" + fileStream.fileSize());
         context.status(200).result(inputStream);
       } catch (IOException | SQLException e) {
         context.status(500).result("Could not load file " + pathInfo.fileName());


### PR DESCRIPTION
We've been seeing a bug in our `aerie-dev` environment *only* that does not appear on localhost: When the browser tries to load certain files from the workspace server, it fails in Chrome with an error of eg. “GET https://aerie-dev....:28000/ws/1/figlet-20250807T060106063Z.txt net::ERR_HTTP2_PROTOCOL_ERROR 200 (OK)”. Firefox gives an error about the content-length header being incorrectly set.

Our theory is:
* In the workspace server Java code, we were manually setting the content-length header to the size of the file
* Responses beyond a certain size automatically get Gzipped by Javalin and sent with a gzip header
* In those cases, the content-length header was actually *wrong*, because it reflected the uncompressed file size before gzip
* BUT, the browser didn't care, because **HTTP/1** parsing in the browser is lenient
* However, in aerie-dev, we have an AWS Application Load Balancer (ALB) that sits in front of the app, speaking HTTP/2 to clients and HTTP/1.1 to the container. this is how we proxy everything behind HTTPS. It automatically translates to HTTP/2.
* The browser's parsing of HTTP/2 is more strict, and an error is thrown if content-length is wrong! Therefore this only appears when served behind a proxy/load balancer that speaks HTTP/2. Our response was always malformed in this case, but that was ignored before.

We fixed this by:
* Removing our manual setting of `content-length` in the workspace file `get` handler, allowing Javalin to set the header automatically.
* Using a raw `FileStream` instead a buffered stream, since the extra layer of buffering wasn't needed. (probably unnecessary to this fix but sightly simplifies it)