### PR TITLE
update postgres docker image 16.4 -> 16.12-bookworm

### DIFF
--- a/.github/workflows/pgcmp.yml
+++ b/.github/workflows/pgcmp.yml
@@ -70,7 +70,7 @@ jobs:
         run: sudo curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
       - name: Start Postgres
         run: |
-          sed -i 's/postgres:14.8/postgres:16.4/' docker-compose.yml
+          sed -i 's/postgres:14.8/postgres:16.12-bookworm/' docker-compose.yml
           docker compose up -d postgres hasura
           docker images
           docker ps -a
@@ -266,7 +266,7 @@ jobs:
           sudo apt update
           sudo apt -y install postgresql-client-16
       - name: Start Postgres
-        run: docker run -d -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust --name=postgres postgres:16.4
+        run: docker run -d -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust --name=postgres postgres:16.12-bookworm
       - name: Sleep for 5 Seconds
         run: sleep 5s
         shell: bash
@@ -328,7 +328,7 @@ jobs:
           sudo apt update
           sudo apt -y install postgresql-client-16
       - name: Start Postgres
-        run: docker run -d -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust --name=postgres postgres:16.4
+        run: docker run -d -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust --name=postgres postgres:16.12-bookworm
       - name: Sleep for 5 Seconds
         run: sleep 5s
         shell: bash

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -243,7 +243,7 @@ services:
       SCHEDULER_DB_PASSWORD: "${SCHEDULER_PASSWORD}"
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
-    image: postgres:16.4
+    image: postgres:16.12-bookworm
     ports: ["5432:5432"]
     restart: always
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -314,7 +314,7 @@ services:
       SCHEDULER_DB_PASSWORD: "${SCHEDULER_PASSWORD}"
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
-    image: postgres:16.4
+    image: postgres:16.12-bookworm
     ports: ["5432:5432"]
     restart: always
     volumes:

--- a/docker/Dockerfile.postgres
+++ b/docker/Dockerfile.postgres
@@ -1,2 +1,2 @@
-FROM postgres:16.4
+FROM postgres:16.12-bookworm
 COPY deployment/postgres-init-db /docker-entrypoint-initdb.d

--- a/e2e-tests/docker-compose-many-workers.yml
+++ b/e2e-tests/docker-compose-many-workers.yml
@@ -256,7 +256,7 @@ services:
       SCHEDULER_DB_PASSWORD: "${SCHEDULER_PASSWORD}"
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
-    image: postgres:16.4
+    image: postgres:16.12-bookworm
     ports: ["5432:5432"]
     restart: always
     volumes:

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -300,7 +300,7 @@ services:
       SCHEDULER_DB_PASSWORD: "${SCHEDULER_PASSWORD}"
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
-    image: postgres:16.4
+    image: postgres:16.12-bookworm
     ports: ['5432:5432']
     restart: always
     volumes:


### PR DESCRIPTION
Updates postgres image from `postgres:16.4` to `postgres:16.12-bookworm`.

This picks up the latest postgres 16 patch release and ensures the image is based on **debian 12 (bookworm)** with current security fixes, (hopefully) resolving container scans (openssl CVE-2025-15467).

No functional changes. major version and debian suite unchanged.