### PR TITLE
Fix action server crash from unhandled duplicate secrets

### DIFF
--- a/action-server/src/app.ts
+++ b/action-server/src/app.ts
@@ -3,6 +3,7 @@ import { configuration } from "./config";
 import {authMiddleware, corsMiddleware, jsonErrorMiddleware} from "./middleware";
 import { ActionRunner } from "./type/actionRunner";
 import { extractCookies } from "./utils/auth";
+import logger from "./utils/logger";
 
 
 // init express app and middleware
@@ -36,7 +37,9 @@ app.post(
       user: JSON.stringify(res.locals.user),
       userRole: res.locals.userRole
     }
-    ActionRunner.addActionSecret(actionRunId, fullSecrets);
+    ActionRunner.addActionSecret(actionRunId, fullSecrets).catch((error: unknown) => {
+      logger.error(`Error processing secrets for Action Run ${actionRunId}: ${String(error)}`);
+    });
 
     res.status(200).send({ success: true });
   }

--- a/action-server/src/app.ts
+++ b/action-server/src/app.ts
@@ -10,7 +10,6 @@ import logger from "./utils/logger";
 export const app = express();
 app.use(express.json()); // Middleware for parsing JSON bodies
 app.use(corsMiddleware); // TODO: set more strict CORS rules
