### PR TITLE
Fix: Make Workspaces Extension Matching Ignore Case

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -193,6 +193,7 @@ services:
       PUBLIC_HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
       PUBLIC_HASURA_SERVER_URL: http://hasura:8080/v1/graphql
       PUBLIC_HASURA_WEB_SOCKET_URL: ws://localhost:8080/v1/graphql
+      PUBLIC_WORKSPACE_CLIENT_URL: http://localhost:28000
     image: "${REPOSITORY_DOCKER_URL}/aerie-ui:${DOCKER_TAG}"
     ports: ["80:80"]
     restart: always

--- a/deployment/kubernetes/aerie-ui-deployment.yaml
+++ b/deployment/kubernetes/aerie-ui-deployment.yaml
@@ -29,6 +29,8 @@ spec:
               value: http://hasura:8080/v1/graphql
             - name: PUBLIC_HASURA_WEB_SOCKET_URL
               value: ws://localhost:8080/v1/graphql
+            - name: PUBLIC_WORKSPACE_CLIENT_URL
+              value: http://localhost:28000
           image: ghcr.io/nasa-ammos/aerie-ui:develop
           name: aerie-ui
           ports:

--- a/deployment/proxy/docker-compose-proxy.yml
+++ b/deployment/proxy/docker-compose-proxy.yml
@@ -42,6 +42,7 @@ services:
       PUBLIC_GATEWAY_CLIENT_URL: https://${AERIE_HOST}:9000
       PUBLIC_HASURA_CLIENT_URL: https://${AERIE_HOST}:8080/v1/graphql
       PUBLIC_HASURA_WEB_SOCKET_URL: wss://${AERIE_HOST}:8080/v1/graphql
+      PUBLIC_WORKSPACE_CLIENT_URL: https://{AERIE_HOST}:28000
   hasura:
     ports: !reset []
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,6 +166,7 @@ services:
       PUBLIC_HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
       PUBLIC_HASURA_SERVER_URL: http://hasura:8080/v1/graphql
       PUBLIC_HASURA_WEB_SOCKET_URL: ws://localhost:8080/v1/graphql
+      PUBLIC_WORKSPACE_CLIENT_URL: http://localhost:28000
       PUBLIC_COMMAND_EXPANSION_MODE: "typescript"
     image: "ghcr.io/nasa-ammos/aerie-ui:develop"
     ports: ["80:80"]

--- a/e2e-tests/docker-compose-many-workers.yml
+++ b/e2e-tests/docker-compose-many-workers.yml
@@ -161,6 +161,7 @@ services:
       PUBLIC_HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
       PUBLIC_HASURA_SERVER_URL: http://hasura:8080/v1/graphql
       PUBLIC_HASURA_WEB_SOCKET_URL: ws://localhost:8080/v1/graphql
+      PUBLIC_WORKSPACE_CLIENT_URL: http://localhost:28000
     image: "ghcr.io/nasa-ammos/aerie-ui:develop"
     ports: ["80:80"]
     restart: always

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -159,6 +159,7 @@ services:
       PUBLIC_HASURA_CLIENT_URL: http://localhost:8080/v1/graphql
       PUBLIC_HASURA_SERVER_URL: http://hasura:8080/v1/graphql
       PUBLIC_HASURA_WEB_SOCKET_URL: ws://localhost:8080/v1/graphql
+      PUBLIC_WORKSPACE_CLIENT_URL: http://localhost:28000
     image: 'ghcr.io/nasa-ammos/aerie-ui:develop'
     ports: ['80:80']
     restart: always

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/postgres/GetExtensionMappingsAction.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/postgres/GetExtensionMappingsAction.java
@@ -6,9 +6,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
+import java.util.TreeMap;
 
 public class GetExtensionMappingsAction implements AutoCloseable {
   private static final @Language("SQL") String getMappingSql = """
@@ -35,7 +35,7 @@ public class GetExtensionMappingsAction implements AutoCloseable {
    */
   public Map<String, RenderType> get() throws SQLException {
     try(final var res = mappingStatement.executeQuery()) {
-      final var extensionsMapping = new HashMap<String, RenderType>();
+      final var extensionsMapping = new TreeMap<String, RenderType>(String.CASE_INSENSITIVE_ORDER);
       while(res.next()) {
         final String extension = res.getString("file_extension");
         final RenderType renderType = RenderType.valueOf(res.getString("content_type").toUpperCase());


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Changes the `Map` generated from the `GetExtensionMappings` from a HashMap to a case-insensitive TreeMap. This fixes the bug where a file with a differently capitalized extension is treated as having an "unknown" file extension. (ie `seqN.txt` vs `seqn.txt`)

Also provides a value to `PUBLIC_WORKSPACE_CLIENT_URL` to all of the backend's docker compose files (needed or else the UI can't find the workspace server when developing)

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I made a workspace, and uploaded:
1) a file with no extension (`ExampleFile`) (having no extension, it will return as an "unknown")
2) a file with an extension that matched exactly with the string in the db (`ExampleFile.seqN.txt`)
3) a file with an extension that had a different capitalization than the string in the db (`ExampleFile copy.seqn.txt`)

On this branch, both 2 and 3 are correctly considered to be sequencing files

On `develop`, 3 is considered to be an "text" file type, since it fails to match `.seqn.txt` but succeeds on matching `.txt`

Image of this branch:
<img width="434" height="231" alt="bugfixbranch" src="https://github.com/user-attachments/assets/21421a92-bf75-49c4-8586-429ee39a1cf4" />

Image of develop:
<img width="434" height="231" alt="devbranch" src="https://github.com/user-attachments/assets/b649f954-5a92-49fd-bac3-4bb2af538f79" />
