### PR TITLE
Improve sequencing server tests to login as test user before tests start

### DIFF
--- a/sequencing-server/jestGlobalSetup.js
+++ b/sequencing-server/jestGlobalSetup.js
@@ -3,6 +3,7 @@ import fetch from 'node-fetch';
 import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { loginTestUser } from "./test/testUtils/testUtils.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -27,6 +28,12 @@ export default async () => {
     await fetchWithTimeout(`${process.env.MERLIN_GRAPHQL_URL.replace('/v1/graphql', '')}/healthz`);
   } catch (e) {
     throw new Error(`Merlin GraphQL API is not running at ${process.env.MERLIN_GRAPHQL_URL}`, { cause: e });
+  }
+
+  try {
+    await loginTestUser();
+  } catch (e) {
+    throw new Error(`Failed to login as test user`, { cause: e });
   }
 };
 

--- a/sequencing-server/jestGlobalSetup.js
+++ b/sequencing-server/jestGlobalSetup.js
@@ -3,7 +3,7 @@ import fetch from 'node-fetch';
 import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { loginTestUser } from "./test/testUtils/testUtils.js";
+import { loginTestUser } from "./test/testUtils/login.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/sequencing-server/test/testUtils/MissionModel.ts
+++ b/sequencing-server/test/testUtils/MissionModel.ts
@@ -1,7 +1,7 @@
-import fetch, { FormData, fileFrom } from 'node-fetch';
-import { gql, GraphQLClient } from 'graphql-request';
-import { randomUUID } from 'crypto';
-import { waitMs } from './testUtils';
+import fetch, {fileFrom, FormData} from 'node-fetch';
+import {gql, GraphQLClient} from 'graphql-request';
+import {randomUUID} from 'crypto';
+import {loginTestUser, waitMs} from './testUtils';
 import fs from 'node:fs/promises';
 
 export async function uploadMissionModel(graphqlClient: GraphQLClient): Promise<number> {
@@ -31,7 +31,7 @@ export async function uploadMissionModel(graphqlClient: GraphQLClient): Promise<
   formData.set('file', file, 'banananation-latest.jar');
 
   // Get an authorization token
-  const authHeader = `Bearer ${await login()}`;
+  const authHeader = `Bearer ${await loginTestUser()}`;
 
   // Upload File
   const uploadRes = await fetch(`${process.env['MERLIN_GATEWAY_URL']}/file`, {
@@ -64,18 +64,6 @@ export async function uploadMissionModel(graphqlClient: GraphQLClient): Promise<
   );
   await waitMs(3000);
   return (res.insert_mission_model_one as { id: number } as { id: number }).id;
-}
-
-async function login() {
-  const response = await fetch(`${process.env['MERLIN_GATEWAY_URL']}/auth/login`, {
-    method: 'POST',
-    body: `{"username": "AerieE2ESequencingTests", "password": "password"}`,
-    headers: { 'Content-Type': 'application/json' },
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to login: ${response.statusText}`);
-  }
-  return (await response.json() as {token: string}).token;
 }
 
 export async function removeMissionModel(graphqlClient: GraphQLClient, missionModelId: number): Promise<void> {

--- a/sequencing-server/test/testUtils/MissionModel.ts
+++ b/sequencing-server/test/testUtils/MissionModel.ts
@@ -1,7 +1,8 @@
 import fetch, {fileFrom, FormData} from 'node-fetch';
 import {gql, GraphQLClient} from 'graphql-request';
 import {randomUUID} from 'crypto';
-import {loginTestUser, waitMs} from './testUtils';
+import {waitMs} from './testUtils';
+import {loginTestUser} from './login.js';
 import fs from 'node:fs/promises';
 
 export async function uploadMissionModel(graphqlClient: GraphQLClient): Promise<number> {

--- a/sequencing-server/test/testUtils/login.js
+++ b/sequencing-server/test/testUtils/login.js
@@ -1,0 +1,13 @@
+import fetch from "node-fetch";
+
+export async function loginTestUser() {
+  const response = await fetch(`${process.env['MERLIN_GATEWAY_URL']}/auth/login`, {
+    method: 'POST',
+    body: `{"username": "AerieE2ESequencingTests", "password": "password"}`,
+    headers: {'Content-Type': 'application/json'},
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to login: ${response.statusText}`);
+  }
+  return (await response.json()).token;
+}

--- a/sequencing-server/test/testUtils/testUtils.ts
+++ b/sequencing-server/test/testUtils/testUtils.ts
@@ -1,5 +1,4 @@
 import {GraphQLClient} from 'graphql-request';
-import fetch from "node-fetch";
 
 export async function waitMs(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -13,16 +12,4 @@ export async function getGraphQLClient(): Promise<GraphQLClient> {
       'x-hasura-role': 'aerie_admin',
     },
   });
-}
-
-export async function loginTestUser() {
-  const response = await fetch(`${process.env['MERLIN_GATEWAY_URL']}/auth/login`, {
-    method: 'POST',
-    body: `{"username": "AerieE2ESequencingTests", "password": "password"}`,
-    headers: {'Content-Type': 'application/json'},
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to login: ${response.statusText}`);
-  }
-  return (await response.json() as { token: string }).token;
 }

--- a/sequencing-server/test/testUtils/testUtils.ts
+++ b/sequencing-server/test/testUtils/testUtils.ts
@@ -1,4 +1,5 @@
-import { GraphQLClient } from 'graphql-request';
+import {GraphQLClient} from 'graphql-request';
+import fetch from "node-fetch";
 
 export async function waitMs(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -12,4 +13,16 @@ export async function getGraphQLClient(): Promise<GraphQLClient> {
       'x-hasura-role': 'aerie_admin',
     },
   });
+}
+
+export async function loginTestUser() {
+  const response = await fetch(`${process.env['MERLIN_GATEWAY_URL']}/auth/login`, {
+    method: 'POST',
+    body: `{"username": "AerieE2ESequencingTests", "password": "password"}`,
+    headers: {'Content-Type': 'application/json'},
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to login: ${response.statusText}`);
+  }
+  return (await response.json() as { token: string }).token;
 }


### PR DESCRIPTION
Related to https://github.com/NASA-AMMOS/aerie/issues/1636 and https://github.com/NASA-AMMOS/aerie-gateway/pull/132

In general, with the sequencing tests, they may be run in parallel, and multiple tests all try to run the `login` function in parallel. If the user doesn't exist yet, this may result in multiple attempts to create it. By logging in during the global test setup, we can ensure that the user is created and can login before any tests start running.