### PR TITLE
Return Violation Messages from Constraints

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/json/ConstraintParsers.java
@@ -313,9 +313,12 @@ public final class ConstraintParsers {
       productP
           .field("windows", listP(intervalP))
           .field("activityInstanceIds", listP(longP))
+          .optionalField("message", stringP)
           .map(
-              untuple(Violation::new),
-              $ -> tuple($.windows(), $.activityInstanceIds())
+              untuple((windows, aids, message) -> message
+                  .map(s -> new Violation(windows, aids, s))
+                  .orElseGet(() -> new Violation(windows, aids))),
+              $ -> tuple($.windows(), $.activityInstanceIds(), $.message())
           );
 
   public static final JsonParser<EDSLConstraintResult> edslConstraintResultP =

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/Violation.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/Violation.java
@@ -7,10 +7,15 @@ import gov.nasa.jpl.aerie.types.ActivityInstanceId;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
-public record Violation(List<Interval> windows, ArrayList<Long> activityInstanceIds) {
+public record Violation(List<Interval> windows, ArrayList<Long> activityInstanceIds, Optional<String> message) {
   public Violation(List<Interval> windows, List<Long> activityInstanceIds) {
-    this(windows, new ArrayList<>(activityInstanceIds));
+    this(windows, new ArrayList<>(activityInstanceIds), Optional.empty());
+  }
+
+  public Violation(List<Interval> windows, List<Long> activityInstanceIds, String message) {
+    this(windows, new ArrayList<>(activityInstanceIds), Optional.ofNullable(message));
   }
 
   public static List<Violation> fromProceduralViolations(Violations violations, gov.nasa.jpl.aerie.merlin.driver.SimulationResults simResults) {
@@ -42,7 +47,10 @@ public record Violation(List<Interval> windows, ArrayList<Long> activityInstance
         }
       }
 
-      constraintViolations.add(new Violation(List.of(Interval.fromProceduralInterval(v.getInterval())), activityInstanceIds));
+      constraintViolations.add(new Violation(
+          List.of(Interval.fromProceduralInterval(v.getInterval())),
+          activityInstanceIds,
+          v.getMessage()));
     }
     return constraintViolations;
   }

--- a/deployment/hasura/metadata/actions.graphql
+++ b/deployment/hasura/metadata/actions.graphql
@@ -343,6 +343,7 @@ type ConstraintResult {
 }
 
 type ConstraintViolation {
+  message: String,
   windows: [Interval!]!,
   activityInstanceIds: [Int!]!
 }

--- a/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/NoMessageConstraint.java
+++ b/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/NoMessageConstraint.java
@@ -9,8 +9,11 @@ import gov.nasa.ammos.aerie.procedural.timeline.plan.Plan;
 import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Equivalent to FruitThresholdConstraint, except it does not include a message in the violations
+ */
 @ConstraintProcedure
-public record FruitThresholdConstraint(int lowerBound, int upperBound) implements Constraint {
+public record NoMessageConstraint(int lowerBound, int upperBound) implements Constraint {
   @NotNull
   @Override
   public Violations run(@NotNull Plan plan, @NotNull SimulationResults simResults) {
@@ -19,7 +22,7 @@ public record FruitThresholdConstraint(int lowerBound, int upperBound) implement
     return Violations.on(
         fruit.lessThan(upperBound).and(fruit.greaterThan(lowerBound)),
         false
-    ).withDefaultMessage("Fruit count is outside of boundaries: [%d, %d]".formatted(lowerBound, upperBound));
+    );
   }
 
   @WithDefaults

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/constraints/BasicConstraintTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/constraints/BasicConstraintTests.java
@@ -18,24 +18,35 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BasicConstraintTests extends ProceduralTestingSetup {
-  private ConstraintInvocationId fruitTresholdConstraintId;
+  private ConstraintInvocationId fruitThresholdConstraintId;
+  private ConstraintInvocationId noMessageConstraintId;
 
   @BeforeEach
   void localBeforeEach() throws IOException {
     try (final var gateway = new GatewayRequests(playwright)) {
-      final int fruitTresholdConstraintJarId = gateway.uploadJarFile("build/libs/FruitThresholdConstraint.jar");
-      // Add Scheduling Procedure
-      fruitTresholdConstraintId = hasura.createConstraintSpecProcedure(
-          "Test Constraint Procedure 1",
-          fruitTresholdConstraintJarId,
+      final int fruitThresholdConstraintJarId = gateway.uploadJarFile("build/libs/FruitThresholdConstraint.jar");
+      final int noMessageConstraintJarId = gateway.uploadJarFile("build/libs/NoMessageConstraint.jar");
+      // Add Constraint Procedures
+      fruitThresholdConstraintId = hasura.createConstraintSpecProcedure(
+          "Fruit Threshold Constraint",
+          fruitThresholdConstraintJarId,
           planId
       );
+      noMessageConstraintId = hasura.createConstraintSpecProcedure(
+          "No Message Constraint",
+          noMessageConstraintJarId,
+          planId
+      );
+
+      // Disable the noMessageConstraint by default
+      hasura.updatePlanConstraintSpecEnabled(noMessageConstraintId.invocationId(), false);
     }
   }
 
   @AfterEach
   void localAfterEach() throws IOException {
-    hasura.deleteConstraint(fruitTresholdConstraintId.id());
+    hasura.deleteConstraint(fruitThresholdConstraintId.id());
+    hasura.deleteConstraint(noMessageConstraintId.id());
   }
 
   /**
@@ -47,8 +58,15 @@ public class BasicConstraintTests extends ProceduralTestingSetup {
     hasura.awaitSimulation(planId);
     final var resp = hasura.checkConstraints(planId);
     assertEquals(1, resp.constraintsRun().size());
-    assertEquals(1, resp.constraintsRun().getFirst().errors().size());
-    assertTrue(resp.constraintsRun().getFirst().errors().getFirst().message().contains("gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException: Invalid arguments for input type \"FruitThresholdConstraint\": extraneous arguments: [], unconstructable arguments: [], missing arguments: [MissingArgument[parameterName=upperBound, schema=IntSchema[]]], valid arguments: [ValidArgument[parameterName=lowerBound, serializedValue=NumericValue[value=5]]]"));
+    final var constraint =  resp.constraintsRun().getFirst();
+    assertEquals(1, constraint.errors().size());
+    assertTrue(constraint.errors().getFirst().message().contains(
+        "gov.nasa.jpl.aerie.merlin.protocol.types.InstantiationException: Invalid arguments for input type "
+        + "\"FruitThresholdConstraint\": "
+        + "extraneous arguments: [], "
+        + "unconstructable arguments: [], "
+        + "missing arguments: [MissingArgument[parameterName=upperBound, schema=IntSchema[]]], "
+        + "valid arguments: [ValidArgument[parameterName=lowerBound, serializedValue=NumericValue[value=5]]]"));
   }
 
   /**
@@ -57,7 +75,7 @@ public class BasicConstraintTests extends ProceduralTestingSetup {
   @Test
   void executeConstraintRunWithArguments() throws IOException {
     final var args = Json.createObjectBuilder().add("upperBound", 10).build();
-    hasura.updateConstraintArguments(fruitTresholdConstraintId.invocationId(), args);
+    hasura.updateConstraintArguments(fruitThresholdConstraintId.invocationId(), args);
     hasura.awaitSimulation(planId);
     final var resp = hasura.checkConstraints(planId);
     assertTrue(resp.constraintsRun().getFirst().success());
@@ -69,19 +87,54 @@ public class BasicConstraintTests extends ProceduralTestingSetup {
   }
 
   /**
+   * Test that constraints with a violation message include said violation message.
+   */
+  @Test
+  void messageReturnedIfPresent() throws IOException {
+    // Enable the NoMessageConstraint
+    hasura.updatePlanConstraintSpecEnabled(noMessageConstraintId.invocationId(), true);
+
+    // Assign args to the constraints
+    final var args = Json.createObjectBuilder().add("upperBound", 10).build();
+    hasura.updateConstraintArguments(fruitThresholdConstraintId.invocationId(), args);
+    hasura.updateConstraintArguments(noMessageConstraintId.invocationId(), args);
+
+    // Get Constraint Results
+    hasura.awaitSimulation(planId);
+    final var resp = hasura.checkConstraints(planId);
+
+    assertEquals(2, resp.constraintsRun().size());
+
+    final var firstConstraint = resp.constraintsRun().getFirst();
+    assertEquals(fruitThresholdConstraintId.invocationId(), firstConstraint.constraintInvocationId());
+    assertTrue(firstConstraint.success());
+    assertEquals(1, firstConstraint.result().get().violations().size());
+    final var firstConstraintViolation = firstConstraint.result().get().violations().getFirst();
+    assertTrue(firstConstraintViolation.message().isPresent());
+    assertEquals("Fruit count is outside of boundaries: [5, 10]", firstConstraintViolation.message().get());
+
+    final var secondConstraint = resp.constraintsRun().getLast();
+    assertEquals(noMessageConstraintId.invocationId(), secondConstraint.constraintInvocationId());
+    assertTrue(secondConstraint.success());
+    assertEquals(1, secondConstraint.result().get().violations().size());
+    final var secondConstraintViolation = secondConstraint.result().get().violations().getFirst();
+    assertTrue(secondConstraintViolation.message().isEmpty());
+  }
+
+  /**
    * Queries the procedural constraints arguments.
    */
   @Test
   void effectiveArgumentsQuery() throws IOException {
     final var effectiveArgs = hasura.getEffectiveProceduralConstraintsArgumentsBulk(
-        List.of(Pair.of(fruitTresholdConstraintId.id(), Json.createObjectBuilder().add("upperBound", 10).build())));
+        List.of(Pair.of(fruitThresholdConstraintId.id(), Json.createObjectBuilder().add("upperBound", 10).build())));
     assertEquals(1, effectiveArgs.size());
-    assertTrue(effectiveArgs.get(0).success());
-    assertTrue(effectiveArgs.get(0).arguments().isPresent());
-    assertTrue(effectiveArgs.get(0).errors().isEmpty());
+    assertTrue(effectiveArgs.getFirst().success());
+    assertTrue(effectiveArgs.getFirst().arguments().isPresent());
+    assertTrue(effectiveArgs.getFirst().errors().isEmpty());
 
     // Check returned Arguments
-    final var args = effectiveArgs.get(0).arguments().get();
+    final var args = effectiveArgs.getFirst().arguments().get();
     assertEquals(2, args.size());
     assertEquals(10, args.getInt("upperBound"));
     assertEquals(5, args.getInt("lowerBound"));

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ConstraintResult.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/ConstraintResult.java
@@ -4,20 +4,23 @@ import javax.json.JsonNumber;
 import javax.json.JsonObject;
 import javax.json.JsonString;
 import java.util.List;
+import java.util.Optional;
 
 public record ConstraintResult(
     List<String> resourceIds,
     List<ConstraintResult.ConstraintViolation> violations,
     List<ConstraintResult.Interval> gaps
 ) {
-  public record ConstraintViolation(List<Integer> activityInstanceIds, List<Interval> windows) {
+  public record ConstraintViolation(List<Integer> activityInstanceIds, List<Interval> windows, Optional<String> message) {
 
     public static ConstraintViolation fromJSON(JsonObject json) {
       return new ConstraintViolation(
           json.getJsonArray("activityInstanceIds")
               .getValuesAs(JsonNumber::intValue),
           json.getJsonArray("windows")
-              .getValuesAs(Interval::fromJSON));
+              .getValuesAs(Interval::fromJSON),
+          Optional.ofNullable(json.getString("message", null))
+      );
     }
   }
 

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/GQL.java
@@ -75,6 +75,7 @@ public enum GQL {
               start
             }
             violations {
+              message
               activityInstanceIds
               windows {
                 end

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/http/ResponseSerializers.java
@@ -35,6 +35,7 @@ import javax.json.stream.JsonParsingException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -287,7 +288,7 @@ public final class ResponseSerializers {
         .build();
   }
 
-  public static JsonValue serializeConstraintResults(final int requestId, final Map<ConstraintRecord, Fallible<ConstraintResult, List<? extends Exception>>> resultMap) {
+  public static JsonValue serializeConstraintResults(final int requestId, final SortedMap<ConstraintRecord, Fallible<ConstraintResult, List<? extends Exception>>> resultMap) {
     var results = resultMap.entrySet().stream().map(entry -> {
 
       final var constraint = entry.getKey();
@@ -323,7 +324,7 @@ public final class ResponseSerializers {
       }
 
       // successful runs
-      var constraintResult = (ConstraintResult) fallible.getOptional().get();
+      var constraintResult = fallible.getOptional().get();
       return Json.createObjectBuilder()
                  .add("success", JsonValue.TRUE)
                  .add("constraintId", constraint.constraintId())

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ConstraintRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ConstraintRecord.java
@@ -23,4 +23,10 @@ public record ConstraintRecord(
     String description,
     ConstraintType type,
     Map<String, SerializedValue> arguments
-) {}
+) implements Comparable<ConstraintRecord> {
+
+  @Override
+  public int compareTo(final ConstraintRecord o) {
+    return Long.compare(this.priority, o.priority);
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintAction.java
@@ -89,7 +89,7 @@ public class ConstraintAction {
    * @throws MissionModelService.NoSuchMissionModelException If the plan's mission model does not exist.
    * @throws SimulationDatasetMismatchException If the specified simulation is not a simulation of the specified plan.
    */
-  public Pair<Integer, Map<ConstraintRecord, Fallible<ConstraintResult, List<? extends Exception>>>> getViolations(
+  public Pair<Integer, SortedMap<ConstraintRecord, Fallible<ConstraintResult, List<? extends Exception>>>> getViolations(
       final PlanId planId,
       final Optional<SimulationDatasetId> simulationDatasetId,
       final boolean force,
@@ -117,7 +117,7 @@ public class ConstraintAction {
     final SimulationDatasetId simDatasetId = resultsHandle.getSimulationDatasetId();
 
     final var constraints = new ArrayList<>(this.planService.getConstraintsForPlan(planId));
-    final var constraintResultMap = new HashMap<ConstraintRecord, Fallible<ConstraintResult, List<? extends Exception>>>();
+    final var constraintResultMap = new TreeMap<ConstraintRecord, Fallible<ConstraintResult, List<? extends Exception>>>();
 
     // Load cached results if the force rerun flag is not set
     final var validConstraintRuns = force ? new HashMap<ConstraintRecord, ConstraintResult>() :


### PR DESCRIPTION
* **Tickets addressed:** Closes #1781 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
If a Procedural Constraint has a message on a Violation, it is now included alongside the `windows` and `activityId` fields.

The changes match those in the ticket, except one more file was updated: `actions.graphql` was also updated so that Hasura is aware of this new optional field.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
A new test was added to `BasicConstraintTests`: `messageReturnedIfPresent`. It runs the constraints `FruitThresholdConstraint` (which has been updated to include a violation message) and `NoMessageConstraint` (a new constraint that is equivalent to `FruitThresholdConstraint, except it does not contain a message) and shows that the `message` field is now populated if the Violation contained a message.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->
The API example for checking constraints should be updated to include the new field.
Done, PR is [here](https://github.com/NASA-AMMOS/plandev-docs/pull/9).

## Future work
<!-- What next steps can we anticipate from here, if any? -->
The UI needs to be update to display these messages, if they are present.