### PR TITLE
Add another false positive CVE for gosu to trivyignore

### DIFF
--- a/.github/config/.trivyignore
+++ b/.github/config/.trivyignore
@@ -6,9 +6,11 @@
 # for details see:
 # - https://github.com/tianon/gosu/blob/master/SECURITY.md
 # - https://github.com/NASA-AMMOS/aerie/pull/1546
+# - https://github.com/tianon/gosu/pull/173#issuecomment-3936440684
 CVE-2023-24538
 CVE-2023-24540
 CVE-2024-24790
+CVE-2025-68121
 
 # Not relevant to Aerie, as it requires an attacker to craft a malicious JSON string to perform a Denial of Service attack
 # https://access.redhat.com/security/cve/CVE-2023-7272


### PR DESCRIPTION
Addresses recent trivy CVE flag for gosu that is a false positive, see https://github.com/tianon/gosu/pull/173#issuecomment-3936440684