### PR TITLE
Treat only record components in procedures as parameters

### DIFF
--- a/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/ProcedureProcessor.java
+++ b/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/ProcedureProcessor.java
@@ -266,7 +266,7 @@ public final class ProcedureProcessor implements Processor {
   private List<ParameterRecord> getExportParameters(final TypeElement exportTypeElement)
   {
     return exportTypeElement.getEnclosedElements().stream()
-                            .filter(e -> e.getKind() == ElementKind.FIELD) // Element must be a field
+                            .filter(e -> e.getKind() == ElementKind.RECORD_COMPONENT) // Element must be a record component
                             .map(e -> new ParameterRecord(e.getSimpleName().toString(), e.asType(), e))
                             .toList();
   }


### PR DESCRIPTION
* **Tickets addressed:** Fixes #1776 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
@dandelany and @AaronPlave noticed that the annotation processor generates invalid code for scheduling procedures that contain static fields.

The cause was identified as filtering by FIELD (which includes static fields) instead of by RECORD_COMPONENT (which excludes static fields).

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
@dandelany made the change locally and tested that the orbiter model compiles and runs successfully

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
This is a bugfix; no documentation has been invalidated

## Future work
<!-- What next steps can we anticipate from here, if any? -->
- We observed that jar files now have the `Mapper` suffix, when in previous versions they didn't. Not sure what's up with that