### PR TITLE
Fix MerlinServiceException when Scheduling Posts Sim Results with Unfinished Activities

### DIFF
--- a/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/DecompositionSchedulingGoal.java
+++ b/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/DecompositionSchedulingGoal.java
@@ -1,0 +1,50 @@
+package gov.nasa.jpl.aerie.e2e.procedural.scheduling.procedures;
+
+import gov.nasa.ammos.aerie.procedural.scheduling.Goal;
+import gov.nasa.ammos.aerie.procedural.scheduling.annotations.SchedulingProcedure;
+import gov.nasa.ammos.aerie.procedural.scheduling.plan.EditablePlan;
+import gov.nasa.ammos.aerie.procedural.scheduling.plan.NewDirective;
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.AnyDirective;
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.DirectiveStart;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+/**
+ * Schedules each stage of the decomposition as separate activities
+ */
+@SchedulingProcedure
+public record DecompositionSchedulingGoal() implements Goal
+{
+  @Override
+  public void run(@NotNull final EditablePlan plan) {
+    final var blankArgs = new AnyDirective(Map.of());
+
+    plan.create(
+        new NewDirective(
+            blankArgs,
+            "Placed Parent Activity",
+            "parent",
+            new DirectiveStart.Absolute(Duration.ZERO)
+        ));
+    plan.create(
+        new NewDirective(
+            blankArgs,
+            "Placed Child Activity",
+            "child",
+            new DirectiveStart.Absolute(Duration.MINUTE)
+        ));
+    plan.create(
+        new NewDirective(
+            blankArgs,
+            "Placed Grandchild Activity",
+            "grandchild",
+            new DirectiveStart.Absolute(Duration.HOUR)
+        ));
+
+    plan.simulate();
+    plan.commit();
+    plan.simulate();
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/BasicSchedulingTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/BasicSchedulingTests.java
@@ -1,6 +1,8 @@
 package gov.nasa.jpl.aerie.e2e.procedural.scheduling;
 
 import gov.nasa.jpl.aerie.e2e.types.GoalInvocationId;
+import gov.nasa.jpl.aerie.e2e.types.Plan;
+import gov.nasa.jpl.aerie.e2e.types.SimulationDataset;
 import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,27 +10,33 @@ import org.junit.jupiter.api.Test;
 
 import javax.json.Json;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BasicSchedulingTests extends ProceduralSchedulingSetup {
   private int dumbRecurrenceGoalJarId;
+  private int decompositionGoalJarId;
   private GoalInvocationId dumbRecurrenceGoalId;
 
   @BeforeEach
   void localBeforeEach() throws IOException {
+    // Upload the Jars
     try (final var gateway = new GatewayRequests(playwright)) {
       dumbRecurrenceGoalJarId = gateway.uploadJarFile("build/libs/DumbRecurrenceGoal.jar");
-      // Add Scheduling Procedure
-      dumbRecurrenceGoalId = hasura.createSchedulingSpecProcedure(
-          "Test Scheduling Procedure 1",
-          dumbRecurrenceGoalJarId,
-          specId,
-          0
-      );
+      decompositionGoalJarId = gateway.uploadJarFile("build/libs/DecompositionSchedulingGoal.jar");
     }
+
+    // Add Scheduling Procedure
+    dumbRecurrenceGoalId = hasura.createSchedulingSpecProcedure(
+        "Test Scheduling Procedure 1",
+        dumbRecurrenceGoalJarId,
+        specId,
+        0
+    );
   }
 
   @AfterEach
@@ -171,5 +179,52 @@ public class BasicSchedulingTests extends ProceduralSchedulingSetup {
 
     assertEquals(2, activities.size());
     assertEquals("It's a bite banana activity", activities.getFirst().name());
+  }
+
+  /**
+   * Run a spec that includes unfinished activities
+   */
+  @Test
+  void IncludesUnfinishedActivities() throws IOException {
+    // Disable the recurrence goal to simplify scheduling results
+    hasura.updateSchedulingSpecEnabled(dumbRecurrenceGoalId.invocationId(), false);
+
+    // Add the decomposition goal that will generate unfinished spans
+    hasura.createSchedulingSpecProcedure(
+        "Unfinished Spans Goal",
+        decompositionGoalJarId,
+        specId,
+        0);
+
+    final var schedulingResp = hasura.awaitScheduling(specId);
+    assertEquals("complete", schedulingResp.status());
+
+    final var plan = hasura.getPlan(planId);
+    final var activities = plan.activityDirectives();
+
+    // There should be 3 activities
+    assertEquals(3, activities.size());
+
+    assertEquals(1, activities.stream()
+                              .filter(a -> a.type().equals("parent")
+                                           && a.name().equals("Placed Parent Activity"))
+                              .count());
+    assertEquals(1, activities.stream()
+                              .filter(a -> a.type().equals("child")
+                                           && a.name().equals("Placed Child Activity"))
+                              .count());
+    assertEquals(1, activities.stream()
+                              .filter(a -> a.type().equals("grandchild")
+                                           && a.name().equals("Placed Grandchild Activity"))
+                              .count());
+
+    // Check the posted simulation results
+    // There should be 6 spans, all unfinished (3 from parent, 2 from child, one from grandchild)
+    final var simResults =  hasura.getSimulationDatasetByDatasetId(schedulingResp.datasetId());
+    assertEquals(SimulationDataset.SimulationStatus.success, simResults.status());
+    assertEquals(6, simResults.activities().size());
+    for(final var act : simResults.activities()) {
+      assertNull(act.duration());
+    }
   }
 }

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinDatabaseService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinDatabaseService.java
@@ -1894,18 +1894,21 @@ public record GraphQLMerlinDatabaseService(URI merlinGraphqlURI, String hasuraGr
       final var act = spans.get(id);
 
       final var startTime = graphQLIntervalFromDuration(simulationStart, act.start);
-      spansJson.add(Json.createObjectBuilder()
-                        .add("span_id",id.id())
-                        .add("dataset_id", datasetId.id())
-                        .add("start_offset", startTime.toString())
-                        .add("duration", act.duration.isPresent() ? graphQLIntervalFromDuration(act.duration().get()).toString() : "null")
-                        .add("type", act.type())
-                        .add("attributes", buildAttributes(
-                            act.attributes().directiveId().map($ -> uploadIdMap.get(new ActivityDirectiveId($)).id()),
-                            act.attributes().arguments(),
-                            act.attributes().computedAttributes()
-                        ))
-                        .build());
+      final var spanBuilder = Json.createObjectBuilder()
+                                  .add("span_id",id.id())
+                                  .add("dataset_id", datasetId.id())
+                                  .add("start_offset", startTime.toString())
+                                  .add("type", act.type())
+                                  .add("attributes", buildAttributes(
+                                      act.attributes().directiveId().map($ -> uploadIdMap.get(new ActivityDirectiveId($)).id()),
+                                      act.attributes().arguments(),
+                                      act.attributes().computedAttributes()
+                                  ));
+      if (act.duration.isPresent()){
+        spanBuilder.add("duration", graphQLIntervalFromDuration(act.duration().get()).toString());
+      }
+
+      spansJson.add(spanBuilder.build());
     }
     final var arguments = Json.createObjectBuilder()
                               .add("spans", spansJson)


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
There was a bug in how the scheduler was posting spans for unfinished activities to Hasura, where it would try to set to value of its duration to the _string_ `"null"` instead of the _value_ `null`. This PR fixes this by only including the `duration` field in the JSON version of the span if the Java version has a duration.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I added a new test and example procedure to the Scheduling E2E Tests. If you try and schedule this procedure on `develop`, you will see the `MerlinServiceException` when the scheduler attempts to post simulation results. Meanwhile, the results will post successfully if scheduled against this branch.
