### PR TITLE
Pin trivy-action to save 0.24.0 in response to security compromise

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -158,7 +158,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Scan ${{ matrix.image }} for vulnerabilities
-        uses: aquasecurity/trivy-action@0.24.0
+        # pinned to commit for release https://github.com/aquasecurity/trivy-action/releases/tag/v0.24.0
+        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db


### PR DESCRIPTION
More details:
https://github.com/aquasecurity/trivy-action/issues/541
https://github.com/NASA-AMMOS/aerie/issues/1805

This patches our exposure by pinning to the safe commit that has been republished for v0.24.0, the version we are using:

https://github.com/aquasecurity/trivy-action/releases/tag/v0.24.0

I am also rotating any affected secrets.
