### PR TITLE
Add Deliveries to Database

### DIFF
--- a/deployment/hasura/metadata/databases/tables/actions/action_configuration.yaml
+++ b/deployment/hasura/metadata/databases/tables/actions/action_configuration.yaml
@@ -1,0 +1,47 @@
+table:
+  name: action_configuration
+  schema: actions
+configuration:
+  custom_name: "action_configuration"
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: user
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+update_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [name, description, action_parameters, action_settings]
+      filter: {}
+  - role: user
+    permission:
+      columns: [name, description, action_parameters, action_settings]
+      filter: {}
+delete_permissions:
+  - role: aerie_admin
+    permission:
+      filter: {}
+  - role: user
+    permission:
+      filter: {}
+insert_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [name, description, action_parameters, action_settings, action_definition_id]
+      check: {}
+  - role: user
+    permission:
+      columns: [name, description, action_parameters, action_settings, action_definition_id]
+      check: {}
+

--- a/deployment/hasura/metadata/databases/tables/deliveries/action_to_delivery.yaml
+++ b/deployment/hasura/metadata/databases/tables/deliveries/action_to_delivery.yaml
@@ -1,0 +1,67 @@
+table:
+  name: action_to_delivery
+  schema: deliveries
+configuration:
+  custom_name: "action_to_delivery"
+object_relationships:
+- name: delivery
+  using:
+    foreign_key_constraint_on: delivery_id
+- name: action
+  using:
+    manual_configuration:
+      column_mapping:
+        action_id: id
+      remote_table:
+        name: action_definition
+        schema: actions
+- name: action_configuration
+  using:
+    manual_configuration:
+      column_mapping:
+        action_id: action_definition_id
+        configuration_name: name
+      remote_table:
+        name: action_configuration
+        schema: actions
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: user
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+insert_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [delivery_id, configuration_name, action_id]
+      check: {}
+  - role: user
+    permission:
+      columns: [delivery_id, configuration_name, action_id]
+      check: {}
+update_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [delivery_id, configuration_name, action_id]
+      filter: {}
+  - role: user
+    permission:
+      columns: [delivery_id, configuration_name, action_id]
+      filter: {}
+delete_permissions:
+  - role: aerie_admin
+    permission:
+      filter: {}
+  - role: user
+    permission:
+      filter: {}

--- a/deployment/hasura/metadata/databases/tables/deliveries/action_to_target.yaml
+++ b/deployment/hasura/metadata/databases/tables/deliveries/action_to_target.yaml
@@ -1,0 +1,67 @@
+table:
+  name: action_to_target
+  schema: deliveries
+configuration:
+  custom_name: "action_to_target"
+object_relationships:
+- name: target
+  using:
+    foreign_key_constraint_on: target_name
+- name: action
+  using:
+    manual_configuration:
+      column_mapping:
+        action_id: id
+      remote_table:
+        name: action_definition
+        schema: actions
+- name: action_configuration
+  using:
+    manual_configuration:
+      column_mapping:
+        action_id: action_definition_id
+        configuration_name: name
+      remote_table:
+        name: action_configuration
+        schema: actions
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: user
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+insert_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [target_name, configuration_name, action_id]
+      check: {}
+  - role: user
+    permission:
+      columns: [target_name, configuration_name, action_id]
+      check: {}
+update_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [target_name, configuration_name, action_id]
+      filter: {}
+  - role: user
+    permission:
+      columns: [target_name, configuration_name, action_id]
+      filter: {}
+delete_permissions:
+  - role: aerie_admin
+    permission:
+      filter: {}
+  - role: user
+    permission:
+      filter: {}

--- a/deployment/hasura/metadata/databases/tables/deliveries/delivery.yaml
+++ b/deployment/hasura/metadata/databases/tables/deliveries/delivery.yaml
@@ -1,0 +1,62 @@
+table:
+  name: delivery
+  schema: deliveries
+configuration:
+  custom_name: "delivery"
+array_relationships:
+  - name: files
+    using:
+      foreign_key_constraint_on:
+        column: delivery_id
+        table:
+          name: file_to_delivery
+          schema: deliveries
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: user
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+insert_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [name, status, target]
+      check: {}
+      set:
+        updated_by: "x-hasura-user-id"
+  - role: user
+    permission:
+      columns: [name, status, target]
+      check: {}
+      set:
+        updated_by: "x-hasura-user-id"
+update_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [name, status, target]
+      filter: {}
+      set:
+        updated_by: "x-hasura-user-id"
+  - role: user
+    permission:
+      columns: [name, status, target]
+      filter: {}
+      set:
+        updated_by: "x-hasura-user-id"
+delete_permissions:
+  - role: aerie_admin
+    permission:
+      filter: {}
+  - role: user
+    permission:
+      filter: {}

