### PR TITLE
Small action server test improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,7 @@ jobs:
             **/e2e-tests/build/reports/tests/e2eTest
             **/db-tests/build/reports/tests/e2eTest
             **/sequencing-server/test-report.*
+            **/action-server/action-server-test-report.log
       - name: Print Logs for Services
         if: always()
         run: docker compose -f ./e2e-tests/docker-compose-test.yml logs -t

--- a/action-server/.gitignore
+++ b/action-server/.gitignore
@@ -1,0 +1,1 @@
+action-server-test-report.log

--- a/action-server/package.json
+++ b/action-server/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf build",
     "start": "npm run clean; npm run build-quiet; node build/app.js",
     "dev": "npm run clean; npm run build; nodemon --watch  src/**/*  -e ts --exec 'node --inspect=0.0.0.0:9229 --require ts-node/register build/app.js'",
-    "test": "node -r ts-node/register tests/*.test.ts",
+    "test": "bash -c 'node -r ts-node/register tests/*.test.ts | tee action-server-test-report.log; exit ${PIPESTATUS[0]}'",
     "lint": "eslint src/**/*.ts",
     "reformat": "npx prettier --config ./.prettierrc.json -w ./src"
   },

--- a/action-server/src/utils/codeRunner.ts
+++ b/action-server/src/utils/codeRunner.ts
@@ -28,7 +28,9 @@ function injectLogger(oldConsole: any, logBuffer: string[], secrets?: Record<str
           const secretValues = Object.values(secrets);
 
           for (const secretValue of secretValues) {
-            output = output.replaceAll(secretValue, "*****");
+            if(secretValue.length) {
+              output = output.replaceAll(secretValue, "*****");
+            }
           }
         }
 


### PR DESCRIPTION
Two small fixes to action server:

* Updated the logic for replacing secrets - if this code was called with empty values for any secrets, it would add "*****" between every character of the logs. In general we should just ignore empty secrets and bypass the "censorship" logic
* @Mythicaeda noticed that the action server test outputs were not being written to the CI artifact like the other test reports were - updated to write to a file and include it in the artifact.
