### PR TITLE
Allow external sources to have their derivation group changed

### DIFF
--- a/deployment/hasura/metadata/databases/tables/merlin/external_source.yaml
+++ b/deployment/hasura/metadata/databases/tables/merlin/external_source.yaml
@@ -49,6 +49,15 @@ insert_permissions:
       check: {}
       set:
         owner: "x-hasura-user-id"
+update_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [derivation_group_name]
+      filter: {}
+  - role: user
+    permission:
+      columns: [derivation_group_name]
+      filter: {}
 delete_permissions:
   - role: aerie_admin
     permission:


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR updates the Hasura metadata for `external_source` to allow `derivation_group_name` to be changed - allowing sources to have the derivation group they belong to changed _after_ upload (previously, the group was locked in at the time of upload).

The potential downside of this change is that moving a source out of a derivation group that is currently tied to a plan will not provide any notification to the user that a source they may _expect_ to be part of the plan is not longer part of the plan because it's derivation group was changed. The UI PR attempts to alleviate this by providing the user a warning if they are changing a source from a derivation group that is currently used by any plan(s).

This change should help allow more flexibility with derivation groups. Currently the process to change a derivation group is to delete the source and re-upload it with the new derivation group name, this also includes dis-associating the original derivation group from all plans its tied to prior to deleting the source and then re-associating the group afterwards.

## Verification
Via. Hasura and UI PR

## Documentation
`aerie-docs` should be updated to reflect this option

## Future work
N/A