--- a/deployment/hasura/metadata/databases/tables/deliveries/file_to_delivery.yaml
+++ b/deployment/hasura/metadata/databases/tables/deliveries/file_to_delivery.yaml
@@ -1,0 +1,50 @@
+table:
+  name: file_to_delivery
+  schema: deliveries
+configuration:
+  custom_name: "file_to_delivery"
+object_relationships:
+- name: delivery
+  using:
+    foreign_key_constraint_on: delivery_id
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: user
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+insert_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [filename, delivery_id]
+      check: {}
+  - role: user
+    permission:
+      columns: [filename, delivery_id]
+      check: {}
+update_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [filename, delivery_id]
+      filter: {}
+  - role: user
+    permission:
+      columns: [filename, delivery_id]
+      filter: {}
+delete_permissions:
+  - role: aerie_admin
+    permission:
+      filter: {}
+  - role: user
+    permission:
+      filter: {}

--- a/deployment/hasura/metadata/databases/tables/deliveries/target.yaml
+++ b/deployment/hasura/metadata/databases/tables/deliveries/target.yaml
@@ -1,0 +1,56 @@
+table:
+  name: target
+  schema: deliveries
+configuration:
+  custom_name: "target"
+array_relationships:
+  - name: actions
+    using:
+      manual_configuration:
+        column_mapping:
+          name: target_name
+        remote_table:
+          schema: deliveries
+          name: action_to_target
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: user
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+update_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [name]
+      filter: {}
+  - role: user
+    permission:
+      columns: [name]
+      filter: {}
+delete_permissions:
+  - role: aerie_admin
+    permission:
+      filter: {}
+  - role: user
+    permission:
+      filter: {}
+insert_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [name]
+      check: {}
+  - role: user
+    permission:
+      columns: [name]
+      check: {}
+

--- a/deployment/hasura/metadata/databases/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/tables/tables.yaml
@@ -195,3 +195,13 @@
 #################
 - "!include actions/action_definition.yaml"
 - "!include actions/action_run.yaml"
+- "!include actions/action_configuration.yaml"
+
+#####################
+#### Deliveries #####
+#####################
+- "!include deliveries/delivery.yaml"
+- "!include deliveries/file_to_delivery.yaml"
+- "!include deliveries/target.yaml"
+- "!include deliveries/action_to_target.yaml"
+- "!include deliveries/action_to_delivery.yaml"

--- a/deployment/hasura/migrations/Aerie/28_deliveries/down.sql
+++ b/deployment/hasura/migrations/Aerie/28_deliveries/down.sql
@@ -1,0 +1,13 @@
+drop table deliveries.action_to_target;
+drop table deliveries.action_to_delivery;
+drop table actions.action_configuration;
+
+drop trigger set_timestamp on deliveries.delivery;
+
+drop table deliveries.file_to_delivery;
+drop table deliveries.delivery;
+drop table deliveries.target;
+
+drop schema deliveries;
+
+call migrations.mark_migration_rolled_back('28');

