### PR TITLE
Add External Event Visibility to Procedural Constraints

### DIFF
--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/EvaluationEnvironment.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/model/EvaluationEnvironment.java
@@ -1,8 +1,10 @@
 package gov.nasa.jpl.aerie.constraints.model;
 
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
 import gov.nasa.jpl.aerie.constraints.time.Interval;
 import gov.nasa.jpl.aerie.constraints.time.Spans;
 
+import java.util.List;
 import java.util.Map;
 
 /** A container for additional context needed for Constraints AST evaluation. */
@@ -11,13 +13,14 @@ public record EvaluationEnvironment(
     Map<String, Spans> spansInstances,
     Map<String, Interval> intervals,
     Map<String, LinearProfile> realExternalProfiles,
-    Map<String, DiscreteProfile> discreteExternalProfiles
+    Map<String, DiscreteProfile> discreteExternalProfiles,
+    Map<String, List<ExternalEvent>> externalEventsByDerivationGroup
 ) {
   public EvaluationEnvironment() {
-    this(Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
+    this(Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
   }
 
-  public EvaluationEnvironment(Map<String, LinearProfile> realExternalProfiles, Map<String, DiscreteProfile> discreteExternalProfiles) {
-    this(Map.of(), Map.of(), Map.of(), realExternalProfiles, discreteExternalProfiles);
+  public EvaluationEnvironment(Map<String, LinearProfile> realExternalProfiles, Map<String, DiscreteProfile> discreteExternalProfiles, Map<String, List<ExternalEvent>> externalEventsByDerivationGroup) {
+    this(Map.of(), Map.of(), Map.of(), realExternalProfiles, discreteExternalProfiles, externalEventsByDerivationGroup);
   }
 }

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivitySpans.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivitySpans.java
@@ -35,7 +35,8 @@ public record ForEachActivitySpans(
             environment.spansInstances(),
             environment.intervals(),
             environment.realExternalProfiles(),
-            environment.discreteExternalProfiles()
+            environment.discreteExternalProfiles(),
+            environment.externalEventsByDerivationGroup()
         );
         newEnvironment.activityInstances().put(this.alias, activity);
 

--- a/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivityViolations.java
+++ b/constraints/src/main/java/gov/nasa/jpl/aerie/constraints/tree/ForEachActivityViolations.java
@@ -22,7 +22,8 @@ public record ForEachActivityViolations(
             environment.spansInstances(),
             environment.intervals(),
             environment.realExternalProfiles(),
-            environment.discreteExternalProfiles()
+            environment.discreteExternalProfiles(),
+            environment.externalEventsByDerivationGroup()
         );
         newEnvironment.activityInstances().put(this.alias, activity);
 

--- a/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
+++ b/constraints/src/test/java/gov/nasa/jpl/aerie/constraints/tree/ASTTests.java
@@ -472,7 +472,8 @@ public class ASTTests {
         Map.of(),
         Map.of()
     );
-    final var environment = new EvaluationEnvironment(Map.of("act", act), Map.of(), Map.of(), Map.of(), Map.of());
+    final var environment = new EvaluationEnvironment(Map.of("act", act),
+                                                      Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
 
     final var result = new RealParameter("act", "p1").evaluate(simResults, environment);
 
@@ -809,6 +810,7 @@ public class ASTTests {
         Map.of(),
         Map.of(),
         Map.of(),
+        Map.of(),
         Map.of()
     );
 
@@ -839,6 +841,7 @@ public class ASTTests {
                 Map.of(),
                 Interval.between(4, 8, SECONDS))
         ),
+        Map.of(),
         Map.of(),
         Map.of(),
         Map.of(),
@@ -873,6 +876,7 @@ public class ASTTests {
                 Map.of(),
                 Interval.between(4, 8, SECONDS))
         ),
+        Map.of(),
         Map.of(),
         Map.of(),
         Map.of(),
@@ -974,7 +978,8 @@ public class ASTTests {
             "discrete1", new DiscreteProfile(Segment.of(Interval.at(4, SECONDS), SerializedValue.of("one"))),
             "discrete2", new DiscreteProfile(Segment.of(Interval.at(5, SECONDS), SerializedValue.of("two"))),
             "discrete3", new DiscreteProfile(Segment.of(Interval.at(6, SECONDS), SerializedValue.of("three")))
-        )
+        ),
+        Map.of()
     );
 
     final var result = new DiscreteResource("discrete2").evaluate(simResults, environment);
@@ -1003,7 +1008,8 @@ public class ASTTests {
             "discrete1", new DiscreteProfile(Segment.of(Interval.at(4, SECONDS), SerializedValue.of("one"))),
             "discrete2", new DiscreteProfile(Segment.of(Interval.at(5, SECONDS), SerializedValue.of("two"))),
             "discrete3", new DiscreteProfile(Segment.of(Interval.at(6, SECONDS), SerializedValue.of("three")))
-        )
+        ),
+        Map.of()
     );
 
     final var result = new RealResource("real2").evaluate(simResults, environment);
