### PR TITLE
stringify + parse action results before returning them, to sanitize to only serializable values

### DIFF
--- a/action-server/src/utils/codeRunner.ts
+++ b/action-server/src/utils/codeRunner.ts
@@ -134,7 +134,11 @@ export const jsExecute = async (
     const actionsAPI = new ActionsAPI(client, workspaceId, actionConfig);
     const results = await context.main(parameters, settings, actionsAPI);
 
-    return { results, console: logBuffer, errors: null };
+    // clone + serialize results returned from action
+    // to sanitize unserializable things in object (todo: investigate more)
+    const cleanResults = JSON.parse(JSON.stringify(results));
+
+    return { results: cleanResults, console: logBuffer, errors: null };
   } catch (error: any) {
     // wrap `throw 10` into a `new throw(10)`
     let errorResponse: Error;

--- a/action-server/src/utils/codeRunner.ts
+++ b/action-server/src/utils/codeRunner.ts
@@ -136,7 +136,7 @@ export const jsExecute = async (
 
     // clone + serialize results returned from action
     // to sanitize unserializable things in object (todo: investigate more)
-    const cleanResults = JSON.parse(JSON.stringify(results));
+    const cleanResults = results ? JSON.parse(JSON.stringify(results)) : results;
 
     return { results: cleanResults, console: logBuffer, errors: null };
   } catch (error: any) {


### PR DESCRIPTION
## Description
Fixes an issue with actions, where in certain cases, if the Action returns results with certain unserializable values, action server will fail mysteriously. In particular, this happens if an action tries to return the adaptation (from `loadAdaptation`).

This deserves some future investigation (why does this fail **silently**?) - but ultimately we decided results should only be serializable values anyway (it doesn't make much sense for an action to return a function or a class in results). For truly unserializable values, this should cause a *loud* error which will end up in logs, rather than a silent one.

## Verification

1. Run this version of action server
2. Upload an action which calls `loadAdaptation` & returns it in results

for example:

```
import type { SeqJson } from "@nasa-jpl/seq-json-schema/types.js";
import {
  seqJsonLanguage,
  seqnLanguage,
  type OutputLanguage,
  type PhoenixAdaptation,
  type PhoenixContext,
  seqJsonToSeqn,
  seqnToSeqJson,
  seqnParser,
} from "@nasa-jpl/aerie-sequence-languages";

function toInputFormat(output: string) {
  const seqJson = JSON.parse(output) as SeqJson;
  return seqJsonToSeqn(seqJson);
}

function toOutputFormat(input: string, context: PhoenixContext, name: string) {
  const tree = seqnParser.parse(input);
  const seqJson = seqnToSeqJson(tree, input, context.commandDictionary, name);
  return JSON.stringify(seqJson, null, 2);
}

const seqJsonOutputLanguage: OutputLanguage = {
  ...seqJsonLanguage,
  toOutputFormat,
  toInputFormat,
};

// Create the main phoenix adaptation and export it for consumers
const adaptation: PhoenixAdaptation = {
  input: seqnLanguage,
  outputs: [seqJsonOutputLanguage]
}

export { adaptation };
```