-app.use(jsonErrorMiddleware);
 
 app.get("/", async (req, res, next) => {
   res.send("Aerie Action Service");
@@ -23,7 +22,7 @@ app.get("/health", async (req, res, next) => {
 app.post(
   "/secrets",
   authMiddleware,
-  async (req, res, next) => {
+  (req, res, next) => {
     const { action_run_id, secrets } = req.body;
     const actionRunId = action_run_id as string;
 
@@ -37,11 +36,15 @@ app.post(
       user: JSON.stringify(res.locals.user),
       userRole: res.locals.userRole
     }
-    ActionRunner.addActionSecret(actionRunId, fullSecrets).catch((error: unknown) => {
-      logger.error(`Error processing secrets for Action Run ${actionRunId}: ${String(error)}`);
+    const actionRunFunc = ActionRunner.addActionSecret(actionRunId, fullSecrets);
+
+    actionRunFunc(actionRunId).finally(() => {
+      ActionRunner.deleteActionSecret(actionRunId);
     });
 
     res.status(200).send({ success: true });
   }
 );
 
+// attach error-handling middleware AFTER routes
+app.use(jsonErrorMiddleware);

--- a/action-server/src/type/actionRunner.ts
+++ b/action-server/src/type/actionRunner.ts
@@ -49,8 +49,10 @@ export class ActionRunner {
 
     const actionRunFunc = this.actionRunQueue.get(actionRunId);
     if(!actionRunFunc || typeof actionRunFunc !== "function") {
+      logger.warn(`Action Run ${actionRunId} not found in queue (may have already been processed). Ignoring duplicate secrets.`);
       this.deleteActionSecret(actionRunId);
-      throw new Error(`Action Run ${actionRunId} not found in queue: ${actionRunFunc}`);
+
+      return;
     }
 
     setTimeout(() => {

--- a/action-server/src/type/actionRunner.ts
+++ b/action-server/src/type/actionRunner.ts
@@ -42,7 +42,8 @@ export class ActionRunner {
     }, this.WAIT_FOR_SECRET_TIMEOUT);
   }
 
-  static async addActionSecret(actionRunId: string, actionSecrets: Record<string, string>): Promise<void> {
+
+  static addActionSecret(actionRunId: string, actionSecrets: Record<string, string>) {
     this.actionSecretsMap.set(actionRunId, actionSecrets);
 
     logger.info(`Secrets received for Action Run: ${actionRunId}, running action...`);
@@ -51,8 +52,7 @@ export class ActionRunner {
     if(!actionRunFunc || typeof actionRunFunc !== "function") {
       logger.warn(`Action Run ${actionRunId} not found in queue (may have already been processed). Ignoring duplicate secrets.`);
       this.deleteActionSecret(actionRunId);
-
-      return;
+      throw new Error(`Action Run ${actionRunId} not found in queue: ${actionRunFunc}`);
     }
 
     setTimeout(() => {
@@ -63,8 +63,7 @@ export class ActionRunner {
       }
     }, this.WAIT_FOR_ACTION_RUN_TIMEOUT);
 
-    await actionRunFunc(actionRunId);
-    this.deleteActionSecret(actionRunId);
+    return actionRunFunc;
   }
 
   static deleteActionRun(actionRunId: string): void {

--- a/action-server/tests/app.test.mts
+++ b/action-server/tests/app.test.mts
@@ -11,6 +11,8 @@ mock.module('../src/threads/workerPool', {
   namedExports: { ActionWorkerPool: { setup: () => {} } }
 });
 
+const ERROR_CAUSING_ID = "ERROR_CAUSING_ID";
+
 const called: any[] = [];
 mock.module('../src/type/actionRunner', {
   namedExports: {
@@ -19,6 +21,7 @@ mock.module('../src/type/actionRunner', {
         console.log('mocked action runner');
         called.push({ id, secrets });
         // mock actionRunFunc
+        if(id === ERROR_CAUSING_ID) throw new Error("Expected error");
         return () => Promise.resolve();
       },
       deleteActionSecret: (id: string) => {}
@@ -87,8 +90,6 @@ test('cookie forwarding', async () => {
         .set('Authorization', `Bearer ${validToken}`)
         .set('Cookie', 'ssosession=token123; other_cookie=abc; unrelated=xyz');
 
-    console.log("HELLO??");
-    console.log(res.body);
     assert.equal(res.status, 200);
     assert.equal(called.length, 1);
     assert.equal(called[0].secrets.cookies.ssosession, 'token123');
@@ -125,5 +126,32 @@ test('cookie forwarding', async () => {
     assert.equal(res.status, 200);
     assert.equal(called.length, 1);
     assert.equal(called[0].secrets.cookies.ssosession, 'base64value==');
+  });
+
+  await test('returns a 404 for missing route', async () => {
+    called.length = 0;
+
+    const res = await request(app)
+        .get('/nothing')
+        .set('Authorization', `Bearer ${validToken}`)
+        .set('Cookie', 'ssosession=base64value==;');
+
+    assert.equal(res.status, 404);
+  });
+
+  await test('thrown errors are returned in proper JSON format', async () => {
+    called.length = 0;
+
+    const res = await request(app)
+        .post('/secrets')
+        .send({ action_run_id: ERROR_CAUSING_ID, secrets: {} })
+        .set('Authorization', `Bearer ${validToken}`)
+        .set('Cookie', 'ssosession=base64value==;');
+
+    assert.equal(res.status, 500);
+    const parsedError = JSON.parse(res.text);
+    assert.equal(!!parsedError.error, true);
+    assert.equal(parsedError.error.message, "Expected error");
+    assert.equal(!!parsedError.error.stack, true);
   });
 });

--- a/action-server/tests/app.test.mts
+++ b/action-server/tests/app.test.mts
@@ -15,10 +15,13 @@ const called: any[] = [];
 mock.module('../src/type/actionRunner', {
   namedExports: {
     ActionRunner: {
-      addActionSecret: async (id: string, secrets: Record<string, string>) => {
+      addActionSecret: (id: string, secrets: Record<string, string>) => {
         console.log('mocked action runner');
         called.push({ id, secrets });
+        // mock actionRunFunc
+        return () => Promise.resolve();
       },
+      deleteActionSecret: (id: string) => {}
     },
   },
 });
@@ -84,6 +87,8 @@ test('cookie forwarding', async () => {
         .set('Authorization', `Bearer ${validToken}`)
         .set('Cookie', 'ssosession=token123; other_cookie=abc; unrelated=xyz');
 
+    console.log("HELLO??");
+    console.log(res.body);
     assert.equal(res.status, 200);
     assert.equal(called.length, 1);
     assert.equal(called[0].secrets.cookies.ssosession, 'token123');


### PR DESCRIPTION
- Handle duplicate secrets gracefully by logging a warning and returning
- Add .catch() to the floating addActionSecret promise in the /secrets endpoint

* **Tickets addressed:** AERIE-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
