### PR TITLE
Fix/docs java version

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,4 +1,5 @@
 # Developer
+# testing...
 
 This document describes how to set up your development environment to build and develop Aerie.
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,5 +1,4 @@
 # Developer
-# testing...
 
 This document describes how to set up your development environment to build and develop Aerie.
 
@@ -25,10 +24,10 @@ Before you can run Aerie you must install and configure the following products o
 
 - [Docker](https://www.docker.com/) which is used to run the Aerie services.
 
-- [OpenJDK Temurin LTS](https://adoptium.net/temurin/) which is used to build the Java-based Aerie services. If you're on OSX you can use [brew](https://brew.sh/):
+- [OpenJDK Temurin LTS](https://adoptium.net/temurin/) which is used to build the Java-based Aerie services. If you're on OSX you can use [brew](https://brew.sh/). Note Aerie is currently compatible with Java temurin V21, which can be installed with brew using:
 
   ```sh
-  brew install --cask temurin
+  brew install --cask temurin@21
   ```
 
   Make sure you update your `JAVA_HOME` environment variable. For example with [Zsh](https://www.zsh.org/) you can set your `.zshrc` to:


### PR DESCRIPTION
Just a minor fix to DEVELOPER.md to specify temurin V21 specifically (since Aerie is not currently compatible with later versions, given build errors I hit with a new mac and V24).