--- a/deployment/hasura/migrations/Aerie/28_deliveries/up.sql
+++ b/deployment/hasura/migrations/Aerie/28_deliveries/up.sql
@@ -1,0 +1,162 @@
+create table actions.action_configuration (
+  name text not null,
+  description text null,
+  action_parameters jsonb default '{}'::jsonb,
+  action_settings jsonb default '{}'::jsonb,
+  action_definition_id integer not null,
+
+  constraint action_parameter_configuration_primary_key
+    primary key (name, action_definition_id),
+
+  foreign key (action_definition_id)
+    references actions.action_definition (id)
+    on delete cascade
+);
+
+comment on table actions.action_configuration is e''
+  'Configuration of an action''s parameters and/or settings to be used during a run.';
+comment on column actions.action_configuration.name is e''
+  'The name of the configuration.';
+comment on column actions.action_configuration.description is e''
+  'The description of the configuration.';
+comment on column actions.action_configuration.action_parameters is e''
+  'The parameter configuration for the action.';
+comment on column actions.action_configuration.action_settings is e''
+  'The settings configuration for the action.';
+comment on column actions.action_configuration.action_definition_id is e''
+  'The ID of the action the configuration is for.';
+
+create schema deliveries;
+
+create table deliveries.target (
+  name text not null,
+
+  constraint delivery_target_primary_key
+    primary key (name)
+);
+
+comment on table deliveries.target is e''
+  'A target system to for deliveries to be sent to.';
+comment on column deliveries.target.name is e''
+  'The name of the target.';
+
+create table deliveries.delivery (
+  id integer generated always as identity,
+  name text,
+  status text not null,
+  target text not null,
+  updated_at timestamptz not null default now(),
+  updated_by text,
+
+  constraint delivery_primary_key
+    primary key (id),
+  constraint target_fkey
+    foreign key (target) references deliveries.target
+    on update cascade
+    on delete cascade,
+  foreign key (updated_by)
+    references permissions.users
+    on update cascade
+    on delete set null
+);
+
+create trigger set_timestamp
+  before update on deliveries.delivery
+  for each row
+  execute function util_functions.set_updated_at();
+
+comment on table deliveries.delivery is e''
+  'A delivery.';
+comment on column deliveries.delivery.id is e''
+  'The ID for the delivery.';
+comment on column deliveries.delivery.name is e''
+  'An optional name to describe the delivery.';
+comment on column deliveries.delivery.status is e''
+  'The status of the delivery.';
+comment on column deliveries.delivery.target is e''
+  'The target to send the delivery to.';
+comment on column deliveries.delivery.updated_at is e''
+  'The last time the delivery was updated.';
+comment on column deliveries.delivery.updated_by is e''
+  'The user who last updated the delivery.';
+
+create table deliveries.action_to_delivery (
+  delivery_id int not null,
+  configuration_name text null,
+  action_id int not null,
+
+  constraint action_to_delivery_pkey
+    primary key (delivery_id, action_id),
+  constraint delivery_id_fkey
+    foreign key (delivery_id)
+    references deliveries.delivery (id)
+    on delete cascade,
+  constraint configuration_name_fkey
+    foreign key (configuration_name, action_id)
+    references actions.action_configuration (name, action_definition_id)
+    on delete cascade,
+  constraint action_id_fkey
+    foreign key (action_id)
+    references actions.action_definition (id)
+    on delete cascade
+);
+
+comment on table deliveries.action_to_delivery is e''
+  'Join table for actions and deliveries.';
+comment on column deliveries.action_to_delivery.delivery_id is e''
+  'ID of the delivery being linked.';
+comment on column deliveries.action_to_delivery.configuration_name is e''
+  'Optional, name of the configuration to use for the action.';
+comment on column deliveries.action_to_delivery.action_id is e''
+  'ID of the action being linked.';
+
+create table deliveries.action_to_target (
+  target_name text not null,
+  configuration_name text null,
+  action_id int not null,
+
+  constraint action_to_target_pkey
+    primary key (target_name, action_id),
+  constraint target_name_fkey
+    foreign key (target_name)
+    references deliveries.target (name)
+    on delete cascade,
+  constraint configuration_name_fkey
+    foreign key (configuration_name, action_id)
+    references actions.action_configuration (name, action_definition_id)
+    on delete cascade,
+  constraint action_id_fkey
+    foreign key (action_id)
+    references actions.action_definition (id)
+    on delete cascade
+);
+
+comment on table deliveries.action_to_target is e''
+  'Join table for actions and targets.';
+comment on column deliveries.action_to_target.target_name is e''
+  'Name of the target being linked.';
+comment on column deliveries.action_to_target.configuration_name is e''
+  'Optional, name of the configuration to use for the action.';
+comment on column deliveries.action_to_target.action_id is e''
+  'ID of the action being linked.';
+
+create table deliveries.file_to_delivery (
+    filename text not null,
+    delivery_id int not null,
+
+    constraint file_to_delivery_primary_key
+      primary key (filename, delivery_id),
+    constraint delivery_id_fkey
+      foreign key (delivery_id)
+      references deliveries.delivery (id)
+      on delete cascade
+);
+
+comment on table deliveries.file_to_delivery is e''
+  'Join table for files and deliveries.';
+comment on column deliveries.file_to_delivery.filename is e''
+  'Name of the joining file.';
+comment on column deliveries.file_to_delivery.delivery_id is e''
+  'ID of the joining delivery.';
+
+call  migrations.mark_migration_applied('28');

--- a/deployment/postgres-init-db/sql/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/applied_migrations.sql
@@ -29,3 +29,4 @@ call migrations.mark_migration_applied(24);
 call migrations.mark_migration_applied(25);
 call migrations.mark_migration_applied(26);
 call migrations.mark_migration_applied(27);
