### PR TITLE
Fix Generated Procedure Names

### DIFF
--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -108,7 +108,7 @@ tasks.create("generateProcedureJarTasks") {
   }
 
   files.toList().each { file ->
-    final nameWithoutExtension = file.name.replace(".java", "").replace("Mapper", "")
+    final nameWithoutExtension = file.name.replace(".java", "")
     final taskName = "buildProcedureJar_${nameWithoutExtension}"
 
     println "Generating ${taskName} task, which will build ${nameWithoutExtension}.jar"

--- a/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/AllStaticallyDefinedMethodMaker.java
+++ b/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/AllStaticallyDefinedMethodMaker.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
   @Override
   public MethodSpec makeInstantiateMethod() {
-    final var activityTypeName = inputType.declaration().getQualifiedName().toString();
+    final var procedureName = inputType.declaration().getQualifiedName().toString();
 
     var methodBuilder = MethodSpec.methodBuilder("instantiate")
         .addModifiers(Modifier.PUBLIC)
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
       if (element.getKind() != ElementKind.METHOD && element.getKind() != ElementKind.CONSTRUCTOR) continue;
       if (element.getAnnotation(Template.class) == null) continue;
       var templateName = element.getSimpleName().toString();
-      methodBuilder = methodBuilder.addStatement("final var template = $L.$L()", activityTypeName, templateName);
+      methodBuilder = methodBuilder.addStatement("final var template = $L.$L()", procedureName, templateName);
 
       methodBuilder = methodBuilder.addCode(
           inputType.parameters()

--- a/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/AllStaticallyDefinedMethodMaker.java
+++ b/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/AllStaticallyDefinedMethodMaker.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
   @Override
   public MethodSpec makeInstantiateMethod() {
-    final var activityTypeName = inputType.declaration().getSimpleName().toString();
+    final var activityTypeName = inputType.declaration().getQualifiedName().toString();
 
     var methodBuilder = MethodSpec.methodBuilder("instantiate")
         .addModifiers(Modifier.PUBLIC)

--- a/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/AutoValueMappers.java
+++ b/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/AutoValueMappers.java
@@ -33,7 +33,7 @@ import java.util.Set;
 public class AutoValueMappers {
   static TypeRule recordTypeRule(final Element autoValueMapperElement, final ClassName generatedClassName) {
     if (!autoValueMapperElement.getKind().equals(ElementKind.RECORD)) {
-      throw new RuntimeException("SchedulingProcedures must be records");
+      throw new RuntimeException("Procedures must be records");
     }
 
     final var componentsAndMappers = getComponentsAndMappers(autoValueMapperElement);

--- a/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/MapperRecord.java
+++ b/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/MapperRecord.java
@@ -26,7 +26,7 @@ public final class MapperRecord {
 
     final var mapperName = ClassName.get(
         jarPackage + ".generated" + generatedSuffix,
-        procedureTypeName.simpleName() + "Mapper");
+        procedureTypeName.simpleName());
 
     return new MapperRecord(mapperName);
   }

--- a/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/SomeStaticallyDefinedMethodMaker.java
+++ b/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/SomeStaticallyDefinedMethodMaker.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 
   @Override
   public MethodSpec makeInstantiateMethod() {
-    var activityTypeName = inputType.declaration().getQualifiedName().toString();
+    var procedureName = inputType.declaration().getQualifiedName().toString();
 
     var methodBuilder = MethodSpec.methodBuilder("instantiate")
         .addModifiers(Modifier.PUBLIC)
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
       var defaultsName = element.getSimpleName().toString();
       methodBuilder = methodBuilder.addStatement(
           "final var defaults = new $L.$L()",
-          activityTypeName,
+          procedureName,
           defaultsName);
 
       methodBuilder = methodBuilder.addCode(

--- a/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/SomeStaticallyDefinedMethodMaker.java
+++ b/procedural/processor/src/main/java/gov/nasa/ammos/aerie/procedural/processor/SomeStaticallyDefinedMethodMaker.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 
   @Override
   public MethodSpec makeInstantiateMethod() {
-    var activityTypeName = inputType.declaration().getSimpleName().toString();
+    var activityTypeName = inputType.declaration().getQualifiedName().toString();
 
     var methodBuilder = MethodSpec.methodBuilder("instantiate")
         .addModifiers(Modifier.PUBLIC)


### PR DESCRIPTION
* **Tickets addressed:** fixes #1776  
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The generated Procedures now match the name of the user code procedure.

Remove bandaid fix done to `e2e-tests` package

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
Checked the output of compilation when running `./gradlew clean assemble buildAllProcedureJars`. The Jars and compiled files no longer have `Mapper` attached to the end

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
Only docs update needed is unrelated to this change in specific: Adrien's changes are breaking (procedures compiled on versions prior to 4.0 will not run on 4.0), and our upgrade guide should call that out.