### PR TITLE
Bug fix: Consult clock for fixedTimeCondition

### DIFF
--- a/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialResources.java
+++ b/contrib/src/main/java/gov/nasa/jpl/aerie/contrib/streamline/modeling/polynomial/PolynomialResources.java
@@ -461,15 +461,18 @@ public final class PolynomialResources {
   }
 
   private static Condition fixedTimeCondition(Optional<Duration> time) {
-    return time.<Condition>map(time$ -> (positive, atEarliest, atLatest) -> {
-      if (positive) {
-        return time.filter(atLatest::noShorterThan).map(t -> Duration.max(atEarliest, t));
-      } else {
-        return Optional.of(atEarliest).filter(time$::longerThan);
-      }
+    return time.<Condition>map(time$ -> {
+      var targetTime = Resources.currentTime().plus(time$);
+      return (positive, atEarliest, atLatest) -> {
+        var timeRemaining = targetTime.minus(Resources.currentTime());
+        if (positive) {
+          return Optional.of(timeRemaining).filter(atLatest::noShorterThan).map(t -> Duration.max(atEarliest, t));
+        } else {
+          return Optional.of(atEarliest).filter(timeRemaining::longerThan);
+        }
+      };
     }).orElse(Condition.FALSE);
   }
-
   private record ClampedIntegrateInternalResult(
           Polynomial integral,
           Polynomial overflow,


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
When doing clamped integration, we need to build fixed-time conditions. These conditions fire after a fixed time, computed in advance for performance. Previously, the fixed time condition reported it would be satisfied in a fixed amount of time, regardless of when it was asked. This is incorrect if the condition is queried at any time later than its creation; the condition appears to "retreat" in time as it's queried.

Fix this bug by having the fixedTimeCondition consult the clock, so it can factor in the time elapsed since its creation.


## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
@bradNASA discovered the faulty behavior, and he tested the change locally for me.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A
