### PR TITLE
update action-server to pull user role from action requests and pass to action

### DIFF
--- a/action-server/package.json
+++ b/action-server/package.json
@@ -30,7 +30,7 @@
     "tsx": "^4.20.6"
   },
   "dependencies": {
-    "@nasa-jpl/aerie-actions": "1.1.0",
+    "@nasa-jpl/aerie-actions": "1.1.1",
     "express": "^5.0.1",
     "jsonwebtoken": "9.0.2",
     "pg": "^8.13.3",

--- a/action-server/src/app.ts
+++ b/action-server/src/app.ts
@@ -27,7 +27,8 @@ app.post(
     const fullSecrets = {
       ...secrets,
       authorization: res.locals.authorization,
-      user: JSON.stringify(res.locals.user)
+      user: JSON.stringify(res.locals.user),
+      userRole: res.locals.userRole
     }
     ActionRunner.addActionSecret(actionRunId, fullSecrets);
 

--- a/action-server/src/middleware.ts
+++ b/action-server/src/middleware.ts
@@ -24,12 +24,14 @@ export const corsMiddleware: RequestHandler = (req, res, next) => {
 
 export const authMiddleware: RequestHandler = async (req, res, next) => {
   const authorizationHeader = req.get('authorization');
+  const userRoleHeader = req.get('x-hasura-role');
   const { jwtErrorMessage, jwtPayload } = decodeJwt(authorizationHeader);
   if (jwtPayload) {
     // token is valid
     // set jwt payload on `user` local, so other things can access it
     res.locals.authorization = authorizationHeader;
     res.locals.user = jwtPayload;
+    res.locals.userRole = userRoleHeader;
     next();
   } else {
     res.status(401).send({ message: `Unauthorized: ${jwtErrorMessage}`, success: false });

--- a/action-server/src/type/types.ts
+++ b/action-server/src/type/types.ts
@@ -28,6 +28,7 @@ export type ActionConfig = {
   SECRETS?: Record<string, string> | undefined;
   WORKSPACE_BASE_URL: string;
   USERNAME?: string;
+  USER_ROLE?: string;
 };
 
 export type ActionTask = {

--- a/action-server/src/utils/codeRunner.ts
+++ b/action-server/src/utils/codeRunner.ts
@@ -95,6 +95,14 @@ export const jsExecute = async (
   // create a clone of the global object
   // to be passed to the context so it has access to eg. node built-ins
   const aerieGlobal = getGlobals();
+
+  // don't treat role as a secret so we don't censor it
+  let userRole = "";
+  if(secrets && secrets.userRole) {
+    userRole = secrets.userRole;
+    delete secrets.userRole;
+  }
+
   // inject custom logger to capture logs from action run
   const logBuffer: string[] = [];
   aerieGlobal.console = injectLogger(aerieGlobal.console, logBuffer, secrets);
@@ -120,7 +128,8 @@ export const jsExecute = async (
       SECRETS: secrets,
       SEQUENCING_FILE_STORE: SEQUENCING_LOCAL_STORE,
       USERNAME: username,
-      WORKSPACE_BASE_URL: WORKSPACE_BASE_URL,
+      USER_ROLE: userRole,
+      WORKSPACE_BASE_URL: WORKSPACE_BASE_URL
     };
     const actionsAPI = new ActionsAPI(client, workspaceId, actionConfig);
     const results = await context.main(parameters, settings, actionsAPI);


### PR DESCRIPTION
Addresses user role bug reported by Parker:

When users run actions that make requests back to workspace server (eg. to create files in the workspace), as of v3.8.0, they're making these requests as the user who ran the action. However, the user's *role* is not being set in the headers of this request, and therefore they default back to the user's DEFAULT role, rather than the one they have set.

Must merge with accompanying actions library change: https://github.com/NASA-AMMOS/aerie-actions/pull/14/files