### PR TITLE
Add Workspace Permissions

### DIFF
--- a/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PermissionsTest.java
+++ b/db-tests/src/test/java/gov/nasa/jpl/aerie/database/PermissionsTest.java
@@ -8,17 +8,23 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SuppressWarnings("SqlSourceToSinkFlow")
 public class PermissionsTest {
   private static final String testRole = "testRole";
   private enum FunctionPermissionKey {
@@ -52,6 +58,7 @@ public class PermissionsTest {
     PLAN_OWNER_SOURCE, PLAN_COLLABORATOR_SOURCE, PLAN_OWNER_COLLABORATOR_SOURCE,
     PLAN_OWNER_TARGET, PLAN_COLLABORATOR_TARGET, PLAN_OWNER_COLLABORATOR_TARGET
   }
+  private enum WorkspacePermission { NO_CHECK, OWNER, COLLABORATOR, OWNER_COLLABORATOR }
 
   private DatabaseTestHelper helper;
   private MerlinDatabaseTestHelper merlinHelper;
@@ -161,38 +168,18 @@ public class PermissionsTest {
 
   private void updateUserRolePermissions(
       String role,
-      String actionPermissionsJson,
-      String functionPermissionsJson)
+      Optional<String> actionPermissionsJson,
+      Optional<String> functionPermissionsJson,
+      Optional<String> workspacePermissionsJson)
   throws SQLException {
     try(final var statement = connection.createStatement()){
-      if(actionPermissionsJson == null){
-        statement.execute(
-        //language=sql
-        """
-        update permissions.user_role_permission
-        set function_permissions = '%s'::jsonb
-        where role = '%s';
-        """.formatted(functionPermissionsJson, role));
-      } else if (functionPermissionsJson == null) {
-        statement.execute(
-        //language=sql
-        """
-        update permissions.user_role_permission
-        set action_permissions = '%s'::jsonb
-        where role = '%s';
-        """.formatted(actionPermissionsJson, role));
-      }
-      else {
-        statement.execute(
-        //language=sql
-        """
-        update permissions.user_role_permission
-        set action_permissions = '%s'::jsonb,
-            function_permissions = '%s'::jsonb
-        where role = '%s';
-        """.formatted(actionPermissionsJson, functionPermissionsJson, role));
-      }
-
+      final var sqlBuilder = new StringBuilder("update permissions.user_role_permission\n set ");
+      actionPermissionsJson.ifPresent(s -> sqlBuilder.append("action_permissions = '%s'::jsonb, ".formatted(s)));
+      functionPermissionsJson.ifPresent(s -> sqlBuilder.append("function_permissions = '%s'::jsonb, ".formatted(s)));
+      workspacePermissionsJson.ifPresent(s -> sqlBuilder.append("workspace_permissions = '%s'::jsonb, ".formatted(s)));
+      sqlBuilder.deleteCharAt(sqlBuilder.length()-2); // remove trailing ','
+      sqlBuilder.append("\nwhere role = '%s';".formatted(role));
+      statement.execute(sqlBuilder.toString());
     }
   }
   //endregion
@@ -791,237 +778,359 @@ public class PermissionsTest {
   }
 
   @Nested
-  class UserRolePermissionsValidation{
+  class UserRolePermissionsValidation {
     private final String invalidJsonTextErrCode = "22032";
-    @Test
-    void emptyIsValid() {
-      // Action
-      assertDoesNotThrow(() -> updateUserRolePermissions(testRole, "{}", null));
-      // Function
-      assertDoesNotThrow(() -> updateUserRolePermissions(testRole, null, "{}"));
-      // Both
-      assertDoesNotThrow(() -> updateUserRolePermissions(testRole, "{}", "{}"));
+
+    /**
+     * Checks that:
+     *  - An empty JSON array is permitted for the permissions json (emptyIsValidProvider)
+     *  - Permission Keys are allowed be excluded from the permissions jsons (incompleteIsValidProvider)
+     *  - The permissions json is allowed to contain a complete set of permission keys (completeIsValidProvider)
+     */
+    @ParameterizedTest
+    @MethodSource({"emptyIsValidProvider", "incompleteIsValidProvider", "completeIsValidProvider"})
+    void validCases(String actionPermissions, String functionPermissions, String workspacePermissions) {
+      assertDoesNotThrow(() -> updateUserRolePermissions(
+          testRole,
+          Optional.ofNullable(actionPermissions),
+          Optional.ofNullable(functionPermissions),
+          Optional.ofNullable(workspacePermissions)));
     }
 
-    @Test
-    void nonsenseKeys() throws SQLException {
-      // Nonsense Values for Keys are caught
+    /**
+     * Checks that:
+     *  - Nonsense values for keys are not permitted (nonsenseKeyProvider)
+     *  - Nonsense values for permissions are not permitted (nonsensePermissionsProvider)
+     *  - Plan merge permissions are not permitted on non-plan merge keys (invalidPlanMergePermissionsProvider)
+     */
+    @ParameterizedTest
+    @MethodSource({"nonsenseKeyProvider", "nonsensePermissionsProvider", "invalidPlanMergePermissionsProvider"})
+    void invalidCases(
+        String actionPermissions,
+        String functionPermissions,
+        String workspacePermissions,
+        String expectedExceptionMessage
+    ) throws SQLException {
+      final var exception = assertThrows(
+          SQLException.class,
+          () -> updateUserRolePermissions(
+              testRole,
+              Optional.ofNullable(actionPermissions),
+              Optional.ofNullable(functionPermissions),
+              Optional.ofNullable(workspacePermissions)));
+      if (!exception.getMessage().contains(expectedExceptionMessage)
+          || !exception.getSQLState().equals(invalidJsonTextErrCode)) {
+        throw exception;
+      }
+    }
+
+    @ParameterizedTest
+    @EnumSource(WorkspacePermission.class)
+    void createWorkspaceCoarseGrained(WorkspacePermission permission) throws SQLException {
+      // Check that create_workspace only permits "NO_CHECK"
+      final String workspacePermissions = "{\"create_workspace\": \"%s\"}".formatted(permission.toString());
+      if (permission.equals(WorkspacePermission.NO_CHECK)) {
+        assertDoesNotThrow(() -> updateUserRolePermissions(
+            testRole,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(workspacePermissions)));
+      } else {
+        final String exMsg =
+            """
+                ERROR: invalid permissions in supplied row
+                  Detail: The following workspace keys have invalid permissions: {create_workspace: %s}
+                  Hint:
+                """.formatted(permission.toString()).trim();
+        final var ex = assertThrows(
+            SQLException.class,
+            () -> updateUserRolePermissions(
+                testRole,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(workspacePermissions)));
+        if (!ex.getMessage().contains(exMsg)
+            || !ex.getSQLState().equals(invalidJsonTextErrCode)) {
+          throw ex;
+        }
+      }
+    }
+
+
+    // region ArgumentGeneration
+    /**
+     * Generate an argument stream for a parametrized test from the three input strings
+     */
+    private static Stream<Arguments> generateArgumentStream(
+        String actionPermissions,
+        String functionPermissions,
+        String workspacePermissions
+    )
+    {
+      return Stream.of(
+          // Action
+          arguments(actionPermissions, null, null),
+          // Function
+          arguments(null, functionPermissions, null),
+          // Workspace
+          arguments(null, null, workspacePermissions),
+          // Action and Function
+          arguments(actionPermissions, functionPermissions, null),
+          // Action and Workspace
+          arguments(actionPermissions, null, workspacePermissions),
+          // Function and Workspace
+          arguments(null, functionPermissions, workspacePermissions),
+          // All
+          arguments(actionPermissions, functionPermissions, workspacePermissions)
+      );
+    }
+
+    /**
+     * Generate an argument stream for a parametrized test, where each input is expected to raise an exception
+     * Exceptions messages are generated from a formatted template
+     *
+     * @param actionExceptionMsg the action related part of the exception message
+     * @param functionExceptionMsg the function related part of the exception message
+     * @param workspaceExceptionMsg the workspace related part of the exception message
+     */
+    private static Stream<Arguments> generateArgumentStream(
+        String actionPermissions,
+        String functionPermissions,
+        String workspacePermissions,
+        String exceptionTemplate,
+        String actionExceptionMsg,
+        String functionExceptionMsg,
+        String workspaceExceptionMsg
+    )
+    {
+      // Trim the template to avoid tests failing on a leading/trailing newline
+      final String exTemplate = exceptionTemplate.trim();
+
+      return Stream.of(
+          // Action
+          arguments(actionPermissions, null, null, exTemplate.formatted(actionExceptionMsg)),
+          // Function
+          arguments(null, functionPermissions, null, exTemplate.formatted(functionExceptionMsg)),
+          // Workspace
+          arguments(null, null, workspacePermissions, exTemplate.formatted(workspaceExceptionMsg)),
+          // Action and Function
+          arguments(actionPermissions, functionPermissions, null,
+                    exTemplate.formatted(actionExceptionMsg + "\n" + functionExceptionMsg)),
+          // Action and Workspace
+          arguments(actionPermissions, null, workspacePermissions,
+                    exTemplate.formatted(actionExceptionMsg + "\n" + workspaceExceptionMsg)),
+          // Function and Workspace
+          arguments(null, functionPermissions, workspacePermissions,
+                    exTemplate.formatted(functionExceptionMsg + "\n" + workspaceExceptionMsg)),
+          // All
+          arguments(actionPermissions, functionPermissions, workspacePermissions,
+                    exTemplate.formatted(actionExceptionMsg
+                                         + "\n"
+                                         + functionExceptionMsg
+                                         + "\n"
+                                         + workspaceExceptionMsg))
+      );
+    }
+
+
+    /**
+     * Nonsense values for keys are not permitted
+     */
+    static Stream<Arguments> nonsenseKeyProvider() {
       final String actionPermissions = "{\"fake_action_key\": \"NO_CHECK\"}";
       final String functionPermissions = "{\"fake_function_key\": \"NO_CHECK\"}";
-      // Action
-      final String actionExceptionMsg =
-          """
-          ERROR: invalid keys in supplied row
-            Detail: The following action keys are not valid: fake_action_key
-            Hint:
-          """.trim();
-      final var actionException = assertThrows(SQLException.class,
-                                               () -> updateUserRolePermissions(testRole, actionPermissions, null));
-      if( !actionException.getMessage().contains(actionExceptionMsg)
-         || !actionException.getSQLState().equals(invalidJsonTextErrCode)){
-        throw actionException;
-      }
+      final String workspacePermissions = "{\"fake_workspace_key\": \"NO_CHECK\"}";
 
-      // Function
-      final String fnExceptionMsg =
+      final String actionExceptionMsg = "The following action keys are not valid: fake_action_key";
+      final String fnExceptionMsg = "The following function keys are not valid: fake_function_key";
+      final String wsExceptionMsg = "The following workspace keys are not valid: fake_workspace_key";
+
+      final String exceptionTemplate =
           """
-          ERROR: invalid keys in supplied row
-            Detail: The following function keys are not valid: fake_function_key
-            Hint:
-          """.trim();
-      final var fnException = assertThrows(SQLException.class,
-                                           () -> updateUserRolePermissions(testRole, null, functionPermissions));
-      if(!fnException.getMessage().contains(fnExceptionMsg)
-         || !fnException.getSQLState().equals(invalidJsonTextErrCode)){
-        throw fnException;
-      }
-      // Both
-      final String bothExceptionMsg =
-          """
-          ERROR: invalid keys in supplied row
-            Detail: The following action keys are not valid: fake_action_key
-          The following function keys are not valid: fake_function_key
-            Hint:
-          """.trim();
-      final var bothException = assertThrows(SQLException.class,
-                                             () -> updateUserRolePermissions(testRole, actionPermissions, functionPermissions));
-      if(!bothException.getMessage().contains(bothExceptionMsg)
-         || !bothException.getSQLState().equals(invalidJsonTextErrCode)){
-        throw bothException;
-      }
+              ERROR: invalid keys in supplied row
+                Detail: %s
+                Hint:
+              """.trim();
+
+      return generateArgumentStream(
+          actionPermissions,
+          functionPermissions,
+          workspacePermissions,
+          exceptionTemplate,
+          actionExceptionMsg,
+          fnExceptionMsg,
+          wsExceptionMsg);
     }
 
-    @Test
-    void nonsensePermissions() throws SQLException {
-      // Nonsense Values for Permissions are caught
+    /**
+     * Nonsense values for permissions are not permitted.
+     */
+    static Stream<Arguments> nonsensePermissionsProvider() {
       final String actionPermissions = "{\"simulate\": \"NONSENSE_PERMISSION\"}";
       final String functionPermissions = "{\"begin_merge\": \"NONSENSE_PERMISSION\"}";
-      // Action
-      final String actionExceptionMsg =
-          """
-          ERROR: invalid permissions in supplied row
-            Detail: The following action keys have invalid permissions: {simulate: NONSENSE_PERMISSION}
-            Hint:
-          """.trim();
-      final var actionException = assertThrows(SQLException.class,
-                                               () -> updateUserRolePermissions(testRole, actionPermissions, null));
-      if( !actionException.getMessage().contains(actionExceptionMsg)
-         || !actionException.getSQLState().equals(invalidJsonTextErrCode)){
-        throw actionException;
-      }
+      final String workspacePermissions = "{\"read_file_directory\": \"NONSENSE_PERMISSION\"}";
 
-      // Function
+      final String actionExceptionMsg =
+          "The following action keys have invalid permissions: {simulate: NONSENSE_PERMISSION}";
       final String fnExceptionMsg =
-          """
+          "The following function keys have invalid permissions: {begin_merge: NONSENSE_PERMISSION}";
+      final String wsExceptionMsg =
+          "The following workspace keys have invalid permissions: {read_file_directory: NONSENSE_PERMISSION}";
+
+      final String exceptionTemplate = """
           ERROR: invalid permissions in supplied row
-            Detail: The following function keys have invalid permissions: {begin_merge: NONSENSE_PERMISSION}
+            Detail: %s
             Hint:
-          """.trim();
-      final var fnException = assertThrows(SQLException.class,
-                                           () -> updateUserRolePermissions(testRole, null, functionPermissions));
-      if(!fnException.getMessage().contains(fnExceptionMsg)
-         || !fnException.getSQLState().equals(invalidJsonTextErrCode)){
-        throw fnException;
-      }
-      // Both
-      final String bothExceptionMsg =
-          """
-          ERROR: invalid permissions in supplied row
-            Detail: The following action keys have invalid permissions: {simulate: NONSENSE_PERMISSION}
-          The following function keys have invalid permissions: {begin_merge: NONSENSE_PERMISSION}
-            Hint:
-          """.trim();
-      final var bothException = assertThrows(SQLException.class,
-                                             () -> updateUserRolePermissions(testRole, actionPermissions, functionPermissions));
-      if(!bothException.getMessage().contains(bothExceptionMsg)
-         || !bothException.getSQLState().equals(invalidJsonTextErrCode)){
-        throw bothException;
-      }
+          """;
+
+      return generateArgumentStream(
+          actionPermissions,
+          functionPermissions,
+          workspacePermissions,
+          exceptionTemplate,
+          actionExceptionMsg,
+          fnExceptionMsg,
+          wsExceptionMsg);
     }
 
-    @Test
-    void invalidPermissions() throws SQLException {
+    /**
+     * Improperly applied Plan Merge Permissions are not permitted
+     */
+    static Stream<Arguments> invalidPlanMergePermissionsProvider() {
       // Improperly applied Plan Merge Permissions are caught
       final String actionPermissions = "{\"simulate\": \"PLAN_OWNER_SOURCE\"}";
       final String functionPermissions = "{\"apply_preset\": \"PLAN_OWNER_TARGET\"}";
-      // Action
+      final String workspacePermissions = "{\"read_file_directory\": \"PLAN_OWNER_TARGET\"}";
+
       final String actionExceptionMsg =
-          """
-          ERROR: invalid permissions in supplied row
-            Detail: The following action keys may not take plan merge permissions: {simulate: PLAN_OWNER_SOURCE}
-            Hint:
-          """.trim();
-      final var actionException = assertThrows(SQLException.class,
-                                               () -> updateUserRolePermissions(testRole, actionPermissions, null));
-      if( !actionException.getMessage().contains(actionExceptionMsg)
-         || !actionException.getSQLState().equals(invalidJsonTextErrCode)){
-        throw actionException;
-      }
-
-      // Function
+          "The following action keys may not take plan merge permissions: {simulate: PLAN_OWNER_SOURCE}";
       final String fnExceptionMsg =
-          """
+          "The following function keys may not take plan merge permissions: {apply_preset: PLAN_OWNER_TARGET}";
+      // Workspace keys can't accept plan merge permissions, so it throws an invalid permission error
+      final String wsExceptionMsg =
+          "The following workspace keys have invalid permissions: {read_file_directory: PLAN_OWNER_TARGET}";
+
+      final String exceptionTemplate = """
           ERROR: invalid permissions in supplied row
-            Detail: The following function keys may not take plan merge permissions: {apply_preset: PLAN_OWNER_TARGET}
+            Detail: %s
             Hint:
           """.trim();
-      final var fnException = assertThrows(SQLException.class,
-                                           () -> updateUserRolePermissions(testRole, null, functionPermissions));
-      if(!fnException.getMessage().contains(fnExceptionMsg)
-         || !fnException.getSQLState().equals(invalidJsonTextErrCode)){
-        throw fnException;
-      }
-      // Both
-      final String bothExceptionMsg =
-          """
-          ERROR: invalid permissions in supplied row
-            Detail: The following action keys may not take plan merge permissions: {simulate: PLAN_OWNER_SOURCE}
-          The following function keys may not take plan merge permissions: {apply_preset: PLAN_OWNER_TARGET}
-            Hint:
-          """.trim();
-      final var bothException = assertThrows(SQLException.class,
-                                             () -> updateUserRolePermissions(testRole, actionPermissions, functionPermissions));
-      if(!bothException.getMessage().contains(bothExceptionMsg)
-         || !bothException.getSQLState().equals(invalidJsonTextErrCode)){
-        throw bothException;
-      }
+
+      return Stream.of(
+          // Action
+          arguments(actionPermissions, null, null, exceptionTemplate.formatted(actionExceptionMsg)),
+          // Function
+          arguments(null, functionPermissions, null, exceptionTemplate.formatted(fnExceptionMsg)),
+          // Workspace
+          arguments(null, null, workspacePermissions, exceptionTemplate.formatted(wsExceptionMsg)),
+          // Action and Function
+          arguments(actionPermissions, functionPermissions, null,
+                    exceptionTemplate.formatted(actionExceptionMsg + "\n" + fnExceptionMsg)),
+          // Cases that include workspaces
+          // invalid permission value errors take priority over improper use of plan merge permissions, so the
+          // ws error will be the only one returned
+          // Action and Workspace
+          arguments(actionPermissions, null, workspacePermissions, exceptionTemplate.formatted(wsExceptionMsg)),
+          // Function and Workspace
+          arguments(null, functionPermissions, workspacePermissions, exceptionTemplate.formatted(wsExceptionMsg)),
+          // All
+          arguments(actionPermissions, functionPermissions, workspacePermissions, exceptionTemplate.formatted(wsExceptionMsg)));
     }
 
-    @Test
-    void incompleteIsValid() {
-      // Updates Viewer Role Permissions, which is an incomplete set
-      final String actionPermissions = """
-      {
-        "sequence_seq_json_bulk": "NO_CHECK",
-        "resource_samples": "NO_CHECK"
-      }
-      """;
-      final String functionPermissions = """
-      {
-        "get_conflicting_activities": "NO_CHECK",
-        "get_non_conflicting_activities": "NO_CHECK",
-        "get_plan_history": "NO_CHECK"
-      }
-      """;
-      // Action
-      assertDoesNotThrow(() -> updateUserRolePermissions(testRole, actionPermissions, null));
-      // Function
-      assertDoesNotThrow(() -> updateUserRolePermissions(testRole, null, functionPermissions));
-      // Both
-      assertDoesNotThrow(() -> updateUserRolePermissions(testRole, actionPermissions, functionPermissions));
+    /**
+     * An empty JSON array is permitted for the permissions json
+     */
+    static Stream<Arguments> emptyIsValidProvider() {
+      return generateArgumentStream("{}", "{}", "{}");
     }
 
-    @Test
-    void completeIsValid() {
-      // Uses User Role Permissions to check that a complete set is valid
-      // and that plan merge permissions on plan merge functions is valid
+    /**
+     * Permission Keys are allowed be excluded from the permissions jsons
+     */
+    static Stream<Arguments> incompleteIsValidProvider() {
       final String actionPermissions = """
           {
-            "check_constraints": "PLAN_OWNER_COLLABORATOR",
-            "create_expansion_rule": "NO_CHECK",
-            "create_expansion_set": "NO_CHECK",
-            "expand_all_activities": "NO_CHECK",
-            "expand_all_templates": "NO_CHECK",
-            "assign_activities_by_filter": "NO_CHECK",
-            "insert_ext_dataset": "PLAN_OWNER",
-            "resource_samples": "NO_CHECK",
-            "schedule":"PLAN_OWNER_COLLABORATOR",
             "sequence_seq_json_bulk": "NO_CHECK",
-            "simulate":"PLAN_OWNER_COLLABORATOR"
+            "resource_samples": "NO_CHECK"
           }
           """;
       final String functionPermissions = """
           {
-            "apply_preset": "PLAN_OWNER_COLLABORATOR",
-            "begin_merge": "PLAN_OWNER_TARGET",
-            "branch_plan": "NO_CHECK",
-            "cancel_merge": "PLAN_OWNER_TARGET",
-            "commit_merge": "PLAN_OWNER_TARGET",
-            "create_merge_rq": "PLAN_OWNER_SOURCE",
-            "create_snapshot": "PLAN_OWNER_COLLABORATOR",
-            "delete_activity_reanchor": "PLAN_OWNER_COLLABORATOR",
-            "delete_activity_reanchor_bulk": "PLAN_OWNER_COLLABORATOR",
-            "delete_activity_reanchor_plan": "PLAN_OWNER_COLLABORATOR",
-            "delete_activity_reanchor_plan_bulk": "PLAN_OWNER_COLLABORATOR",
-            "delete_activity_subtree": "PLAN_OWNER_COLLABORATOR",
-            "delete_activity_subtree_bulk": "PLAN_OWNER_COLLABORATOR",
-            "deny_merge": "PLAN_OWNER_TARGET",
             "get_conflicting_activities": "NO_CHECK",
             "get_non_conflicting_activities": "NO_CHECK",
-            "get_plan_history": "NO_CHECK",
-            "restore_activity_changelog": "PLAN_OWNER_COLLABORATOR",
-            "restore_snapshot": "PLAN_OWNER_COLLABORATOR",
-            "set_resolution": "PLAN_OWNER_TARGET",
-            "set_resolution_bulk": "PLAN_OWNER_TARGET",
-            "withdraw_merge_rq": "PLAN_OWNER_SOURCE"
+            "get_plan_history": "NO_CHECK"
           }
           """;
-      // Action
-      assertDoesNotThrow(() -> updateUserRolePermissions(testRole, actionPermissions, null));
-      // Function
-      assertDoesNotThrow(() -> updateUserRolePermissions(testRole, null, functionPermissions));
-      // Both
-      assertDoesNotThrow(() -> updateUserRolePermissions(testRole, actionPermissions, functionPermissions));
+      final String workspacePermissions = """
+          {
+            "list_workspace_contents": "NO_CHECK",
+            "read_file_directory": "NO_CHECK"
+          }
+          """;
+      return generateArgumentStream(actionPermissions, functionPermissions, workspacePermissions);
     }
+
+    /**
+     * The permissions json is allowed to contain a complete set of permission keys
+     */
+    static Stream<Arguments> completeIsValidProvider() {
+      final String actionPermissions =
+          """
+              {
+                "check_constraints": "PLAN_OWNER_COLLABORATOR",
+                "create_expansion_rule": "NO_CHECK",
+                "create_expansion_set": "NO_CHECK",
+                "expand_all_activities": "NO_CHECK",
+                "expand_all_templates": "NO_CHECK",
+                "assign_activities_by_filter": "NO_CHECK",
+                "insert_ext_dataset": "PLAN_OWNER",
+                "resource_samples": "NO_CHECK",
+                "schedule":"PLAN_OWNER_COLLABORATOR",
+                "sequence_seq_json_bulk": "NO_CHECK",
+                "simulate":"PLAN_OWNER_COLLABORATOR"
+              }
+              """;
+      final String functionPermissions =
+          """
+              {
+                "apply_preset": "PLAN_OWNER_COLLABORATOR",
+                "begin_merge": "PLAN_OWNER_TARGET",
+                "branch_plan": "NO_CHECK",
+                "cancel_merge": "PLAN_OWNER_TARGET",
+                "commit_merge": "PLAN_OWNER_TARGET",
+                "create_merge_rq": "PLAN_OWNER_SOURCE",
+                "create_snapshot": "PLAN_OWNER_COLLABORATOR",
+                "delete_activity_reanchor": "PLAN_OWNER_COLLABORATOR",
+                "delete_activity_reanchor_bulk": "PLAN_OWNER_COLLABORATOR",
+                "delete_activity_reanchor_plan": "PLAN_OWNER_COLLABORATOR",
+                "delete_activity_reanchor_plan_bulk": "PLAN_OWNER_COLLABORATOR",
+                "delete_activity_subtree": "PLAN_OWNER_COLLABORATOR",
+                "delete_activity_subtree_bulk": "PLAN_OWNER_COLLABORATOR",
+                "deny_merge": "PLAN_OWNER_TARGET",
+                "get_conflicting_activities": "NO_CHECK",
+                "get_non_conflicting_activities": "NO_CHECK",
+                "get_plan_history": "NO_CHECK",
+                "restore_activity_changelog": "PLAN_OWNER_COLLABORATOR",
+                "restore_snapshot": "PLAN_OWNER_COLLABORATOR",
+                "set_resolution": "PLAN_OWNER_TARGET",
+                "set_resolution_bulk": "PLAN_OWNER_TARGET",
+                "withdraw_merge_rq": "PLAN_OWNER_SOURCE"
+              }
+              """;
+      final String workspacePermissions =
+          """
+              {
+                "create_workspace": "NO_CHECK",
+                "delete_workspace": "OWNER",
+                "list_workspace_contents": "OWNER_COLLABORATOR",
+                "read_file_directory": "NO_CHECK",
+                "write_file_directory": "OWNER_COLLABORATOR",
+                "delete_file_directory": "OWNER_COLLABORATOR"
+              }
+              """;
+
+      return generateArgumentStream(actionPermissions, functionPermissions, workspacePermissions);
+    }
+    //endregion
   }
 }

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -171,6 +171,7 @@ services:
       WORKSPACE_PORT: 28000
       HASURA_GRAPHQL_JWT_SECRET: "${HASURA_GRAPHQL_JWT_SECRET}"
       HASURA_GRAPHQL_ADMIN_SECRET: "${HASURA_GRAPHQL_ADMIN_SECRET}"
+      HASURA_GRAPHQL_URL: http://hasura:8080/v1/graphql
       JAVA_OPTS: >
         -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO

--- a/deployment/hasura/metadata/databases/tables/actions/action_run.yaml
+++ b/deployment/hasura/metadata/databases/tables/actions/action_run.yaml
@@ -33,7 +33,7 @@ insert_permissions:
   - role: user
     permission:
       columns: [settings, parameters, action_definition_id, has_secrets]
-      check: {}
+      check: { "action_definition": { "workspace": { "_or": [ { "owner": { "_eq": "X-Hasura-User-Id" } },{ "collaborators": { "collaborator": { "_eq": "X-Hasura-User-Id" } } } ] } } }
       set:
         requested_by: "x-hasura-user-id"
 update_permissions:
@@ -44,7 +44,7 @@ update_permissions:
   - role: user
     permission:
       columns: [canceled]
-      filter: {}
+      filter: { "action_definition": { "workspace": { "_or": [ { "owner": { "_eq": "X-Hasura-User-Id" } },{ "collaborators": { "collaborator": { "_eq": "X-Hasura-User-Id" } } } ] } } }
 delete_permissions:
   - role: aerie_admin
     permission:

--- a/deployment/hasura/metadata/databases/tables/permissions/user_role_permission.yaml
+++ b/deployment/hasura/metadata/databases/tables/permissions/user_role_permission.yaml
@@ -22,10 +22,10 @@ select_permissions:
 insert_permissions:
   - role: aerie_admin
     permission:
-      columns: [role, action_permissions, function_permissions]
+      columns: [role, action_permissions, function_permissions, workspace_permissions]
       check: {}
 update_permissions:
   - role: aerie_admin
     permission:
-      columns: [action_permissions, function_permissions]
+      columns: [action_permissions, function_permissions, workspace_permissions]
       filter: {}

--- a/deployment/hasura/migrations/Aerie/30_workspace_permissions/down.sql
+++ b/deployment/hasura/migrations/Aerie/30_workspace_permissions/down.sql
@@ -1,0 +1,157 @@
+-- Reset trigger functions for user_role_permission table
+create or replace function permissions.validate_permissions_json()
+returns trigger
+language plpgsql as $$
+  declare
+    error_msg text;
+    plan_merge_fns text[];
+begin
+  error_msg = '';
+
+  plan_merge_fns := '{
+    "begin_merge",
+    "cancel_merge",
+    "commit_merge",
+    "create_merge_rq",
+    "deny_merge",
+    "get_conflicting_activities",
+    "get_non_conflicting_activities",
+    "set_resolution",
+    "set_resolution_bulk",
+    "withdraw_merge_rq"
+    }';
+
+  -- Do all the validation checks up front
+  -- Duplicate keys are not checked for, as as all but the last instance is removed
+  -- during conversion of JSON Text to JSONB (https://www.postgresql.org/docs/14/datatype-json.html)
+  create temp table _validate_functions_table as
+  select
+    jsonb_object_keys(new.function_permissions) as function_key,
+    new.function_permissions ->> jsonb_object_keys(new.function_permissions) as function_permission,
+    jsonb_object_keys(new.function_permissions) = any(enum_range(null::permissions.function_permission_key)::text[]) as valid_function_key,
+    new.function_permissions ->> jsonb_object_keys(new.function_permissions) = any(enum_range(null::permissions.permission)::text[]) as valid_function_permission,
+    jsonb_object_keys(new.function_permissions) = any(plan_merge_fns) as is_plan_merge_key,
+  	new.function_permissions ->> jsonb_object_keys(new.function_permissions) = any(enum_range('PLAN_OWNER_SOURCE'::permissions.permission, 'PLAN_OWNER_COLLABORATOR_TARGET'::permissions.permission)::text[]) as is_plan_merge_permission;
+
+  create temp table _validate_actions_table as
+  select
+    jsonb_object_keys(new.action_permissions) as action_key,
+    new.action_permissions ->> jsonb_object_keys(new.action_permissions) as action_permission,
+    jsonb_object_keys(new.action_permissions) = any(enum_range(null::permissions.action_permission_key)::text[]) as valid_action_key,
+    new.action_permissions ->> jsonb_object_keys(new.action_permissions) = any(enum_range(null::permissions.permission)::text[]) as valid_action_permission,
+  	new.action_permissions ->> jsonb_object_keys(new.action_permissions) = any(enum_range('PLAN_OWNER_SOURCE'::permissions.permission, 'PLAN_OWNER_COLLABORATOR_TARGET'::permissions.permission)::text[]) as is_plan_merge_permission;
+
+
+  -- Get any invalid Action Keys
+  if exists(select from _validate_actions_table where not valid_action_key)
+  then
+    error_msg = 'The following action keys are not valid: '
+                 || (select string_agg(action_key, ', ')
+                     from _validate_actions_table
+                     where not valid_action_key)
+                 ||e'\n';
+  end if;
+  -- Get any invalid Function Keys
+  if exists(select from _validate_functions_table where not valid_function_key)
+  then
+    error_msg = error_msg
+                 || 'The following function keys are not valid: '
+                 || (select string_agg(function_key, ', ')
+                     from _validate_functions_table
+                     where not valid_function_key);
+  end if;
+
+  -- Raise if there were invalid Action/Function Keys
+  if error_msg != '' then
+    raise exception using
+      message = 'invalid keys in supplied row',
+      detail = trim(both e'\n' from error_msg),
+      errcode = 'invalid_json_text',
+      hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for a list of valid keys.';
+  end if;
+
+  -- Get any values that aren't Action Permissions
+  if exists(select from _validate_actions_table where not valid_action_permission)
+  then
+    error_msg = 'The following action keys have invalid permissions: {'
+                || (select string_agg(action_key || ': ' || action_permission, ', ')
+                    from _validate_actions_table
+                    where not valid_action_permission)
+                ||e'}\n';
+  end if;
+
+  -- Get any values that aren't Function Permissions
+  if exists(select from _validate_functions_table where not valid_function_permission)
+  then
+    error_msg = error_msg
+                || 'The following function keys have invalid permissions: {'
+                || (select string_agg(function_key || ': ' || function_permission, ', ')
+                    from _validate_functions_table
+                    where not valid_function_permission)
+                || '}';
+  end if;
+
+  -- Raise if there were invalid Action/Function Permissions
+  if error_msg != '' then
+    raise exception using
+      message = 'invalid permissions in supplied row',
+      detail = trim(both e'\n' from error_msg),
+      errcode = 'invalid_json_text',
+      hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for a list of valid Permissions.';
+  end if;
+
+	-- Check that no Actions have Plan Merge Permissions
+  if exists(select from _validate_actions_table where is_plan_merge_permission)
+  then
+    error_msg = 'The following action keys may not take plan merge permissions: {'
+                || (select string_agg(action_key || ': ' || action_permission, ', ')
+                    from _validate_actions_table
+                    where is_plan_merge_permission)
+                ||e'}\n';
+  end if;
+
+  -- Check that no non-Plan Merge Functions have Plan Merge Permissions
+  if exists(select from _validate_functions_table where is_plan_merge_permission and not is_plan_merge_key)
+  then
+    error_msg = error_msg
+                || 'The following function keys may not take plan merge permissions: {'
+                || (select string_agg(function_key || ': ' || function_permission, ', ')
+                    from _validate_functions_table
+                    where is_plan_merge_permission and not is_plan_merge_key)
+                  || '}';
+  end if;
+
+  -- Raise if Plan Merge Permissions were improperly applied
+  if error_msg != '' then
+    raise exception using
+      message = 'invalid permissions in supplied row',
+      detail = trim(both e'\n' from error_msg),
+      errcode = 'invalid_json_text',
+      hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for more information.';
+  end if;
+
+  -- Drop Temp Tables
+  drop table _validate_functions_table;
+  drop table _validate_actions_table;
+
+  return new;
+end
+$$;
+
+drop function permissions.validate_workspace_permissions_json(_workspace_permissions jsonb);
+drop function permissions.validate_function_permissions_json(_function_permissions jsonb);
+drop function permissions.validate_action_permissions_json(_action_permissions jsonb);
+
+-- Drop new column and reset table comment
+comment on table permissions.user_role_permission is e''
+  'Permissions for a role that cannot be expressed in Hasura. Permissions take the form {KEY:PERMISSION}.'
+  'A list of valid KEYs and PERMISSIONs can be found at https://github.com/NASA-AMMOS/aerie/discussions/983#discussioncomment-6257146';
+
+alter table permissions.user_role_permission
+  drop column workspace_permissions;
+
+-- Drop new Enums
+drop type permissions.workspace_permission_key;
+drop type permissions.workspace_permission;
+
+call migrations.mark_migration_rolled_back(30);

--- a/deployment/hasura/migrations/Aerie/30_workspace_permissions/up.sql
+++ b/deployment/hasura/migrations/Aerie/30_workspace_permissions/up.sql
@@ -311,6 +311,7 @@ where role = 'aerie_admin';
 -- Set user permissions
 update permissions.user_role_permission
 set workspace_permissions = '{
+      "create_workspace": "NO_CHECK",
       "delete_file_directory": "OWNER_COLLABORATOR",
       "delete_workspace": "OWNER",
       "list_workspace_contents": "NO_CHECK",

--- a/deployment/hasura/migrations/Aerie/30_workspace_permissions/up.sql
+++ b/deployment/hasura/migrations/Aerie/30_workspace_permissions/up.sql
@@ -1,0 +1,322 @@
+-- Add new Permissions Types
+create type permissions.workspace_permission
+ as enum (
+   'NO_CHECK',
+   'OWNER',
+   'COLLABORATOR',
+   'OWNER_COLLABORATOR'
+  );
+create type permissions.workspace_permission_key
+ as enum (
+   'create_workspace',
+   'delete_file_directory',
+   'delete_workspace',
+   'list_workspace_contents',
+   'read_file_directory',
+   'write_file_directory'
+  );
+
+-- Add new permissions to permissions table
+alter table permissions.user_role_permission
+  add column workspace_permissions jsonb not null default '{}';
+
+comment on table permissions.user_role_permission is e''
+  'Permissions for a role that cannot be expressed in Hasura. Permissions take the form {KEY:PERMISSION}.'
+  'A list of valid KEYs and PERMISSIONs can be found at https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions';
+
+comment on column permissions.user_role_permission.workspace_permissions is ''
+  'The permissions the role has on Workspace Functions.';
+
+-- Update trigger functions
+create function permissions.validate_action_permissions_json(_action_permissions jsonb)
+returns table(key_error_msg text, value_error_msg text, plan_merge_error_msg text)
+language plpgsql as $$
+declare
+  key_error_msg text;
+  value_error_msg text;
+  plan_merge_error_msg text;
+begin
+  key_error_msg = '';
+  value_error_msg = '';
+  plan_merge_error_msg = '';
+
+  -- Do all the validation checks up front
+  -- Duplicate keys are not checked for, as as all but the last instance is removed
+  -- during conversion of JSON Text to JSONB (https://www.postgresql.org/docs/14/datatype-json.html)
+  create temp table _validate_actions_table as
+  select
+    jsonb_object_keys(_action_permissions) as action_key,
+    _action_permissions ->> jsonb_object_keys(_action_permissions) as action_permission,
+    jsonb_object_keys(_action_permissions) = any(enum_range(null::permissions.action_permission_key)::text[]) as valid_action_key,
+    _action_permissions ->> jsonb_object_keys(_action_permissions) = any(enum_range(null::permissions.permission)::text[]) as valid_action_permission,
+  	_action_permissions ->> jsonb_object_keys(_action_permissions) = any(enum_range('PLAN_OWNER_SOURCE'::permissions.permission, 'PLAN_OWNER_COLLABORATOR_TARGET'::permissions.permission)::text[]) as is_plan_merge_permission;
+
+  -- Get any invalid Action Keys
+  if exists(select from _validate_actions_table where not valid_action_key)
+  then
+    key_error_msg = 'The following action keys are not valid: '
+                 || (select string_agg(action_key, ', ')
+                     from _validate_actions_table
+                     where not valid_action_key);
+  end if;
+
+  -- Get any values that aren't Action Permissions
+  if exists(select from _validate_actions_table where not valid_action_permission)
+  then
+    value_error_msg = 'The following action keys have invalid permissions: {'
+                || (select string_agg(action_key || ': ' || action_permission, ', ')
+                    from _validate_actions_table
+                    where not valid_action_permission)
+                ||e'}';
+  end if;
+
+	-- Check that no Actions have Plan Merge Permissions
+  if exists(select from _validate_actions_table where is_plan_merge_permission)
+  then
+    plan_merge_error_msg = 'The following action keys may not take plan merge permissions: {'
+                || (select string_agg(action_key || ': ' || action_permission, ', ')
+                    from _validate_actions_table
+                    where is_plan_merge_permission)
+                ||e'}';
+  end if;
+
+  -- Drop Temp Table
+  drop table _validate_actions_table;
+
+  return query select key_error_msg, value_error_msg, plan_merge_error_msg;
+end;
+$$;
+
+create function permissions.validate_function_permissions_json(_function_permissions jsonb)
+returns table(key_error_msg text, value_error_msg text, plan_merge_error_msg text)
+language plpgsql as $$
+declare
+  key_error_msg text;
+  value_error_msg text;
+  plan_merge_error_msg text;
+  plan_merge_fns text[];
+begin
+  key_error_msg = '';
+  value_error_msg = '';
+  plan_merge_error_msg = '';
+
+  plan_merge_fns := '{
+    "begin_merge",
+    "cancel_merge",
+    "commit_merge",
+    "create_merge_rq",
+    "deny_merge",
+    "get_conflicting_activities",
+    "get_non_conflicting_activities",
+    "set_resolution",
+    "set_resolution_bulk",
+    "withdraw_merge_rq"
+    }';
+
+  -- Do all the validation checks up front
+  -- Duplicate keys are not checked for, as as all but the last instance is removed
+  -- during conversion of JSON Text to JSONB (https://www.postgresql.org/docs/14/datatype-json.html)
+  create temp table _validate_functions_table as
+  select
+    jsonb_object_keys(_function_permissions) as function_key,
+    _function_permissions ->> jsonb_object_keys(_function_permissions) as function_permission,
+    jsonb_object_keys(_function_permissions) = any(enum_range(null::permissions.function_permission_key)::text[]) as valid_function_key,
+    _function_permissions ->> jsonb_object_keys(_function_permissions) = any(enum_range(null::permissions.permission)::text[]) as valid_function_permission,
+    jsonb_object_keys(_function_permissions) = any(plan_merge_fns) as is_plan_merge_key,
+  	_function_permissions ->> jsonb_object_keys(_function_permissions) = any(enum_range('PLAN_OWNER_SOURCE'::permissions.permission, 'PLAN_OWNER_COLLABORATOR_TARGET'::permissions.permission)::text[]) as is_plan_merge_permission;
+
+  -- Get any invalid Function Keys
+  if exists(select from _validate_functions_table where not valid_function_key)
+  then
+   key_error_msg = 'The following function keys are not valid: '
+                || (select string_agg(function_key, ', ')
+                     from _validate_functions_table
+                     where not valid_function_key);
+  end if;
+
+  -- Get any values that aren't Function Permissions
+  if exists(select from _validate_functions_table where not valid_function_permission)
+  then
+    value_error_msg = 'The following function keys have invalid permissions: {'
+                || (select string_agg(function_key || ': ' || function_permission, ', ')
+                    from _validate_functions_table
+                    where not valid_function_permission)
+                || '}';
+  end if;
+
+  -- Check that no non-Plan Merge Functions have Plan Merge Permissions
+  if exists(select from _validate_functions_table where is_plan_merge_permission and not is_plan_merge_key)
+  then
+    plan_merge_error_msg = 'The following function keys may not take plan merge permissions: {'
+                || (select string_agg(function_key || ': ' || function_permission, ', ')
+                    from _validate_functions_table
+                    where is_plan_merge_permission and not is_plan_merge_key)
+                  || '}';
+  end if;
+
+  -- Drop Temp Tables
+  drop table _validate_functions_table;
+
+  return query select key_error_msg, value_error_msg, plan_merge_error_msg;
+end;
+$$;
+
+create function permissions.validate_workspace_permissions_json(_workspace_permissions jsonb)
+returns table(key_error_msg text, value_error_msg text)
+language plpgsql as $$
+declare
+  key_error_msg text;
+  value_error_msg text;
+begin
+  key_error_msg = '';
+  value_error_msg = '';
+
+  -- Do all the validation checks up front
+  -- Duplicate keys are not checked for, as as all but the last instance is removed
+  -- during conversion of JSON Text to JSONB (https://www.postgresql.org/docs/14/datatype-json.html)
+  create temp table _validate_workspaces_table as
+  select
+    jsonb_object_keys(_workspace_permissions) as workspace_key,
+    _workspace_permissions ->> jsonb_object_keys(_workspace_permissions) as workspace_permission,
+    jsonb_object_keys(_workspace_permissions) = any(enum_range(null::permissions.workspace_permission_key)::text[]) as valid_workspace_key,
+    _workspace_permissions ->> jsonb_object_keys(_workspace_permissions) = any(enum_range(null::permissions.workspace_permission)::text[]) as valid_workspace_permission;
+
+  -- Ensure that "create_workspace", if the permission is provided, is set to "NO_CHECK"
+  -- if not, flag the key as having an invalid permission
+  update _validate_workspaces_table
+  set valid_workspace_permission = false
+  where workspace_key = 'create_workspace' and workspace_permission != 'NO_CHECK';
+
+  -- Get any invalid Workspace Action Keys
+  if exists(select from _validate_workspaces_table where not valid_workspace_key)
+  then
+    key_error_msg = 'The following workspace keys are not valid: '
+                 || (select string_agg(workspace_key, ', ')
+                     from _validate_workspaces_table
+                     where not valid_workspace_key)
+                 ||e'';
+  end if;
+
+  -- Get any values that aren't Workspace Permissions
+  if exists(select from _validate_workspaces_table where not valid_workspace_permission)
+  then
+    value_error_msg = 'The following workspace keys have invalid permissions: {'
+                || (select string_agg(workspace_key || ': ' || workspace_permission, ', ')
+                    from _validate_workspaces_table
+                    where not valid_workspace_permission)
+                ||e'}';
+  end if;
+
+  -- Drop Temp Table
+  drop table _validate_workspaces_table;
+
+  return query select key_error_msg, value_error_msg;
+end;
+$$;
+
+create or replace function permissions.validate_permissions_json()
+returns trigger
+language plpgsql as $$
+  declare
+    action_error_msgs record;
+    function_error_msgs record;
+    workspace_error_msgs record;
+    key_error_msg text;
+    value_error_msg text;
+    plan_merge_error_msg text;
+begin
+  select *
+  from permissions.validate_action_permissions_json(new.action_permissions)
+  into action_error_msgs;
+
+  select *
+  from permissions.validate_function_permissions_json(new.function_permissions)
+  into function_error_msgs;
+
+  select *
+  from permissions.validate_workspace_permissions_json(new.workspace_permissions)
+  into workspace_error_msgs;
+
+  with key_errors(msg) as (
+    values (action_error_msgs.key_error_msg),
+           (function_error_msgs.key_error_msg),
+           (workspace_error_msgs.key_error_msg)
+  ) select string_agg(msg, e'\n')
+    from key_errors
+    where msg != ''
+    into key_error_msg;
+
+  with value_errors(msg) as (
+    values (action_error_msgs.value_error_msg),
+           (function_error_msgs.value_error_msg),
+           (workspace_error_msgs.value_error_msg)
+  ) select string_agg(msg, e'\n')
+    from value_errors
+    where msg != ''
+    into value_error_msg;
+
+  with plan_merge_errors(msg) as (
+    values (action_error_msgs.plan_merge_error_msg),
+           (function_error_msgs.plan_merge_error_msg)
+  ) select string_agg(msg, e'\n')
+    from plan_merge_errors
+    where msg != ''
+    into plan_merge_error_msg;
+
+  -- Raise if there were invalid Action/Function Keys
+  if key_error_msg != '' then
+    raise exception using
+      message = 'invalid keys in supplied row',
+      detail = key_error_msg,
+      errcode = 'invalid_json_text',
+      hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for a list of valid keys.';
+  end if;
+
+  -- Raise if there were invalid Action/Function Permissions
+  if value_error_msg != '' then
+    raise exception using
+      message = 'invalid permissions in supplied row',
+      detail = value_error_msg,
+      errcode = 'invalid_json_text',
+      hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for a list of valid Permissions.';
+  end if;
+
+  -- Raise if Plan Merge Permissions were improperly applied
+  if plan_merge_error_msg != '' then
+    raise exception using
+      message = 'invalid permissions in supplied row',
+      detail = plan_merge_error_msg,
+      errcode = 'invalid_json_text',
+      hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for more information.';
+  end if;
+
+  return new;
+end
+$$;
+
+
+-- Initialize default permissions for user roles
+-- No filter so that all custom roles end up with basic read permissions
+update permissions.user_role_permission
+set workspace_permissions = '{
+      "list_workspace_contents": "NO_CHECK",
+      "read_file_directory": "NO_CHECK"
+    }';
+
+-- Reset admin to {}
+update permissions.user_role_permission
+set workspace_permissions = '{}'
+where role = 'aerie_admin';
+
+-- Set user permissions
+update permissions.user_role_permission
+set workspace_permissions = '{
+      "delete_file_directory": "OWNER_COLLABORATOR",
+      "delete_workspace": "OWNER",
+      "list_workspace_contents": "NO_CHECK",
+      "read_file_directory": "NO_CHECK",
+      "write_file_directory": "OWNER_COLLABORATOR"
+    }'
+where role = 'user';
+
+call migrations.mark_migration_applied(30);

--- a/deployment/postgres-init-db/sql/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/applied_migrations.sql
@@ -31,3 +31,4 @@ call migrations.mark_migration_applied(26);
 call migrations.mark_migration_applied(27);
 call migrations.mark_migration_applied(28);
 call migrations.mark_migration_applied(29);
+call migrations.mark_migration_applied(30);

--- a/deployment/postgres-init-db/sql/default_user_roles.sql
+++ b/deployment/postgres-init-db/sql/default_user_roles.sql
@@ -5,7 +5,8 @@ insert into permissions.user_roles(role) values ('aerie_admin'), ('user'), ('vie
 -- 'aerie_admin' permissions aren't specified since 'aerie_admin' is always considered to have "NO_CHECK" permissions
 update permissions.user_role_permission
 set action_permissions = '{}',
-    function_permissions = '{}'
+    function_permissions = '{}',
+    workspace_permissions = '{}'
 where role = 'aerie_admin';
 
 update permissions.user_role_permission
@@ -46,6 +47,13 @@ set action_permissions = '{
       "set_resolution": "PLAN_OWNER_TARGET",
       "set_resolution_bulk": "PLAN_OWNER_TARGET",
       "withdraw_merge_rq": "PLAN_OWNER_SOURCE"
+    }',
+  workspace_permissions = '{
+      "delete_file_directory": "OWNER_COLLABORATOR",
+      "delete_workspace": "OWNER",
+      "list_workspace_contents": "NO_CHECK",
+      "read_file_directory": "NO_CHECK",
+      "write_file_directory": "OWNER_COLLABORATOR"
     }'
 where role = 'user';
 
@@ -58,6 +66,10 @@ set action_permissions = '{
       "get_conflicting_activities": "NO_CHECK",
       "get_non_conflicting_activities": "NO_CHECK",
       "get_plan_history": "NO_CHECK"
+    }',
+    workspace_permissions = '{
+      "list_workspace_contents": "NO_CHECK",
+      "read_file_directory": "NO_CHECK"
     }'
 where role = 'viewer';
 

--- a/deployment/postgres-init-db/sql/default_user_roles.sql
+++ b/deployment/postgres-init-db/sql/default_user_roles.sql
@@ -49,6 +49,7 @@ set action_permissions = '{
       "withdraw_merge_rq": "PLAN_OWNER_SOURCE"
     }',
   workspace_permissions = '{
+      "create_workspace": "NO_CHECK",
       "delete_file_directory": "OWNER_COLLABORATOR",
       "delete_workspace": "OWNER",
       "list_workspace_contents": "NO_CHECK",

--- a/deployment/postgres-init-db/sql/tables/permissions/user_role_permission.sql
+++ b/deployment/postgres-init-db/sql/tables/permissions/user_role_permission.sql
@@ -5,18 +5,21 @@ create table permissions.user_role_permission(
       on update cascade
       on delete cascade,
   action_permissions jsonb not null default '{}',
-  function_permissions jsonb not null default '{}'
+  function_permissions jsonb not null default '{}',
+  workspace_permissions jsonb not null default '{}'
 );
 
 comment on table permissions.user_role_permission is e''
   'Permissions for a role that cannot be expressed in Hasura. Permissions take the form {KEY:PERMISSION}.'
-  'A list of valid KEYs and PERMISSIONs can be found at https://github.com/NASA-AMMOS/aerie/discussions/983#discussioncomment-6257146';
+  'A list of valid KEYs and PERMISSIONs can be found at https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions';
 comment on column permissions.user_role_permission.role is e''
   'The role these permissions apply to.';
 comment on column permissions.user_role_permission.action_permissions is ''
   'The permissions the role has on Hasura Actions.';
 comment on column permissions.user_role_permission.function_permissions is ''
   'The permissions the role has on Hasura Functions.';
+comment on column permissions.user_role_permission.workspace_permissions is ''
+  'The permissions the role has on Workspace Functions.';
 
 create function permissions.validate_action_permissions_json(_action_permissions jsonb)
 returns table(key_error_msg text, value_error_msg text, plan_merge_error_msg text)
@@ -47,8 +50,7 @@ begin
     key_error_msg = 'The following action keys are not valid: '
                  || (select string_agg(action_key, ', ')
                      from _validate_actions_table
-                     where not valid_action_key)
-                 ||e'\n';
+                     where not valid_action_key);
   end if;
 
   -- Get any values that aren't Action Permissions
@@ -58,7 +60,7 @@ begin
                 || (select string_agg(action_key || ': ' || action_permission, ', ')
                     from _validate_actions_table
                     where not valid_action_permission)
-                ||e'}\n';
+                ||e'}';
   end if;
 
 	-- Check that no Actions have Plan Merge Permissions
@@ -68,7 +70,7 @@ begin
                 || (select string_agg(action_key || ': ' || action_permission, ', ')
                     from _validate_actions_table
                     where is_plan_merge_permission)
-                ||e'}\n';
+                ||e'}';
   end if;
 
   -- Drop Temp Table
@@ -138,8 +140,7 @@ begin
   -- Check that no non-Plan Merge Functions have Plan Merge Permissions
   if exists(select from _validate_functions_table where is_plan_merge_permission and not is_plan_merge_key)
   then
-    plan_merge_error_msg =
-                || 'The following function keys may not take plan merge permissions: {'
+    plan_merge_error_msg = 'The following function keys may not take plan merge permissions: {'
                 || (select string_agg(function_key || ': ' || function_permission, ', ')
                     from _validate_functions_table
                     where is_plan_merge_permission and not is_plan_merge_key)
@@ -153,12 +154,66 @@ begin
 end;
 $$;
 
+create function permissions.validate_workspace_permissions_json(_workspace_permissions jsonb)
+returns table(key_error_msg text, value_error_msg text)
+language plpgsql as $$
+declare
+  key_error_msg text;
+  value_error_msg text;
+begin
+  key_error_msg = '';
+  value_error_msg = '';
+
+  -- Do all the validation checks up front
+  -- Duplicate keys are not checked for, as as all but the last instance is removed
+  -- during conversion of JSON Text to JSONB (https://www.postgresql.org/docs/14/datatype-json.html)
+  create temp table _validate_workspaces_table as
+  select
+    jsonb_object_keys(_workspace_permissions) as workspace_key,
+    _workspace_permissions ->> jsonb_object_keys(_workspace_permissions) as workspace_permission,
+    jsonb_object_keys(_workspace_permissions) = any(enum_range(null::permissions.workspace_permission_key)::text[]) as valid_workspace_key,
+    _workspace_permissions ->> jsonb_object_keys(_workspace_permissions) = any(enum_range(null::permissions.workspace_permission)::text[]) as valid_workspace_permission;
+
+  -- Ensure that "create_workspace", if the permission is provided, is set to "NO_CHECK"
+  -- if not, flag the key as having an invalid permission
+  update _validate_workspaces_table
+  set valid_workspace_permission = false
+  where workspace_key = 'create_workspace' and workspace_permission != 'NO_CHECK';
+
+  -- Get any invalid Workspace Action Keys
+  if exists(select from _validate_workspaces_table where not valid_workspace_key)
+  then
+    key_error_msg = 'The following workspace keys are not valid: '
+                 || (select string_agg(workspace_key, ', ')
+                     from _validate_workspaces_table
+                     where not valid_workspace_key)
+                 ||e'';
+  end if;
+
+  -- Get any values that aren't Workspace Permissions
+  if exists(select from _validate_workspaces_table where not valid_workspace_permission)
+  then
+    value_error_msg = 'The following workspace keys have invalid permissions: {'
+                || (select string_agg(workspace_key || ': ' || workspace_permission, ', ')
+                    from _validate_workspaces_table
+                    where not valid_workspace_permission)
+                ||e'}';
+  end if;
+
+  -- Drop Temp Table
+  drop table _validate_workspaces_table;
+
+  return query select key_error_msg, value_error_msg;
+end;
+$$;
+
 create function permissions.validate_permissions_json()
 returns trigger
 language plpgsql as $$
   declare
     action_error_msgs record;
     function_error_msgs record;
+    workspace_error_msgs record;
     key_error_msg text;
     value_error_msg text;
     plan_merge_error_msg text;
@@ -171,15 +226,41 @@ begin
   from permissions.validate_function_permissions_json(new.function_permissions)
   into function_error_msgs;
 
-  key_error_msg = '' || action_error_msgs.key_error_msg || function_error_msgs.key_error_msg;
-  value_error_msg = '' || action_error_msgs.value_error_msg || function_error_msgs.value_error_msg;
-  plan_merge_error_msg = '' || action_error_msgs.plan_merge_error_msg || function_error_msgs.plan_merge_error_msg;
+  select *
+  from permissions.validate_workspace_permissions_json(new.workspace_permissions)
+  into workspace_error_msgs;
+
+  with key_errors(msg) as (
+    values (action_error_msgs.key_error_msg),
+           (function_error_msgs.key_error_msg),
+           (workspace_error_msgs.key_error_msg)
+  ) select string_agg(msg, e'\n')
+    from key_errors
+    where msg != ''
+    into key_error_msg;
+
+  with value_errors(msg) as (
+    values (action_error_msgs.value_error_msg),
+           (function_error_msgs.value_error_msg),
+           (workspace_error_msgs.value_error_msg)
+  ) select string_agg(msg, e'\n')
+    from value_errors
+    where msg != ''
+    into value_error_msg;
+
+  with plan_merge_errors(msg) as (
+    values (action_error_msgs.plan_merge_error_msg),
+           (function_error_msgs.plan_merge_error_msg)
+  ) select string_agg(msg, e'\n')
+    from plan_merge_errors
+    where msg != ''
+    into plan_merge_error_msg;
 
   -- Raise if there were invalid Action/Function Keys
   if key_error_msg != '' then
     raise exception using
       message = 'invalid keys in supplied row',
-      detail = trim(both e'\n' from key_error_msg),
+      detail = key_error_msg,
       errcode = 'invalid_json_text',
       hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for a list of valid keys.';
   end if;
@@ -188,7 +269,7 @@ begin
   if value_error_msg != '' then
     raise exception using
       message = 'invalid permissions in supplied row',
-      detail = trim(both e'\n' from value_error_msg),
+      detail = value_error_msg,
       errcode = 'invalid_json_text',
       hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for a list of valid Permissions.';
   end if;
@@ -197,7 +278,7 @@ begin
   if plan_merge_error_msg != '' then
     raise exception using
       message = 'invalid permissions in supplied row',
-      detail = trim(both e'\n' from plan_merge_error_msg),
+      detail = plan_merge_error_msg,
       errcode = 'invalid_json_text',
       hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for more information.';
   end if;

--- a/deployment/postgres-init-db/sql/tables/permissions/user_role_permission.sql
+++ b/deployment/postgres-init-db/sql/tables/permissions/user_role_permission.sql
@@ -18,14 +18,78 @@ comment on column permissions.user_role_permission.action_permissions is ''
 comment on column permissions.user_role_permission.function_permissions is ''
   'The permissions the role has on Hasura Functions.';
 
-create function permissions.validate_permissions_json()
-returns trigger
+create function permissions.validate_action_permissions_json(_action_permissions jsonb)
+returns table(key_error_msg text, value_error_msg text, plan_merge_error_msg text)
 language plpgsql as $$
-  declare
-    error_msg text;
-    plan_merge_fns text[];
+declare
+  key_error_msg text;
+  value_error_msg text;
+  plan_merge_error_msg text;
 begin
-  error_msg = '';
+  key_error_msg = '';
+  value_error_msg = '';
+  plan_merge_error_msg = '';
+
+  -- Do all the validation checks up front
+  -- Duplicate keys are not checked for, as as all but the last instance is removed
+  -- during conversion of JSON Text to JSONB (https://www.postgresql.org/docs/14/datatype-json.html)
+  create temp table _validate_actions_table as
+  select
+    jsonb_object_keys(_action_permissions) as action_key,
+    _action_permissions ->> jsonb_object_keys(_action_permissions) as action_permission,
+    jsonb_object_keys(_action_permissions) = any(enum_range(null::permissions.action_permission_key)::text[]) as valid_action_key,
+    _action_permissions ->> jsonb_object_keys(_action_permissions) = any(enum_range(null::permissions.permission)::text[]) as valid_action_permission,
+  	_action_permissions ->> jsonb_object_keys(_action_permissions) = any(enum_range('PLAN_OWNER_SOURCE'::permissions.permission, 'PLAN_OWNER_COLLABORATOR_TARGET'::permissions.permission)::text[]) as is_plan_merge_permission;
+
+  -- Get any invalid Action Keys
+  if exists(select from _validate_actions_table where not valid_action_key)
+  then
+    key_error_msg = 'The following action keys are not valid: '
+                 || (select string_agg(action_key, ', ')
+                     from _validate_actions_table
+                     where not valid_action_key)
+                 ||e'\n';
+  end if;
+
+  -- Get any values that aren't Action Permissions
+  if exists(select from _validate_actions_table where not valid_action_permission)
+  then
+    value_error_msg = 'The following action keys have invalid permissions: {'
+                || (select string_agg(action_key || ': ' || action_permission, ', ')
+                    from _validate_actions_table
+                    where not valid_action_permission)
+                ||e'}\n';
+  end if;
+
+	-- Check that no Actions have Plan Merge Permissions
+  if exists(select from _validate_actions_table where is_plan_merge_permission)
+  then
+    plan_merge_error_msg = 'The following action keys may not take plan merge permissions: {'
+                || (select string_agg(action_key || ': ' || action_permission, ', ')
+                    from _validate_actions_table
+                    where is_plan_merge_permission)
+                ||e'}\n';
+  end if;
+
+  -- Drop Temp Table
+  drop table _validate_actions_table;
+
+  return query select key_error_msg, value_error_msg, plan_merge_error_msg;
+end;
+$$;
+
+create function permissions.validate_function_permissions_json(_function_permissions jsonb)
+returns table(key_error_msg text, value_error_msg text, plan_merge_error_msg text)
+language plpgsql as $$
+declare
+  key_error_msg text;
+  value_error_msg text;
+  plan_merge_error_msg text;
+  plan_merge_fns text[];
+begin
+  key_error_msg = '';
+  value_error_msg = '';
+  plan_merge_error_msg = '';
 
   plan_merge_fns := '{
     "begin_merge",
@@ -45,94 +109,36 @@ begin
   -- during conversion of JSON Text to JSONB (https://www.postgresql.org/docs/14/datatype-json.html)
   create temp table _validate_functions_table as
   select
-    jsonb_object_keys(new.function_permissions) as function_key,
-    new.function_permissions ->> jsonb_object_keys(new.function_permissions) as function_permission,
-    jsonb_object_keys(new.function_permissions) = any(enum_range(null::permissions.function_permission_key)::text[]) as valid_function_key,
-    new.function_permissions ->> jsonb_object_keys(new.function_permissions) = any(enum_range(null::permissions.permission)::text[]) as valid_function_permission,
-    jsonb_object_keys(new.function_permissions) = any(plan_merge_fns) as is_plan_merge_key,
-  	new.function_permissions ->> jsonb_object_keys(new.function_permissions) = any(enum_range('PLAN_OWNER_SOURCE'::permissions.permission, 'PLAN_OWNER_COLLABORATOR_TARGET'::permissions.permission)::text[]) as is_plan_merge_permission;
+    jsonb_object_keys(_function_permissions) as function_key,
+    _function_permissions ->> jsonb_object_keys(_function_permissions) as function_permission,
+    jsonb_object_keys(_function_permissions) = any(enum_range(null::permissions.function_permission_key)::text[]) as valid_function_key,
+    _function_permissions ->> jsonb_object_keys(_function_permissions) = any(enum_range(null::permissions.permission)::text[]) as valid_function_permission,
+    jsonb_object_keys(_function_permissions) = any(plan_merge_fns) as is_plan_merge_key,
+  	_function_permissions ->> jsonb_object_keys(_function_permissions) = any(enum_range('PLAN_OWNER_SOURCE'::permissions.permission, 'PLAN_OWNER_COLLABORATOR_TARGET'::permissions.permission)::text[]) as is_plan_merge_permission;
 
-  create temp table _validate_actions_table as
-  select
-    jsonb_object_keys(new.action_permissions) as action_key,
-    new.action_permissions ->> jsonb_object_keys(new.action_permissions) as action_permission,
-    jsonb_object_keys(new.action_permissions) = any(enum_range(null::permissions.action_permission_key)::text[]) as valid_action_key,
-    new.action_permissions ->> jsonb_object_keys(new.action_permissions) = any(enum_range(null::permissions.permission)::text[]) as valid_action_permission,
-  	new.action_permissions ->> jsonb_object_keys(new.action_permissions) = any(enum_range('PLAN_OWNER_SOURCE'::permissions.permission, 'PLAN_OWNER_COLLABORATOR_TARGET'::permissions.permission)::text[]) as is_plan_merge_permission;
-
-
-  -- Get any invalid Action Keys
-  if exists(select from _validate_actions_table where not valid_action_key)
-  then
-    error_msg = 'The following action keys are not valid: '
-                 || (select string_agg(action_key, ', ')
-                     from _validate_actions_table
-                     where not valid_action_key)
-                 ||e'\n';
-  end if;
   -- Get any invalid Function Keys
   if exists(select from _validate_functions_table where not valid_function_key)
   then
-    error_msg = error_msg
-                 || 'The following function keys are not valid: '
-                 || (select string_agg(function_key, ', ')
+   key_error_msg = 'The following function keys are not valid: '
+                || (select string_agg(function_key, ', ')
                      from _validate_functions_table
                      where not valid_function_key);
-  end if;
-
-  -- Raise if there were invalid Action/Function Keys
-  if error_msg != '' then
-    raise exception using
-      message = 'invalid keys in supplied row',
-      detail = trim(both e'\n' from error_msg),
-      errcode = 'invalid_json_text',
-      hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for a list of valid keys.';
-  end if;
-
-  -- Get any values that aren't Action Permissions
-  if exists(select from _validate_actions_table where not valid_action_permission)
-  then
-    error_msg = 'The following action keys have invalid permissions: {'
-                || (select string_agg(action_key || ': ' || action_permission, ', ')
-                    from _validate_actions_table
-                    where not valid_action_permission)
-                ||e'}\n';
   end if;
 
   -- Get any values that aren't Function Permissions
   if exists(select from _validate_functions_table where not valid_function_permission)
   then
-    error_msg = error_msg
-                || 'The following function keys have invalid permissions: {'
+    value_error_msg = 'The following function keys have invalid permissions: {'
                 || (select string_agg(function_key || ': ' || function_permission, ', ')
                     from _validate_functions_table
                     where not valid_function_permission)
                 || '}';
   end if;
 
-  -- Raise if there were invalid Action/Function Permissions
-  if error_msg != '' then
-    raise exception using
-      message = 'invalid permissions in supplied row',
-      detail = trim(both e'\n' from error_msg),
-      errcode = 'invalid_json_text',
-      hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for a list of valid Permissions.';
-  end if;
-
-	-- Check that no Actions have Plan Merge Permissions
-  if exists(select from _validate_actions_table where is_plan_merge_permission)
-  then
-    error_msg = 'The following action keys may not take plan merge permissions: {'
-                || (select string_agg(action_key || ': ' || action_permission, ', ')
-                    from _validate_actions_table
-                    where is_plan_merge_permission)
-                ||e'}\n';
-  end if;
-
   -- Check that no non-Plan Merge Functions have Plan Merge Permissions
   if exists(select from _validate_functions_table where is_plan_merge_permission and not is_plan_merge_key)
   then
-    error_msg = error_msg
+    plan_merge_error_msg =
                 || 'The following function keys may not take plan merge permissions: {'
                 || (select string_agg(function_key || ': ' || function_permission, ', ')
                     from _validate_functions_table
@@ -140,18 +146,61 @@ begin
                   || '}';
   end if;
 
-  -- Raise if Plan Merge Permissions were improperly applied
-  if error_msg != '' then
+  -- Drop Temp Tables
+  drop table _validate_functions_table;
+
+  return query select key_error_msg, value_error_msg, plan_merge_error_msg;
+end;
+$$;
+
+create function permissions.validate_permissions_json()
+returns trigger
+language plpgsql as $$
+  declare
+    action_error_msgs record;
+    function_error_msgs record;
+    key_error_msg text;
+    value_error_msg text;
+    plan_merge_error_msg text;
+begin
+  select *
+  from permissions.validate_action_permissions_json(new.action_permissions)
+  into action_error_msgs;
+
+  select *
+  from permissions.validate_function_permissions_json(new.function_permissions)
+  into function_error_msgs;
+
+  key_error_msg = '' || action_error_msgs.key_error_msg || function_error_msgs.key_error_msg;
+  value_error_msg = '' || action_error_msgs.value_error_msg || function_error_msgs.value_error_msg;
+  plan_merge_error_msg = '' || action_error_msgs.plan_merge_error_msg || function_error_msgs.plan_merge_error_msg;
+
+  -- Raise if there were invalid Action/Function Keys
+  if key_error_msg != '' then
+    raise exception using
+      message = 'invalid keys in supplied row',
+      detail = trim(both e'\n' from key_error_msg),
+      errcode = 'invalid_json_text',
+      hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for a list of valid keys.';
+  end if;
+
+  -- Raise if there were invalid Action/Function Permissions
+  if value_error_msg != '' then
     raise exception using
       message = 'invalid permissions in supplied row',
-      detail = trim(both e'\n' from error_msg),
+      detail = trim(both e'\n' from value_error_msg),
+      errcode = 'invalid_json_text',
+      hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for a list of valid Permissions.';
+  end if;
+
+  -- Raise if Plan Merge Permissions were improperly applied
+  if plan_merge_error_msg != '' then
+    raise exception using
+      message = 'invalid permissions in supplied row',
+      detail = trim(both e'\n' from plan_merge_error_msg),
       errcode = 'invalid_json_text',
       hint = 'Visit https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions for more information.';
   end if;
-
-  -- Drop Temp Tables
-  drop table _validate_functions_table;
-  drop table _validate_actions_table;
 
   return new;
 end

--- a/deployment/postgres-init-db/sql/types/permissions/permissions.sql
+++ b/deployment/postgres-init-db/sql/types/permissions/permissions.sql
@@ -16,6 +16,15 @@ create type permissions.permission
     'PLAN_OWNER_COLLABORATOR_TARGET'
   );
 
+-- Workspaces have a separate permission set, as workspaces are detached from the concept of plans and mission models
+create type permissions.workspace_permission
+ as enum (
+   'NO_CHECK',
+   'OWNER',
+   'COLLABORATOR',
+   'OWNER_COLLABORATOR'
+  );
+
 create type permissions.action_permission_key
   as enum (
     'assign_activities_by_filter',
@@ -56,4 +65,14 @@ create type permissions.function_permission_key
     'set_resolution',
     'set_resolution_bulk',
     'withdraw_merge_rq'
+  );
+
+create type permissions.workspace_permission_key
+ as enum (
+   'create_workspace',
+   'delete_file_directory',
+   'delete_workspace',
+   'list_workspace_contents',
+   'read_file_directory',
+   'write_file_directory'
   );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,7 @@ services:
       WORKSPACE_PORT: 28000
       HASURA_GRAPHQL_JWT_SECRET: "${HASURA_GRAPHQL_JWT_SECRET}"
       HASURA_GRAPHQL_ADMIN_SECRET: "${HASURA_GRAPHQL_ADMIN_SECRET}"
+      HASURA_GRAPHQL_URL: http://hasura:8080/v1/graphql
       JAVA_OPTS: >
         -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
         -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO

--- a/e2e-tests/docker-compose-many-workers.yml
+++ b/e2e-tests/docker-compose-many-workers.yml
@@ -139,6 +139,7 @@ services:
       WORKSPACE_PORT: 28000
       HASURA_GRAPHQL_JWT_SECRET: "${HASURA_GRAPHQL_JWT_SECRET}"
       HASURA_GRAPHQL_ADMIN_SECRET: "${HASURA_GRAPHQL_ADMIN_SECRET}"
+      HASURA_GRAPHQL_URL: http://hasura:8080/v1/graphql
       JAVA_OPTS: >
         -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
         -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -137,6 +137,7 @@ services:
       WORKSPACE_PORT: 28000
       HASURA_GRAPHQL_JWT_SECRET: "${HASURA_GRAPHQL_JWT_SECRET}"
       HASURA_GRAPHQL_ADMIN_SECRET: "${HASURA_GRAPHQL_ADMIN_SECRET}"
+      HASURA_GRAPHQL_URL: http://hasura:8080/v1/graphql
       JAVA_OPTS: >
         -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
         -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/BindingsTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/BindingsTests.java
@@ -4,6 +4,8 @@ import com.microsoft.playwright.APIRequest;
 import com.microsoft.playwright.APIRequestContext;
 import com.microsoft.playwright.APIResponse;
 import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.FilePayload;
+import com.microsoft.playwright.options.FormData;
 import com.microsoft.playwright.options.RequestOptions;
 import gov.nasa.jpl.aerie.e2e.types.ActionPermissionsSet;
 import gov.nasa.jpl.aerie.e2e.types.ActionPermissionsSet.*;
@@ -13,6 +15,7 @@ import gov.nasa.jpl.aerie.e2e.types.ValueSchema;
 import gov.nasa.jpl.aerie.e2e.utils.BaseURL;
 import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
 import gov.nasa.jpl.aerie.e2e.utils.HasuraRequests;
+import gov.nasa.jpl.aerie.e2e.utils.WorkspaceRequests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -24,6 +27,8 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.json.Json;
 import javax.json.JsonArray;
@@ -31,8 +36,10 @@ import javax.json.JsonObject;
 import javax.json.JsonValue;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -47,13 +54,19 @@ public class BindingsTests {
   private static final User admin = new User(
       "bindings_admin_user",
       "aerie_admin",
-      new String[]{"aerie_admin"},
+      new String[]{"aerie_admin", "viewer"},
       Map.of("x-hasura-role", "aerie_admin", "x-hasura-user-id", "bindings_admin_user"));
   private static final User nonOwner = new User(
       "bindings_not_owner",
       "user",
-      new String[]{"user"},
+      new String[]{"user", "viewer"},
       Map.of("x-hasura-role", "user", "x-hasura-user-id", "bindings_not_owner"));
+  private static final User viewer = new User(
+      "bindings_viewer",
+      "viewer",
+      new String[]{"viewer"},
+      Map.of("x-hasura-role", "viewer", "x-hasura-user-id", "bindings_viewer"));
+
   @BeforeAll
   static void beforeAll() throws IOException {
     try(final var playwright = Playwright.create();
@@ -61,6 +74,7 @@ public class BindingsTests {
       // Insert the Users
       hasura.createUser(admin);
       hasura.createUser(nonOwner);
+      hasura.createUser(viewer);
     }
   }
   @AfterAll
@@ -70,6 +84,7 @@ public class BindingsTests {
       // Remove the Users
       hasura.deleteUser(admin);
       hasura.deleteUser(nonOwner);
+      hasura.deleteUser(viewer);
     }
   }
 
@@ -173,8 +188,8 @@ public class BindingsTests {
       }
 
       @Test
-      void unauthorized() {
-        // Returns a 403 if Unauthorized
+      void forbidden() {
+        // Returns a 403 if Forbidden
         final String data = Json.createObjectBuilder()
                                 .add("action", Json.createObjectBuilder().add("name", "simulate"))
                                 .add("input", Json.createObjectBuilder().add("planId", planId))
@@ -256,8 +271,8 @@ public class BindingsTests {
         assertEquals("no such plan", getBody(response).getString("message"));
       }
       @Test
-      void unauthorized() throws IOException {
-        // 403: Unauthorized requires updating permissions
+      void forbidden() throws IOException {
+        // 403: Forbidden requires updating permissions
         final var ogPermissions = hasura.getActionPermissionsForRole("user");
         final var tempPermission = new ActionPermissionsSet(Map.of(ActionKey.resource_samples, Permission.PLAN_OWNER));
         hasura.updateActionPermissionsForRole("user", tempPermission);
@@ -377,8 +392,8 @@ public class BindingsTests {
       }
 
       @Test
-      void unauthorized() {
-        // Returns a 403 if unauthorized
+      void forbidden() {
+        // Returns a 403 if Forbidden
         final String data = Json.createObjectBuilder()
                                 .add("action", Json.createObjectBuilder().add("name", "check_constraints"))
                                 .add("input", Json.createObjectBuilder().add("planId", planId))
@@ -1081,8 +1096,8 @@ public class BindingsTests {
         assertEquals("no such scheduling specification", getBody(response).getString("message"));
       }
       @Test
-      void unauthorized(){
-        // Returns a 403 if the user isn't authorized to schedule
+      void forbidden(){
+        // Returns a 403 if the user isn't allowed to run scheduling on the plan
         final String data = Json.createObjectBuilder()
                                 .add("action", Json.createObjectBuilder().add("name", "scheduler"))
                                 .add("input", Json.createObjectBuilder().add("specificationId", schedulingSpecId))
@@ -1205,6 +1220,924 @@ public class BindingsTests {
           assertTrue(file.containsKey("filePath"));
           assertTrue(file.containsKey("content"));
           assertFalse(file.getString("content").isEmpty());
+        }
+      }
+    }
+  }
+
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  class WorkspaceBindings {
+    // Requests
+    private Playwright playwright;
+    private HasuraRequests hasura;
+    private WorkspaceRequests wsServer;
+
+    // Class-Wide Data
+    private int cdictId;
+    private int parcelId;
+
+    private User owner = new User(
+        "ws_bindings_owner",
+        "user",
+        new String[] {"user"},
+        Map.of("x-hasura-role", "user", "x-hasura-user-id", "ws_bindings_owner"));
+
+    private String adminToken;
+    private String ownerToken;
+    private String nonOwnerToken;
+    private String viewerToken;
+
+    @BeforeAll
+    void beforeAll() throws IOException {
+      // Setup Requests
+      playwright = Playwright.create();
+      hasura = new HasuraRequests(playwright);
+      wsServer = new WorkspaceRequests(playwright);
+
+      // Get valid JWT tokens for the users
+      try (final var gateway = new GatewayRequests(playwright)) {
+        adminToken = gateway.login(admin);
+        ownerToken = gateway.login(owner);
+        nonOwnerToken = gateway.login(nonOwner);
+        viewerToken = gateway.login(viewer);
+      }
+
+      // Set up parcel and dictionary to use across the tests
+      cdictId = hasura.createMockCommandDictionary("WorkspaceBindingsTest", "Workspace E2E Test");
+      parcelId = hasura.createMockParcel("Workspace Bindings Parcel", cdictId);
+    }
+
+    @AfterAll
+    void afterAll() throws IOException {
+      // Cleanup parcel and dictionary
+      hasura.deleteMockCommandDictionary(cdictId);
+      hasura.deleteMockParcel(parcelId);
+
+      // Cleanup Requests
+      wsServer.close();
+      hasura.close();
+      playwright.close();
+    }
+
+    /**
+     * Tests for the /ws/create and /ws/{workspace_id} routes
+     *
+     * Tests that have yet to be implemented are disabled
+     */
+    @Nested
+    class WorkspaceManagementRoutes {
+      @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+      @Nested
+      class CreateWorkspace {
+        /**
+         * The workspace server returns a 403 Forbidden response when a user with insufficient role privileges
+         * attempts to create a workspace
+         */
+        @Test
+        void forbiddenInsufficientPrivileges() {
+          final var response = wsServer.createWorkspace(viewerToken, "Should Fail", Optional.empty(), parcelId);
+          assertEquals(403, response.status());
+          final var body = getBody(response);
+          assertEquals("FORBIDDEN", body.getString("type"));
+          assertEquals("Role 'viewer' is not allowed to perform action 'create_workspace'", body.getString("message"));
+          assertEquals("aerie_workspace", body.getString("service"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("improperlyFormattedBodyArgs")
+        @Disabled
+        void improperlyFormattedBody(JsonObject jsonBodyString) {
+          // TODO: make this a parametrized test that includes:
+          //  no body,
+          //  empty body,
+          //  missing workspace location,
+          //  missing parcel id,
+          //  missing both
+          //  (extra params is excluded bc we don't check from them currently)
+          //  In all cases, request should be rejected
+        }
+
+        Stream<Arguments> improperlyFormattedBodyArgs() {
+          return Stream.of(
+              Arguments.arguments(named("no body", null)),
+              Arguments.arguments(named("empty body", JsonValue.EMPTY_JSON_OBJECT)),
+              Arguments.arguments(named("array", JsonValue.EMPTY_JSON_ARRAY)),
+              Arguments.arguments(named("no workspace location", Json.createObjectBuilder()
+                                                                     .add("parcelId", parcelId)
+                                                                     .build())),
+              Arguments.arguments(named("no parcel id", Json.createObjectBuilder()
+                                                            .add("workspaceLocation", "improperBodyArgsWs")
+                                                            .build())),
+              Arguments.arguments(named("no workspace location or parcel id", Json.createObjectBuilder()
+                                                                                  .add("workspaceName", "Improper Body WS")
+                                                                                  .build()))
+          );
+        }
+
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = { "/", "~", ".", "~/.", "~/usr/src/worspaces.myworkspace.txt"})
+        @Disabled
+        void invalidCharactersWorkspaceString(String workspaceLocation) {
+          // TODO: make this a parametrized test w/ the 'NullAndEmptySource' annotation that includes:
+          //  empty string,
+          //  null,
+          //  "/",
+          //  ".",
+          //  "~",
+          //  all three bad symbols
+          //  In all cases, the request should be rejected.
+        }
+
+        @Test
+        @Disabled
+        void validInputsNoWorkspaceName() {
+          // TODO: expected success with the resulting workspace's name equalling its path (use a GQL query to check this)
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @Disabled
+        void invalidWorkspaceName(String workspaceName) {
+          /*
+          TODO: WS server should reject both a null and empty workspace name
+           */
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"nameTestWS", "Workspace Names Test WS", "/", "~", ".", "~/.", "~/fakepath.ext"})
+        @Disabled
+        void validWorkspaceName(String workspaceName) {
+          /*
+           TODO: Make this a parametrized tests that includes a custom workspace name:
+            - That matches the workspace name
+            - "/"
+            - "."
+            - "~"
+            - all three bad symbols
+            In all cases, the custom name should be accepted and set as the workspace's name (use a GQL query to check this)
+           */
+        }
+      }
+
+      @Nested
+      class DeleteWorkspace {
+        // Per-Test Data
+        private int workspaceId;
+
+        @BeforeEach
+        void beforeEach() throws IOException {
+          workspaceId = wsServer.createWorkspace("deleteWSTests", parcelId);
+        }
+
+        @AfterEach
+        void afterEach() throws IOException {
+          wsServer.deleteWorkspace(workspaceId);
+        }
+
+        /**
+         * The workspace server returns a 403 Forbidden response when a user with insufficient role privileges
+         * attempts to delete a workspace
+         */
+        @Test
+        void forbiddenInsufficientPrivileges() {
+          final var response = wsServer.deleteWorkspace(nonOwnerToken, workspaceId);
+          assertEquals(403, response.status());
+          final var body = getBody(response);
+          assertEquals("FORBIDDEN", body.getString("type"));
+          assertEquals(("User 'bindings_not_owner' with role 'user' cannot perform 'delete_workspace' "
+                        + "because they are not a 'OWNER' for workspace with id '%d'").formatted(workspaceId),
+                       body.getString("message"));
+          assertEquals("aerie_workspace", body.getString("service"));
+        }
+
+        /**
+         * The workspace server returns a 403 Forbidden response when a user with the `user` role who isn't the
+         * OWNER attempts to delete a workspace
+         */
+        @Test
+        void forbiddenNotOwner() {
+          final var response = wsServer.deleteWorkspace(nonOwnerToken, workspaceId);
+          assertEquals(403, response.status());
+          final var body = getBody(response);
+          assertEquals("FORBIDDEN", body.getString("type"));
+          assertEquals(("User 'bindings_not_owner' with role 'user' cannot perform 'delete_workspace' "
+                        + "because they are not a 'OWNER' for workspace with id '%d'").formatted(workspaceId),
+                       body.getString("message"));
+          assertEquals("aerie_workspace", body.getString("service"));
+        }
+
+        /**
+         * The workspace server returns a 404 Resource Not Found response when an invalid id is provided.
+         *
+         * Disabled because test is not implemented
+         */
+        @Test
+        @Disabled
+        void invalidId() {
+          // TODO: test:
+          //  - not a number (may return a 500 instead b/c of a parsing error),
+          //  - negative number
+        }
+
+        @Test
+        void ownerCanDelete() throws IOException {
+          final var wsId = wsServer.createWorkspace("OwnerCanDelete", parcelId);
+          hasura.changeOwner(wsId, nonOwner);
+          final var deleteResp = wsServer.deleteWorkspace(nonOwnerToken, wsId);
+          assertEquals(200, deleteResp.status());
+          assertEquals("Workspace deleted.", deleteResp.text());
+        }
+      }
+
+      // Suite disabled until tests are written
+      @Nested
+      @Disabled
+      class ListWorkspaceContents {
+        /*
+         * No auth tests because
+         * 1. This endpoint is used in "WSAuthorizeTests", meaning it auth is pretty thoroughly tested
+         * 2. There are no default roles that cannot access this method
+         *
+         * No input validation because this endpoint defers its behavior to `listContents`,
+         * which is tested in WSRoutes.GET
+         */
+        @Test
+        void emptyWorkspace() {
+          // TODO: Expected results: success with an empty JSON
+        }
+
+        @Test
+        void nonEmptyWorkspaceNoDepth() {
+          // TODO: Place some non-empty nested folders in the workspace
+          //  Expected results: success with the workspace contents
+        }
+
+        @Test
+        void nonEmptyWorkspaceWithDepth() {
+          // TODO: Place some non-empty nested folders in the workspace and provide the depth query variable
+          //  Expected results: success with the workspace contents up to the specified depth
+        }
+      }
+    }
+
+    /**
+     * Tests for the /ws/{workspaceId}/<filePath> routes.
+     *
+     * Disabled because the suite is skeletoned but not implemented.
+     */
+    @Nested
+    @Disabled
+    class WSRoutes {
+      @Nested
+      class Get {
+        @Test
+        void forbidden() {
+          // TODO: Returns a 403 if Forbidden. Will need to temporarily update permissions to actually get this effect
+        }
+
+        @Test
+        void noSuchFile() {
+          // TODO: Returns a 404 if the file specified does not exist
+        }
+
+        @Test
+        void noSuchWorkspace() {
+          // TODO: returns a 404 if the workspace does not exist
+        }
+
+        @Test
+        void getFile() {
+          // TODO: Returns the file's contents
+        }
+
+        @Test
+        void getDirectoryEmpty() {
+          // TODO: Returns a list of the directory's contents
+          //  The directory in this test is empty
+        }
+
+        @Test
+        void getDirectoryAllFileTypes() {
+          // TODO: Returns a list of the directory's contents
+          //  The directory in this test has one file of each supported content type (including a nested directory)
+          //  Once metadata is added, this method should be updated to include the fetched metadata info
+        }
+
+        @Test
+        void getDirectoryValidDepth() {
+          // TODO: pass the depth flag and set it to 1. run it against a folder with a nested folder.
+          //  expected result: only the first level is returned
+        }
+
+        @Test
+        void getDirectoryInvalidDepth() {
+          // TODO: Pass invalid values to the depth flag. Should return 400 errors.
+        }
+      }
+
+      @Nested
+      class Put {
+        @Test
+        void forbidden() {
+          // TODO: Returns a 403 if Forbidden. Use viewer role for this
+        }
+
+        @Test
+        void forbiddenNotOwner() {
+          // TODO: Someone who is not the owner cannot put a file in
+        }
+
+        @Test
+        void noSuchWorkspace() {
+          // TODO: Expected 404
+        }
+
+        @Test
+        void ownerCanPutFile() {
+          // TODO: Owner can put a file in the workspace
+        }
+
+        @Test
+        void collaboratorCanPutFile() {
+          // TODO: Collaborator can put a file in the workspace
+        }
+
+        @Test
+        void ownerCanPutDirectory() {
+          // TODO: Owner can put a directory in the workspace
+        }
+
+        @Test
+        void collaboratorCanPutDirectory() {
+          // TODO: Collaborator can put a directory in the workspace
+        }
+
+        @Test
+        void putCreatesParentDirs() {
+          // TODO: When an file's parent directory does not exist,
+          //  the ws server automatically creates the parent directory.
+        }
+
+        @Test
+        void noTypeProvided() {
+          // TODO: mandatory query param 'type' is skipped. Expected 400
+        }
+
+        @Test
+        void invalidTypeProvided() {
+          // TODO: mandatory query param 'type' is set to an invalid value. Expected 400
+        }
+
+        @Test
+        void nameConflictOverwriteFalse() {
+          // TODO: If there already exists a file with the same name as the file trying to be set,
+          //  and the query param 'overwrite' is set to 'false', the ws server will return 409 Conflicted
+          //  and not post the new file (check the file contents)
+        }
+
+        @Test
+        void overwriteDefaultsToFalse() {
+          // TODO: If there already exists a file with the same name as the file trying to be set,
+          //  and the query param 'overwrite' is set to 'true', the ws server will return 200 and update the file
+          //  (check the file contents)
+        }
+
+        @Test
+        void nameConflictOverwriteTrue() {
+          // TODO: If there already exists a file with the same name as the file trying to be set,
+          //  and the query param 'overwrite' is not included, the ws server will return 409 Conflicted
+          //  and not post the new file (check the file contents)
+        }
+
+        @Test
+        void overwriteForbiddenOnDirectory() {
+          // TODO: The query param 'overwrite' is forbidden when trying to create a directory. Expected 400
+        }
+
+        @Test
+        void nameConflictDirectory() {
+          // TODO: When the user tries to create a directory that does not exist,
+          //  the ws server does nothing and returns 200.
+          //  (Put sth in the directory and check its contents before and after)
+        }
+
+        @Test
+        void cannotPutOutsideOfWorkspace() {
+          // TODO: The user cannot put a file outside of the workspace's directory (ie, using ../ or ~/)
+        }
+
+        @Test
+        void fileNotIncluded() {
+          // TODO: No file is attached to the body. Expected 400
+        }
+
+        @Test
+        void fileAttachedWrongName() {
+          // TODO: File is attached, but under the wrong name. Expected 400
+        }
+      }
+
+      @Nested
+      class Delete {
+        @Test
+        void forbidden() {
+          // TODO: Returns a 403 if Forbidden. Use viewer role for this
+        }
+
+        @Test
+        void forbiddenNotOwner() {
+          // TODO: Someone who is not the owner cannot delete an item
+        }
+
+        @Test
+        void noSuchWorkspace() {
+          // TODO: Expected 404
+        }
+
+        @Test
+        void ownerCanDeleteFile() {
+          // TODO: Owner can delete a file in the workspace
+        }
+
+        @Test
+        void collaboratorCanDeleteFile() {
+          // TODO: Collaborator can delete a file in the workspace
+        }
+
+        @Test
+        void ownerCanDeleteDirectory() {
+          // TODO: Owner can delete a directory in the workspace
+        }
+
+        @Test
+        void collaboratorCanDeleteDirectory() {
+          // TODO: Collaborator can delete a directory in the workspace
+        }
+
+        @Test
+        void deleteRecursive() {
+          // TODO: Deleting a directory is recursive (removes all content below)
+          //  (Notable as this behavior diverges from the default behavior of rm or rmdir, and for the most part
+          //    our endpoints follow standard OS behaviors, ie mv and cp)
+        }
+
+        @Test
+        void deleteIncludesMetadata() {
+          // TODO: When a file with a metadata file is deleted, its metadata file is deleted as well.
+        }
+
+        @Test
+        void cannotDeleteOutsideOfWorkspace() {
+          // TODO: A file outside of the workspace cannot be targeted for deletion (ie, using ../ or ~/)
+        }
+      }
+
+      @Nested
+      class Post {
+        @Test
+        void noMoveOrCopyKey() {
+          // TODO: Expected 400 error. Error message should include the endpoint's helptext.
+        }
+
+        @Nested
+        class Move {
+          @Test
+          void forbiddenCannotReadSource() {
+            // TODO: The role requires the "read_file_directory" permission
+            //  (additionally, the user must pass the permission's check for the source ws)
+            //    Testing this requires permissions modifications (remember to revert at the end of test)
+            //    (to remove the permission from a role and then set the permission to OWNER
+            //      (and have the user NOT be the owner of the source ws))
+          }
+
+          @Test
+          void forbiddenCannotDeleteSource() {
+            // TODO: The role requires the "delete_file_directory" permission
+            //  (additionally, the user must pass the permission's check for the source ws)
+            //  The "viewer" role and the "user" role where the user is not owner/collaborator of the source ws
+            //    will test both cases
+          }
+
+          @Test
+          void forbiddenCannotWriteTarget() {
+            // TODO: The role requires the "write_file_directory" permission
+            //  (additionally, the user must pass the permission's check for the source ws)
+            //  The "viewer" role and the "user" role where the user is not owner/collaborator of the target ws
+            //    will test both cases
+          }
+
+          @Test
+          void withinWSMove() {
+            /*
+                TODO: Test cases:
+                  - Owner
+                  - Collaborator
+                  - Both (as in the owner is also listed as a collaborator)
+                 Expected Results: All cases succeed
+             */
+          }
+
+          @Test
+          void crossWSMove() {
+            /*
+              TODO: Test cases:
+                - owner source, collaborator target
+                - owner source,  owner target
+                - collaborator source, owner target
+                - collaborator source, collaborator target
+               Expected Results: All cases succeed
+             */
+          }
+
+          @Test
+          void noSuchSourceWS() {
+            // TODO: Expected 404
+          }
+
+          @Test
+          void noSuchTargetWS() {
+            // TODO: Expected 404
+          }
+
+          @Test
+          void noSuchFile() {
+            // TODO: The file trying to be moved does not exist. Expected 404
+          }
+
+          @Test
+          void noSuchDirectory() {
+            // TODO: The directory trying to be moved does not exist. Expected 404
+          }
+
+          @Test
+          void cannotMoveFileNotInSource() {
+            // TODO: Cannot move a file that exists, but is not in the source workspace
+          }
+
+          @Test
+          void cannotMoveOutsideWSBounds() {
+            // TODO: Show that the file cannot be moved to somewhere "outside" of the target workspace's path
+          }
+
+          @Test
+          void cannotMoveRecursive() {
+            // TODO: A directory cannot be moved within itself
+          }
+
+          @Test
+          void moveIncludesContents() {
+            // TODO: All contents of a directory, including subdirectories, are moved as well
+          }
+
+          @Test
+          void moveIncludesMetadata() {
+            // TODO: When a file with a metadata file is moved, its metadata file is moved as well
+          }
+
+          @Test
+          void conflictedIfDestinationExists() {
+            // TODO: When the destination file exists, the move returns a 409 Conflicted and will not move the file
+          }
+        }
+
+        @Nested
+        class Copy {
+          @Test
+          void forbiddenCannotReadSource() {
+            // TODO: The role requires the "read_file_directory" permission
+            //  (additionally, the user must pass the permission's check for the source ws)
+            //    Testing this requires permissions modifications (remember to revert at the end of test)
+            //    (to remove the permission from a role and then set the permission to OWNER
+            //      (and have the user NOT be the owner of the source ws))
+          }
+
+          @Test
+          void forbiddenCannotWriteTarget() {
+            // TODO: The role requires the "write_file_directory" permission
+            //  (additionally, the user must pass the permission's check for the source ws)
+            //  The "viewer" role and the "user" role where the user is not owner/collaborator of the target ws
+            //    will test both cases
+          }
+
+          @Test
+          void withinWSCopy() {
+            /*
+                TODO: Test cases:
+                  - Owner
+                  - Collaborator
+                  - Both (as in the owner is also listed as a collaborator)
+                 Expected Results: All cases succeed
+             */
+          }
+
+          @Test
+          void crossWSCopy() {
+            /*
+              TODO: Test cases:
+                - owner source, collaborator target
+                - owner source,  owner target
+                - collaborator source, owner target
+                - collaborator source, collaborator target
+               Expected Results: All cases succeed
+             */
+          }
+
+          @Test
+          void noSuchSourceWS() {
+            // TODO: Expected 404
+          }
+
+          @Test
+          void noSuchTargetWS() {
+            // TODO: Expected 404
+          }
+
+          @Test
+          void noSuchFile() {
+            // TODO: The file trying to be copied does not exist. Expected 404
+          }
+
+          @Test
+          void noSuchDirectory() {
+            // TODO: The directory trying to be copied does not exist. Expected 404
+          }
+
+          @Test
+          void cannotCopyFileNotInSource() {
+            // TODO: Cannot copy a file that exists, but is not in the source workspace
+          }
+
+          @Test
+          void cannotCopyOutsideWSBounds() {
+            // TODO: Show that the file cannot be copied to somewhere "outside" of the target workspace's path
+          }
+
+          @Test
+          void cannotCopyRecursive() {
+            // TODO: A directory cannot be copied within itself
+          }
+
+          @Test
+          void moveIncludesContents() {
+            // TODO: All contents of a directory, including subdirectories, are copied as well
+          }
+
+          @Test
+          void moveIncludesMetadata() {
+            // TODO: When a file with a metadata file is copied, its metadata file is copied as well
+          }
+
+          @Test
+          void conflictedIfDestinationExists() {
+            // TODO: When the destination file exists, the endpoint returns a 409 Conflicted and will not copy the file
+          }
+        }
+      }
+    }
+
+    /**
+     * Tests for the response of the `authorize` before on `/ws/*` routes.
+     * Uses GET /ws/{workspaceId} for testing
+     *
+     * Does not test the case where the Workspace Server doesn't have the HasuraAdminSecret provided,
+     * as our test environment has that set.
+     */
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class WSAuthorizeTests {
+      private int workspaceId;
+
+      @BeforeAll
+      void beforeAll() throws IOException {
+        workspaceId = wsServer.createWorkspace("wsAuthorizeTests", parcelId);
+      }
+
+      @AfterAll
+      void afterAll() throws IOException {
+        wsServer.deleteWorkspace(workspaceId);
+      }
+
+      /**
+       * The workspace server returns a 401 Unauthorized response when no authorization headers are provided.
+       */
+      @Test
+      void noAuthHeader() {
+        final var response = wsServer.listWorkspaceContents(Map.of(), workspaceId);
+        assertEquals(401, response.status());
+        final var body = getBody(response);
+        assertEquals("UNAUTHORIZED", body.getString("type"));
+        assertEquals("Invalid Authorization header provided.", body.getString("message"));
+        assertEquals("aerie_workspace", body.getString("service"));
+      }
+
+      @Nested
+      class AdminSecret {
+        private static final String adminSecret = System.getenv("HASURA_GRAPHQL_ADMIN_SECRET");
+
+        /**
+         * The workspace server returns a 401 Unauthorized response when a request tries to use an invalid admin secret.
+         */
+        @Test
+        void invalidSecret() {
+          final String fakeSecret = adminSecret.substring(0, 1);
+          final var headers = Map.of("x-hasura-role", "user",
+                                     "x-hasura-user-id", "bindings_not_owner",
+                                     "x-hasura-admin-secret", fakeSecret);
+          final var response = wsServer.listWorkspaceContents(headers, workspaceId);
+          assertEquals(401, response.status());
+          final var body = getBody(response);
+          assertEquals("UNAUTHORIZED", body.getString("type"));
+          assertEquals("Invalid Hasura admin secret", body.getString("message"));
+          assertEquals("aerie_workspace", body.getString("service"));
+        }
+
+        /**
+         * The workspace server returns a 401 Unauthorized response when the admin secret is provided
+         * but a user id is not.
+         */
+        @Test
+        void noUserIdProvided() {
+          final var headers = Map.of("x-hasura-role", "user",
+                                     "x-hasura-admin-secret", adminSecret);
+          final var response = wsServer.listWorkspaceContents(headers, workspaceId);
+          assertEquals(401, response.status());
+          final var body = getBody(response);
+          assertEquals("UNAUTHORIZED", body.getString("type"));
+          assertEquals("x-hasura-user-id header is required when x-hasura-admin-secret is set", body.getString("message"));
+          assertEquals("aerie_workspace", body.getString("service"));
+        }
+
+        /**
+         * If the workspace server is provided a valid admin secret and user id, but no active role,
+         * the server will default to the "aerie_admin" role.
+         *
+         * This test proves this using the "put file" endpoint with a user who is neither the owner nor collaborator.
+         * Only the 'aerie_admin' role is allowed to put files on a workspace they don't own.
+         * (see WSRoutes.Put#forbidden for more information)
+         */
+        @Test
+        void noActiveRoleProvided() {
+          final var fileName = "sampleFile";
+          final var filePayload = new FilePayload(fileName,
+                                                  "text/plain",
+                                                  "this is an example file".getBytes(StandardCharsets.UTF_8));
+          final var options = RequestOptions.create()
+                                            .setQueryParam("type", "file")
+                                            .setHeader("x-hasura-admin-secret", adminSecret)
+                                            .setHeader("x-hasura-user-id", "not a user")
+                                            .setMultipart(FormData.create().set("file", filePayload));
+          final var response = wsServer.makeRequest("/ws/%d/%s".formatted(workspaceId, fileName),
+                                                    options,
+                                                    WorkspaceRequests.RequestType.PUT);
+          assertEquals(200, response.status());
+          assertEquals("File %s uploaded to %s".formatted(fileName, fileName), response.text());
+        }
+
+        /**
+         * The workspace server accepts an admin secret, userid, and active role
+         *
+         * This test proves this using the "put file" endpoint with a user trying to use the "viewer" role.
+         * This role is not allowed to use this endpoint, while "aerie_admin" is
+         */
+        @Test
+        void validSecretUserIdActiveRole() {
+          final var fileName = "sampleFile";
+          final var filePayload = new FilePayload(fileName,
+                                                  "text/plain",
+                                                  "this is an example file".getBytes(StandardCharsets.UTF_8));
+          final var options = RequestOptions.create()
+                                            .setQueryParam("type", "file")
+                                            .setHeader("x-hasura-admin-secret", adminSecret)
+                                            .setHeader("x-hasura-user-id", "not a user")
+                                            .setHeader("x-hasura-role", "viewer")
+                                            .setMultipart(FormData.create().set("file", filePayload));
+          final var response = wsServer.makeRequest("/ws/%d/%s".formatted(workspaceId, fileName),
+                                                    options,
+                                                    WorkspaceRequests.RequestType.PUT);
+          assertEquals(403, response.status());
+          final var body = getBody(response);
+          assertEquals("FORBIDDEN", body.getString("type"));
+          assertEquals("Role 'viewer' is not allowed to perform action 'write_file_directory'", body.getString("message"));
+          assertEquals("aerie_workspace", body.getString("service"));
+        }
+      }
+
+      @Nested
+      @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+      class JWTAuth {
+        /**
+         * The workspace server returns a 401 Unauthorized error when the JWT header has an invalid format.
+         */
+        @ParameterizedTest
+        @MethodSource("misformattedJWTHeaderArgs")
+        void misformattedJWTHeader(String token) {
+          final var headers = Map.of("Authorization", token);
+          final var response = wsServer.listWorkspaceContents(headers, workspaceId);
+          assertEquals(401, response.status());
+          final var body = getBody(response);
+          assertEquals("UNAUTHORIZED", body.getString("type"));
+          assertEquals("Invalid Authorization header provided.", body.getString("message"));
+          assertEquals("aerie_workspace", body.getString("service"));
+        }
+
+        private Stream<Arguments> misformattedJWTHeaderArgs() {
+          return Stream.of(
+              Arguments.arguments(named("empty header", "")),
+              Arguments.arguments(named("valid token without Bearer", adminToken)),
+              Arguments.arguments(named("Bearer but no token", "Bearer ")),
+              Arguments.arguments(named("invalid token", "not_a_valid_token"))
+          );
+        }
+
+        /**
+         * The workspace server returns a 401 Unauthorized error when the JWT passed is invalid.
+         */
+        @Test
+        void invalidJWT() {
+          final var headers = Map.of("Authorization", "Bearer not_a_valid_token");
+          final var response = wsServer.listWorkspaceContents(headers, workspaceId);
+          assertEquals(401, response.status());
+          final var body = getBody(response);
+          assertEquals("UNAUTHORIZED", body.getString("type"));
+          assertEquals("The token was expected to have 3 parts, but got 0.", body.getString("message"));
+          assertEquals("aerie_workspace", body.getString("service"));
+        }
+
+        /**
+         * The workspace server accepts a valid JWT.
+         */
+        @Test
+        void validJWT() {
+          final var headers = Map.of("Authorization", "Bearer " +viewerToken);
+          final var response = wsServer.listWorkspaceContents(headers, workspaceId);
+          assertEquals(200, response.status());
+        }
+
+        /**
+         * The workspace server returns a 401 Unauthorized response when a user passes a valid JWT
+         * but attempts to use the x-hasura-role flag for a role they don't have permission to use.
+         */
+        @Test
+        void validJWTInvalidRole() {
+          final var headers = Map.of("Authorization", "Bearer "+viewerToken,
+                                     "x-hasura-role", "aerie_admin");
+          final var response = wsServer.listWorkspaceContents(headers, workspaceId);
+          assertEquals(401, response.status());
+          final var body = getBody(response);
+          assertEquals("UNAUTHORIZED", body.getString("type"));
+          assertEquals("Provided active role is not in the set of permitted roles.", body.getString("message"));
+          assertEquals("aerie_workspace", body.getString("service"));
+        }
+
+        /**
+         * The workspace server allows the user to use the x-hasura-role header to swap to one of their permitted roles.
+         *
+         * This test proves this using the admin token to the "put file" endpoint while setting the current role to "viewer".
+         * While "aerie_admin" (the token's default role) is allowed to access this endpoint,
+         * the "viewer" role will receive a 403 Forbidden error.
+         */
+        @Test
+        void validJWTValidRole() {
+          final var fileName = "sampleFile";
+          final var filePayload = new FilePayload(fileName,
+                                                  "text/plain",
+                                                  "this is an example file".getBytes(StandardCharsets.UTF_8));
+          final var options = RequestOptions.create()
+                                            .setQueryParam("type", "file")
+                                            .setHeader("Authorization", "Bearer "+adminToken)
+                                            .setHeader("x-hasura-role", "viewer")
+                                            .setMultipart(FormData.create().set("file", filePayload));
+          final var response = wsServer.makeRequest("/ws/%d/%s".formatted(workspaceId, fileName),
+                                                    options,
+                                                    WorkspaceRequests.RequestType.PUT);
+          assertEquals(403, response.status());
+          final var body = getBody(response);
+          assertEquals("FORBIDDEN", body.getString("type"));
+          assertEquals("Role 'viewer' is not allowed to perform action 'write_file_directory'", body.getString("message"));
+          assertEquals("aerie_workspace", body.getString("service"));
+        }
+
+        /**
+         * The presence of the `x-hasura-admin-secret` header overrides the presence of the `Authorization` header
+         *
+         * Demonstrated by providing a valid JWT and an invalid admin secret and having the request be rejected
+         * because of the invalid admin secret
+         */
+        @Test
+        void secretOverridesJWT() {
+          final String fakeSecret = System.getenv("HASURA_GRAPHQL_ADMIN_SECRET").substring(0, 1);
+          final var headers = Map.of("Authorization", "Bearer " +viewerToken,
+                                     "x-hasura-admin-secret", fakeSecret,
+                                     "x-hasura-user-id", "bindings_viewer");
+          final var response = wsServer.listWorkspaceContents(headers, workspaceId);
+          assertEquals(401, response.status());
+          final var body = getBody(response);
+          assertEquals("UNAUTHORIZED", body.getString("type"));
+          assertEquals("Invalid Hasura admin secret", body.getString("message"));
+          assertEquals("aerie_workspace", body.getString("service"));
         }
       }
     }

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
@@ -45,6 +45,12 @@ public enum GQL {
         status
       }
     }"""),
+  CHANGE_WS_OWNER("""
+    mutation changeWsOwner($id:Int!, $newOwner: String! ) {
+      update_workspace_by_pk(pk_columns: {id:$id}, _set: {owner: $newOwner}) {
+        owner
+      }
+    }"""),
   CHECK_CONSTRAINTS("""
     query checkConstraints($planId: Int!, $simulationDatasetId: Int) {
       constraintViolations(planId: $planId, simulationDatasetId: $simulationDatasetId) {
@@ -121,6 +127,18 @@ public enum GQL {
   CREATE_MISSION_MODEL("""
     mutation CreateMissionModel($model: mission_model_insert_input!) {
       insert_mission_model_one(object: $model) {
+        id
+      }
+    }"""),
+  CREATE_MOCK_COMMAND_DICTIONARY("""
+    mutation CreateMockCommandDictionary($cdict: command_dictionary_insert_input!) {
+      dictionary: insert_command_dictionary_one(object: $cdict) {
+        id
+      }
+    }"""),
+  CREATE_PARCEL("""
+    mutation CreateParcel($parcel: parcel_insert_input!) {
+      parcel: insert_parcel_one(object: $parcel) {
         id
       }
     }"""),
@@ -225,6 +243,18 @@ public enum GQL {
   DELETE_MISSION_MODEL("""
     mutation DeleteModel($id: Int!) {
       delete_mission_model_by_pk(id: $id) {
+        id
+      }
+    }"""),
+  DELETE_MOCK_COMMAND_DICTIONARY("""
+    mutation DeleteMockCommandDictionary($id: Int!) {
+      delete_command_dictionary_by_pk(id: $id) {
+        id
+      }
+    }"""),
+  DELETE_PARCEL("""
+    mutation DeleteParcel($id: Int!) {
+      delete_parcel_by_pk(id: $id) {
         id
       }
     }"""),

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GatewayRequests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GatewayRequests.java
@@ -6,6 +6,7 @@ import com.microsoft.playwright.Playwright;
 import com.microsoft.playwright.options.FilePayload;
 import com.microsoft.playwright.options.FormData;
 import com.microsoft.playwright.options.RequestOptions;
+import gov.nasa.jpl.aerie.e2e.types.User;
 
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -24,6 +25,9 @@ public class GatewayRequests implements AutoCloseable {
     login();
   }
 
+  /**
+   * Auto-login the AerieE2eTests user, whose token is used to upload mission model JARs
+   */
   private void login() throws IOException {
     if(token != null) return;
     final var response = request.post("/auth/login", RequestOptions.create()
@@ -44,6 +48,33 @@ public class GatewayRequests implements AutoCloseable {
         throw new RuntimeException(bodyJson.toString());
       }
       token = bodyJson.getString("token");
+    }
+  }
+
+  /**
+   * Login a particular user to get a JWT Auth Token
+   * @param user the User to be logged in
+   * @return the JWT token from login
+   */
+  public String login(User user) throws IOException {
+    final var response = request.post("/auth/login", RequestOptions.create()
+                                                                   .setHeader("Content-Type", "application/json")
+                                                                   .setData(Json.createObjectBuilder()
+                                                                                .add("username", user.name())
+                                                                                .add("password", "password")
+                                                                                .build()
+                                                                                .toString()));
+    // Process Response
+    if (!response.ok()) {
+      throw new IOException(response.statusText());
+    }
+    try (final var reader = Json.createReader(new StringReader(response.text()))) {
+      final JsonObject bodyJson = reader.readObject();
+      if (!bodyJson.getBoolean("success")) {
+        System.err.println("Login failed");
+        throw new RuntimeException(bodyJson.toString());
+      }
+      return bodyJson.getString("token");
     }
   }
 

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/HasuraRequests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/HasuraRequests.java
@@ -318,7 +318,6 @@ public class HasuraRequests implements AutoCloseable {
     }
     return res;
   }
-
   //endregion
 
   //region Simulation
@@ -1208,7 +1207,6 @@ public class HasuraRequests implements AutoCloseable {
         .getJsonObject("planDerivationGroupLink")
         .getString("derivation_group_name");
   }
-
   // endregion
 
   //region Constraints
@@ -1343,6 +1341,67 @@ public class HasuraRequests implements AutoCloseable {
                               .add("action_permissions", permissions.toJSON())
                               .build();
     makeRequest(GQL.UPDATE_ROLE_ACTION_PERMISSIONS, variables);
+  }
+  //endregion
+
+  //region Workspaces
+  /**
+   * Creates a mocked command dictionary for the sake of creating Workspaces
+   * Create a different method if a non-mocked command dictionary is required for tests.
+   * @return the dictionary's database id
+   */
+  public int createMockCommandDictionary(String mission, String version) throws IOException {
+    final var insertCommandDictionaryBuilder = Json.createObjectBuilder()
+                                          .add("dictionary_path", "mock_path")
+                                          .add("mission", mission)
+                                          .add("version", version);
+
+    final var variables = Json.createObjectBuilder().add("cdict", insertCommandDictionaryBuilder).build();
+    // Only the Hasura Admin role may insert into this table
+    return makeRequest(GQL.CREATE_MOCK_COMMAND_DICTIONARY, variables, Map.of("x-hasura-role", "admin"))
+        .getJsonObject("dictionary")
+        .getInt("id");
+  }
+
+  /**
+   * Creates a mocked parcel for the sake of creating Workspaces
+   * Create a different method if a non-mocked parcel is required for tests.
+   * @return the parcel's database id
+   */
+  public int createMockParcel(String parcelName, int cdictId) throws IOException {
+    final var insertMockParcelBuilder = Json.createObjectBuilder()
+                                            .add("name", parcelName)
+                                            .add("command_dictionary_id", cdictId);
+
+    final var variables = Json.createObjectBuilder().add("parcel", insertMockParcelBuilder).build();
+
+    return makeRequest(GQL.CREATE_PARCEL, variables)
+        .getJsonObject("parcel")
+        .getInt("id");
+  }
+
+  /**
+   * Delete a mocked command dictionary.
+   */
+  public void deleteMockCommandDictionary(int cdictId) throws IOException {
+    makeRequest(GQL.DELETE_MOCK_COMMAND_DICTIONARY, Json.createObjectBuilder().add("id", cdictId).build());
+  }
+
+  /**
+   * Delete a mocked parcel.
+   */
+  public void deleteMockParcel(int parcelId) throws IOException {
+    makeRequest(GQL.DELETE_PARCEL, Json.createObjectBuilder().add("id", parcelId).build());
+  }
+
+  /**
+   * Change the workspace's owner to another user
+   */
+  public void changeOwner(int workspaceId, User newOwner) throws IOException {
+    makeRequest(GQL.CHANGE_WS_OWNER, Json.createObjectBuilder()
+                                         .add("id", workspaceId)
+                                         .add("newOwner", newOwner.name())
+                                         .build());
   }
   //endregion
 }

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/WorkspaceRequests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/WorkspaceRequests.java
@@ -1,0 +1,198 @@
+package gov.nasa.jpl.aerie.e2e.utils;
+
+import com.microsoft.playwright.APIRequest;
+import com.microsoft.playwright.APIRequestContext;
+import com.microsoft.playwright.APIResponse;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.FilePayload;
+import com.microsoft.playwright.options.FormData;
+import com.microsoft.playwright.options.RequestOptions;
+
+import javax.json.Json;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+public class WorkspaceRequests implements AutoCloseable {
+  private final APIRequestContext request;
+  private static final String hasuraAdminSecret = System.getenv("HASURA_GRAPHQL_ADMIN_SECRET");
+  private static final Map<String, String> defaultHeaders = Map.of("x-hasura-role", "aerie_admin", "x-hasura-user-id", "Aerie Legacy");
+  public enum RequestType {GET, PUT, POST, DELETE}
+
+  public WorkspaceRequests(Playwright playwright){
+    request = playwright.request().newContext(new APIRequest.NewContextOptions()
+                                                  .setBaseURL(BaseURL.WORKSPACE_SERVER.url));
+  }
+
+  /**
+   * Generic 'makeRequest' method for sending a request to the workspace server
+   * that is not covered by any of the helper methods
+   */
+  public APIResponse makeRequest(String endpoint, RequestOptions options, RequestType type) {
+    switch (type) {
+      case GET -> {
+        return request.get(endpoint, options);
+      }
+      case PUT -> {
+        return request.put(endpoint, options);
+      }
+      case POST -> {
+        return request.post(endpoint, options);
+      }
+      case DELETE -> {
+        return request.delete(endpoint, options);
+      }
+      default -> throw new IllegalArgumentException("Unrecognized Request Type: "+type);
+    }
+  }
+
+  /**
+   * Helper method to create an empty workspace. Parses out the workspaceId from the response.
+   * @param workspaceLocation the name of the folder to be created
+   * @param parcelId the parcel id to use for the workspace
+   * @return the created workspace's id
+   */
+  public int createWorkspace(String workspaceLocation, int parcelId) throws IOException {
+    final String body = Json.createObjectBuilder()
+                            .add("workspaceLocation", workspaceLocation)
+                            .add("parcelId", parcelId)
+                            .build()
+                            .toString();
+    final var options = RequestOptions.create()
+                                      .setHeader("x-hasura-admin-secret", hasuraAdminSecret);
+    defaultHeaders.forEach(options::setHeader);
+    options.setData(body);
+    final var response = request.post("/ws/create", options);
+
+    if(!response.ok()){
+      throw new IOException(response.statusText());
+    }
+
+    return Integer.parseInt(response.text());
+  }
+
+  /**
+   * Call the workspace creation endpoint using JWT authorization
+   * @param userToken the JWT token to use
+   * @param workspaceLocation where to place the workspace
+   * @param workspaceName if set, what to name the workspace instead
+   * @param parcelId the parcel to use
+   * @return the workspace server's response
+   */
+  public APIResponse createWorkspace(String userToken, String workspaceLocation, Optional<String> workspaceName, int parcelId) {
+    final var body = Json.createObjectBuilder()
+                            .add("workspaceLocation", workspaceLocation)
+                            .add("parcelId", parcelId);
+    workspaceName.ifPresent(n -> body.add("workspaceName", n));
+
+    final var options = RequestOptions.create()
+                                      .setHeader("Authorization", "Bearer "+userToken)
+                                      .setData(body.build().toString());
+    return request.post("/ws/create", options);
+  }
+
+
+  /**
+   * Call the 'put file' endpoint in the Workspace server. Does not pass the "overwrite" flag.
+   * @param token The JWT token for the user making the request
+   * @param workspaceId The workspace to insert the file into
+   * @param fileLocation Where to place the plan
+   * @param fileContents The contents of the file to be inserted
+   * @return The APIResponse from the server
+   */
+  public APIResponse putFile(String token, int workspaceId, Path fileLocation, String fileContents) {
+    final var filePayload = new FilePayload(
+        fileLocation.getFileName().toString(),
+        "text/plain",
+        fileContents.getBytes(StandardCharsets.UTF_8));
+    final var options = RequestOptions
+        .create()
+        .setQueryParam("type", "file")
+        .setHeader("Authorization", "Bearer "+token)
+        .setMultipart(FormData.create().set("file", filePayload));
+    return request.put("/ws/%d/%s".formatted(workspaceId, fileLocation), options);
+  }
+
+  /**
+   * Call the 'put file' endpoint in the Workspace server. Passes the overwrite flag
+   * @param token The JWT token for the user making the request
+   * @param workspaceId The workspace to insert the file into
+   * @param fileLocation Where to place the plan
+   * @param fileContents The contents of the file to be inserted
+   * @param overwrite whether to overwrite the file should it exist
+   * @return The APIResponse from the server
+   */
+  public APIResponse putFile(String token, int workspaceId, Path fileLocation, String fileContents, boolean overwrite) {
+    final var filePayload = new FilePayload(
+        fileLocation.getFileName().toString(),
+        "text/plain",
+        fileContents.getBytes(StandardCharsets.UTF_8));
+    final var options = RequestOptions
+        .create()
+        .setQueryParam("type", "file")
+        .setQueryParam("overwrite", overwrite)
+        .setHeader("Authorization", "Bearer "+token)
+        .setMultipart(FormData.create().set("file", filePayload));
+    return request.put("/ws/%d/%s".formatted(workspaceId, fileLocation), options);
+  }
+
+  /**
+   * Call the `list workspace contents` endpoint in the Workspace server.
+   * @param token The JWT token for the user making the request.
+   * @param workspaceId The workspace to list the contents of
+   * @return the APIResponse from the Workspace Server
+   */
+  public APIResponse listWorkspaceContents(String token, int workspaceId) {
+    final var options = RequestOptions.create().setHeader("Authorization ", "Bearer " +token);
+    return request.get("/ws/%d".formatted(workspaceId), options);
+  }
+
+  /**
+   * Call the `list workspace contents` endpoint in the Workspace server with the given headers.
+   * Any authorization headers must be put inside the `headers` parameter
+   * @param headers The set of headers to be used in the request
+   * @param workspaceId The workspace to list the contents of
+   * @return the APIResponse from the Workspace Server
+   */
+  public APIResponse listWorkspaceContents(Map<String, String> headers, int workspaceId) {
+    final var options = RequestOptions.create();
+    headers.forEach(options::setHeader);
+    return request.get("/ws/%d".formatted(workspaceId), options);
+  }
+
+  /**
+   * Helper method to delete a workspace during test environment cleanup.
+   * @param workspaceId the id of the workspace to be deleted
+   * @throws IOException if the response code is not 200
+   */
+  public void deleteWorkspace(int workspaceId) throws IOException {
+    final var options = RequestOptions.create()
+                                      .setHeader("x-hasura-admin-secret", hasuraAdminSecret);
+    defaultHeaders.forEach(options::setHeader);
+    final var response = request.delete("/ws/%d".formatted(workspaceId), options);
+
+    if(!response.ok()){
+      throw new IOException(response.statusText());
+    }
+  }
+
+  /**
+   * Call the `deleteWorkspace` endpoint while using a JWT
+   * @param authToken the user's JWT (received from logging them into the Gateway)
+   * @param workspaceId the workspace to be deleted
+   * @return the APIResponse from the Workspace Server
+  */
+  public APIResponse deleteWorkspace(String authToken, int workspaceId) {
+    final var options = RequestOptions.create()
+                                      .setHeader("Authorization", "Bearer "+authToken);
+    return request.delete("/ws/%d".formatted(workspaceId), options);
+  }
+
+
+  @Override
+  public void close() {
+    request.dispose();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.merlin.server.http;
 
 import gov.nasa.jpl.aerie.constraints.InputMismatchException;
+import gov.nasa.jpl.aerie.permissions.exceptions.Forbidden;
 import gov.nasa.jpl.aerie.types.SerializedActivity;
 import gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
@@ -17,7 +18,6 @@ import gov.nasa.jpl.aerie.permissions.HasuraAction;
 import gov.nasa.jpl.aerie.permissions.PermissionsService;
 import gov.nasa.jpl.aerie.permissions.exceptions.ExceptionSerializers;
 import gov.nasa.jpl.aerie.permissions.exceptions.PermissionsServiceException;
-import gov.nasa.jpl.aerie.permissions.exceptions.Unauthorized;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 import io.javalin.plugin.Plugin;
@@ -227,8 +227,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(404).result(ExceptionSerializers.serializeNoSuchPlanException(ex).toString());
     } catch (final PermissionsServiceException ex) {
       ctx.status(503).result(ExceptionSerializers.serializePermissionsServiceException(ex).toString());
-    } catch (final Unauthorized ex) {
-      ctx.status(403).result(ExceptionSerializers.serializeUnauthorizedException(ex).toString());
+    } catch (final Forbidden ex) {
+      ctx.status(403).result(ExceptionSerializers.serializeForbiddenException(ex).toString());
     } catch (final IOException ex) {
       ctx.status(500).result(ExceptionSerializers.serializeIOException(ex).toString());
     }
@@ -253,8 +253,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(404).result(ExceptionSerializers.serializeNoSuchPlanException(ex).toString());
     } catch (final PermissionsServiceException ex) {
       ctx.status(503).result(ExceptionSerializers.serializePermissionsServiceException(ex).toString());
-    } catch (final Unauthorized ex) {
-      ctx.status(403).result(ExceptionSerializers.serializeUnauthorizedException(ex).toString());
+    } catch (final Forbidden ex) {
+      ctx.status(403).result(ExceptionSerializers.serializeForbiddenException(ex).toString());
     } catch (final IOException ex) {
       ctx.status(500).result(ExceptionSerializers.serializeIOException(ex).toString());
     }
@@ -289,8 +289,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(404).result(ResponseSerializers.serializeSimulationDatasetMismatchException(ex).toString());
     } catch (final PermissionsServiceException ex) {
       ctx.status(503).result(ExceptionSerializers.serializePermissionsServiceException(ex).toString());
-    } catch (final Unauthorized ex) {
-      ctx.status(403).result(ExceptionSerializers.serializeUnauthorizedException(ex).toString());
+    } catch (final Forbidden ex) {
+      ctx.status(403).result(ExceptionSerializers.serializeForbiddenException(ex).toString());
     } catch (final IOException ex) {
       ctx.status(500).result(ExceptionSerializers.serializeIOException(ex).toString());
     }
@@ -463,8 +463,8 @@ public final class MerlinBindings implements Plugin {
       ctx.status(404).result(ExceptionSerializers.serializeNoSuchPlanException(ex).toString());
     } catch (final PermissionsServiceException ex) {
       ctx.status(503).result(ExceptionSerializers.serializePermissionsServiceException(ex).toString());
-    } catch (final Unauthorized ex) {
-      ctx.status(403).result(ExceptionSerializers.serializeUnauthorizedException(ex).toString());
+    } catch (final Forbidden ex) {
+      ctx.status(403).result(ExceptionSerializers.serializeForbiddenException(ex).toString());
     } catch (final IOException ex) {
       ctx.status(500).result(ExceptionSerializers.serializeIOException(ex).toString());
     }
@@ -540,7 +540,7 @@ public final class MerlinBindings implements Plugin {
       final HasuraAction action,
       final gov.nasa.jpl.aerie.merlin.server.models.HasuraAction.Session session,
       final PlanId planId
-  ) throws gov.nasa.jpl.aerie.permissions.exceptions.NoSuchPlanException, Unauthorized, IOException, PermissionsServiceException
+  ) throws gov.nasa.jpl.aerie.permissions.exceptions.NoSuchPlanException, Forbidden, IOException, PermissionsServiceException
   {
     final var permissionsPlanId = new gov.nasa.jpl.aerie.permissions.gql.PlanId(planId.id());
     permissionsService.check(action, session.hasuraRole(), session.hasuraUserId(), permissionsPlanId);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/MerlinBindings.java
@@ -7,14 +7,13 @@ import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.SimulationDatasetMismatchException;
 import gov.nasa.jpl.aerie.merlin.server.services.ConstraintAction;
-import gov.nasa.jpl.aerie.merlin.server.models.HasuraAction;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
 import gov.nasa.jpl.aerie.merlin.server.services.GenerateConstraintsLibAction;
 import gov.nasa.jpl.aerie.merlin.server.services.GetSimulationResultsAction;
 import gov.nasa.jpl.aerie.merlin.server.services.LocalMissionModelService;
 import gov.nasa.jpl.aerie.merlin.server.services.MissionModelService;
 import gov.nasa.jpl.aerie.merlin.server.services.PlanService;
-import gov.nasa.jpl.aerie.permissions.Action;
+import gov.nasa.jpl.aerie.permissions.HasuraAction;
 import gov.nasa.jpl.aerie.permissions.PermissionsService;
 import gov.nasa.jpl.aerie.permissions.exceptions.ExceptionSerializers;
 import gov.nasa.jpl.aerie.permissions.exceptions.PermissionsServiceException;
@@ -212,7 +211,7 @@ public final class MerlinBindings implements Plugin {
       final var planId = body.input().planId();
       final var force = body.input().force().orElse(false);
 
-      this.checkPermissions(Action.simulate, body.session(), planId);
+      this.checkPermissions(HasuraAction.simulate, body.session(), planId);
 
       final var response = this.simulationAction.run(planId, force, body.session());
       ctx.result(ResponseSerializers.serializeSimulationResultsResponse(response).toString());
@@ -240,7 +239,7 @@ public final class MerlinBindings implements Plugin {
       final var body = parseJson(ctx.body(), hasuraPlanActionP);
       final var planId = body.input().planId();
 
-      this.checkPermissions(Action.resource_samples, body.session(), planId);
+      this.checkPermissions(HasuraAction.resource_samples, body.session(), planId);
 
       final var resourceSamples = this.simulationAction.getResourceSamples(planId);
       ctx.result(ResponseSerializers.serializeResourceSamples(resourceSamples).toString());
@@ -266,7 +265,7 @@ public final class MerlinBindings implements Plugin {
       final var input = body.input();
       final var planId = input.planId();
 
-      this.checkPermissions(Action.check_constraints, body.session(), planId);
+      this.checkPermissions(HasuraAction.check_constraints, body.session(), planId);
 
       final var simulationDatasetId = input.simulationDatasetId();
       final var force = input.force().orElse(false);
@@ -445,7 +444,7 @@ public final class MerlinBindings implements Plugin {
       final var input = body.input();
 
       final var planId = input.planId();
-      this.checkPermissions(Action.insert_ext_dataset, body.session(), planId);
+      this.checkPermissions(HasuraAction.insert_ext_dataset, body.session(), planId);
 
       final var simulationDatasetId = input.simulationDatasetId();
       final var datasetStart = input.datasetStart();
@@ -538,8 +537,8 @@ public final class MerlinBindings implements Plugin {
   }
 
   private void checkPermissions(
-      final Action action,
-      final HasuraAction.Session session,
+      final HasuraAction action,
+      final gov.nasa.jpl.aerie.merlin.server.models.HasuraAction.Session session,
       final PlanId planId
   ) throws gov.nasa.jpl.aerie.permissions.exceptions.NoSuchPlanException, Unauthorized, IOException, PermissionsServiceException
   {

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/Action.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/Action.java
@@ -1,9 +1,3 @@
 package gov.nasa.jpl.aerie.permissions;
 
-public enum Action {
-  simulate,
-  schedule,
-  insert_ext_dataset,
-  check_constraints,
-  resource_samples,
-}
+public sealed interface Action permits HasuraAction, WorkspaceAction {}

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/HasuraAction.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/HasuraAction.java
@@ -1,0 +1,9 @@
+package gov.nasa.jpl.aerie.permissions;
+
+public enum HasuraAction implements Action {
+  simulate,
+  schedule,
+  insert_ext_dataset,
+  check_constraints,
+  resource_samples,
+}

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/OwnerOrCollaborator.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/OwnerOrCollaborator.java
@@ -1,26 +1,26 @@
 package gov.nasa.jpl.aerie.permissions;
 
-public enum PlanOwnerOrCollaborator {
+public enum OwnerOrCollaborator {
   NEITHER,
   ONLY_OWNER,
   ONLY_COLLABORATOR,
   OWNER_AND_COLLABORATOR;
 
-  boolean isPlanOwner() {
+  boolean isOwner() {
     return switch(this) {
       case NEITHER, ONLY_COLLABORATOR -> false;
       case ONLY_OWNER, OWNER_AND_COLLABORATOR -> true;
     };
   }
 
-  boolean isPlanCollaborator() {
+  boolean isCollaborator() {
     return switch(this) {
       case NEITHER, ONLY_OWNER -> false;
       case ONLY_COLLABORATOR, OWNER_AND_COLLABORATOR -> true;
     };
   }
 
-  boolean isPlanOwnerOrCollaborator() {
+  boolean isOwnerOrCollaborator() {
     return switch(this) {
       case NEITHER -> false;
       case ONLY_OWNER, ONLY_COLLABORATOR, OWNER_AND_COLLABORATOR -> true;

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PermissionType.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PermissionType.java
@@ -1,28 +1,3 @@
 package gov.nasa.jpl.aerie.permissions;
 
-public enum PermissionType {
-  /**
-   * The given role is always allowed to perform this action
-   */
-  NO_CHECK,
-  /**
-   * The given user must be the owner of the relevant object. The interpretation can vary by action
-   */
-  OWNER,
-  /**
-   * The given user must be the owner of the given mission model
-   */
-  MISSION_MODEL_OWNER,
-  /**
-   * The given user must be the plan owner of the given plan
-   */
-  PLAN_OWNER,
-  /**
-   * The given user must be a plan collaborator on the given plan
-   */
-  PLAN_COLLABORATOR,
-  /**
-   * The given user must be either the plan owner or a plan collaborator on the given plan
-   */
-  PLAN_OWNER_COLLABORATOR,
-}
+public sealed interface PermissionType permits PlanPermissionType, WorkspacePermissionType {}

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PermissionsService.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PermissionsService.java
@@ -48,17 +48,17 @@ public final class PermissionsService {
     if (!authorized) throw new Unauthorized(action, role, username, permissionType, workspaceId);
   }
 
-  private PermissionType getActionPermission(final HasuraAction action, final String role)
+  private PlanPermissionType getActionPermission(final HasuraAction action, final String role)
   throws Unauthorized, IOException, PermissionsServiceException
   {
     if (role.equals("aerie_admin")) {
-      return PermissionType.NO_CHECK;
+      return PlanPermissionType.NO_CHECK;
     }
     return gqlService.getActionPermission(action, role);
   }
 
   private boolean canPerformAction(
-      final PermissionType permissionType,
+      final PlanPermissionType permissionType,
       final String username,
       final PlanId planId)
   throws IOException, PermissionsServiceException, NoSuchPlanException {

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PermissionsService.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PermissionsService.java
@@ -1,10 +1,10 @@
 package gov.nasa.jpl.aerie.permissions;
 
+import gov.nasa.jpl.aerie.permissions.exceptions.Forbidden;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchSchedulingSpecificationException;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException;
 import gov.nasa.jpl.aerie.permissions.exceptions.PermissionsServiceException;
-import gov.nasa.jpl.aerie.permissions.exceptions.Unauthorized;
 import gov.nasa.jpl.aerie.permissions.gql.GraphQLPermissionsService;
 import gov.nasa.jpl.aerie.permissions.gql.PlanId;
 import gov.nasa.jpl.aerie.permissions.gql.SchedulingSpecificationId;
@@ -20,10 +20,10 @@ public final class PermissionsService {
   }
 
   public void check(final HasuraAction action, final String role, final String username, final PlanId planId)
-  throws Unauthorized, IOException, PermissionsServiceException, NoSuchPlanException {
+  throws Forbidden, IOException, PermissionsServiceException, NoSuchPlanException {
     final var permissionType = getActionPermission(action, role);
     final var authorized = canPerformAction(permissionType, username, planId);
-    if (!authorized) throw new Unauthorized(action, role, username, permissionType, planId);
+    if (!authorized) throw new Forbidden(action, role, username, permissionType, planId);
   }
 
   public void check(
@@ -31,7 +31,7 @@ public final class PermissionsService {
       final String role,
       final String username,
       final SchedulingSpecificationId specificationId)
-  throws Unauthorized, IOException, PermissionsServiceException, NoSuchSchedulingSpecificationException,
+  throws Forbidden, IOException, PermissionsServiceException, NoSuchSchedulingSpecificationException,
          NoSuchPlanException
   {
     final var planId = gqlService.getPlanIdFromSchedulingSpecificationId(specificationId);
@@ -43,15 +43,15 @@ public final class PermissionsService {
       final String role,
       final String username,
       final WorkspaceId workspaceId)
-  throws Unauthorized, IOException, PermissionsServiceException, NoSuchWorkspaceException
+  throws Forbidden, IOException, PermissionsServiceException, NoSuchWorkspaceException
   {
     final var permissionType = getWorkspaceActionPermission(action, role);
     final var authorized = canPerformWorkspaceAction(permissionType, username, workspaceId);
-    if (!authorized) throw new Unauthorized(action, role, username, permissionType, workspaceId);
+    if (!authorized) throw new Forbidden(action, role, username, permissionType, workspaceId);
   }
 
   public void checkCoarseGrained(final Action action, final String role)
-  throws PermissionsServiceException, Unauthorized, IOException
+  throws PermissionsServiceException, Forbidden, IOException
   {
     if(action instanceof WorkspaceAction workspaceAction) {
       getWorkspaceActionPermission(workspaceAction, role);
@@ -62,7 +62,7 @@ public final class PermissionsService {
   }
 
   private PlanPermissionType getActionPermission(final HasuraAction action, final String role)
-  throws Unauthorized, IOException, PermissionsServiceException
+  throws Forbidden, IOException, PermissionsServiceException
   {
     if (role.equals("aerie_admin")) {
       return PlanPermissionType.NO_CHECK;
@@ -91,7 +91,7 @@ public final class PermissionsService {
   }
 
   private WorkspacePermissionType getWorkspaceActionPermission(final WorkspaceAction action, final String role)
-  throws Unauthorized, IOException, PermissionsServiceException
+  throws Forbidden, IOException, PermissionsServiceException
   {
     if (role.equals("aerie_admin")) {
       return WorkspacePermissionType.NO_CHECK;

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PermissionsService.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PermissionsService.java
@@ -50,6 +50,17 @@ public final class PermissionsService {
     if (!authorized) throw new Unauthorized(action, role, username, permissionType, workspaceId);
   }
 
+  public void checkCoarseGrained(final Action action, final String role)
+  throws PermissionsServiceException, Unauthorized, IOException
+  {
+    if(action instanceof WorkspaceAction workspaceAction) {
+      getWorkspaceActionPermission(workspaceAction, role);
+    }
+    else {
+      throw new IllegalArgumentException("Unsupported action subtype: "+action.getClass());
+    }
+  }
+
   private PlanPermissionType getActionPermission(final HasuraAction action, final String role)
   throws Unauthorized, IOException, PermissionsServiceException
   {

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PermissionsService.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PermissionsService.java
@@ -2,11 +2,13 @@ package gov.nasa.jpl.aerie.permissions;
 
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchSchedulingSpecificationException;
+import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException;
 import gov.nasa.jpl.aerie.permissions.exceptions.PermissionsServiceException;
 import gov.nasa.jpl.aerie.permissions.exceptions.Unauthorized;
 import gov.nasa.jpl.aerie.permissions.gql.GraphQLPermissionsService;
 import gov.nasa.jpl.aerie.permissions.gql.PlanId;
 import gov.nasa.jpl.aerie.permissions.gql.SchedulingSpecificationId;
+import gov.nasa.jpl.aerie.permissions.gql.WorkspaceId;
 
 import java.io.IOException;
 
@@ -65,16 +67,43 @@ public final class PermissionsService {
     return switch (permissionType) {
       case NO_CHECK -> true;
       case MISSION_MODEL_OWNER -> gqlService.checkMissionModelOwner(planId, username);
-      case OWNER, PLAN_OWNER -> getPlanPermissions(username, planId).isPlanOwner();
-      case PLAN_COLLABORATOR -> getPlanPermissions(username, planId).isPlanCollaborator();
-      case PLAN_OWNER_COLLABORATOR -> getPlanPermissions(username, planId).isPlanOwnerOrCollaborator();
+      case OWNER, PLAN_OWNER -> getPlanPermissions(username, planId).isOwner();
+      case PLAN_COLLABORATOR -> getPlanPermissions(username, planId).isCollaborator();
+      case PLAN_OWNER_COLLABORATOR -> getPlanPermissions(username, planId).isOwnerOrCollaborator();
     };
   }
 
-  private PlanOwnerOrCollaborator getPlanPermissions(final String username, final PlanId planId)
+  private OwnerOrCollaborator getPlanPermissions(final String username, final PlanId planId)
   throws IOException, PermissionsServiceException, NoSuchPlanException
   {
     return gqlService.checkPlanOwnerCollaborator(planId, username);
   }
 
+  private WorkspacePermissionType getWorkspaceActionPermission(final WorkspaceAction action, final String role)
+  throws Unauthorized, IOException, PermissionsServiceException
+  {
+    if (role.equals("aerie_admin")) {
+      return WorkspacePermissionType.NO_CHECK;
+    }
+    return gqlService.getWorkspaceActionPermission(action, role);
+  }
+
+  private boolean canPerformWorkspaceAction(
+      final WorkspacePermissionType permissionType,
+      final String username,
+      final WorkspaceId workspaceId)
+  throws IOException, PermissionsServiceException, NoSuchWorkspaceException {
+    return switch (permissionType) {
+      case NO_CHECK -> true;
+      case OWNER -> getWorkspacePermissions(username, workspaceId).isOwner();
+      case COLLABORATOR -> getWorkspacePermissions(username, workspaceId).isCollaborator();
+      case OWNER_COLLABORATOR -> getWorkspacePermissions(username, workspaceId).isOwnerOrCollaborator();
+    };
+  }
+
+  private OwnerOrCollaborator getWorkspacePermissions(final String username, final WorkspaceId workspaceId)
+  throws IOException, PermissionsServiceException, NoSuchWorkspaceException
+  {
+    return gqlService.checkWorkspaceOwnerCollaborator(workspaceId, username);
+  }
 }

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PermissionsService.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PermissionsService.java
@@ -16,15 +16,16 @@ public final class PermissionsService {
   public PermissionsService(final GraphQLPermissionsService gqlService) {
     this.gqlService = gqlService;
   }
-  public void check(final Action action, final String role, final String username, final PlanId planId)
+
+  public void check(final HasuraAction action, final String role, final String username, final PlanId planId)
   throws Unauthorized, IOException, PermissionsServiceException, NoSuchPlanException {
     final var permissionType = getActionPermission(action, role);
     final var authorized = canPerformAction(permissionType, username, planId);
     if (!authorized) throw new Unauthorized(action, role, username, permissionType, planId);
   }
 
-    public void check(
-      final Action action,
+  public void check(
+      final HasuraAction action,
       final String role,
       final String username,
       final SchedulingSpecificationId specificationId)
@@ -35,7 +36,19 @@ public final class PermissionsService {
     check(action, role, username, planId);
   }
 
-  private PermissionType getActionPermission(final Action action, final String role)
+  public void check(
+      final WorkspaceAction action,
+      final String role,
+      final String username,
+      final WorkspaceId workspaceId)
+  throws Unauthorized, IOException, PermissionsServiceException, NoSuchWorkspaceException
+  {
+    final var permissionType = getWorkspaceActionPermission(action, role);
+    final var authorized = canPerformWorkspaceAction(permissionType, username, workspaceId);
+    if (!authorized) throw new Unauthorized(action, role, username, permissionType, workspaceId);
+  }
+
+  private PermissionType getActionPermission(final HasuraAction action, final String role)
   throws Unauthorized, IOException, PermissionsServiceException
   {
     if (role.equals("aerie_admin")) {

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PlanPermissionType.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/PlanPermissionType.java
@@ -1,0 +1,28 @@
+package gov.nasa.jpl.aerie.permissions;
+
+public enum PlanPermissionType implements PermissionType {
+  /**
+   * The given role is always allowed to perform this action
+   */
+  NO_CHECK,
+  /**
+   * The given user must be the owner of the relevant object. The interpretation can vary by action
+   */
+  OWNER,
+  /**
+   * The given user must be the owner of the given mission model
+   */
+  MISSION_MODEL_OWNER,
+  /**
+   * The given user must be the plan owner of the given plan
+   */
+  PLAN_OWNER,
+  /**
+   * The given user must be a plan collaborator on the given plan
+   */
+  PLAN_COLLABORATOR,
+  /**
+   * The given user must be either the plan owner or a plan collaborator on the given plan
+   */
+  PLAN_OWNER_COLLABORATOR,
+}

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/WorkspaceAction.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/WorkspaceAction.java
@@ -1,0 +1,10 @@
+package gov.nasa.jpl.aerie.permissions;
+
+public enum WorkspaceAction implements Action {
+  createWorkspace,
+  deleteWorkspace,
+  listWorkspaceContents,
+  readFileDirectory,
+  writeFileDirectory,
+  deleteFileDirectory,
+}

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/WorkspaceAction.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/WorkspaceAction.java
@@ -1,10 +1,10 @@
 package gov.nasa.jpl.aerie.permissions;
 
 public enum WorkspaceAction implements Action {
-  createWorkspace,
-  deleteWorkspace,
-  listWorkspaceContents,
-  readFileDirectory,
-  writeFileDirectory,
-  deleteFileDirectory,
+  create_workspace,
+  delete_file_directory,
+  delete_workspace,
+  list_workspace_contents,
+  read_file_directory,
+  write_file_directory,
 }

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/WorkspacePermissionType.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/WorkspacePermissionType.java
@@ -1,0 +1,20 @@
+package gov.nasa.jpl.aerie.permissions;
+
+public enum WorkspacePermissionType implements PermissionType {
+  /**
+   * The given role is always allowed to perform this action
+   */
+  NO_CHECK,
+  /**
+   * The given user must be the owner of the given workspace
+   */
+  OWNER,
+  /**
+   * The given user must be a collaborator on the given workspace
+   */
+  COLLABORATOR,
+  /**
+   * The given user must be either the owner or a collaborator on the given workspace
+   */
+  OWNER_COLLABORATOR,
+}

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/exceptions/ExceptionSerializers.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/exceptions/ExceptionSerializers.java
@@ -27,7 +27,7 @@ public class ExceptionSerializers {
                .build();
   }
 
-  public static JsonValue serializeUnauthorizedException(final Unauthorized ex) {
+  public static JsonValue serializeForbiddenException(final Forbidden ex) {
     return Json.createObjectBuilder().add("message", ex.getMessage()).build();
   }
 

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/exceptions/Forbidden.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/exceptions/Forbidden.java
@@ -8,12 +8,12 @@ import gov.nasa.jpl.aerie.permissions.WorkspacePermissionType;
 import gov.nasa.jpl.aerie.permissions.gql.PlanId;
 import gov.nasa.jpl.aerie.permissions.gql.WorkspaceId;
 
-public class Unauthorized extends Exception {
-  public Unauthorized(final String role, final Action action) {
+public class Forbidden extends Exception {
+  public Forbidden(final String role, final Action action) {
     super("Role '%s' is not allowed to perform action '%s'".formatted(role, action));
   }
 
-  public Unauthorized(
+  public Forbidden(
       final HasuraAction action,
       final String role,
       final String username,
@@ -27,7 +27,7 @@ public class Unauthorized extends Exception {
         planId.id()));
   }
 
-  public Unauthorized(
+  public Forbidden(
       final WorkspaceAction action,
       final String role,
       final String username,

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/exceptions/NoSuchWorkspaceException.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/exceptions/NoSuchWorkspaceException.java
@@ -1,0 +1,12 @@
+package gov.nasa.jpl.aerie.permissions.exceptions;
+
+import gov.nasa.jpl.aerie.permissions.gql.WorkspaceId;
+
+public class NoSuchWorkspaceException extends Exception {
+  public final WorkspaceId id;
+
+  public NoSuchWorkspaceException(final WorkspaceId id) {
+    super("No workspace exists with id '%s'".formatted(id));
+    this.id = id;
+  }
+}

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/exceptions/Unauthorized.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/exceptions/Unauthorized.java
@@ -3,7 +3,10 @@ package gov.nasa.jpl.aerie.permissions.exceptions;
 import gov.nasa.jpl.aerie.permissions.Action;
 import gov.nasa.jpl.aerie.permissions.HasuraAction;
 import gov.nasa.jpl.aerie.permissions.PlanPermissionType;
+import gov.nasa.jpl.aerie.permissions.WorkspaceAction;
+import gov.nasa.jpl.aerie.permissions.WorkspacePermissionType;
 import gov.nasa.jpl.aerie.permissions.gql.PlanId;
+import gov.nasa.jpl.aerie.permissions.gql.WorkspaceId;
 
 public class Unauthorized extends Exception {
   public Unauthorized(final String role, final Action action) {
@@ -17,6 +20,20 @@ public class Unauthorized extends Exception {
       final PlanPermissionType permissionType,
       final PlanId planId) {
     super("User '%s' with role '%s' cannot perform '%s' because they are not a '%s' for plan with id '%d'".formatted(
+        username,
+        role,
+        action,
+        permissionType,
+        planId.id()));
+  }
+
+  public Unauthorized(
+      final WorkspaceAction action,
+      final String role,
+      final String username,
+      final WorkspacePermissionType permissionType,
+      final WorkspaceId planId) {
+    super("User '%s' with role '%s' cannot perform '%s' because they are not a '%s' for workspace with id '%d'".formatted(
         username,
         role,
         action,

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/exceptions/Unauthorized.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/exceptions/Unauthorized.java
@@ -2,7 +2,7 @@ package gov.nasa.jpl.aerie.permissions.exceptions;
 
 import gov.nasa.jpl.aerie.permissions.Action;
 import gov.nasa.jpl.aerie.permissions.HasuraAction;
-import gov.nasa.jpl.aerie.permissions.PermissionType;
+import gov.nasa.jpl.aerie.permissions.PlanPermissionType;
 import gov.nasa.jpl.aerie.permissions.gql.PlanId;
 
 public class Unauthorized extends Exception {
@@ -14,7 +14,7 @@ public class Unauthorized extends Exception {
       final HasuraAction action,
       final String role,
       final String username,
-      final PermissionType permissionType,
+      final PlanPermissionType permissionType,
       final PlanId planId) {
     super("User '%s' with role '%s' cannot perform '%s' because they are not a '%s' for plan with id '%d'".formatted(
         username,

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/exceptions/Unauthorized.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/exceptions/Unauthorized.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.permissions.exceptions;
 
 import gov.nasa.jpl.aerie.permissions.Action;
+import gov.nasa.jpl.aerie.permissions.HasuraAction;
 import gov.nasa.jpl.aerie.permissions.PermissionType;
 import gov.nasa.jpl.aerie.permissions.gql.PlanId;
 
@@ -10,7 +11,7 @@ public class Unauthorized extends Exception {
   }
 
   public Unauthorized(
-      final Action action,
+      final HasuraAction action,
       final String role,
       final String username,
       final PermissionType permissionType,

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/gql/GraphQLPermissionsService.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/gql/GraphQLPermissionsService.java
@@ -5,11 +5,11 @@ import gov.nasa.jpl.aerie.permissions.PlanPermissionType;
 import gov.nasa.jpl.aerie.permissions.OwnerOrCollaborator;
 import gov.nasa.jpl.aerie.permissions.WorkspaceAction;
 import gov.nasa.jpl.aerie.permissions.WorkspacePermissionType;
+import gov.nasa.jpl.aerie.permissions.exceptions.Forbidden;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchSchedulingSpecificationException;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException;
 import gov.nasa.jpl.aerie.permissions.exceptions.PermissionsServiceException;
-import gov.nasa.jpl.aerie.permissions.exceptions.Unauthorized;
 
 import javax.json.Json;
 import javax.json.JsonException;
@@ -79,7 +79,8 @@ public record GraphQLPermissionsService(
     }
   }
 
-  public PlanPermissionType getActionPermission(final HasuraAction action, final String role) throws IOException, Unauthorized, PermissionsServiceException {
+  public PlanPermissionType getActionPermission(final HasuraAction action, final String role)
+  throws IOException, Forbidden, PermissionsServiceException {
     final var query = """
         query getActionPermission($role: user_roles_enum!, $action: String!) {
           check: user_role_permission_by_pk(role: $role) {
@@ -92,13 +93,14 @@ public record GraphQLPermissionsService(
                               .add("role", role)
                               .build();
 
-    final var response = postRequest(query, variables).orElseThrow(() -> new Unauthorized(role, action));
+    final var response = postRequest(query, variables).orElseThrow(() -> new Forbidden(role, action));
     final var check = response.getJsonObject("data").getJsonObject("check");
-    if (check.isNull("permission")) { throw new Unauthorized(role, action); }
+    if (check.isNull("permission")) { throw new Forbidden(role, action); }
     return PlanPermissionType.valueOf(check.getString("permission"));
   }
 
-  public WorkspacePermissionType getWorkspaceActionPermission(final WorkspaceAction action, final String role) throws IOException, Unauthorized, PermissionsServiceException {
+  public WorkspacePermissionType getWorkspaceActionPermission(final WorkspaceAction action, final String role)
+  throws IOException, Forbidden, PermissionsServiceException {
     final var query = """
         query getWorkspaceActionPermission($role: user_roles_enum!, $action: String!) {
           check: user_role_permission_by_pk(role: $role) {
@@ -111,9 +113,9 @@ public record GraphQLPermissionsService(
                               .add("role", role)
                               .build();
 
-    final var response = postRequest(query, variables).orElseThrow(() -> new Unauthorized(role, action));
+    final var response = postRequest(query, variables).orElseThrow(() -> new Forbidden(role, action));
     final var check = response.getJsonObject("data").getJsonObject("check");
-    if (check.isNull("permission")) { throw new Unauthorized(role, action); }
+    if (check.isNull("permission")) { throw new Forbidden(role, action); }
     return WorkspacePermissionType.valueOf(check.getString("permission"));
   }
 

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/gql/GraphQLPermissionsService.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/gql/GraphQLPermissionsService.java
@@ -1,7 +1,7 @@
 package gov.nasa.jpl.aerie.permissions.gql;
 
 import gov.nasa.jpl.aerie.permissions.HasuraAction;
-import gov.nasa.jpl.aerie.permissions.PermissionType;
+import gov.nasa.jpl.aerie.permissions.PlanPermissionType;
 import gov.nasa.jpl.aerie.permissions.PlanOwnerOrCollaborator;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchSchedulingSpecificationException;
@@ -76,7 +76,7 @@ public record GraphQLPermissionsService(
     }
   }
 
-  public PermissionType getActionPermission(final HasuraAction action, final String role) throws IOException, Unauthorized, PermissionsServiceException {
+  public PlanPermissionType getActionPermission(final HasuraAction action, final String role) throws IOException, Unauthorized, PermissionsServiceException {
     final var query = """
         query getActionPermission($role: user_roles_enum!, $action: String!) {
           check: user_role_permission_by_pk(role: $role) {
@@ -92,7 +92,7 @@ public record GraphQLPermissionsService(
     final var response = postRequest(query, variables).orElseThrow(() -> new Unauthorized(role, action));
     final var check = response.getJsonObject("data").getJsonObject("check");
     if (check.isNull("permission")) { throw new Unauthorized(role, action); }
-    return PermissionType.valueOf(check.getString("permission"));
+    return PlanPermissionType.valueOf(check.getString("permission"));
   }
 
   public PlanOwnerOrCollaborator checkPlanOwnerCollaborator(final PlanId planId, final String username) throws IOException, NoSuchPlanException, PermissionsServiceException {

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/gql/GraphQLPermissionsService.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/gql/GraphQLPermissionsService.java
@@ -90,8 +90,9 @@ public record GraphQLPermissionsService(
                               .build();
 
     final var response = postRequest(query, variables).orElseThrow(() -> new Unauthorized(role, action));
-    final String permission = response.getJsonObject("data").getJsonObject("check").getString("permission");
-    return PermissionType.valueOf(permission);
+    final var check = response.getJsonObject("data").getJsonObject("check");
+    if (check.isNull("permission")) { throw new Unauthorized(role, action); }
+    return PermissionType.valueOf(check.getString("permission"));
   }
 
   public PlanOwnerOrCollaborator checkPlanOwnerCollaborator(final PlanId planId, final String username) throws IOException, NoSuchPlanException, PermissionsServiceException {

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/gql/GraphQLPermissionsService.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/gql/GraphQLPermissionsService.java
@@ -1,6 +1,6 @@
 package gov.nasa.jpl.aerie.permissions.gql;
 
-import gov.nasa.jpl.aerie.permissions.Action;
+import gov.nasa.jpl.aerie.permissions.HasuraAction;
 import gov.nasa.jpl.aerie.permissions.PermissionType;
 import gov.nasa.jpl.aerie.permissions.PlanOwnerOrCollaborator;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchPlanException;
@@ -76,7 +76,7 @@ public record GraphQLPermissionsService(
     }
   }
 
-  public PermissionType getActionPermission(final Action action, final String role) throws IOException, Unauthorized, PermissionsServiceException {
+  public PermissionType getActionPermission(final HasuraAction action, final String role) throws IOException, Unauthorized, PermissionsServiceException {
     final var query = """
         query getActionPermission($role: user_roles_enum!, $action: String!) {
           check: user_role_permission_by_pk(role: $role) {

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/gql/GraphQLPermissionsService.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/gql/GraphQLPermissionsService.java
@@ -2,9 +2,12 @@ package gov.nasa.jpl.aerie.permissions.gql;
 
 import gov.nasa.jpl.aerie.permissions.HasuraAction;
 import gov.nasa.jpl.aerie.permissions.PlanPermissionType;
-import gov.nasa.jpl.aerie.permissions.PlanOwnerOrCollaborator;
+import gov.nasa.jpl.aerie.permissions.OwnerOrCollaborator;
+import gov.nasa.jpl.aerie.permissions.WorkspaceAction;
+import gov.nasa.jpl.aerie.permissions.WorkspacePermissionType;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchSchedulingSpecificationException;
+import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException;
 import gov.nasa.jpl.aerie.permissions.exceptions.PermissionsServiceException;
 import gov.nasa.jpl.aerie.permissions.exceptions.Unauthorized;
 
@@ -95,7 +98,26 @@ public record GraphQLPermissionsService(
     return PlanPermissionType.valueOf(check.getString("permission"));
   }
 
-  public PlanOwnerOrCollaborator checkPlanOwnerCollaborator(final PlanId planId, final String username) throws IOException, NoSuchPlanException, PermissionsServiceException {
+  public WorkspacePermissionType getWorkspaceActionPermission(final WorkspaceAction action, final String role) throws IOException, Unauthorized, PermissionsServiceException {
+    final var query = """
+        query getWorkspaceActionPermission($role: user_roles_enum!, $action: String!) {
+          check: user_role_permission_by_pk(role: $role) {
+            permission: workspace_permissions(path: $action)
+          }
+        }
+        """;
+    final var variables = Json.createObjectBuilder()
+                              .add("action", action.toString())
+                              .add("role", role)
+                              .build();
+
+    final var response = postRequest(query, variables).orElseThrow(() -> new Unauthorized(role, action));
+    final var check = response.getJsonObject("data").getJsonObject("check");
+    if (check.isNull("permission")) { throw new Unauthorized(role, action); }
+    return WorkspacePermissionType.valueOf(check.getString("permission"));
+  }
+
+  public OwnerOrCollaborator checkPlanOwnerCollaborator(final PlanId planId, final String username) throws IOException, NoSuchPlanException, PermissionsServiceException {
     final var query = """
         query getPlanOwnerCollaborators($id: Int!, $username: String!) {
           plan: plan_by_pk(id: $id) {
@@ -117,15 +139,47 @@ public record GraphQLPermissionsService(
 
     if (response.isNull("plan")) throw new NoSuchPlanException(planId);
 
-    final var plan = response.getJsonObject("plan");
+    return getOwnerCollaboratorStatus(response.getJsonObject("plan"), username);
+  }
 
-    final boolean isOwner = username.equals(plan.getString("owner"));
-    final boolean isCollaborator = !plan.getJsonArray("collaborators").isEmpty();
+  public OwnerOrCollaborator checkWorkspaceOwnerCollaborator(final WorkspaceId workspaceId, final String username)
+  throws IOException, NoSuchWorkspaceException, PermissionsServiceException {
+    final var query = """
+        query getWorkspaceOwnerCollaborators($id: Int!, $username: String!) {
+          workspace: workspace_by_pk(id: $id) {
+            owner
+            collaborators(where: {collaborator: {_eq: $username}}) {
+              collaborator
+            }
+          }
+        }
+        """;
+    final var variables = Json.createObjectBuilder()
+                              .add("id", workspaceId.id())
+                              .add("username", username)
+                              .build();
 
-    if (isOwner && isCollaborator) return PlanOwnerOrCollaborator.OWNER_AND_COLLABORATOR;
-    if (isOwner) return PlanOwnerOrCollaborator.ONLY_OWNER;
-    if (isCollaborator) return PlanOwnerOrCollaborator.ONLY_COLLABORATOR;
-    return PlanOwnerOrCollaborator.NEITHER;
+    final var response = postRequest(query, variables)
+        .orElseThrow(() -> new NoSuchWorkspaceException(workspaceId))
+        .getJsonObject("data");
+
+    if (response.isNull("workspace")) throw new NoSuchWorkspaceException(workspaceId);
+
+    return getOwnerCollaboratorStatus(response.getJsonObject("workspace"), username);
+  }
+
+  /**
+   * Extract from the "owner-collaborator" json object
+   * whether the given user is the owner, a collaborator, both, or neither
+   */
+  private OwnerOrCollaborator getOwnerCollaboratorStatus(JsonObject ownerCollaborators, String username){
+    final boolean isOwner = username.equals(ownerCollaborators.getString("owner"));
+    final boolean isCollaborator = !ownerCollaborators.getJsonArray("collaborators").isEmpty();
+
+    if (isOwner && isCollaborator) return OwnerOrCollaborator.OWNER_AND_COLLABORATOR;
+    if (isOwner) return OwnerOrCollaborator.ONLY_OWNER;
+    if (isCollaborator) return OwnerOrCollaborator.ONLY_COLLABORATOR;
+    return OwnerOrCollaborator.NEITHER;
   }
 
   public boolean checkMissionModelOwner(final PlanId planId, final String username)

--- a/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/gql/WorkspaceId.java
+++ b/permissions/src/main/java/gov/nasa/jpl/aerie/permissions/gql/WorkspaceId.java
@@ -1,0 +1,3 @@
+package gov.nasa.jpl.aerie.permissions.gql;
+
+public record WorkspaceId(int id) {}

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
@@ -18,7 +18,7 @@ import gov.nasa.jpl.aerie.permissions.exceptions.ExceptionSerializers;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchPlanException;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchSchedulingSpecificationException;
 import gov.nasa.jpl.aerie.permissions.exceptions.PermissionsServiceException;
-import gov.nasa.jpl.aerie.permissions.exceptions.Unauthorized;
+import gov.nasa.jpl.aerie.permissions.exceptions.Forbidden;
 import gov.nasa.jpl.aerie.permissions.gql.SchedulingSpecificationId;
 import gov.nasa.jpl.aerie.scheduler.server.exceptions.NoSuchSpecificationException;
 import gov.nasa.jpl.aerie.scheduler.server.services.GenerateSchedulingLibAction;
@@ -109,8 +109,8 @@ public record SchedulerBindings(
       ctx.status(404).result(ExceptionSerializers.serializeNoSuchSchedulingSpecificationException(ex).toString());
     } catch (final PermissionsServiceException ex) {
       ctx.status(503).result(ExceptionSerializers.serializePermissionsServiceException(ex).toString());
-    } catch (final Unauthorized ex) {
-      ctx.status(403).result(ExceptionSerializers.serializeUnauthorizedException(ex).toString());
+    } catch (final Forbidden ex) {
+      ctx.status(403).result(ExceptionSerializers.serializeForbiddenException(ex).toString());
     }
   }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/http/SchedulerBindings.java
@@ -12,7 +12,7 @@ import static gov.nasa.jpl.aerie.scheduler.server.http.SchedulerParsers.hasuraSc
 import static gov.nasa.jpl.aerie.scheduler.server.http.SchedulerParsers.hasuraSpecificationActionP;
 import static io.javalin.apibuilder.ApiBuilder.*;
 import gov.nasa.jpl.aerie.json.JsonParser;
-import gov.nasa.jpl.aerie.permissions.Action;
+import gov.nasa.jpl.aerie.permissions.HasuraAction;
 import gov.nasa.jpl.aerie.permissions.PermissionsService;
 import gov.nasa.jpl.aerie.permissions.exceptions.ExceptionSerializers;
 import gov.nasa.jpl.aerie.permissions.exceptions.NoSuchPlanException;
@@ -86,7 +86,7 @@ public record SchedulerBindings(
       final var session = body.session();
       final var permissionsSpecId = new SchedulingSpecificationId(specificationId.id());
       try {
-        permissionsService.check(Action.schedule, session.hasuraRole(), session.hasuraUserId(), permissionsSpecId);
+        permissionsService.check(HasuraAction.schedule, session.hasuraRole(), session.hasuraUserId(), permissionsSpecId);
       } catch (final IOException ex) {
         // this IOException is caught here so that it isn't mistaken for an IOException during scheduling
         ctx.status(500).result(ExceptionSerializers.serializeIOException(ex).toString());

--- a/workspace-server/build.gradle
+++ b/workspace-server/build.gradle
@@ -24,6 +24,7 @@ repositories {
 
 dependencies {
   implementation project(':parsing-utilities')
+  implementation project(':permissions')
 
   implementation 'io.javalin:javalin:5.6.3'
   implementation 'org.slf4j:slf4j-simple:2.0.7'

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/FormattedError.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/FormattedError.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import gov.nasa.jpl.aerie.permissions.exceptions.Forbidden;
 import gov.nasa.jpl.aerie.permissions.exceptions.PermissionsServiceException;
-import gov.nasa.jpl.aerie.permissions.exceptions.Unauthorized;
 import gov.nasa.jpl.aerie.workspace.server.postgres.NoSuchWorkspaceException;
 import io.javalin.http.UnauthorizedResponse;
 import io.javalin.validation.ValidationException;
@@ -107,11 +107,12 @@ final class FormattedError {
     this("FILE_OPERATION_EXCEPTION", message, wfe);
   }
 
-  // Unauthorized
-  public FormattedError(Unauthorized ue) {
+  // Forbidden
+  public FormattedError(Forbidden ue) {
     this("FORBIDDEN", ue);
   }
 
+  // Unauthorized
   public FormattedError(UnauthorizedResponse ue) {
     this.type = "UNAUTHORIZED";
     this.message = ue.getMessage() != null ? ue.getMessage() : "Unauthorized";

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/FormattedError.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/FormattedError.java
@@ -1,0 +1,199 @@
+package gov.nasa.jpl.aerie.workspace.server;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import gov.nasa.jpl.aerie.permissions.exceptions.PermissionsServiceException;
+import gov.nasa.jpl.aerie.permissions.exceptions.Unauthorized;
+import gov.nasa.jpl.aerie.workspace.server.postgres.NoSuchWorkspaceException;
+import io.javalin.http.UnauthorizedResponse;
+import io.javalin.validation.ValidationException;
+
+import javax.json.Json;
+import javax.json.JsonException;
+import javax.json.JsonObject;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.sql.SQLException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+/**
+ * Class for formatting exceptions thrown during in Workspaces into JSON objects
+ * that meet the Aerie HTTP endpoint error message format
+ * Relevant ticket going over said format: https://github.com/NASA-AMMOS/aerie/issues/1732
+ */
+@JsonSerialize(using = FormattedError.FormattedErrorSerializer.class)
+final class FormattedError {
+  private final String type;
+  private final String message;
+  private final String timestamp = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.BASIC_ISO_DATE);
+  private final static String service = "aerie_workspace";
+  private Optional<String> cause = Optional.empty();
+  private Optional<String> trace = Optional.empty();
+  private Optional<JsonObject> data = Optional.empty();
+
+  /**
+   * For use in the event of an endpoint failing without throwing an exception.
+   * i.e. Workspace's delete file endpoint failing because java.nio.File#deleteFile returned "false"
+   */
+  public FormattedError(String message) {
+    this.type = "INTERNAL_ERROR";
+    this.message = message;
+  }
+
+  /**
+   * Create a FormattedException from a generic Exception object.
+   * @param type the category of exception. Should be in SCREAMING_SNAKE_CASE
+   * @param ex the exception to be formatted.
+   */
+  public FormattedError(String type, Exception ex) {
+    this.type = type;
+    message = ex.getMessage() == null ? "No exception message provided." : ex.getMessage();
+    trace = Optional.of(generateTrace(ex));
+  }
+
+  /**
+   * Create a FormattedException from a generic Exception object with a custom error message.
+   * The exception's built-in error message, if included, will be put into the 'cause' field.
+   * @param type the category of exception. Should be in SCREAMING_SNAKE_CASE
+   * @param message the custom error message explaining the cause of the error.
+   *  Should be human-readable and between 1-2 sentences.
+   * @param ex the exception to be formatted.
+   */
+  public FormattedError(String type, String message, Exception ex) {
+    this.type = type;
+    this.message = message;
+    cause = Optional.ofNullable(ex.getMessage());
+    trace = Optional.of(generateTrace(ex));
+  }
+
+  // region Constructors for specific exceptions
+  //  This helps `type` be consistent every time the exception is thrown.
+  // NoSuchWorkspace
+  public FormattedError(NoSuchWorkspaceException nse) {
+    this("NO_SUCH_WORKSPACE", nse);
+  }
+  public FormattedError(NoSuchWorkspaceException nse, String message) {
+    this("NO_SUCH_WORKSPACE", message, nse);
+  }
+
+  public FormattedError(gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nse, String message) {
+    this("NO_SUCH_WORKSPACE", message, nse);
+  }
+
+  // IOException
+  public FormattedError(IOException nse) {
+    this("IO_EXCEPTION", nse);
+  }
+  public FormattedError(IOException nse, String message) {
+    this("IO_EXCEPTION", message, nse);
+  }
+
+  // SQLException
+  public FormattedError(SQLException se) {
+    this("SQL_EXCEPTION", se);
+  }
+  public FormattedError(SQLException se, String message) {
+    this("SQL_EXCEPTION", message, se);
+  }
+
+  // WorkspaceFileOpException
+  public FormattedError(WorkspaceFileOpException wfe, String message) {
+    this("FILE_OPERATION_EXCEPTION", message, wfe);
+  }
+
+  // Unauthorized
+  public FormattedError(Unauthorized ue) {
+    this("FORBIDDEN", ue);
+  }
+
+  public FormattedError(UnauthorizedResponse ue) {
+    this.type = "UNAUTHORIZED";
+    this.message = ue.getMessage() != null ? ue.getMessage() : "Unauthorized";
+    // Include additional details, if present
+    if(!ue.getDetails().isEmpty()) {
+      final var dataBuilder = Json.createObjectBuilder();
+      ue.getDetails().forEach(dataBuilder::add);
+      this.data = Optional.of(dataBuilder.build());
+    }
+  }
+
+  // PermissionsServiceException
+  public FormattedError(PermissionsServiceException pse, String message) {
+    this("PERMISSIONS_SERVICE_EXCEPTION", message, pse);
+  }
+
+  // NumberFormatException
+  public FormattedError(NumberFormatException nfe) {
+    this("NUMBER_PARSING_EXCEPTION", nfe);
+  }
+
+  // IllegalArgumentException
+  public FormattedError(IllegalArgumentException iae, String message) {
+    this("ILLEGAL_ARGUMENT", message, iae);
+  }
+
+  // JSONException
+  public FormattedError(JsonException je, String message){
+    this("JSON_PARSING_EXCEPTION", message, je);
+  }
+
+  // ValidationException
+  public FormattedError(ValidationException ve) {
+    this.type = "ENDPOINT_VALIDATION_EXCEPTION";
+    this.message = ve.getMessage() != null ? ve.getMessage() : "Invalid request";
+    trace = Optional.of(generateTrace(ve));
+  }
+  //endregion
+
+  /**
+   * Generate a stack trace string from an Exception.
+   */
+  private String generateTrace(Exception ex) {
+    final var sw = new StringWriter();
+    try(final var pw = new PrintWriter(sw)) {
+      ex.printStackTrace(pw);
+    }
+    return sw.toString();
+  }
+
+  /**
+   * Export this object to a JsonObject.
+   */
+  public JsonObject toJson() {
+    // Include all mandatory fields
+    final var builder = Json.createObjectBuilder()
+                            .add("type", type)
+                            .add("message", message)
+                            .add("timestamp", timestamp)
+                            .add("service", service); // Not mandatory on spec, but always known
+
+    // Include optional fields, if present
+    cause.ifPresent((c) -> builder.add("cause", c));
+    trace.ifPresent((t) -> builder.add("trace", t));
+    data.ifPresent((d) -> builder.add("data", d));
+
+    return builder.build();
+  }
+
+  /**
+   * Internal class so that Javalin serializes the FormattedError class using its `toJson` method.
+   * This avoids needing to call `toJson` every time the FormattedError class is used as an endpoint return.
+   * The class implements Jackson's JsonSerializer in specific because Javalin uses Jackson as its default JSON Mapper.
+   */
+  static final class FormattedErrorSerializer extends JsonSerializer<FormattedError> {
+    @Override
+    public void serialize(
+        final FormattedError formattedError,
+        final JsonGenerator jsonGenerator,
+        final SerializerProvider serializerProvider) throws IOException
+    {
+      jsonGenerator.writeObject(formattedError.toJson());
+    }
+  }
+}

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/FormattedError.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/FormattedError.java
@@ -194,7 +194,7 @@ final class FormattedError {
         final JsonGenerator jsonGenerator,
         final SerializerProvider serializerProvider) throws IOException
     {
-      jsonGenerator.writeObject(formattedError.toJson());
+      jsonGenerator.writeRaw(formattedError.toJson().toString());
     }
   }
 }

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/FormattedError.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/FormattedError.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 final class FormattedError {
   private final String type;
   private final String message;
-  private final String timestamp = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.BASIC_ISO_DATE);
+  private final String timestamp = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
   private final static String service = "aerie_workspace";
   private Optional<String> cause = Optional.empty();
   private Optional<String> trace = Optional.empty();

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceAppDriver.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceAppDriver.java
@@ -2,6 +2,8 @@ package gov.nasa.jpl.aerie.workspace.server;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import gov.nasa.jpl.aerie.permissions.PermissionsService;
+import gov.nasa.jpl.aerie.permissions.gql.GraphQLPermissionsService;
 import gov.nasa.jpl.aerie.workspace.server.config.AppConfiguration;
 import gov.nasa.jpl.aerie.workspace.server.config.PostgresStore;
 import gov.nasa.jpl.aerie.workspace.server.config.Store;
@@ -23,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import javax.json.Json;
 import javax.json.JsonObject;
 import java.io.StringReader;
+import java.net.URI;
 import java.nio.file.Path;
 
 public final class WorkspaceAppDriver {
@@ -35,7 +38,13 @@ public final class WorkspaceAppDriver {
     final var stores = loadStores(configuration);
 
     // Assemble the core non-web object graph.
-    final var workspaceBindings = new WorkspaceBindings(stores.jwt, stores.workspace, configuration.hasuraAdminSecret());
+    final var permissionsService = new PermissionsService(
+        new GraphQLPermissionsService(configuration.hasuraGraphqlURI(), configuration.hasuraAdminSecret()));
+    final var workspaceBindings = new WorkspaceBindings(
+        stores.jwt,
+        stores.workspace,
+        permissionsService,
+        configuration.hasuraAdminSecret());
     // Configure an HTTP server.
     //default javalin jetty server has a QueuedThreadPool with maxThreads to 250
     final var server = new Server(new QueuedThreadPool(250));
@@ -125,6 +134,7 @@ public final class WorkspaceAppDriver {
         logger.isDebugEnabled(),
         Path.of(getEnv("WORKSPACE_STORE", "/usr/src/ws")),
         jwtSecret,
+        URI.create(getEnv("HASURA_GRAPHQL_URL", "http://hasura:8080/v1/graphql")),
         getEnv("HASURA_GRAPHQL_ADMIN_SECRET", ""),
         new PostgresStore(getEnv("AERIE_DB_HOST", "postgres"),
                           getEnv("SEQUENCING_DB_USER", ""),

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceAppDriver.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceAppDriver.java
@@ -70,12 +70,6 @@ public final class WorkspaceAppDriver {
       config.jetty.server(() -> server);
     });
 
-    javalin.exception(UnauthorizedResponse.class, (e, ctx) -> {
-      var message = e.getMessage() != null ? e.getMessage() : "Unauthorized";
-      logger.warn("401 Unauthorized: {}", message);
-      ctx.status(401).result(message);
-    });
-
     // Start the HTTP server.
     javalin.start(configuration.httpPort());
 

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
@@ -148,7 +148,7 @@ public class WorkspaceBindings implements Plugin {
     // Permissions check
     try {
       final var user = authorize(context);
-      permissionsService.checkCoarseGrained(WorkspaceAction.createWorkspace, user.activeRole());
+      permissionsService.checkCoarseGrained(WorkspaceAction.create_workspace, user.activeRole());
     } catch (Forbidden ue) {
       context.status(403).json(new FormattedError(ue));
       return;
@@ -232,7 +232,7 @@ public class WorkspaceBindings implements Plugin {
   private void deleteWorkspace(Context context) {
     // Permissions Check
     final int workspaceId  = Integer.parseInt(context.pathParam("workspaceId"));
-    if(!checkPermissions(context, workspaceId, WorkspaceAction.deleteWorkspace)) {
+    if(!checkPermissions(context, workspaceId, WorkspaceAction.delete_workspace)) {
       return;
     }
 
@@ -253,7 +253,7 @@ public class WorkspaceBindings implements Plugin {
   private void listWorkspaceContents(Context context) {
     // Permissions Check
     final var workspaceId = Integer.parseInt(context.pathParam("workspaceId"));
-    if(!checkPermissions(context, workspaceId, WorkspaceAction.listWorkspaceContents)) {
+    if(!checkPermissions(context, workspaceId, WorkspaceAction.list_workspace_contents)) {
       return;
     }
 
@@ -293,7 +293,7 @@ public class WorkspaceBindings implements Plugin {
   private void get(Context context) throws NoSuchWorkspaceException {
     // Permissions Check
     final var pathInfo = PathInformation.of(context);
-    if(!checkPermissions(context, pathInfo.workspaceId, WorkspaceAction.readFileDirectory)) {
+    if(!checkPermissions(context, pathInfo.workspaceId, WorkspaceAction.read_file_directory)) {
       return;
     }
 
@@ -323,7 +323,7 @@ public class WorkspaceBindings implements Plugin {
   private void put(Context context) throws NoSuchWorkspaceException, IOException {
     // Permissions Check
     final var pathInfo = PathInformation.of(context);
-    if(!checkPermissions(context, pathInfo.workspaceId, WorkspaceAction.writeFileDirectory)) {
+    if(!checkPermissions(context, pathInfo.workspaceId, WorkspaceAction.write_file_directory)) {
       return;
     }
 
@@ -489,9 +489,9 @@ public class WorkspaceBindings implements Plugin {
     // Permissions Check
     // Moving between workspaces requires "readFile", "deleteFile" on Workspace 1 and "writeFile" on Workspace 2
     // (Permission derived from mv -v, which shows that moving a file is "copy, then delete")
-    if (!(checkPermissions(context, sourceWorkspace, WorkspaceAction.readFileDirectory)
-          && checkPermissions(context, sourceWorkspace, WorkspaceAction.deleteFileDirectory)
-          && checkPermissions(context, targetWorkspace, WorkspaceAction.writeFileDirectory))) {
+    if (!(checkPermissions(context, sourceWorkspace, WorkspaceAction.read_file_directory)
+          && checkPermissions(context, sourceWorkspace, WorkspaceAction.delete_file_directory)
+          && checkPermissions(context, targetWorkspace, WorkspaceAction.write_file_directory))) {
       return false;
     }
 
@@ -545,8 +545,8 @@ public class WorkspaceBindings implements Plugin {
 
     // Permissions Check
     // Copying between workspaces requires "readFile" on Workspace 1 and "writeFile" on Workspace 2
-    if (!(checkPermissions(context, sourceWorkspace, WorkspaceAction.readFileDirectory)
-          && checkPermissions(context, targetWorkspace, WorkspaceAction.writeFileDirectory))) {
+    if (!(checkPermissions(context, sourceWorkspace, WorkspaceAction.read_file_directory)
+          && checkPermissions(context, targetWorkspace, WorkspaceAction.write_file_directory))) {
       return false;
     }
 
@@ -592,7 +592,7 @@ public class WorkspaceBindings implements Plugin {
     final var errorMsg = "Could not delete %s.".formatted(pathInfo.filePath);
 
     // Permissions Check
-    if(!checkPermissions(context, pathInfo.workspaceId, WorkspaceAction.deleteFileDirectory)) {
+    if(!checkPermissions(context, pathInfo.workspaceId, WorkspaceAction.delete_file_directory)) {
       return;
     }
 

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.workspace.server;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import gov.nasa.jpl.aerie.permissions.PermissionsService;
 import gov.nasa.jpl.aerie.workspace.server.postgres.NoSuchWorkspaceException;
 import io.javalin.Javalin;
 import io.javalin.apibuilder.ApiBuilder;
@@ -16,7 +17,6 @@ import javax.json.Json;
 import javax.json.JsonException;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Path;
@@ -33,11 +33,17 @@ public class WorkspaceBindings implements Plugin {
   private static final Logger logger = LoggerFactory.getLogger(WorkspaceBindings.class);
   private final JWTService jwtService;
   private final WorkspaceService workspaceService;
+  private final PermissionsService permissionsService;
   private final String hasuraAdminSecret;
 
-  public WorkspaceBindings(final JWTService jwtService, final WorkspaceService workspaceService, final String hasuraAdminSecret) {
+  public WorkspaceBindings(
+      final JWTService jwtService,
+      final WorkspaceService workspaceService,
+      final PermissionsService permissionsService,
+      final String hasuraAdminSecret) {
     this.jwtService = jwtService;
     this.workspaceService = workspaceService;
+    this.permissionsService = permissionsService;
     this.hasuraAdminSecret = hasuraAdminSecret;
   }
 

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
@@ -2,6 +2,10 @@ package gov.nasa.jpl.aerie.workspace.server;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import gov.nasa.jpl.aerie.permissions.PermissionsService;
+import gov.nasa.jpl.aerie.permissions.WorkspaceAction;
+import gov.nasa.jpl.aerie.permissions.exceptions.PermissionsServiceException;
+import gov.nasa.jpl.aerie.permissions.exceptions.Unauthorized;
+import gov.nasa.jpl.aerie.permissions.gql.WorkspaceId;
 import gov.nasa.jpl.aerie.workspace.server.postgres.NoSuchWorkspaceException;
 import io.javalin.Javalin;
 import io.javalin.apibuilder.ApiBuilder;
@@ -84,7 +88,7 @@ public class WorkspaceBindings implements Plugin {
 
       // CRD operations for Workspaces
       path("/ws/{workspaceId}", () -> {
-        ApiBuilder.get(this::listContents);
+        ApiBuilder.get(this::listWorkspaceContents);
         ApiBuilder.delete(this::deleteWorkspace);
       });
       path("/ws/create", () -> ApiBuilder.post(this::createWorkspace));
@@ -129,6 +133,18 @@ public class WorkspaceBindings implements Plugin {
   }
 
   private void createWorkspace(Context context) {
+    // Permissions check
+    try {
+      final var user = authorize(context);
+      permissionsService.checkCoarseGrained(WorkspaceAction.createWorkspace, user.activeRole());
+    } catch (Unauthorized ioe) {
+      throw new UnauthorizedResponse(ioe.getMessage());
+    } catch (IOException | PermissionsServiceException ioe) {
+      context.status(500).result("Could not create workspace.");
+      return;
+    }
+
+    // Message format check
     final String helpText = """
         {
             "workspaceLocation": text     // Name of the folder the workspace will live in
@@ -183,7 +199,25 @@ public class WorkspaceBindings implements Plugin {
   }
 
   private void deleteWorkspace(Context context) {
+    // Permissions Check
     final int workspaceId  = Integer.parseInt(context.pathParam("workspaceId"));
+
+    try {
+      final var user = authorize(context);
+      permissionsService.check(
+          WorkspaceAction.deleteWorkspace,
+          user.activeRole(),
+          user.userId(),
+          new WorkspaceId(workspaceId));
+    } catch (Unauthorized ioe) {
+      throw new UnauthorizedResponse(ioe.getMessage());
+    } catch (IOException | PermissionsServiceException ioe) {
+      context.status(500).result("Could not delete workspace.");
+      return;
+    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
+      context.status(404).result(nsw.getMessage());
+      return;
+    }
 
     try {
       if (workspaceService.deleteWorkspace(workspaceId)) {
@@ -196,6 +230,30 @@ public class WorkspaceBindings implements Plugin {
     } catch (SQLException e) {
       context.status(500).result("Unable to delete workspace. " +e.getMessage());
     }
+  }
+
+  private void listWorkspaceContents(Context context) {
+    // Permissions Check
+    final var workspaceId = Integer.parseInt(context.pathParam("workspaceId"));
+
+    try {
+      final var user = authorize(context);
+      permissionsService.check(
+          WorkspaceAction.listWorkspaceContents,
+          user.activeRole(),
+          user.userId(),
+          new WorkspaceId(workspaceId));
+    } catch (Unauthorized ioe) {
+      throw new UnauthorizedResponse(ioe.getMessage());
+    } catch (IOException | PermissionsServiceException ioe) {
+      context.status(500).result("Could not list workspace contents.");
+      return;
+    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
+      context.status(404).result(nsw.getMessage());
+      return;
+    }
+
+    listContents(context);
   }
 
   private void listContents(Context context) {
@@ -231,6 +289,23 @@ public class WorkspaceBindings implements Plugin {
   private void get(Context context) throws NoSuchWorkspaceException {
     final var pathInfo = PathInformation.of(context);
 
+    // Permissions Check
+    try {
+      final var user = authorize(context);
+      permissionsService.check(
+          WorkspaceAction.readFileDirectory,
+          user.activeRole(),
+          user.userId(),
+          new WorkspaceId(pathInfo.workspaceId));
+    } catch (Unauthorized ioe) {
+      throw new UnauthorizedResponse(ioe.getMessage());
+    } catch (IOException | PermissionsServiceException ioe) {
+      context.status(500).result("Could not read object at path " +pathInfo.fileName());
+      return;
+    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
+      throw new NoSuchWorkspaceException(pathInfo.workspaceId);
+    }
+
     if (workspaceService.isDirectory(pathInfo.workspaceId, pathInfo.filePath)) {
       listContents(context);
     } else {
@@ -254,6 +329,24 @@ public class WorkspaceBindings implements Plugin {
 
   private void put(Context context) throws NoSuchWorkspaceException, IOException {
     final var pathInfo = PathInformation.of(context);
+
+    // Permissions Check
+    try {
+      final var user = authorize(context);
+      permissionsService.check(
+          WorkspaceAction.writeFileDirectory,
+          user.activeRole(),
+          user.userId(),
+          new WorkspaceId(pathInfo.workspaceId));
+    } catch (Unauthorized ioe) {
+      throw new UnauthorizedResponse(ioe.getMessage());
+    } catch (IOException | PermissionsServiceException ioe) {
+      context.status(500).result("Could not create object at path " +pathInfo.fileName());
+      return;
+    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
+      throw new NoSuchWorkspaceException(pathInfo.workspaceId);
+    }
+
     final String type;
     final Optional<Boolean> overwrite;
 
@@ -408,6 +501,43 @@ public class WorkspaceBindings implements Plugin {
       targetWorkspace = bodyJson.getInt("toWorkspace");
     }
 
+    // Permissions Check
+    try {
+      final var user = authorize(context);
+      final var sourceWSId = new WorkspaceId(sourceWorkspace);
+      final var targetWSId = new WorkspaceId(targetWorkspace);
+
+      // Moving between workspaces requires "readFile", "deleteFile" on Workspace 1 and "writeFile" on Workspace 2
+      // (Permission derived from mv -v, which shows that moving a file is "copy, then delete")
+      permissionsService.check(
+          WorkspaceAction.readFileDirectory,
+          user.activeRole(),
+          user.userId(),
+          sourceWSId
+      );
+      permissionsService.check(
+          WorkspaceAction.deleteFileDirectory,
+          user.activeRole(),
+          user.userId(),
+          sourceWSId
+      );
+      permissionsService.check(
+          WorkspaceAction.writeFileDirectory,
+          user.activeRole(),
+          user.userId(),
+          targetWSId // defaults to "sourceWSId" when moving within the same workspace
+      );
+    } catch (Unauthorized ioe) {
+      throw new UnauthorizedResponse(ioe.getMessage());
+    } catch (IOException | PermissionsServiceException ioe) {
+      context.status(500).result("Could not move object.");
+      return false;
+    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
+      context.status(404).result(nsw.getMessage());
+      return false;
+    }
+
+
     CopyMoveValid validMove = isCopyOrMoveValid(sourceWorkspace, pathInfo.filePath, targetWorkspace, destination);
     if (validMove.status != 200) {
       context.status(validMove.status).result(validMove.message);
@@ -458,6 +588,35 @@ public class WorkspaceBindings implements Plugin {
       targetWorkspace = bodyJson.getInt("toWorkspace");
     }
 
+    // Permissions Check
+    try {
+      final var user = authorize(context);
+      final var sourceWSId = new WorkspaceId(sourceWorkspace);
+      final var targetWSId = new WorkspaceId(targetWorkspace);
+
+      // Copying between workspaces requires "readFile" on Workspace 1 and "writeFile" on Workspace 2
+      permissionsService.check(
+          WorkspaceAction.readFileDirectory,
+          user.activeRole(),
+          user.userId(),
+          sourceWSId
+      );
+      permissionsService.check(
+          WorkspaceAction.writeFileDirectory,
+          user.activeRole(),
+          user.userId(),
+          targetWSId // defaults to "sourceWSId" when copying within the same workspace
+      );
+    } catch (Unauthorized ioe) {
+      throw new UnauthorizedResponse(ioe.getMessage());
+    } catch (IOException | PermissionsServiceException ioe) {
+      context.status(500).result("Could not copy object.");
+      return false;
+    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
+      context.status(404).result(nsw.getMessage());
+      return false;
+    }
+
     CopyMoveValid validCopy = isCopyOrMoveValid(sourceWorkspace, pathInfo.filePath, targetWorkspace, destination);
     if (validCopy.status != 200) {
         context.status(validCopy.status).result(validCopy.message);
@@ -500,6 +659,23 @@ public class WorkspaceBindings implements Plugin {
 
   private void delete(Context context) throws NoSuchWorkspaceException, IOException {
     final var pathInfo = PathInformation.of(context);
+
+    // Permissions Check
+    try {
+      final var user = authorize(context);
+      permissionsService.check(
+          WorkspaceAction.deleteFileDirectory,
+          user.activeRole(),
+          user.userId(),
+          new WorkspaceId(pathInfo.workspaceId));
+    } catch (Unauthorized ioe) {
+      throw new UnauthorizedResponse(ioe.getMessage());
+    } catch (IOException | PermissionsServiceException ioe) {
+      context.status(500).result("Could not delete " +pathInfo.fileName());
+      return;
+    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
+      throw new NoSuchWorkspaceException(pathInfo.workspaceId);
+    }
 
     if (!workspaceService.checkFileExists(pathInfo.workspaceId, pathInfo.filePath)) {
       context.status(404).result(pathInfo.fileName() + " does not exist.");

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
@@ -95,8 +95,19 @@ public class WorkspaceBindings implements Plugin {
     });
 
     // Default exception handlers for common endpoint exceptions
-    javalin.exception(NoSuchWorkspaceException.class, (ex, ctx) -> ctx.status(404).result(ex.getMessage()));
-    javalin.exception(IOException.class, (ex, ctx) -> ctx.status(500).result(ex.getMessage()));
+    javalin.exception(NoSuchWorkspaceException.class,
+                      (ex, ctx) -> ctx.status(404).json(new FormattedError(ex)));
+    javalin.exception(IOException.class,
+                      (ex, ctx) -> ctx.status(500).json(new FormattedError(ex)));
+    javalin.exception(SQLException.class,
+                      (ex, ctx) -> ctx.status(500).json(new FormattedError(ex)));
+    javalin.exception(UnauthorizedResponse.class, (ex, ctx) -> {
+      final var message = ex.getMessage() != null ? ex.getMessage() : "Unauthorized";
+      logger.warn("401 Unauthorized: {}", message);
+      ctx.status(401).json(new FormattedError(ex));
+    });
+    javalin.exception(NumberFormatException.class,
+                      (ex, ctx) -> ctx.status(400).json(new FormattedError(ex)));
   }
 
   /**
@@ -122,7 +133,8 @@ public class WorkspaceBindings implements Plugin {
         throw new UnauthorizedResponse("Invalid Hasura admin secret");
       }
 
-      return new JWTService.UserSession(userId, activeRole);
+      return activeRole == null ? new JWTService.UserSession(userId, "aerie_admin")
+                                : new JWTService.UserSession(userId, activeRole);
     } else {
       try {
         return jwtService.validateAuthorization(authHeader, activeRole);
@@ -137,10 +149,14 @@ public class WorkspaceBindings implements Plugin {
     try {
       final var user = authorize(context);
       permissionsService.checkCoarseGrained(WorkspaceAction.createWorkspace, user.activeRole());
-    } catch (Unauthorized ioe) {
-      throw new UnauthorizedResponse(ioe.getMessage());
-    } catch (IOException | PermissionsServiceException ioe) {
-      context.status(500).result("Could not create workspace.");
+    } catch (Unauthorized ue) {
+      context.status(403).json(new FormattedError(ue));
+      return;
+    } catch (IOException ioe) {
+      context.status(500).json(new FormattedError(ioe, "Could not create workspace."));
+      return;
+    } catch (PermissionsServiceException pse) {
+      context.status(500).json(new FormattedError(pse, "Could not create workspace."));
       return;
     }
 
@@ -159,30 +175,45 @@ public class WorkspaceBindings implements Plugin {
 
     try(final var reader = Json.createReader(new StringReader(context.body()))) {
       final var bodyJson = reader.readObject();
+      final String errorMsg = "Mandatory body parameter '%s' is missing or null. Request body format is:\n" + helpText;
 
       // Parcel Id
-      if (!bodyJson.containsKey("parcelId")) {
-        context.status(400).result("Mandatory body parameter 'parcelId' is missing or null. Request body format is:\n" + helpText);
+      if (!bodyJson.containsKey("parcelId") || bodyJson.isNull("parcelId")) {
+        context.status(400).json(new FormattedError(errorMsg.formatted("parcelId")));
         return;
       }
       parcelId = bodyJson.getInt("parcelId");
 
       // Workspace Location
-      if (!bodyJson.containsKey("workspaceLocation")) {
-        context.status(400).result("Mandatory body parameter 'workspaceLocation' is missing or null. Request body format is:\n" + helpText);
+      if (!bodyJson.containsKey("workspaceLocation") || bodyJson.isNull("workspaceLocation")) {
+        context.status(400).json(new FormattedError(errorMsg.formatted("workspaceLocation")));
         return;
       }
       final var workspaceString = bodyJson.getString("workspaceLocation");
       if(workspaceString.contains("/") || workspaceString.contains(".") || workspaceString.contains("~")){
-        context.status(400).result("Workspace location may not contain '/' or '.' or '~'");
+        context.status(400).json(new FormattedError("Workspace location may not contain '/' or '.' or '~'"));
+        return;
+      }
+      if(workspaceString.isBlank()) {
+        context.status(400).json(new FormattedError("Workspace location may not be blank."));
         return;
       }
       workspaceLocation = Path.of(workspaceString);
 
       // Workspace Name
-      workspaceName = bodyJson.containsKey("workspaceName") ? bodyJson.getString("workspaceName") : workspaceString;
+      if(bodyJson.containsKey("workspaceName")) {
+        if(bodyJson.isNull("workspaceName")) {
+          context.status(400).json(new FormattedError("Workspace name may not be null."));
+        }
+        workspaceName = bodyJson.getString("workspaceName");
+        if(workspaceName.isBlank()) {
+          context.status(400).json(new FormattedError("Workspace name may not be blank"));
+        }
+      } else {
+        workspaceName = workspaceString;
+      }
     } catch (JsonException je) {
-      context.status(400).result("Request body is malformed. Request body format is:\n" + helpText);
+      context.status(400).json(new FormattedError(je, "Request body is malformed. Request body format is:\n" + helpText));
       return;
     }
 
@@ -194,62 +225,35 @@ public class WorkspaceBindings implements Plugin {
     if(workspaceId.isPresent()) {
       context.status(200).result(workspaceId.get().toString());
     } else {
-      context.status(500).result("Unable to create workspace.");
+      context.status(500).json(new FormattedError("Unable to create workspace."));
     }
   }
 
   private void deleteWorkspace(Context context) {
     // Permissions Check
     final int workspaceId  = Integer.parseInt(context.pathParam("workspaceId"));
-
-    try {
-      final var user = authorize(context);
-      permissionsService.check(
-          WorkspaceAction.deleteWorkspace,
-          user.activeRole(),
-          user.userId(),
-          new WorkspaceId(workspaceId));
-    } catch (Unauthorized ioe) {
-      throw new UnauthorizedResponse(ioe.getMessage());
-    } catch (IOException | PermissionsServiceException ioe) {
-      context.status(500).result("Could not delete workspace.");
-      return;
-    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
-      context.status(404).result(nsw.getMessage());
+    if(!checkPermissions(context, workspaceId, WorkspaceAction.deleteWorkspace)) {
       return;
     }
 
+    final var errorMsg = "Unable to delete Workspace %d.".formatted(workspaceId);
     try {
       if (workspaceService.deleteWorkspace(workspaceId)) {
         context.status(200).result("Workspace deleted.");
       } else {
-        context.status(500).result("Unable to delete workspace.");
+        context.status(500).json(new FormattedError(errorMsg));
       }
     } catch (NoSuchWorkspaceException ex) {
-      context.status(404).result(ex.getMessage());
+      context.status(404).json(new FormattedError(ex, errorMsg));
     } catch (SQLException e) {
-      context.status(500).result("Unable to delete workspace. " +e.getMessage());
+      context.status(500).json(new FormattedError(e, errorMsg));
     }
   }
 
   private void listWorkspaceContents(Context context) {
     // Permissions Check
     final var workspaceId = Integer.parseInt(context.pathParam("workspaceId"));
-
-    try {
-      final var user = authorize(context);
-      permissionsService.check(
-          WorkspaceAction.listWorkspaceContents,
-          user.activeRole(),
-          user.userId(),
-          new WorkspaceId(workspaceId));
-    } catch (Unauthorized ioe) {
-      throw new UnauthorizedResponse(ioe.getMessage());
-    } catch (IOException | PermissionsServiceException ioe) {
-      context.status(500).result("Could not list workspace contents.");
-      return;
-    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
-      context.status(404).result(nsw.getMessage());
+    if(!checkPermissions(context, workspaceId, WorkspaceAction.listWorkspaceContents)) {
       return;
     }
 
@@ -272,45 +276,32 @@ public class WorkspaceBindings implements Plugin {
 
     try {
       final var fileTree = workspaceService.listFiles(workspaceId, directoryPath, depth);
-
       if (fileTree == null) {
-        context.status(404).result("No such directory.");
+        context.status(404).json(new FormattedError("No such directory."));
         return;
       }
-
       context.status(200).json(fileTree.toJson().toString());
-    } catch (IOException | SQLException e) {
-      context.status(500).result(e.getMessage());
+    } catch (IOException ioe) {
+      context.status(500).json(new FormattedError(ioe));
+    } catch (SQLException se) {
+      context.status(500).json(new FormattedError(se));
     } catch (NoSuchWorkspaceException ex) {
-      context.status(404).result(ex.getMessage());
+      context.status(404).json(new FormattedError(ex));
     }
   }
 
   private void get(Context context) throws NoSuchWorkspaceException {
-    final var pathInfo = PathInformation.of(context);
-
     // Permissions Check
-    try {
-      final var user = authorize(context);
-      permissionsService.check(
-          WorkspaceAction.readFileDirectory,
-          user.activeRole(),
-          user.userId(),
-          new WorkspaceId(pathInfo.workspaceId));
-    } catch (Unauthorized ioe) {
-      throw new UnauthorizedResponse(ioe.getMessage());
-    } catch (IOException | PermissionsServiceException ioe) {
-      context.status(500).result("Could not read object at path " +pathInfo.fileName());
+    final var pathInfo = PathInformation.of(context);
+    if(!checkPermissions(context, pathInfo.workspaceId, WorkspaceAction.readFileDirectory)) {
       return;
-    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
-      throw new NoSuchWorkspaceException(pathInfo.workspaceId);
     }
 
     if (workspaceService.isDirectory(pathInfo.workspaceId, pathInfo.filePath)) {
       listContents(context);
     } else {
       if (!workspaceService.checkFileExists(pathInfo.workspaceId, pathInfo.filePath)) {
-        context.status(404).result("No such file exists in the workspace: " + pathInfo.filePath);
+        context.status(404).json(new FormattedError("No such file exists in the workspace: " + pathInfo.filePath));
         return;
       }
 
@@ -321,30 +312,19 @@ public class WorkspaceBindings implements Plugin {
         context.contentType(ContentType.OCTET_STREAM);
         context.header("Content-Disposition", "attachment; filename=\"" + pathInfo.fileName() + "\"");
         context.status(200).result(inputStream);
-      } catch (IOException | SQLException e) {
-        context.status(500).result("Could not load file " + pathInfo.fileName());
+      } catch (IOException ioe) {
+        context.status(500).json(new FormattedError(ioe, "Could not load file " + pathInfo.fileName()));
+      } catch (SQLException se) {
+        context.status(500).json(new FormattedError(se, "Could not load file " + pathInfo.fileName()));
       }
     }
   }
 
   private void put(Context context) throws NoSuchWorkspaceException, IOException {
-    final var pathInfo = PathInformation.of(context);
-
     // Permissions Check
-    try {
-      final var user = authorize(context);
-      permissionsService.check(
-          WorkspaceAction.writeFileDirectory,
-          user.activeRole(),
-          user.userId(),
-          new WorkspaceId(pathInfo.workspaceId));
-    } catch (Unauthorized ioe) {
-      throw new UnauthorizedResponse(ioe.getMessage());
-    } catch (IOException | PermissionsServiceException ioe) {
-      context.status(500).result("Could not create object at path " +pathInfo.fileName());
+    final var pathInfo = PathInformation.of(context);
+    if(!checkPermissions(context, pathInfo.workspaceId, WorkspaceAction.writeFileDirectory)) {
       return;
-    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
-      throw new NoSuchWorkspaceException(pathInfo.workspaceId);
     }
 
     final String type;
@@ -361,7 +341,7 @@ public class WorkspaceBindings implements Plugin {
       final var overwriteValidator =  context.queryParamAsClass("overwrite", Boolean.class);
       overwrite = overwriteValidator.hasValue() ? Optional.of(overwriteValidator.get()) : Optional.empty();
     } catch (ValidationException ve) {
-      context.status(400).result(ve.getMessage() != null ? ve.getMessage() : "Invalid request");
+      context.status(400).json(new FormattedError(ve));
       return;
     }
 
@@ -370,36 +350,36 @@ public class WorkspaceBindings implements Plugin {
       // "overwrite" defaults to "false" if unspecified
       if(workspaceService.checkFileExists(pathInfo.workspaceId, pathInfo.filePath)
          && !overwrite.orElse(false)) {
-        context.status(409).result(pathInfo.fileName() + " already exists.");
+        context.status(409).json(new FormattedError(pathInfo.fileName() + " already exists."));
         return;
       }
 
       // Reject the request if the file isn't provided.
       final var file = context.uploadedFile("file");
       if (file == null || !pathInfo.fileName().equals(file.filename())) {
-        context.status(400).result("No file provided with the name " + pathInfo.fileName());
+        context.status(400).json(new FormattedError("No file provided with the name " + pathInfo.fileName()));
         return;
       }
 
       if (workspaceService.saveFile(pathInfo.workspaceId, pathInfo.filePath, file)) {
         context.status(200).result("File " + pathInfo.fileName() + " uploaded to " + pathInfo.filePath);
       } else {
-        context.status(500).result("Could not save file.");
+        context.status(500).json(new FormattedError("Could not save file."));
       }
     } else if ("directory".equalsIgnoreCase(type)) {
       // Reject the request if the "overwrite" flag is supplied
       if(overwrite.isPresent()) {
-        context.status(400).result("Query parameter 'overwrite' is not permitted when creating a directory.");
+        context.status(400).json(new FormattedError("Query parameter 'overwrite' is not permitted when creating a directory."));
         return;
       }
 
       if (workspaceService.createDirectory(pathInfo.workspaceId, pathInfo.filePath)) {
         context.status(200).result("Directory created.");
       } else {
-        context.status(500).result("Could not create directory.");
+        context.status(500).json(new FormattedError("Could not create directory."));
       }
     } else {
-      context.status(400).result("Query param 'type' has invalid value "+type);
+      context.status(400).json(new FormattedError("Query param 'type' has invalid value "+type));
     }
   }
 
@@ -429,7 +409,7 @@ public class WorkspaceBindings implements Plugin {
       } else if (bodyJson.containsKey("copyTo")) {
         success = handleCopy(context, bodyJson);
       } else {
-        context.status(400).result("Invalid request. Must include either 'moveTo' or 'copyTo' key.\n\n" + helpText);
+        context.status(400).json(new FormattedError("Invalid request. Must include either 'moveTo' or 'copyTo' key.\n\n" + helpText));
         return;
       }
 
@@ -439,27 +419,31 @@ public class WorkspaceBindings implements Plugin {
       // If the copy or move did not return successfully, but did not set a status code, set the status code to 500
       // Works because `context.status` initializes to HttpStatus.OK
       else if (context.status().equals(HttpStatus.OK)) {
-        context.status(500).result("Internal Error");
+        context.status(500).json(new FormattedError("Internal Error"));
       }
 
 
-    } catch (JsonException e) {
+    } catch (JsonException je) {
       // Malformed JSON in request body
-      context.status(400).result("Malformed JSON: " + e.getMessage() + "\n\n" + helpText);
-    } catch (IllegalArgumentException e) {
+      context.status(400).json(new FormattedError(je, "Malformed JSON.\n\n" + helpText));
+    } catch (IllegalArgumentException iae) {
       // Logical errors or unsupported operations
-      context.status(400).result("Invalid request: " + e.getMessage() + "\n\n" + helpText);
-    } catch (NoSuchWorkspaceException e) {
+      context.status(400).json(new FormattedError(iae, "Invalid request.\n\n" + helpText));
+    } catch (NoSuchWorkspaceException nsw) {
       // Workspace not found
-      context.status(404).result("Workspace not found: " + e.getMessage());
-    } catch (IOException | SQLException e) {
+      context.status(404).json(new FormattedError(nsw));
+    } catch (IOException ioe) {
+      logger.error("Error processing workspace request", ioe);
+      context.status(500).json(new FormattedError(ioe));
+    } catch (SQLException se) {
       // Internal server error
-      logger.error("Error processing workspace request", e);
-      context.status(500).result("Internal server error while processing the request: " + e.getMessage());
+      logger.error("Error processing workspace request", se);
+      context.status(500).json(new FormattedError(se));
     } catch (Exception e) {
       // Catch-all for unexpected issues
       logger.error("Unexpected error processing workspace request", e);
-      context.status(500).result("Unexpected error: " + (e.getMessage() != null ? e.getMessage() : "Unknown error\n\n" + helpText));
+      final var message = e.getMessage() != null ? e.getMessage() : "Unknown error.\n\n" + helpText;
+      context.status(500).json(new FormattedError("UNKNOWN_ERROR", message, e));
     }
   }
 
@@ -491,7 +475,8 @@ public class WorkspaceBindings implements Plugin {
   }
 
   private boolean handleMove(Context context, JsonObject bodyJson)
-  throws IOException, NoSuchWorkspaceException, SQLException {
+  throws IOException, NoSuchWorkspaceException, SQLException
+  {
     final var pathInfo = PathInformation.of(context);
 
     final var destination = Path.of(bodyJson.getString("moveTo"));
@@ -502,83 +487,53 @@ public class WorkspaceBindings implements Plugin {
     }
 
     // Permissions Check
-    try {
-      final var user = authorize(context);
-      final var sourceWSId = new WorkspaceId(sourceWorkspace);
-      final var targetWSId = new WorkspaceId(targetWorkspace);
-
-      // Moving between workspaces requires "readFile", "deleteFile" on Workspace 1 and "writeFile" on Workspace 2
-      // (Permission derived from mv -v, which shows that moving a file is "copy, then delete")
-      permissionsService.check(
-          WorkspaceAction.readFileDirectory,
-          user.activeRole(),
-          user.userId(),
-          sourceWSId
-      );
-      permissionsService.check(
-          WorkspaceAction.deleteFileDirectory,
-          user.activeRole(),
-          user.userId(),
-          sourceWSId
-      );
-      permissionsService.check(
-          WorkspaceAction.writeFileDirectory,
-          user.activeRole(),
-          user.userId(),
-          targetWSId // defaults to "sourceWSId" when moving within the same workspace
-      );
-    } catch (Unauthorized ioe) {
-      throw new UnauthorizedResponse(ioe.getMessage());
-    } catch (IOException | PermissionsServiceException ioe) {
-      context.status(500).result("Could not move object.");
-      return false;
-    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
-      context.status(404).result(nsw.getMessage());
+    // Moving between workspaces requires "readFile", "deleteFile" on Workspace 1 and "writeFile" on Workspace 2
+    // (Permission derived from mv -v, which shows that moving a file is "copy, then delete")
+    if (!(checkPermissions(context, sourceWorkspace, WorkspaceAction.readFileDirectory)
+          && checkPermissions(context, sourceWorkspace, WorkspaceAction.deleteFileDirectory)
+          && checkPermissions(context, targetWorkspace, WorkspaceAction.writeFileDirectory))) {
       return false;
     }
-
 
     CopyMoveValid validMove = isCopyOrMoveValid(sourceWorkspace, pathInfo.filePath, targetWorkspace, destination);
     if (validMove.status != 200) {
-      context.status(validMove.status).result(validMove.message);
+      context.status(validMove.status).json(new FormattedError(validMove.message));
       return false;
     }
 
-    if (workspaceService.isDirectory(sourceWorkspace, pathInfo.filePath())) {
-      try {
+    final var errorMsg = "Unable to move '%s' in Workspace %d to '%s' in Workspace %d."
+        .formatted(pathInfo, sourceWorkspace, destination, targetWorkspace);
+    try {
+      if (workspaceService.isDirectory(sourceWorkspace, pathInfo.filePath())) {
         if (workspaceService.moveDirectory(sourceWorkspace, pathInfo.filePath, targetWorkspace, destination)) {
           return true;
         } else {
-          context.status(500).result("Unable to move directory.");
+          context.status(500).json(new FormattedError(errorMsg));
           return false;
         }
-      } catch (NoSuchWorkspaceException ex) {
-        context.status(404).result(ex.getMessage());
-        return false;
-      } catch (SQLException | WorkspaceFileOpException e) {
-        context.status(500).result("Unable to move directory: " + e.getMessage());
-        return false;
-      }
-    } else {
-      try {
+      } else {
         if (workspaceService.moveFile(sourceWorkspace, pathInfo.filePath, targetWorkspace, destination)) {
           return true;
         } else {
-          context.status(500).result("Unable to move file.");
+          context.status(500).json(new FormattedError(errorMsg));
           return false;
         }
-      } catch (NoSuchWorkspaceException ex) {
-        context.status(404).result(ex.getMessage());
-        return false;
-      } catch (SQLException | WorkspaceFileOpException e) {
-        context.status(500).result("Unable to move file. " + e.getMessage());
-        return false;
       }
+    } catch (NoSuchWorkspaceException ex) {
+      context.status(404).json(new FormattedError(ex, errorMsg));
+      return false;
+    } catch (SQLException se) {
+      context.status(500).json(new FormattedError(se, errorMsg));
+      return false;
+    } catch (WorkspaceFileOpException wfe) {
+      context.status(500).json(new FormattedError(wfe, errorMsg));
+      return false;
     }
   }
 
   private boolean handleCopy(Context context, JsonObject bodyJson)
-  throws NoSuchWorkspaceException, SQLException {
+  throws NoSuchWorkspaceException, SQLException
+  {
     final var pathInfo = PathInformation.of(context);
 
     final var destination = Path.of(bodyJson.getString("copyTo"));
@@ -589,96 +544,60 @@ public class WorkspaceBindings implements Plugin {
     }
 
     // Permissions Check
-    try {
-      final var user = authorize(context);
-      final var sourceWSId = new WorkspaceId(sourceWorkspace);
-      final var targetWSId = new WorkspaceId(targetWorkspace);
-
-      // Copying between workspaces requires "readFile" on Workspace 1 and "writeFile" on Workspace 2
-      permissionsService.check(
-          WorkspaceAction.readFileDirectory,
-          user.activeRole(),
-          user.userId(),
-          sourceWSId
-      );
-      permissionsService.check(
-          WorkspaceAction.writeFileDirectory,
-          user.activeRole(),
-          user.userId(),
-          targetWSId // defaults to "sourceWSId" when copying within the same workspace
-      );
-    } catch (Unauthorized ioe) {
-      throw new UnauthorizedResponse(ioe.getMessage());
-    } catch (IOException | PermissionsServiceException ioe) {
-      context.status(500).result("Could not copy object.");
-      return false;
-    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
-      context.status(404).result(nsw.getMessage());
+    // Copying between workspaces requires "readFile" on Workspace 1 and "writeFile" on Workspace 2
+    if (!(checkPermissions(context, sourceWorkspace, WorkspaceAction.readFileDirectory)
+          && checkPermissions(context, targetWorkspace, WorkspaceAction.writeFileDirectory))) {
       return false;
     }
 
     CopyMoveValid validCopy = isCopyOrMoveValid(sourceWorkspace, pathInfo.filePath, targetWorkspace, destination);
     if (validCopy.status != 200) {
-        context.status(validCopy.status).result(validCopy.message);
-        return false;
+      context.status(validCopy.status).json(new FormattedError(validCopy.message));
+      return false;
     }
 
-    if (workspaceService.isDirectory(sourceWorkspace, pathInfo.filePath())) {
-      try {
+    // Error message to use if the operation fails
+    final var errorMessage = "Unable to copy '%s' in Workspace %d to '%s' in Workspace %d"
+        .formatted(pathInfo.filePath, sourceWorkspace, destination, targetWorkspace);
+    try {
+      if (workspaceService.isDirectory(sourceWorkspace, pathInfo.filePath())) {
         if (workspaceService.copyDirectory(sourceWorkspace, pathInfo.filePath, targetWorkspace, destination)) {
           return true;
         } else {
-          context.status(500).result("Unable to copy directory.");
+          context.status(500).json(new FormattedError(errorMessage));
           return false;
         }
-      } catch (NoSuchWorkspaceException ex) {
-        context.status(404).result(ex.getMessage());
-        return false;
-      } catch (SQLException | WorkspaceFileOpException e) {
-        context.status(500).result("Unable to copy directory: " + e.getMessage());
-        return false;
-      }
-    } else {
-      try {
+      } else {
         if (workspaceService.copyFile(sourceWorkspace, pathInfo.filePath, targetWorkspace, destination)) {
           return true;
         } else {
-          context.status(500).result("Unable to copy file.");
+          context.status(500).json(new FormattedError(errorMessage));
           return false;
         }
-      } catch (NoSuchWorkspaceException ex) {
-        context.status(404).result(ex.getMessage());
-        return false;
-      } catch (SQLException | WorkspaceFileOpException e) {
-        context.status(500).result("Unable to copy file: " + e.getMessage());
-        return false;
       }
+    } catch (NoSuchWorkspaceException ex) {
+      context.status(404).json(new FormattedError(ex));
+      return false;
+    } catch (SQLException ex) {
+      context.status(500).json(new FormattedError(ex, errorMessage));
+      return false;
+    } catch (WorkspaceFileOpException ex) {
+      context.status(500).json(new FormattedError(ex, errorMessage));
+      return false;
     }
   }
 
-
   private void delete(Context context) throws NoSuchWorkspaceException, IOException {
     final var pathInfo = PathInformation.of(context);
+    final var errorMsg = "Could not delete %s.".formatted(pathInfo.filePath);
 
     // Permissions Check
-    try {
-      final var user = authorize(context);
-      permissionsService.check(
-          WorkspaceAction.deleteFileDirectory,
-          user.activeRole(),
-          user.userId(),
-          new WorkspaceId(pathInfo.workspaceId));
-    } catch (Unauthorized ioe) {
-      throw new UnauthorizedResponse(ioe.getMessage());
-    } catch (IOException | PermissionsServiceException ioe) {
-      context.status(500).result("Could not delete " +pathInfo.fileName());
+    if(!checkPermissions(context, pathInfo.workspaceId, WorkspaceAction.deleteFileDirectory)) {
       return;
-    } catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
-      throw new NoSuchWorkspaceException(pathInfo.workspaceId);
     }
 
     if (!workspaceService.checkFileExists(pathInfo.workspaceId, pathInfo.filePath)) {
-      context.status(404).result(pathInfo.fileName() + " does not exist.");
+      context.status(404).json(new FormattedError(pathInfo.fileName() + " does not exist."));
       return;
     }
 
@@ -686,14 +605,43 @@ public class WorkspaceBindings implements Plugin {
       if (workspaceService.deleteDirectory(pathInfo.workspaceId, pathInfo.filePath)) {
         context.status(200).result("Directory deleted.");
       } else {
-        context.status(500).result("Could not delete directory.");
+        context.status(500).json(new FormattedError(errorMsg));
       }
     } else {
       if (workspaceService.deleteFile(pathInfo.workspaceId, pathInfo.filePath)) {
         context.status(200).result("File deleted.");
       } else {
-        context.status(500).result("Could not delete file.");
+        context.status(500).json(new FormattedError(errorMsg));
       }
+    }
+  }
+
+  /**
+   * Check that the request meets the permissions to perform the given action on the workspace.
+   * If it does not, format the context into an appropriate error state.
+   * @return true, if the user passes the permissions check. false otherwise
+   */
+  private boolean checkPermissions(Context context, int workspaceId, WorkspaceAction action) {
+    try {
+      final var user = authorize(context);
+      permissionsService.check(
+          action,
+          user.activeRole(),
+          user.userId(),
+          new WorkspaceId(workspaceId));
+      return true;
+    } catch (Unauthorized ue) {
+      context.status(403).json(new FormattedError(ue));
+      return false;
+    } catch (IOException ioe) {
+      context.status(500).json(new FormattedError(ioe, "Could not check permissions."));
+      return false;
+    } catch (PermissionsServiceException pse) {
+      context.status(500).json(new FormattedError(pse, "Could not check permissions."));
+      return false;
+    }catch (gov.nasa.jpl.aerie.permissions.exceptions.NoSuchWorkspaceException nsw) {
+      context.status(404).json(new FormattedError(nsw, "Could not check permissions on Workspace %d.".formatted(nsw.id.id())));
+      return false;
     }
   }
 }

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/WorkspaceBindings.java
@@ -3,8 +3,8 @@ package gov.nasa.jpl.aerie.workspace.server;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import gov.nasa.jpl.aerie.permissions.PermissionsService;
 import gov.nasa.jpl.aerie.permissions.WorkspaceAction;
+import gov.nasa.jpl.aerie.permissions.exceptions.Forbidden;
 import gov.nasa.jpl.aerie.permissions.exceptions.PermissionsServiceException;
-import gov.nasa.jpl.aerie.permissions.exceptions.Unauthorized;
 import gov.nasa.jpl.aerie.permissions.gql.WorkspaceId;
 import gov.nasa.jpl.aerie.workspace.server.postgres.NoSuchWorkspaceException;
 import io.javalin.Javalin;
@@ -149,7 +149,7 @@ public class WorkspaceBindings implements Plugin {
     try {
       final var user = authorize(context);
       permissionsService.checkCoarseGrained(WorkspaceAction.createWorkspace, user.activeRole());
-    } catch (Unauthorized ue) {
+    } catch (Forbidden ue) {
       context.status(403).json(new FormattedError(ue));
       return;
     } catch (IOException ioe) {
@@ -630,7 +630,7 @@ public class WorkspaceBindings implements Plugin {
           user.userId(),
           new WorkspaceId(workspaceId));
       return true;
-    } catch (Unauthorized ue) {
+    } catch (Forbidden ue) {
       context.status(403).json(new FormattedError(ue));
       return false;
     } catch (IOException ioe) {

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/config/AppConfiguration.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/config/AppConfiguration.java
@@ -1,6 +1,7 @@
 package gov.nasa.jpl.aerie.workspace.server.config;
 
 import javax.json.JsonObject;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Objects;
 
@@ -9,6 +10,7 @@ public record AppConfiguration (
     boolean enableJavalinDevLogging,
     Path workspaceFileStore,
     JsonObject jwtSecret,
+    URI hasuraGraphqlURI,
     String hasuraAdminSecret,
     Store store
 ) {

--- a/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/postgres/NoSuchWorkspaceException.java
+++ b/workspace-server/src/main/java/gov/nasa/jpl/aerie/workspace/server/postgres/NoSuchWorkspaceException.java
@@ -1,9 +1,7 @@
 package gov.nasa.jpl.aerie.workspace.server.postgres;
 
 public class NoSuchWorkspaceException extends Exception {
-  private final int workspaceId;
   public NoSuchWorkspaceException(final int workspaceId) {
     super("No such workspace exists with id "+workspaceId+".");
-    this.workspaceId = workspaceId;
   }
 }


### PR DESCRIPTION
* **Tickets addressed:** Closes #1733 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Note: users using their own version of `docker-compose` will now need to specify `HASURA_GRAPHQL_URL` on the Workspace server. This is because the Permissions service uses GQL to get permissions information.

Adds role-based permissions to the Workspaces Server. Now every endpoint properly checks that the user has permission to run the specific action on the Workspace, as opposed to before, where any user could perform any action so long as they had a valid JWT or used the Hasura Admin Secret.

The role-based permissions are stored in the `user_role_permissions` table, in a new column `workspace_permissions`. The set of permissions are:
```
'create_workspace', 
'delete_workspace',
'list_workspace_contents', 
'delete_file_directory', 
'read_file_directory', 
'write_file_directory'
```

Aside from `create_workspace`, which is a coarse-grained permission and must only either be unset or set to `NO_CHECK`, the remaining permissions are fine-grained. They can be configured to one of the following values:

```
'NO_CHECK', 
'OWNER',
'COLLABORATOR',
'OWNER_COLLABORATOR'
```

The code that validates the `permissions` columns for the `user_role_permissions` table has been split out into several functions to aid with readability, but the baseline behavior for `action_permissions` and `function_permissions` hasn't changed.

Additionally, this PR updates the workspace server error responses to be in line with the schema proposed in #1732.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
- Adds DB tests for the new permissions column.
- Adds E2E tests for the new authorization behavior
- Outlines but does not implement a more complete Workspace Bindings test suite. 

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Our custom role docs need to be updated with information about the new column, and what keys and values it accepts.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- Complete E2E tests
- Create API docs
- Refactor PermissionsService so that it uses a DB connection instead of a GQL connection