@@ -1029,6 +1035,7 @@ public class ASTTests {
     final var environment = new EvaluationEnvironment(
         Map.of(),
         Map.of("my spans", spans),
+        Map.of(),
         Map.of(),
         Map.of(),
         Map.of()

--- a/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventAbsenceConstraint.java
+++ b/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventAbsenceConstraint.java
@@ -1,0 +1,31 @@
+package gov.nasa.jpl.aerie.e2e.procedural.scheduling.procedures;
+
+import gov.nasa.ammos.aerie.procedural.constraints.Constraint;
+import gov.nasa.ammos.aerie.procedural.constraints.Violation;
+import gov.nasa.ammos.aerie.procedural.constraints.Violations;
+import gov.nasa.ammos.aerie.procedural.constraints.annotations.ConstraintProcedure;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.Plan;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults;
+import org.jetbrains.annotations.NotNull;
+
+@ConstraintProcedure
+public record ExternalEventAbsenceConstraint() implements Constraint {
+  @NotNull
+  @Override
+  public Violations run(@NotNull Plan plan, @NotNull SimulationResults simResults) {
+    var events = plan.events();
+
+    // if we have any events
+    if (!events.collect().isEmpty()) {
+      // ...mark those events as violating
+      return new Violations(
+          events.collectIntervals()
+                .stream()
+                .map(e -> new Violation(e.getInterval()))
+                .toList()
+      );
+    }
+    // otherwise, return an empty violations object.
+    return new Violations();
+  }
+}

--- a/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventActivityOverlapConstraint.java
+++ b/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventActivityOverlapConstraint.java
@@ -1,0 +1,39 @@
+package gov.nasa.jpl.aerie.e2e.procedural.scheduling.procedures;
+
+import gov.nasa.ammos.aerie.procedural.constraints.Constraint;
+import gov.nasa.ammos.aerie.procedural.constraints.Violations;
+import gov.nasa.ammos.aerie.procedural.constraints.annotations.ConstraintProcedure;
+import gov.nasa.ammos.aerie.procedural.timeline.collections.Windows;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.EventQuery;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.Plan;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults;
+import org.jetbrains.annotations.NotNull;
+
+@ConstraintProcedure
+public record ExternalEventActivityOverlapConstraint() implements Constraint {
+  @NotNull
+  @Override
+  public Violations run(@NotNull Plan plan, @NotNull SimulationResults simResults) {
+    // create window of events
+    var events = new Windows(plan.events(new EventQuery(null, "TestType", null))
+        .filter(true, e -> {
+          if (e.attributes.get("code").asString().isPresent()) {
+            return e.attributes.get("code").asString().get().equals("B");
+          }
+          return false;
+        })
+        .collectIntervals());
+
+    // create window of activities
+    var activities = new Windows(simResults.instances().collectIntervals());
+
+    // check if any overlap...
+    var overlap = events.intersection(activities);
+    if (!overlap.collect().isEmpty()) {
+      // ...and then set violations where it happens...
+      return Violations.inside(new Windows(overlap));
+    }
+    // ...otherwise, return an empty violations object.
+    return new Violations();
+  }
+}

--- a/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventAttributeConstraint.java
+++ b/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventAttributeConstraint.java
@@ -1,0 +1,40 @@
+package gov.nasa.jpl.aerie.e2e.procedural.scheduling.procedures;
+
+import gov.nasa.ammos.aerie.procedural.constraints.Constraint;
+import gov.nasa.ammos.aerie.procedural.constraints.Violation;
+import gov.nasa.ammos.aerie.procedural.constraints.Violations;
+import gov.nasa.ammos.aerie.procedural.constraints.annotations.ConstraintProcedure;
+import gov.nasa.ammos.aerie.procedural.timeline.collections.Windows;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.EventQuery;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.Plan;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults;
+import org.jetbrains.annotations.NotNull;
+
+@ConstraintProcedure
+public record ExternalEventAttributeConstraint(String codeValue) implements Constraint {
+  @NotNull
+  @Override
+  public Violations run(@NotNull Plan plan, @NotNull SimulationResults simResults) {
+    // filter events on whether attribute "code" equals codeValue
+    var events = plan.events(new EventQuery(null, "TestType", null))
+        .filter(true, e -> {
+          if (e.attributes.get("code").asString().isPresent()) {
+            return e.attributes.get("code").asString().get().equals(codeValue);
+          }
+          return false;
+        });
+
+    // if we have any events with that attribute value
+    if (!events.collect().isEmpty()) {
+      // ...mark those events as violating
+      return new Violations(
+          events.collectIntervals()
+                .stream()
+                .map(e -> new Violation(e.getInterval()))
+                .toList()
+      );
+    }
+    // otherwise, return an empty violations object.
+    return new Violations();
+  }
+}

--- a/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventPresenceConstraint.java
+++ b/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/ExternalEventPresenceConstraint.java
@@ -1,0 +1,57 @@
+package gov.nasa.jpl.aerie.e2e.procedural.scheduling.procedures;
+
+import gov.nasa.ammos.aerie.procedural.constraints.Constraint;
+import gov.nasa.ammos.aerie.procedural.constraints.Violation;
+import gov.nasa.ammos.aerie.procedural.constraints.Violations;
+import gov.nasa.ammos.aerie.procedural.constraints.annotations.ConstraintProcedure;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.EventQuery;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.Plan;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults;
+import org.jetbrains.annotations.NotNull;
+
+// TODO: Make parameters Lists of Strings/SourceQueries for more intricate EventQuery testing in
+//        ExternalEventConstraintsTests when ValueMappers are able to be added, following the resolution of:
+//          https://github.com/NASA-AMMOS/plandev/issues/1737
+//          "@WithMappers does not work in procedural scheduling".
+@ConstraintProcedure
+public record ExternalEventPresenceConstraint(
+    String eventType,
+    String derivationGroup,
+    String sourceKey
+  ) implements Constraint {
+  @NotNull
+  @Override
+  public Violations run(@NotNull Plan plan, @NotNull SimulationResults simResults) {
+    // handle omitted sourceKey/derivationGroup/eventType (setting them to null manually, lest they be considered
+    //    missing arguments
+    final String NULL_VALUE = "NULL";
+    final var updatedEventType = eventType.equals(NULL_VALUE) ? null : eventType;
+    final var updatedDerivationGroup = derivationGroup.equals(NULL_VALUE) ? null : derivationGroup;
+    final var sourceQuery =
+        sourceKey.equals(NULL_VALUE) || derivationGroup.equals(NULL_VALUE)
+            ? null
+            : new EventQuery.SourceQuery(sourceKey, derivationGroup);
+
+    // make the query
+    var events = plan.events(
+        new EventQuery(
+            updatedDerivationGroup,
+            updatedEventType,
+            sourceQuery
+        )
+    );
+
+    // if we have any events that suit the above query
+    if (!events.collect().isEmpty()) {
+      // ...mark those events as violating
+      return new Violations(
+          events.collectIntervals()
+                .stream()
+                .map(e -> new Violation(e.getInterval()))
+                .toList()
+      );
+    }
+    // otherwise, return an empty violations object.
+    return new Violations();
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/constraints/BasicConstraintTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/constraints/BasicConstraintTests.java
@@ -1,6 +1,6 @@
 package gov.nasa.jpl.aerie.e2e.procedural.constraints;
 
-import gov.nasa.jpl.aerie.e2e.procedural.scheduling.ProceduralSchedulingSetup;
+import gov.nasa.jpl.aerie.e2e.procedural.scheduling.ProceduralTestingSetup;
 import gov.nasa.jpl.aerie.e2e.types.ConstraintInvocationId;
 import gov.nasa.jpl.aerie.e2e.types.ConstraintResult;
 import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
@@ -17,7 +17,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BasicConstraintTests extends ProceduralSchedulingSetup {
+public class BasicConstraintTests extends ProceduralTestingSetup {
   private ConstraintInvocationId fruitTresholdConstraintId;
 
   @BeforeEach

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/constraints/ExternalEventConstraintTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/constraints/ExternalEventConstraintTests.java
@@ -1,0 +1,425 @@
+package gov.nasa.jpl.aerie.e2e.procedural.constraints;
+
+import gov.nasa.jpl.aerie.e2e.procedural.scheduling.ProceduralTestingSetup;
+import gov.nasa.jpl.aerie.e2e.types.ConstraintInvocationId;
+import gov.nasa.jpl.aerie.e2e.types.ConstraintResult;
+import gov.nasa.jpl.aerie.e2e.utils.GatewayRequests;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static gov.nasa.jpl.aerie.e2e.utils.ExternalEventUtils.ADDITIONAL_DERIVATION_GROUP;
+import static gov.nasa.jpl.aerie.e2e.utils.ExternalEventUtils.ADDITIONAL_EVENT_TYPE;
+import static gov.nasa.jpl.aerie.e2e.utils.ExternalEventUtils.ADDITIONAL_SOURCE_KEY;
+import static gov.nasa.jpl.aerie.e2e.utils.ExternalEventUtils.DERIVATION_GROUP;
+import static gov.nasa.jpl.aerie.e2e.utils.ExternalEventUtils.EVENT_TYPE;
+import static gov.nasa.jpl.aerie.e2e.utils.ExternalEventUtils.SOURCE_KEY;
+import static gov.nasa.jpl.aerie.e2e.utils.ExternalEventUtils.SOURCE_TYPE;
+import static gov.nasa.jpl.aerie.e2e.utils.ExternalEventUtils.uploadExternalSourceEventTypes;
+import static gov.nasa.jpl.aerie.e2e.utils.ExternalEventUtils.uploadExternalSources;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Named.named;
+
+public class ExternalEventConstraintTests extends ProceduralTestingSetup {
+  private ConstraintInvocationId procedureId;
+  private final static String NULL_VALUE = "NULL";
+
+  @BeforeAll
+  void localBeforeAll() throws IOException {
+    // Upload some External Events
+    uploadExternalSourceEventTypes(playwright);
+    uploadExternalSources(playwright);
+  }
+
+  @BeforeEach
+  void localBeforeEach() throws IOException {
+    // make associations between plans and derivation groups
+    hasura.insertPlanDerivationGroupAssociation(planId, DERIVATION_GROUP);
+    hasura.insertPlanDerivationGroupAssociation(planId, ADDITIONAL_DERIVATION_GROUP);
+  }
+
+  @AfterAll
+  void localAfterAll() throws IOException {
+    // External Event deletion
+    hasura.deleteExternalSource(SOURCE_KEY, DERIVATION_GROUP);
+    hasura.deleteExternalSource(ADDITIONAL_SOURCE_KEY, ADDITIONAL_DERIVATION_GROUP);
+    hasura.deleteDerivationGroup(DERIVATION_GROUP);
+    hasura.deleteDerivationGroup(ADDITIONAL_DERIVATION_GROUP);
+    hasura.deleteExternalSourceType(SOURCE_TYPE);
+    hasura.deleteExternalEventType(EVENT_TYPE);
+    hasura.deleteExternalEventType(ADDITIONAL_EVENT_TYPE);
+  }
+
+  @AfterEach
+  void localAfterEach() throws IOException {
+    hasura.deleteConstraint(procedureId.id());
+
+    hasura.deletePlanDerivationGroupAssociation(planId, DERIVATION_GROUP);
+    hasura.deletePlanDerivationGroupAssociation(planId, ADDITIONAL_DERIVATION_GROUP);
+  }
+
+  void uploadConstraint(String constraintName, int planId) throws IOException{
+    try (final var gateway = new GatewayRequests(playwright)) {
+      final int constraintJarId = gateway.uploadJarFile("build/libs/" + constraintName + ".jar");
+      // Add Scheduling Procedure
+      procedureId = hasura.createConstraintSpecProcedure(
+          constraintName + ".jar",
+          constraintJarId,
+          planId
+      );
+    }
+  }
+
+  void uploadConstraint(String constraintName) throws IOException{
+    uploadConstraint(constraintName, planId);
+  }
+
+  // check that plan.events() functions correctly if nothing is attached
+  @Test
+  void verifyAbsenceOfExternalEvents() throws IOException{
+    // in this case, create a plan with no derivation group associations
+    var newPlanId = hasura.createPlan(
+        modelId,
+        "No Derivation Groups".formatted(this.getClass().getSimpleName()),
+        "48:00:00",
+        planStartTimestamp);
+
+    // upload the constraint
+    uploadConstraint("ExternalEventAbsenceConstraint", newPlanId);
+
+    // run it
+    hasura.awaitSimulation(newPlanId);
+    final var resp = hasura.checkConstraints(newPlanId);
+
+    // check that there are no violations, and no errors
+    assertEquals(1, resp.constraintsRun().size());
+    assertEquals(0, resp.constraintsRun().getFirst().errors().size());
+    assertEquals(0, resp.constraintsRun().getFirst().result().get().violations().size());
+
+    // manually delete the plan
+    hasura.deletePlan(newPlanId);
+  }
+
+  // verify the presence and location of events of a given type
+  @Test
+  void verifyPresenceOfExternalEventByEventType() throws IOException {
+    // upload the constraint
+    uploadConstraint("ExternalEventPresenceConstraint");
+
+    // update constraint arguments
+    final var args = Json.createObjectBuilder()
+                         .add("eventType", "TestType")
+                         .add("derivationGroup", NULL_VALUE)
+                         .add("sourceKey", NULL_VALUE)
+                         .build();
+    hasura.updateConstraintArguments(procedureId.invocationId(), args);
+
+    // run it
+    hasura.awaitSimulation(planId);
+    final var resp = hasura.checkConstraints(planId);
+
+    // checks that external events of this type are present (expect one violation per event, so 4 total)
+    assertEquals(1, resp.constraintsRun().size());
+    assertEquals(0, resp.constraintsRun().getFirst().errors().size());
+    assertEquals(4, resp.constraintsRun().getFirst().result().get().violations().size());
+
+    // check the windows of those violations, ensuring they line up with the events
+    var violations = resp.constraintsRun().getFirst().result().get().violations();
+
+    // violation 1: single window, for event from 01:00:00 to 02:00:00
+    var firstViolation = violations.getFirst().windows();
+    assertEquals(1, firstViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(3600000000L, 7200000000L),
+        firstViolation.getFirst()
+    );
+    // violation 2: single window, for event from 03:00:00 to 04:00:00
+    var secondViolation = violations.get(1).windows();
+    assertEquals(1, secondViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(10800000000L, 14400000000L),
+        secondViolation.getFirst()
+    );
+    // violation 3: single window, for event from 05:00:00 to 06:00:00
+    var thirdViolation = violations.get(2).windows();
+    assertEquals(1, thirdViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(18000000000L, 21600000000L),
+        thirdViolation.getFirst()
+    );
+    // violation 4: single window, for event from 25:00:00 to 26:00:00
+    var fourthViolation = violations.get(3).windows();
+    assertEquals(1, fourthViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(90000000000L, 93600000000L),
+        fourthViolation.getFirst()
+    );
+  }
+
+  // verify the presence and location of events from a given derivation group
+  @Test
+  void verifyPresenceOfExternalEventByDerivationGroup() throws IOException {
+    // upload the constraint
+    uploadConstraint("ExternalEventPresenceConstraint");
+
+    // update constraint arguments
+    final var args = Json.createObjectBuilder()
+                         .add("derivationGroup", "TestGroup")
+                         .add("eventType", NULL_VALUE)
+                         .add("sourceKey", NULL_VALUE)
+                         .build();
+    hasura.updateConstraintArguments(procedureId.invocationId(), args);
+
+    // run it
+    hasura.awaitSimulation(planId);
+    final var resp = hasura.checkConstraints(planId);
+
+    // checks that external events of this type are present (expect one violation per event, so 3 total)
+    assertEquals(1, resp.constraintsRun().size());
+    assertEquals(0, resp.constraintsRun().getFirst().errors().size());
+    assertEquals(3, resp.constraintsRun().getFirst().result().get().violations().size());
+
+    // check the windows of those violations, ensuring they line up with the events
+    var violations = resp.constraintsRun().getFirst().result().get().violations();
+
+    // violation 1: single window, for event from 01:00:00 to 02:00:00
+    var firstViolation = violations.getFirst().windows();
+    assertEquals(1, firstViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(3600000000L, 7200000000L),
+        firstViolation.getFirst()
+    );
+    // violation 2: single window, for event from 03:00:00 to 04:00:00
+    var secondViolation = violations.get(1).windows();
+    assertEquals(1, secondViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(10800000000L, 14400000000L),
+        secondViolation.getFirst()
+    );
+    // violation 3: single window, for event from 05:00:00 to 06:00:00
+    var thirdViolation = violations.get(2).windows();
+    assertEquals(1, thirdViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(18000000000L, 21600000000L),
+        thirdViolation.getFirst()
+    );
+  }
+
+  // verify the presence and location of events from a given source
+  @Test
+  void verifyPresenceOfExternalEventBySource() throws IOException {
+    // upload the constraint
+    uploadConstraint("ExternalEventPresenceConstraint");
+
+    // update constraint arguments
+    final var args = Json.createObjectBuilder()
+                         .add("sourceKey", "Test.json")
+                         .add("derivationGroup", "TestGroup")
+                         .add("eventType", NULL_VALUE)
+                         .build();
+    hasura.updateConstraintArguments(procedureId.invocationId(), args);
+
+    // run it
+    hasura.awaitSimulation(planId);
+    final var resp = hasura.checkConstraints(planId);
+
+    // checks that external events of this type are present (expect one violation per event, so 3 total)
+    assertEquals(1, resp.constraintsRun().size());
+    assertEquals(0, resp.constraintsRun().getFirst().errors().size());
+    assertEquals(3, resp.constraintsRun().getFirst().result().get().violations().size());
+
+    // check the windows of those violations, ensuring they line up with the events
+    var violations = resp.constraintsRun().getFirst().result().get().violations();
+
+    // violation 1: single window, for event from 01:00:00 to 02:00:00
+    var firstViolation = violations.getFirst().windows();
+    assertEquals(1, firstViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(3600000000L, 7200000000L),
+        firstViolation.getFirst()
+    );
+    // violation 2: single window, for event from 03:00:00 to 04:00:00
+    var secondViolation = violations.get(1).windows();
+    assertEquals(1, secondViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(10800000000L, 14400000000L),
+        secondViolation.getFirst()
+    );
+    // violation 3: single window, for event from 05:00:00 to 06:00:00
+    var thirdViolation = violations.get(2).windows();
+    assertEquals(1, thirdViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(18000000000L, 21600000000L),
+        thirdViolation.getFirst()
+    );
+  }
+
+  private static Stream<Arguments> nonexistentEventCategoryArgs() {
+    var nonexistentTestType = Json.createObjectBuilder()
+                                  .add("eventType", "NonexistentTestType")
+                                  .add("derivationGroup", NULL_VALUE)
+                                  .add("sourceKey", NULL_VALUE)
+                                  .build();
+    var nonexistentDerivationGroup = Json.createObjectBuilder()
+                                         .add("derivationGroup", "NonexistentDerivationGroup")
+                                         .add("eventType", NULL_VALUE)
+                                         .add("sourceKey", NULL_VALUE)
+                                         .build();
+    var nonexistentSource = Json.createObjectBuilder()
+                                .add("derivationGroup", "NonexistentDerivationGroup")
+                                .add("sourceKey", "NonexistentSourceKey")
+                                .add("eventType", NULL_VALUE)
+                                .build();
+
+    return Stream.of(
+      Arguments.arguments(named("NonexistentTestType", nonexistentTestType)),
+      Arguments.arguments(named("NonexistentDerivationGroup", nonexistentDerivationGroup)),
+      Arguments.arguments(named("NonexistentSource", nonexistentSource))
+    );
+  }
+
+  // verify the presence and location of events from a nonexistent ee type
+  @ParameterizedTest
+  @MethodSource("nonexistentEventCategoryArgs")
+  void verifyAbsenceOfExternalEventByNonexistentEventType(JsonObject constraintArgs) throws IOException {
+    // upload the constraint
+    uploadConstraint("ExternalEventPresenceConstraint");
+
+    // update constraint arguments
+    hasura.updateConstraintArguments(procedureId.invocationId(), constraintArgs);
+
+    // run it
+    hasura.awaitSimulation(planId);
+    final var resp = hasura.checkConstraints(planId);
+
+    // checks that no external events of this type are present
+    assertEquals(1, resp.constraintsRun().size());
+    assertEquals(0, resp.constraintsRun().getFirst().errors().size());
+    assertEquals(0, resp.constraintsRun().getFirst().result().get().violations().size());
+  }
+
+  // verify the presence and location of events under a general filter on ee type, source, and derivation group
+  @Test
+  void verifyPresenceOfExternalEventByGeneralFilter() throws IOException {
+    // upload the constraint
+    uploadConstraint("ExternalEventPresenceConstraint");
+
+
+    // update constraint arguments
+    final var args = Json.createObjectBuilder()
+                         .add("eventType", "TestType_2")
+                         .add("derivationGroup", "TestGroup_2")
+                         .add("sourceKey", "NewTest.json")
+                         .build();
+    hasura.updateConstraintArguments(procedureId.invocationId(), args);
+
+    // run it
+    hasura.awaitSimulation(planId);
+    final var resp = hasura.checkConstraints(planId);
+
+    // checks that external events of this type are present (expect one violation per event, so 2 total)
+    assertEquals(1, resp.constraintsRun().size());
+    assertEquals(0, resp.constraintsRun().getFirst().errors().size());
+    assertEquals(2, resp.constraintsRun().getFirst().result().get().violations().size());
+
+    // check the windows of those violations, ensuring they line up with the events
+    var violations = resp.constraintsRun().getFirst().result().get().violations();
+
+    // violation 1: single window, for event from 27:00:00 to 38:00:00
+    var firstViolation = violations.getFirst().windows();
+    assertEquals(1, firstViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(97200000000L, 100800000000L),
+        firstViolation.getFirst()
+    );
+    // violation 2: single window, for event from 29:00:00 to 30:00:00
+    var secondViolation = violations.get(1).windows();
+    assertEquals(1, secondViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(104400000000L, 108000000000L),
+        secondViolation.getFirst()
+    );
+  }
+
+  // check external events have given attribute values, and flag their locations
+  @Test
+  void verifyPropertiesOfExternalEvent() throws IOException {
+    // upload the constraint
+    uploadConstraint("ExternalEventAttributeConstraint");
+
+    // update constraint arguments
+    final var args = Json.createObjectBuilder().add("codeValue", "B").build();
+    hasura.updateConstraintArguments(procedureId.invocationId(), args);
+
+    // run it
+    hasura.awaitSimulation(planId);
+    final var resp = hasura.checkConstraints(planId);
+
+    // checks that external events of this type are present (expect one violation per event, so 2 total)
+    assertEquals(1, resp.constraintsRun().size());
+    assertEquals(0, resp.constraintsRun().getFirst().errors().size());
+    assertEquals(2, resp.constraintsRun().getFirst().result().get().violations().size());
+
+    // check the windows of those violations, ensuring they line up with the events
+    var violations = resp.constraintsRun().getFirst().result().get().violations();
+
+    // violation 1: single window, for event from 05:00:00 to 06:00:00
+    var firstViolation = violations.getFirst().windows();
+    assertEquals(1, firstViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(18000000000L, 21600000000L),
+        firstViolation.getFirst()
+    );
+    // violation 2: single window, for event from 25:00:00 to 26:00:00
+    var secondViolation = violations.get(1).windows();
+    assertEquals(1, secondViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(90000000000L, 93600000000L),
+        secondViolation.getFirst()
+    );
+  }
+
+  // check external event overlaps with activity
+  @Test
+  void testExternalEventActivityOverlap() throws IOException {
+    // upload the constraint
+    uploadConstraint("ExternalEventActivityOverlapConstraint");
+
+    // add hour long activities
+    hasura.insertActivityDirective(
+        planId, "BananaNap", "0h", Json.createObjectBuilder().build());
+    hasura.insertActivityDirective(
+        planId, "BananaNap", "4h30m", Json.createObjectBuilder().build());
+
+    // run it
+    hasura.awaitSimulation(planId);
+    final var resp = hasura.checkConstraints(planId);
+
+    // checks that external events of this type are present (expect one violation per event, so only 1)
+    assertEquals(1, resp.constraintsRun().size());
+    assertEquals(0, resp.constraintsRun().getFirst().errors().size());
+    assertEquals(1, resp.constraintsRun().getFirst().result().get().violations().size());
+
+    // check the windows of those violations, ensuring they line up with the events
+    var violations = resp.constraintsRun().getFirst().result().get().violations();
+
+    // violation 1: single window, for event from 05:00:00, but cut off at 05:30:00
+    var firstViolation = violations.getFirst().windows();
+    assertEquals(1, firstViolation.size());
+    assertEquals(
+        new ConstraintResult.Interval(18000000000L, 19800000000L),
+        firstViolation.getFirst()
+    );
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/AutoDeletionTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/AutoDeletionTests.java
@@ -10,13 +10,12 @@ import javax.json.Json;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AutoDeletionTests extends ProceduralSchedulingSetup {
+public class AutoDeletionTests extends ProceduralTestingSetup {
   private GoalInvocationId edslId;
   private GoalInvocationId procedureId;
 

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/BasicSchedulingTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/BasicSchedulingTests.java
@@ -10,14 +10,13 @@ import org.junit.jupiter.api.Test;
 
 import javax.json.Json;
 import java.io.IOException;
-import java.util.Comparator;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BasicSchedulingTests extends ProceduralSchedulingSetup {
+public class BasicSchedulingTests extends ProceduralTestingSetup {
   private int dumbRecurrenceGoalJarId;
   private int decompositionGoalJarId;
   private GoalInvocationId dumbRecurrenceGoalId;

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/DatabaseDeletionTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/DatabaseDeletionTests.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DatabaseDeletionTests extends ProceduralSchedulingSetup {
+public class DatabaseDeletionTests extends ProceduralTestingSetup {
   private GoalInvocationId procedureId;
 
   @BeforeEach

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/DeletionTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/DeletionTests.java
@@ -14,7 +14,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DeletionTests extends ProceduralSchedulingSetup {
+public class DeletionTests extends ProceduralTestingSetup {
   private GoalInvocationId procedureId;
 
   @BeforeEach

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalEventsSchedulingTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalEventsSchedulingTests.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ExternalEventsSchedulingTests extends ProceduralSchedulingSetup {
+public class ExternalEventsSchedulingTests extends ProceduralTestingSetup {
   private GoalInvocationId procedureId;
   private final static String SOURCE_TYPE = "TestType";
   private final static String EVENT_TYPE = "TestType";

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalEventsSchedulingTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalEventsSchedulingTests.java
@@ -128,6 +128,11 @@ public class ExternalEventsSchedulingTests extends ProceduralTestingSetup {
   void testExternalEventSimple() throws IOException {
     // first, run the goal
     try (final var gateway = new GatewayRequests(playwright)) {
+      // TODO: difficulties were encountered when trying to use a build/libs/scheduling/....jar path owing to a weird
+      //          gradle issue.
+      //       As such, these tests have constraints and scheduling goals in the same folder, but ideally, the
+      //          constraints would go in a constraint subfolder and goals in a scheduling folder
+      //          (i.e. build/libs/scheduling and build/libs/constraints).
       int procedureJarId = gateway.uploadJarFile("build/libs/ExternalEventsSimpleGoal.jar");
       // Add Scheduling Procedure
       procedureId = hasura.createSchedulingSpecProcedure(

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalEventsSchedulingTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalEventsSchedulingTests.java
@@ -8,102 +8,22 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.json.Json;
-import javax.json.JsonObject;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 
+import static gov.nasa.jpl.aerie.e2e.utils.ExternalEventUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ExternalEventsSchedulingTests extends ProceduralTestingSetup {
   private GoalInvocationId procedureId;
-  private final static String SOURCE_TYPE = "TestType";
-  private final static String EVENT_TYPE = "TestType";
-  private final static String ADDITIONAL_EVENT_TYPE = EVENT_TYPE + "_2";
-  private final static String SOURCE_KEY = "Test.json";
-  private final static String ADDITIONAL_SOURCE_KEY = "NewTest.json";
-
-  private final static String DERIVATION_GROUP = "TestGroup";
-  private final static String ADDITIONAL_DERIVATION_GROUP = DERIVATION_GROUP + "_2";
-
-  void uploadExternalSourceEventTypes() throws IOException {
-    final String event_types = """
-        {
-          "%s": {
-            "type": "object",
-            "properties": {
-              "projectUser": {
-                "type": "string"
-              },
-              "code": {
-                "type": "string"
-              },
-              "optional": {
-                "type": "string"
-              }
-            },
-            "required": ["projectUser", "code"]
-          },
-          "%s": {
-            "type": "object",
-            "properties": {
-              "projectUser": {
-                  "type": "string"
-              },
-              "code": {
-                  "type": "string"
-              },
-              "optional": {
-                "type": "string"
-              }
-            },
-            "required": ["projectUser", "code"]
-          }
-        }
-        """.formatted(EVENT_TYPE, ADDITIONAL_EVENT_TYPE);
-
-    final String source_types = """
-        {
-          "%s": {
-            "type": "object",
-            "properties": {
-              "version": {
-                  "type": "number"
-              },
-              "optional": {
-                "type": "string"
-              }
-          },
-          "required": ["version"]
-          }
-        }
-        """.formatted(SOURCE_TYPE);
-
-    final JsonObject schema = Json.createObjectBuilder()
-                                  .add("event_types", event_types)
-                                  .add("source_types", source_types)
-                                  .build();
-
-    try (final var gateway = new GatewayRequests(playwright)) {
-      gateway.uploadExternalSourceEventTypes(schema);
-    }
-  }
-
-
-  void uploadExternalSources() throws IOException {
-    try (final var gateway = new GatewayRequests(playwright)) {
-      gateway.uploadExternalSource("scheduling_source_A.json", DERIVATION_GROUP);
-      gateway.uploadExternalSource("scheduling_source_B.json", ADDITIONAL_DERIVATION_GROUP);
-    }
-  }
 
   @BeforeEach
   void localBeforeEach() throws IOException {
     // Upload some External Events
-    uploadExternalSourceEventTypes();
-    uploadExternalSources();
+    uploadExternalSourceEventTypes(playwright);
+    uploadExternalSources(playwright);
     hasura.insertPlanDerivationGroupAssociation(planId, DERIVATION_GROUP);
     hasura.insertPlanDerivationGroupAssociation(planId, ADDITIONAL_DERIVATION_GROUP);
   }

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalProfilesTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ExternalProfilesTests.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ExternalProfilesTests extends ProceduralSchedulingSetup {
+public class ExternalProfilesTests extends ProceduralTestingSetup {
   private GoalInvocationId procedureId;
   private int datasetId;
 

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ProceduralTestingSetup.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/ProceduralTestingSetup.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.TestInstance;
 import java.io.IOException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public abstract class ProceduralSchedulingSetup {
+public abstract class ProceduralTestingSetup {
 
   // Requests
   protected Playwright playwright;

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/TemplateDefaultsTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/TemplateDefaultsTests.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TemplateDefaultsTests extends ProceduralSchedulingSetup {
+public class TemplateDefaultsTests extends ProceduralTestingSetup {
   private int procedureJarId;
   private GoalInvocationId procedureId;
 

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/TemplateParametersTest.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/TemplateParametersTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class TemplateParametersTest extends ProceduralSchedulingSetup {
+public class TemplateParametersTest extends ProceduralTestingSetup {
   private GoalInvocationId dumbRecurrenceWithTemplateDefaultsGoalId;
   private GoalInvocationId dumbRecurrenceGoalId;
 

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/ExternalEventUtils.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/utils/ExternalEventUtils.java
@@ -1,0 +1,101 @@
+package gov.nasa.jpl.aerie.e2e.utils;
+
+import com.microsoft.playwright.Playwright;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import java.io.IOException;
+
+/**
+ * This class centralizes shared external event upload functionality for use by end-to-end tests.
+ * These upload functions are shared between constraints and scheduling tests.
+ *
+ * It provides two functions that upload a standardized set of source/event types and the sources themselves.
+ * These functions introduce:
+ *    - one source type (TestType)
+ *    - two event types ("TestType", "TestType_2"),
+ *    - and upload sources keyed by "Test.json" and "NewTest.json", which represent
+ *        "scheduling_source_A.json" and "scheduling_source_B.json", falling under two
+ *        separate derivation groups: "TestGroup" and "TestGroup_2", respectively.
+ */
+public class ExternalEventUtils {
+  public final static String SOURCE_TYPE = "TestType";
+  public final static String EVENT_TYPE = "TestType";
+  public final static String ADDITIONAL_EVENT_TYPE = EVENT_TYPE + "_2";
+  public final static String SOURCE_KEY = "Test.json";
+  public final static String ADDITIONAL_SOURCE_KEY = "NewTest.json";
+
+  public final static String DERIVATION_GROUP = "TestGroup";
+  public final static String ADDITIONAL_DERIVATION_GROUP = DERIVATION_GROUP + "_2";
+
+
+  public static void uploadExternalSourceEventTypes(Playwright playwright) throws IOException {
+    final String event_types = """
+        {
+          "%s": {
+            "type": "object",
+            "properties": {
+              "projectUser": {
+                "type": "string"
+              },
+              "code": {
+                "type": "string"
+              },
+              "optional": {
+                "type": "string"
+              }
+            },
+            "required": ["projectUser", "code"]
+          },
+          "%s": {
+            "type": "object",
+            "properties": {
+              "projectUser": {
+                  "type": "string"
+              },
+              "code": {
+                  "type": "string"
+              },
+              "optional": {
+                "type": "string"
+              }
+            },
+            "required": ["projectUser", "code"]
+          }
+        }
+        """.formatted(EVENT_TYPE, ADDITIONAL_EVENT_TYPE);
+
+    final String source_types = """
+        {
+          "%s": {
+            "type": "object",
+            "properties": {
+              "version": {
+                  "type": "number"
+              },
+              "optional": {
+                "type": "string"
+              }
+          },
+          "required": ["version"]
+          }
+        }
+        """.formatted(SOURCE_TYPE);
+
+    final JsonObject schema = Json.createObjectBuilder()
+                                  .add("event_types", event_types)
+                                  .add("source_types", source_types)
+                                  .build();
+
+    try (final var gateway = new GatewayRequests(playwright)) {
+      gateway.uploadExternalSourceEventTypes(schema);
+    }
+  }
+
+  public static void uploadExternalSources(Playwright playwright) throws IOException {
+    try (final var gateway = new GatewayRequests(playwright)) {
+      gateway.uploadExternalSource("scheduling_source_A.json", DERIVATION_GROUP);
+      gateway.uploadExternalSource("scheduling_source_B.json", ADDITIONAL_DERIVATION_GROUP);
+    }
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/mocks/InMemoryPlanRepository.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.mocks;
 
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
@@ -15,6 +16,7 @@ import gov.nasa.jpl.aerie.types.Plan;
 import gov.nasa.jpl.aerie.types.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,6 +144,13 @@ public final class InMemoryPlanRepository implements PlanRepository {
       final SimulationDatasetId simulationDatasetId)
   {
     return List.of();
+  }
+
+  @Override
+  public Map<String, List<ExternalEvent>> getExternalEvents(
+      final PlanId planId,
+      final Instant horizonStart) {
+    return Map.of();
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ReadonlyPlan.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ReadonlyPlan.java
@@ -4,6 +4,7 @@ import gov.nasa.ammos.aerie.procedural.timeline.Interval;
 import gov.nasa.ammos.aerie.procedural.timeline.collections.Directives;
 import gov.nasa.ammos.aerie.procedural.timeline.collections.ExternalEvents;
 import gov.nasa.ammos.aerie.procedural.timeline.ops.SerialSegmentOps;
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.Segment;
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.AnyDirective;
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.Directive;
@@ -14,7 +15,6 @@ import gov.nasa.jpl.aerie.constraints.model.EvaluationEnvironment;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.types.Timestamp;
-import kotlin.NotImplementedError;
 import kotlin.jvm.functions.Function1;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -157,7 +157,35 @@ public final class ReadonlyPlan implements Plan {
   @NotNull
   @Override
   public ExternalEvents events(@NotNull final EventQuery query) {
-    throw new NotImplementedError("Procedural Constraints does not currently support External Events");
+    var events = environment.externalEventsByDerivationGroup();
+    List<ExternalEvent> result = events.values().stream().reduce(List.of(), (curr, acc) -> {
+      acc.addAll(curr);
+      return acc;
+    });
+
+    // filter by dg
+    if (query.getDerivationGroups() != null) {
+      result = result.stream()
+                     .filter(e -> query.getDerivationGroups().contains(e.source.derivationGroup))
+                     .toList();
+    }
+
+    // filter by types
+    if (query.getEventTypes() != null) {
+      result = result.stream()
+                     .filter(e -> query.getEventTypes().contains(e.type))
+                     .toList();
+    }
+
+    // filter by sources
+    if (query.getSources() != null) {
+      result = result.stream()
+                     .filter(e -> query.getSources()
+                                       .contains(new EventQuery.SourceQuery(e.source))
+                     ).toList();
+    }
+
+    return new ExternalEvents(result);
   }
 
   /** Get all external events across all derivation groups associated with this plan. */

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepository.java
@@ -1,5 +1,6 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes;
 
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
@@ -15,6 +16,7 @@ import gov.nasa.jpl.aerie.types.Plan;
 import gov.nasa.jpl.aerie.types.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -46,6 +48,9 @@ public interface PlanRepository {
   List<Pair<Duration, ProfileSet>> getExternalDatasets(
       PlanId planId,
       SimulationDatasetId simulationDatasetId) throws NoSuchPlanException;
+  Map<String, List<ExternalEvent>> getExternalEvents(
+      final PlanId planId,
+      final Instant horizonStart) throws NoSuchPlanException;
   Map<String, ValueSchema> getExternalResourceSchemas(PlanId planId, Optional<SimulationDatasetId> simulationDatasetId) throws NoSuchPlanException;
 
   record CreatedPlan(PlanId planId, List<ActivityDirectiveId> activityIds) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ExternalEventRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ExternalEventRepository.java
@@ -1,0 +1,35 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalSource;
+import gov.nasa.jpl.aerie.merlin.server.http.InvalidEntityException;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/*package-local*/ final class ExternalEventRepository {
+  static Map<String, List<ExternalEvent>> getExternalEvents(
+    final Connection connection,
+    final PlanId planId,
+    final Instant horizonStart
+  ) throws SQLException, InvalidEntityException
+  {
+    try (final var getPlanExternalEventsAction = new GetPlanExternalEventsAction(connection)) {
+        Map<String, ExternalSource> sourceMap = getExternalSources(connection, planId);
+        return getPlanExternalEventsAction.get(planId, horizonStart, sourceMap);
+    }
+  }
+
+  static Map<String, ExternalSource> getExternalSources(
+      final Connection connection,
+      final PlanId planId
+  ) throws SQLException, InvalidEntityException {
+    try (final var getExternalSourcesMapAction = new GetExternalSourcesMapAction(connection)) {
+      return getExternalSourcesMapAction.get(planId);
+    }
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetExternalSourcesMapAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetExternalSourcesMapAction.java
@@ -1,0 +1,69 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalSource;
+import gov.nasa.jpl.aerie.merlin.server.http.InvalidEntityException;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.eventAttributesP;
+import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.getJsonColumn;
+
+/*package-local*/ final class GetExternalSourcesMapAction implements AutoCloseable {
+  private final @Language("SQL") String sql = """
+      select
+        key,
+        attributes,
+        derivation_group_name
+      from merlin.plan_derivation_group as pdg
+      join merlin.external_source as s using (derivation_group_name)
+      where pdg.plan_id = ?;
+    """;
+
+  private final PreparedStatement statement;
+
+  public GetExternalSourcesMapAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public Map<String, ExternalSource> get(final PlanId planId)
+  throws SQLException, InvalidEntityException
+  {
+    final var result = new HashMap<String, ExternalSource>();
+    this.statement.setLong(1, planId.id());
+    final var resultSet = statement.executeQuery();
+
+    while (resultSet.next()) {
+      // get source key
+      final String key = resultSet.getString("key");
+      // get source attributes
+      final var attributes = getJsonColumn(resultSet, "attributes", eventAttributesP)
+          .getSuccessOrThrow(reason -> new InvalidEntityException(List.of(reason)));
+      // get derivation group
+      final String derivationGroup = resultSet.getString("derivation_group_name");
+
+      // create source
+      ExternalSource s = new ExternalSource(
+          key,
+          derivationGroup,
+          attributes
+      );
+
+      if (!result.containsKey(key)) {
+        result.put(key, s);
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanExternalEventsAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetPlanExternalEventsAction.java
@@ -1,0 +1,100 @@
+package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
+
+import gov.nasa.ammos.aerie.procedural.timeline.Interval;
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalSource;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.server.http.InvalidEntityException;
+import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
+
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.eventAttributesP;
+import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.getJsonColumn;
+
+/*package-local*/ final class GetPlanExternalEventsAction implements AutoCloseable {
+  private final @Language("SQL") String sql = """
+      select
+        ee.event_key,
+        ee.event_type_name,
+        ee.source_key,
+        ee.derivation_group_name,
+        ee.start_time,
+        extract(epoch from ee.duration)*1e6 as duration_micros,
+        ee.attributes
+      from merlin.derived_events as ee
+        join (
+          select
+            pdg.derivation_group_name,
+            pdg.plan_id
+          from merlin.plan_derivation_group as pdg
+            ) pdg
+              on pdg.derivation_group_name = ee.derivation_group_name
+        where pdg.plan_id = ?;
+    """;
+
+  private final PreparedStatement statement;
+
+  public GetPlanExternalEventsAction(final Connection connection) throws SQLException {
+    this.statement = connection.prepareStatement(sql);
+  }
+
+  public Map<String, List<ExternalEvent>> get(final PlanId planId, final Instant horizonStart, Map<String, ExternalSource> sources)
+  throws SQLException, InvalidEntityException
+  {
+    final var result = new HashMap<String, List<ExternalEvent>>();
+    this.statement.setLong(1, planId.id());
+    final var resultSet = statement.executeQuery();
+
+    while (resultSet.next()) {
+      // get start
+      final var start = new Duration(
+          horizonStart.until(resultSet.getTimestamp("start_time").toInstant(), ChronoUnit.MICROS)
+      );
+      // get end
+      Duration duration = Duration.of(resultSet.getLong("duration_micros"), Duration.MICROSECOND);
+      final var end = start.plus(duration);
+
+      // get event attributes
+      final var eventAttributes = getJsonColumn(resultSet, "attributes", eventAttributesP)
+          .getSuccessOrThrow(reason -> new InvalidEntityException(List.of(reason)));
+      // get derivation group
+      final String derivationGroup = resultSet.getString("derivation_group_name");
+      // get event key
+      final String key = resultSet.getString("event_key");
+      // get event_type
+      final String eventType = resultSet.getString("event_type_name");
+
+      // retrieve source
+      ExternalSource s = sources.get(resultSet.getString("source_key"));
+
+      // create event
+      ExternalEvent e = new ExternalEvent(
+          key,
+          eventType,
+          s,
+          eventAttributes,
+          Interval.between(start, end)
+      );
+      if (result.containsKey(derivationGroup)) {
+        result.get(derivationGroup).add(e);
+      }
+      else {
+        result.put(derivationGroup, new ArrayList<>(List.of(e)));
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public void close() throws SQLException {
+    this.statement.close();
+  }
+}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresParsers.java
@@ -118,6 +118,7 @@ public final class PostgresParsers {
 
   public static final JsonParser<Map<String, SerializedValue>> constraintArgumentsP = mapP(serializedValueP);
   public static final JsonParser<Map<String, SerializedValue>> activityArgumentsP = mapP(serializedValueP);
+  public static final JsonParser<Map<String, SerializedValue>> eventAttributesP = mapP(serializedValueP);
 
   public static final JsonParser<Map<String, SerializedValue>> simulationArgumentsP = mapP(serializedValueP);
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -1,10 +1,12 @@
 package gov.nasa.jpl.aerie.merlin.server.remotes.postgres;
 
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
+import gov.nasa.jpl.aerie.merlin.server.http.InvalidEntityException;
 import gov.nasa.jpl.aerie.merlin.server.models.ConstraintRecord;
 import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
@@ -22,6 +24,7 @@ import javax.sql.DataSource;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -268,6 +271,22 @@ public final class PostgresPlanRepository implements PlanRepository {
     } catch (final SQLException ex) {
       throw new DatabaseException(
           "Failed to get external datasets for plan with id `%s`".formatted(planId), ex);
+    }
+  }
+
+  @Override
+  public Map<String, List<ExternalEvent>> getExternalEvents(
+      final PlanId planId,
+      final Instant horizonStart) {
+    try (final var connection = this.dataSource.getConnection()) {
+        return ExternalEventRepository.getExternalEvents(connection, planId, horizonStart);
+    } catch (final SQLException ex) {
+      throw new DatabaseException(
+          "Failed to get external events for plan with id `%s`".formatted(planId), ex);
+    } catch (final InvalidEntityException in) {
+      throw new RuntimeException(
+          ("Failed to get external events for plan with id `%s; "
+           + "failed to parse jsonb for external event/source attributes`").formatted(planId), in);
     }
   }
 

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/ConstraintAction.java
@@ -134,6 +134,7 @@ public class ConstraintAction {
     // If the lengths don't match we need check the left-over constraints.
     if (!constraints.isEmpty()) {
       final var externalDatasets = this.planService.getExternalDatasets(planId, simDatasetId);
+      final var externalEventsByDerivationGroup = this.planService.getExternalEvents(planId, plan.planStartInstant());
       final var realExternalProfiles = new HashMap<String, LinearProfile>();
       final var discreteExternalProfiles = new HashMap<String, DiscreteProfile>();
 
@@ -191,7 +192,7 @@ public class ConstraintAction {
       //    a procedural constraint will access
       final var merlinSimResults = resultsHandle.getSimulationResults();
       final var edslSimResults = new SimulationResults(merlinSimResults);
-      final var environment = new EvaluationEnvironment(realExternalProfiles, discreteExternalProfiles);
+      final var environment = new EvaluationEnvironment(realExternalProfiles, discreteExternalProfiles, externalEventsByDerivationGroup);
 
       final var timelinePlan = new ReadonlyPlan(plan, environment);
       final var timelineSimResults = new ReadonlyProceduralSimResults(merlinSimResults, timelinePlan);

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/LocalPlanService.java
@@ -1,10 +1,10 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
-import gov.nasa.jpl.aerie.merlin.server.models.ConstraintId;
 import gov.nasa.jpl.aerie.merlin.server.models.ConstraintRecord;
 import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
@@ -15,6 +15,7 @@ import gov.nasa.jpl.aerie.types.Plan;
 import gov.nasa.jpl.aerie.types.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -72,6 +73,13 @@ public final class LocalPlanService implements PlanService {
       final SimulationDatasetId simulationDatasetId) throws NoSuchPlanException
   {
     return this.planRepository.getExternalDatasets(planId, simulationDatasetId);
+  }
+
+  @Override
+  public Map<String, List<ExternalEvent>> getExternalEvents(
+      final PlanId planId,
+      final Instant horizonStart) throws NoSuchPlanException {
+    return this.planRepository.getExternalEvents(planId, horizonStart);
   }
 
   @Override

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/services/PlanService.java
@@ -1,10 +1,10 @@
 package gov.nasa.jpl.aerie.merlin.server.services;
 
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanDatasetException;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
-import gov.nasa.jpl.aerie.merlin.server.models.ConstraintId;
 import gov.nasa.jpl.aerie.merlin.server.models.ConstraintRecord;
 import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
@@ -14,6 +14,7 @@ import gov.nasa.jpl.aerie.types.Plan;
 import gov.nasa.jpl.aerie.types.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -34,5 +35,8 @@ public interface PlanService {
   List<Pair<Duration, ProfileSet>> getExternalDatasets(
       final PlanId planId,
       final SimulationDatasetId simulationDatasetId) throws NoSuchPlanException;
+  Map<String, List<ExternalEvent>> getExternalEvents(
+      final PlanId planId,
+      final Instant horizonStart) throws NoSuchPlanException;
   Map<String, ValueSchema> getExternalResourceSchemas(final PlanId planId, final Optional<SimulationDatasetId> simulationDatasetId) throws NoSuchPlanException;
 }

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
@@ -1,10 +1,10 @@
 package gov.nasa.jpl.aerie.merlin.server.mocks;
 
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.merlin.protocol.types.ValueSchema;
 import gov.nasa.jpl.aerie.merlin.server.exceptions.NoSuchPlanException;
-import gov.nasa.jpl.aerie.merlin.server.models.ConstraintId;
 import gov.nasa.jpl.aerie.merlin.server.models.ConstraintRecord;
 import gov.nasa.jpl.aerie.merlin.server.models.DatasetId;
 import gov.nasa.jpl.aerie.merlin.server.models.PlanId;
@@ -106,6 +106,14 @@ public final class StubPlanService implements PlanService {
       ) throws NoSuchPlanException
   {
     return List.of();
+  }
+
+  @Override
+  public Map<String, List<ExternalEvent>> getExternalEvents(
+      final PlanId planId,
+      final Instant horizonStart
+      ) throws NoSuchPlanException {
+    return Map.of();
   }
 
   @Override

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CoexistenceGoal.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/CoexistenceGoal.java
@@ -349,7 +349,8 @@ public class CoexistenceGoal extends ActivityTemplateGoal {
           existingEnvironment.spansInstances(),
           existingEnvironment.intervals(),
           existingEnvironment.realExternalProfiles(),
-          existingEnvironment.discreteExternalProfiles()
+          existingEnvironment.discreteExternalProfiles(),
+          existingEnvironment.externalEventsByDerivationGroup()
       );
     } else{
       assert this.alias != null;
@@ -360,7 +361,8 @@ public class CoexistenceGoal extends ActivityTemplateGoal {
           existingEnvironment.spansInstances(),
           intervals,
           existingEnvironment.realExternalProfiles(),
-          existingEnvironment.discreteExternalProfiles()
+          existingEnvironment.discreteExternalProfiles(),
+          existingEnvironment.externalEventsByDerivationGroup()
       );
     }
   }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/solver/PrioritySolver.java
@@ -913,7 +913,7 @@ public class PrioritySolver implements Solver {
     final var resources = new HashSet<String>();
     goal.extractResources(resources);
     final var simulationResults = this.getLatestSimResultsUpTo(this.problem.getPlanningHorizon().getEndAerie(), resources);
-    final var evaluationEnvironment = new EvaluationEnvironment(this.problem.getRealExternalProfiles(), this.problem.getDiscreteExternalProfiles());
+    final var evaluationEnvironment = new EvaluationEnvironment(this.problem.getRealExternalProfiles(), this.problem.getDiscreteExternalProfiles(), this.problem.getEventsByDerivationGroup());
     final var rawConflicts = goal.getConflicts(
         plan,
         simulationResults.constraintsResults(),
@@ -1096,7 +1096,7 @@ public class PrioritySolver implements Solver {
     final var latestSimulationResults = this.getLatestSimResultsUpTo(totalDomain.end, resourceNames);
     //iteratively narrow the windows from each constraint
     //REVIEW: could be some optimization in constraint ordering (smallest domain first to fail fast)
-    final var evaluationEnvironment = new EvaluationEnvironment(this.problem.getRealExternalProfiles(), this.problem.getDiscreteExternalProfiles());
+    final var evaluationEnvironment = new EvaluationEnvironment(this.problem.getRealExternalProfiles(), this.problem.getDiscreteExternalProfiles(), this.problem.getEventsByDerivationGroup());
     for (final var constraint : constraints) {
       //REVIEW: loop through windows more efficient than enveloppe(windows) ?
       final var validity = constraint.evaluate(latestSimulationResults.constraintsResults(), totalDomain, evaluationEnvironment);

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/TestApplyWhen.java
@@ -1119,7 +1119,7 @@ public class TestApplyWhen {
       logger.debug(a.startOffset().toString() + ", " + a.duration().toString());
     }
     final var emptySimulationResults = new SimulationResults(null, null, List.of(), Map.of(), Map.of());
-    final var startOfActivity =   cond.evaluate(emptySimulationResults, Interval.FOREVER, new EvaluationEnvironment(externalRealProfiles, externalDiscreteProfiles)).iterateEqualTo(true).iterator().next().start;
+    final var startOfActivity =   cond.evaluate(emptySimulationResults, Interval.FOREVER, new EvaluationEnvironment(externalRealProfiles, externalDiscreteProfiles, Map.of())).iterateEqualTo(true).iterator().next().start;
     assertEquals(1, plan.get().getActivitiesByTime().size());
     final var act = plan.get().getActivitiesByTime().get(0);
     assertEquals(act.duration(), Duration.of(r3Value.get("amountInMicroseconds").asInt().get(), Duration.MICROSECONDS));

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/InstantiateArgumentsTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/InstantiateArgumentsTest.java
@@ -59,6 +59,7 @@ public class InstantiateArgumentsTest {
         Map.of(),
         Map.of(),
         Map.of(),
+        Map.of(),
         Map.of());
     final SimulationResults simulationResults = new SimulationResults(
         Instant.EPOCH,


### PR DESCRIPTION
* **Tickets addressed:** --
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This pull request introduces visibility of external events in procedural constraints. Conceptually, the approach is extremely similar to that taken when introducing external events to procedural scheduling, and the implementation largely piggybacks off of that implementation. 

That being said, this PR introduces external events to `PlanRepository`, `PlanService`, and other related entities like `EvaluationEnvironment` that previously lacked visibility to external events. These are the analogues in procedural constraints to `MerlinDatabaseService` (and other smaller items like `SchedulerToProcedurePlanAdapter` and `SynchronousSchedulerAgent`). But common entities are still shared, like the Kotlin timeline representations of External Events and Sources. 

## Verification
A few new end-to-end tests were introduced in `ExternalEventConstraintTests` under `e2e-tests`, to verify that several constraints leveraging External Events worked as expected.

## Documentation
No documentation was invalidated, though examples can/should now be added to the "Examples" page under the [Procedural Constraints section of the documentation](https://nasa-ammos.github.io/plandev-docs/scheduling-and-constraints/procedural/constraints/introduction/). As a matter of fact, that page already claims/suggests that external events can be leveraged by the constraints engine!

## Future work
None anticipated.

(Small note: significant issues with the build process arose when trying to organize the procedures in `src/main/java` under `e2e-tests` into separate `constraints` and `scheduling` folders. This organization would be useful but has worked inconsistently when building.)