+call migrations.mark_migration_applied(28);

--- a/deployment/postgres-init-db/sql/init.sql
+++ b/deployment/postgres-init-db/sql/init.sql
@@ -51,4 +51,7 @@ begin;
 
   -- Actions
   \ir init_actions.sql
+
+  -- Deliveries
+  \ir init_deliveries.sql
 end;

--- a/deployment/postgres-init-db/sql/init_deliveries.sql
+++ b/deployment/postgres-init-db/sql/init_deliveries.sql
@@ -7,7 +7,9 @@
  */
 begin;
   -- Tables
-  \ir tables/actions/action_definition.sql
-  \ir tables/actions/action_run.sql
-  \ir tables/actions/action_configuration.sql
+  \ir tables/deliveries/target.sql
+  \ir tables/deliveries/delivery.sql
+  \ir tables/deliveries/file_to_delivery.sql
+  \ir tables/deliveries/action_to_target.sql
+  \ir tables/deliveries/action_to_delivery.sql
 end;

--- a/deployment/postgres-init-db/sql/schemas.sql
+++ b/deployment/postgres-init-db/sql/schemas.sql
@@ -1,6 +1,8 @@
 -- Services
 create schema actions;
 comment on schema actions is 'Actions Service Schema';
+create schema deliveries;
+comment on schema deliveries is 'Deliveries Service Schema';
 create schema merlin;
 comment on schema merlin is 'Merlin Service Schema';
 create schema scheduler;

--- a/deployment/postgres-init-db/sql/tables/actions/action_configuration.sql
+++ b/deployment/postgres-init-db/sql/tables/actions/action_configuration.sql
@@ -1,0 +1,27 @@
+  create table actions.action_configuration (
+  name text not null,
+  description text null,
+  action_parameters jsonb default '{}'::jsonb,
+  action_settings jsonb default '{}'::jsonb,
+  action_definition_id integer not null,
+
+  constraint action_parameter_configuration_primary_key
+    primary key (name, action_definition_id),
+
+  foreign key (action_definition_id)
+    references actions.action_definition (id)
+    on delete cascade
+);
+
+comment on table actions.action_configuration is e''
+  'Configuration of an action''s parameters and/or settings to be used during a run.';
+comment on column actions.action_configuration.name is e''
+  'The name of the configuration.';
+comment on column actions.action_configuration.description is e''
+  'The description of the configuration.';
+comment on column actions.action_configuration.action_parameters is e''
+  'The parameter configuration for the action.';
+comment on column actions.action_configuration.action_settings is e''
+  'The settings configuration for the action.';
+comment on column actions.action_configuration.action_definition_id is e''
+  'The ID of the action the configuration is for.'

--- a/deployment/postgres-init-db/sql/tables/deliveries/action_to_delivery.sql
+++ b/deployment/postgres-init-db/sql/tables/deliveries/action_to_delivery.sql
@@ -1,0 +1,29 @@
+create table deliveries.action_to_delivery (
+  delivery_id int not null,
+  configuration_name text null,
+  action_id int not null,
+
+  constraint action_to_delivery_pkey
+    primary key (delivery_id, action_id),
+  constraint delivery_id_fkey
+    foreign key (delivery_id)
+    references deliveries.delivery (id)
+    on delete cascade,
+  constraint configuration_name_fkey
+    foreign key (configuration_name, action_id)
+    references actions.action_configuration (name, action_definition_id)
+    on delete cascade,
+  constraint action_id_fkey
+    foreign key (action_id)
+    references actions.action_definition (id)
+    on delete cascade
+);
+
+comment on table deliveries.action_to_delivery is e''
+  'Join table for actions and deliveries.';
+comment on column deliveries.action_to_delivery.delivery_id is e''
+  'ID of the delivery being linked.';
+comment on column deliveries.action_to_delivery.configuration_name is e''
+  'Optional, name of the configuration to use for the action.';
+comment on column deliveries.action_to_delivery.action_id is e''
+  'ID of the action being linked.';

--- a/deployment/postgres-init-db/sql/tables/deliveries/action_to_target.sql
+++ b/deployment/postgres-init-db/sql/tables/deliveries/action_to_target.sql
@@ -1,0 +1,29 @@
+create table deliveries.action_to_target (
+  target_name text not null,
+  configuration_name text null,
+  action_id int not null,
+
+  constraint action_to_target_pkey
+    primary key (target_name, action_id),
+  constraint target_name_fkey
+    foreign key (target_name)
+    references deliveries.target (name)
+    on delete cascade,
+  constraint configuration_name_fkey
+    foreign key (configuration_name, action_id)
+    references actions.action_configuration (name, action_definition_id)
+    on delete cascade,
+  constraint action_id_fkey
+    foreign key (action_id)
+    references actions.action_definition (id)
+    on delete cascade
+);
+
+comment on table deliveries.action_to_target is e''
+  'Join table for actions and targets.';
+comment on column deliveries.action_to_target.target_name is e''
+  'Name of the target being linked.';
+comment on column deliveries.action_to_target.configuration_name is e''
+  'Optional, name of the configuration to use for the action.';
+comment on column deliveries.action_to_target.action_id is e''
+  'ID of the action being linked.';

--- a/deployment/postgres-init-db/sql/tables/deliveries/delivery.sql
+++ b/deployment/postgres-init-db/sql/tables/deliveries/delivery.sql
@@ -1,0 +1,41 @@
+-- create type deliveries.delivery_status as enum('Un-delivered', 'Pending', 'Delivered');
+
+create table deliveries.delivery (
+  id integer generated always as identity,
+  name text,
+  status text not null,
+  target text not null,
+  updated_at timestamptz not null default now(),
+  updated_by text,
+
+  constraint delivery_primary_key
+    primary key (id),
+  constraint target_fkey
+    foreign key (target) references deliveries.target
+    on update cascade
+    on delete cascade,
+  foreign key (updated_by)
+    references permissions.users
+    on update cascade
+    on delete set null
+);
+
+create trigger set_timestamp
+  before update on deliveries.delivery
+  for each row
+  execute function util_functions.set_updated_at();
+
+comment on table deliveries.delivery is e''
+  'A delivery.';
+comment on column deliveries.delivery.id is e''
+  'The ID for the delivery.';
+comment on column deliveries.delivery.name is e''
+  'An optional name to describe the delivery.';
+comment on column deliveries.delivery.status is e''
+  'The status of the delivery.';
+comment on column deliveries.delivery.target is e''
+  'The target to send the delivery to.';
+comment on column deliveries.delivery.updated_at is e''
+  'The last time the delivery was updated.';
+comment on column deliveries.delivery.updated_by is e''
+  'The user who last updated the delivery.';

--- a/deployment/postgres-init-db/sql/tables/deliveries/file_to_delivery.sql
+++ b/deployment/postgres-init-db/sql/tables/deliveries/file_to_delivery.sql
@@ -1,0 +1,18 @@
+create table deliveries.file_to_delivery (
+    filename text not null,
+    delivery_id int not null,
+
+    constraint file_to_delivery_primary_key
+      primary key (filename, delivery_id),
+    constraint delivery_id_fkey
+      foreign key (delivery_id)
+      references deliveries.delivery (id)
+      on delete cascade
+);
+
+comment on table deliveries.file_to_delivery is e''
+  'Join table for files and deliveries.';
+comment on column deliveries.file_to_delivery.filename is e''
+  'Name of the joining file.';
+comment on column deliveries.file_to_delivery.delivery_id is e''
+  'ID of the joining delivery.';

--- a/deployment/postgres-init-db/sql/tables/deliveries/target.sql
+++ b/deployment/postgres-init-db/sql/tables/deliveries/target.sql
@@ -1,0 +1,11 @@
+create table deliveries.target (
+  name text not null,
+
+  constraint delivery_target_primary_key
+    primary key (name)
+);
+
+comment on table deliveries.target is e''
+  'A target system to for deliveries to be sent to.';
+comment on column deliveries.target.name is e''
+  'The name of the target.';


### PR DESCRIPTION
* **Tickets addressed:** [Related Pitch](https://github.com/NASA-AMMOS/aerie-team/discussions/76)
* **Review:** By commit
* **Merge strategy:** Squash and merge

## Description
This pull-request implements the back-end required for Deliveries.

Deliveries allow users to define a target (i.e., the target system) and package files from a sequence workspace to be 'delivered' to that target, including running any actions required prior to delivery. See pitch linked at the top of the description for more information.

The diagram below is an ERD representation of the tables being created.
<img width="2311" height="441" alt="DeliveryERD" src="https://github.com/user-attachments/assets/1075a4ed-54b3-41f6-87c9-c7a5597e0b2b" />

## Verification
Tests TODO

## Documentation
Documentation TODO

## Future work
TODO
