### PR TITLE
Split E2E Test tasks into multiple subtasks

### DIFF
--- a/.github/actions/load-node-cache/action.yml
+++ b/.github/actions/load-node-cache/action.yml
@@ -1,15 +1,12 @@
-name: Load NPM Caches
-description: Load cached NPM modules for Sequencing Server and Action Server
+name: Load NPM Cache
+description: Load cached npm package data into the global npm cache
 runs:
   using: composite
   steps:
-    - name: Cache Sequencing NPM Packages
+    - name: Cache global ~/.npm cache
       uses: actions/cache@v5
       with:
-        path: ./sequencing-server/node_modules
-        key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }} }}
-    - name: Cache Action NPM Packages
-      uses: actions/cache@v5
-      with:
-        path: ./action-server/node_modules
-        key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }} }}
+        path: ~/.npm
+        key: npm-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          npm-${{ runner.os }}-

--- a/.github/actions/load-node-cache/action.yml
+++ b/.github/actions/load-node-cache/action.yml
@@ -7,9 +7,9 @@ runs:
       uses: actions/cache@v5
       with:
         path: ./sequencing-server/node_modules
-        key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }}-${{ hashFiles('./sequencing-server/package.json') }}
+        key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }} }}
     - name: Cache Action NPM Packages
       uses: actions/cache@v5
       with:
         path: ./action-server/node_modules
-        key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }}-${{ hashFiles('./action-server/package.json') }}
+        key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }} }}

--- a/.github/actions/load-node-cache/action.yml
+++ b/.github/actions/load-node-cache/action.yml
@@ -1,0 +1,15 @@
+name: Load NPM Caches
+description: Load cached NPM modules for Sequencing Server and Action Server
+runs:
+  using: composite
+  steps:
+    - name: Cache Sequencing NPM Packages
+      uses: actions/cache@v5
+      with:
+        path: ./sequencing-server/node_modules
+        key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }}
+    - name: Cache Action NPM Packages
+      uses: actions/cache@v5
+      with:
+        path: ./action-server/node_modules
+        key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }}

--- a/.github/actions/load-node-cache/action.yml
+++ b/.github/actions/load-node-cache/action.yml
@@ -7,9 +7,9 @@ runs:
       uses: actions/cache@v5
       with:
         path: ./sequencing-server/node_modules
-        key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }}
+        key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }}-${{ hashFiles('./sequencing-server/package.json') }}
     - name: Cache Action NPM Packages
       uses: actions/cache@v5
       with:
         path: ./action-server/node_modules
-        key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }}
+        key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }}-${{ hashFiles('./action-server/package.json') }}

--- a/.github/actions/shutdown-test-backend/action.yml
+++ b/.github/actions/shutdown-test-backend/action.yml
@@ -1,0 +1,20 @@
+name: Shutdown Test Backend
+description: Shuts down and prints logs for the E2E Test Backend
+runs:
+  using: composite
+  steps:
+    - name: Print Logs for Services
+      if: always()
+      shell: bash
+      run: docker compose -f ./e2e-tests/docker-compose-test.yml logs -t
+    - name: Stop Services
+      if: always()
+      shell: bash
+      run: |
+        docker ps -a
+        docker compose -f ./e2e-tests/docker-compose-test.yml down
+        docker ps -a
+    - name: Prune Volumes
+      if: always()
+      shell: bash
+      run: docker volume prune --force

--- a/.github/actions/start-test-backend/action.yml
+++ b/.github/actions/start-test-backend/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Start Hasura and Postgres
       shell: bash
       run: |
-        docker compose -f ./e2e-tests/docker-compose-test.yml up -d postgres hasura
+        docker compose -f ./e2e-tests/docker-compose-test.yml up -d postgres hasura --quiet-pull
     - name: Assemble
       # Don't generate docs for tests
       shell: bash

--- a/.github/actions/start-test-backend/action.yml
+++ b/.github/actions/start-test-backend/action.yml
@@ -1,0 +1,31 @@
+name: Start Test Backend
+description: Compile and start up the backend for E2E Tests
+runs:
+  using: composite
+  steps:
+    - name: Extract PlanDev gateway docker tag from PR body
+      # look in the PR body for the string ___REQUIRES_GATEWAY_PR___=9999, extract the number if so & save to env var
+      # if gateway PR is labeled correctly, it will publish a docker tag called 'pr-9999' to use in tests
+      if: ${{ contains(env.PR_BODY, '___REQUIRES_GATEWAY_PR___=') }}
+      shell: bash
+      run: |
+        echo "GATEWAY_IMAGE_TAG=pr-$(echo $PR_BODY | sed -n 's/.*___REQUIRES_GATEWAY_PR___=\"\([0-9]\+\)\".*/\1/p')" >> $GITHUB_ENV
+    - name: Load NPM Cache
+      uses: ./.github/actions/load-node-cache
+    # Start Hasura and Postgres ahead of assembling the Java code, as the Java code takes a few minutes to compile.
+    # This means Hasura will have time to complete its start-up tasks without needing an extra "sleep 30" command.
+    - name: Start Hasura and Postgres
+      shell: bash
+      run: |
+        docker compose -f ./e2e-tests/docker-compose-test.yml up -d postgres hasura
+    - name: Assemble
+      # Don't generate docs for tests
+      shell: bash
+      run: ./gradlew assemble -x javadoc -x javadocJar -x generateDocumentation --parallel
+    - name: Start Remaining Services
+      shell: bash
+      run: |
+        echo "GATEWAY_IMAGE_TAG: $GATEWAY_IMAGE_TAG"
+        docker compose -f ./e2e-tests/docker-compose-test.yml up -d --build --quiet-pull
+        docker images
+        docker ps -a --no-trunc

--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install cloc
         run: |
           sudo apt-get update

--- a/.github/workflows/create_jnispice.yml
+++ b/.github/workflows/create_jnispice.yml
@@ -20,7 +20,7 @@ jobs:
           7z x JNISpice.zip
           echo "JNISpice unpacked"
       - name: Upload DLL
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Windows Spice
           path: JNISpice/lib/JNISpice.dll
@@ -39,7 +39,7 @@ jobs:
         run: mv libJNISpice.so libJNISpice_Intel.so
         working-directory: JNISpice/lib
       - name: Upload .so
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: x86 Linux Spice
           path: JNISpice/lib/libJNISpice_Intel.so
@@ -64,7 +64,7 @@ jobs:
         working-directory: JNISpice/src/JNISpice
         shell: csh {0}
       - name: Upload Intel Mac .jnilib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: x86 Mac Spice
           path: JNISpice/lib/libJNISpice_Intel.jnilib
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
@@ -104,7 +104,7 @@ jobs:
         working-directory: JNISpice/src/JNISpice
       - name: Upload JAR
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: JNISpice Jar
           path: JNISpice/src/JNISpice/JNISpice-*.jar

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -15,12 +15,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v5
+        with:
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Create Pages Build Directories
         run: mkdir -p build/javadoc/examples
       - name: Build EDSL API Docs
@@ -54,7 +57,7 @@ jobs:
           cp -a ./scheduler-worker/build/docs/javadoc ./build/javadoc/scheduler-worker
           cp -a ./procedural/build/dokka/htmlMultiModule ./build/procedural-apis
       - name: Upload Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: build/
 
@@ -67,4 +70,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -25,16 +25,17 @@ jobs:
     environment: load-test
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v2
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Assemble
         run: ./gradlew assemble --parallel
       - name: Start Services
@@ -51,7 +52,7 @@ jobs:
           ./load-test.sh
       - name: Upload Load Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Load Test Results
           path: "**/load-tests/load-report.*"

--- a/.github/workflows/pgcmp.yml
+++ b/.github/workflows/pgcmp.yml
@@ -42,11 +42,11 @@ jobs:
     environment: e2e-test
     steps:
       - name: Checkout v2.8.0
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: "v2.8.0"
       - name: Clone PGCMP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: NASA-AMMOS/pgcmp
           path: pgcmp
@@ -87,22 +87,23 @@ jobs:
           ./pgcmp/pgcmp-dump
         shell: bash
       - name: Share Database Dump
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: v2_8_0-db-dump
           path: pgdumpV2_8_0
           retention-days: 1
       - name: Checkout Latest
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v2
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Assemble Workspace Server
         run: ./gradlew workspace-server:assemble --parallel
       - name: Restart Hasura and Start Additional Containers
@@ -125,7 +126,7 @@ jobs:
           python aerie_db_migration.py migrate --apply --all
           cd ..
       - name: Clone PGCMP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: NASA-AMMOS/pgcmp
           path: pgcmp
@@ -139,7 +140,7 @@ jobs:
           ./pgcmp/pgcmp-dump
         shell: bash
       - name: Share Database Dump
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: migrated-db-dump
           path: pgdumpmigrated
@@ -160,7 +161,7 @@ jobs:
     environment: e2e-test
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Postgres Client (psql)
         # ubuntu-latest does not currently have psql-16 in its apt library, so we cannot just run
         # sudo apt update && sudo apt-get install --yes postgresql-client-16
@@ -174,7 +175,7 @@ jobs:
           sudo apt update
           sudo apt -y install postgresql-client-16
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: Setup Hasura CLI
@@ -188,7 +189,7 @@ jobs:
         run: sleep 60s
         shell: bash
       - name: Clone PGCMP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: NASA-AMMOS/pgcmp
           path: pgcmp
@@ -202,7 +203,7 @@ jobs:
           ./pgcmp/pgcmp-dump
         shell: bash
       - name: Share Database Dump
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: current-sql-db-dump
           path: pgdumpcurrent
@@ -227,7 +228,7 @@ jobs:
           ./pgcmp/pgcmp-dump
         shell: bash
       - name: Share Database Dump
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: migrated-down-db-dump
           path: pgdumpmigrateddown
@@ -247,9 +248,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Clone PGCMP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: NASA-AMMOS/pgcmp
           path: pgcmp
@@ -289,7 +290,7 @@ jobs:
         shell: bash
       - name: Upload Invalid
         if: ${{ failure() && steps.dbcmp.conclusion == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pgcmpresultsup
           path: "**/results/"
@@ -309,9 +310,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Clone PGCMP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: NASA-AMMOS/pgcmp
           path: pgcmp
@@ -351,7 +352,7 @@ jobs:
         shell: bash
       - name: Upload Invalid
         if: ${{ failure() && steps.dbcmp.conclusion == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pgcmpresultsdown
           path: "**/results/"

--- a/.github/workflows/profile-compilation.yml
+++ b/.github/workflows/profile-compilation.yml
@@ -1,0 +1,33 @@
+name: Profile Compilation
+
+on:
+  workflow_dispatch:
+
+jobs:
+  compile-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+      - name: Load NPM Cache
+        uses: ./.github/actions/load-node-cache
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
+      - name: Assemble
+        # Don't generate docs for tests
+        run: ./gradlew assemble -x javadoc -x javadocJar -x generateDocumentation --parallel --profile
+      - name: Upload Profile
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ProfileResults
+          path: |
+            /home/runner/work/aerie/aerie/build/reports/profile/profile*

--- a/.github/workflows/profile-compilation.yml
+++ b/.github/workflows/profile-compilation.yml
@@ -30,4 +30,4 @@ jobs:
         with:
           name: ProfileResults
           path: |
-            /home/runner/work/aerie/aerie/build/reports/profile/profile*
+            /home/runner/work/plandev/plandev/build/reports/profile/profile*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,13 +30,13 @@ jobs:
       SHOULD_PUBLISH_IMAGES: ${{ env.SHOULD_PUBLISH_IMAGES }}
       SHOULD_PUBLISH_DEPLOYMENT: ${{ env.SHOULD_PUBLISH_DEPLOYMENT }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: gradle/wrapper-validation-action@v2
-
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v5
         with:
           generate-job-summary: false
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
 
       - name: Gradle Version
         run: ./gradlew --version
@@ -83,17 +83,19 @@ jobs:
       - name: Log SHOULD_PUBLISH_IMAGES
         run: echo ${{ needs.init.outputs.SHOULD_PUBLISH_IMAGES }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
 
       - name: Init Gradle cache
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
         with:
           generate-job-summary: false
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -155,7 +157,7 @@ jobs:
       fail-fast: false
     name: scan ${{ matrix.image }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Scan ${{ matrix.image }} for vulnerabilities
         # pinned to commit for release https://github.com/aquasecurity/trivy-action/releases/tag/v0.24.0
@@ -176,7 +178,7 @@ jobs:
 
       - name: Upload ${{ matrix.image }} scan results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Vuln Scan Results - ${{ matrix.image }}
           path: "${{ matrix.image }}-results.html"
@@ -190,12 +192,14 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Gradle Cache
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
         with:
           generate-job-summary: false
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
 
       - name: Publish Package
         run: ./gradlew publish -Pversion.isRelease=$IS_RELEASE --parallel
@@ -206,7 +210,7 @@ jobs:
         run: ./gradlew archiveDeployment
 
       - name: Publish deployment
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Deployment
           path: deployment.tar

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
@@ -36,17 +36,20 @@ jobs:
           queries: +security-extended
           tools: latest
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Build
         run: |
           ./gradlew testClasses
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
       - name: NASA Scrub
         run: |
           python3 -m pip install nasa-scrub
@@ -64,7 +67,7 @@ jobs:
 
           echo "RESULTS_DIR=$results_dir" >> $GITHUB_ENV
       - name: Upload Security Scan Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Security Scan Results - ${{ matrix.language }}
           path: ${{ env.RESULTS_DIR }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,61 +33,13 @@ env:
   PR_BODY: "${{github.event.pull_request.body}}"
 
 jobs:
-  compile-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v6
-
-      - name: Cache Sequencing NPM Packages
-        uses: actions/cache@v5
-        with:
-          path: ./sequencing-server/node_modules
-          key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }}
-      - name: Cache Action NPM Packages
-        uses: actions/cache@v5
-        with:
-          path: ./action-server/node_modules
-          key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }}
-
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: "temurin"
-          java-version: "21"
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-        with:
-          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
-          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
-      - name: Assemble
-        # Don't generate docs for tests
-        run: ./gradlew assemble -x javadoc -x javadocJar -x generateDocumentation --parallel --profile
-      - name: Upload Profile
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: ProfileResults
-          path: |
-            /home/runner/work/aerie/aerie/build/reports/profile/profile*
-
   unit-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
-
-      - name: Cache Sequencing NPM Packages
-        uses: actions/cache@v5
-        with:
-          path: ./sequencing-server/node_modules
-          key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }}
-      - name: Cache Action NPM Packages
-        uses: actions/cache@v5
-        with:
-          path: ./action-server/node_modules
-          key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }}
-
+      - name: Load NPM Cache
+        uses: ./.github/actions/load-node-cache
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
@@ -98,7 +50,6 @@ jobs:
         with:
           # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
-
       - name: Assemble
         # Don't generate docs for tests
         run: ./gradlew assemble -x javadoc -x javadocJar -x generateDocumentation --parallel
@@ -145,15 +96,15 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
+      - name: Setup Postgres Client (psql)
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes postgresql-client
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
-      - name: Setup Postgres Client (psql)
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes postgresql-client
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:
@@ -176,18 +127,8 @@ jobs:
           name: DB Test Results
           path: |
             **/db-tests/build/reports/tests/e2eTest
-      - name: Print Logs for Services
-        if: always()
-        run: docker compose -f ./e2e-tests/docker-compose-test.yml logs -t
-      - name: Stop Services
-        if: always()
-        run: |
-          docker ps -a
-          docker compose -f ./e2e-tests/docker-compose-test.yml down
-          docker ps -a
-      - name: Prune Volumes
-        if: always()
-        run: docker volume prune --force
+      - name: Shutdown Backend
+        uses: ./.github/actions/shutdown-test-backend
 
   sequencing-e2e-tests:
     runs-on: ubuntu-latest
@@ -195,29 +136,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
-      - name: Extract PlanDev gateway docker tag from PR body
-        # look in the PR body for the string ___REQUIRES_GATEWAY_PR___=9999, extract the number if so & save to env var
-        # if gateway PR is labeled correctly, it will publish a docker tag called 'pr-9999' to use in tests
-        if: ${{ contains(env.PR_BODY, '___REQUIRES_GATEWAY_PR___=') }}
-        run: |
-          echo "GATEWAY_IMAGE_TAG=pr-$(echo $PR_BODY | sed -n 's/.*___REQUIRES_GATEWAY_PR___=\"\([0-9]\+\)\".*/\1/p')" >> $GITHUB_ENV
-
-      - name: Cache Sequencing NPM Packages
-        uses: actions/cache@v5
-        with:
-          path: ./sequencing-server/node_modules
-          key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }}
-      - name: Cache Action NPM Packages
-        uses: actions/cache@v5
-        with:
-          path: ./action-server/node_modules
-          key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }}
-
-      # Start Hasura and Postgres ahead of assembling the Java code, as the Java code takes a few minutes to compile.
-      # This means Hasura will have time to complete its start-up tasks without needing an extra "sleep 30" command.
-      - name: Start Hasura and Postgres
-        run: |
-            docker compose -f ./e2e-tests/docker-compose-test.yml up -d postgres hasura
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
@@ -228,15 +146,8 @@ jobs:
         with:
           # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
-      - name: Assemble
-        # Don't generate docs for tests
-        run: ./gradlew assemble -x javadoc -x javadocJar -x generateDocumentation --parallel
-      - name: Start Remaining Services
-        run: |
-          echo "GATEWAY_IMAGE_TAG: $GATEWAY_IMAGE_TAG"
-          docker compose -f ./e2e-tests/docker-compose-test.yml up -d --build --quiet-pull
-          docker images
-          docker ps -a --no-trunc
+      - name: Start E2E Test Backend
+        uses: ./.github/actions/start-test-backend
       - name: Run Sequencing E2E Tests
         run: ./gradlew sequencing-server:e2eTest
       - name: Upload Sequencing E2E Test Results
@@ -246,18 +157,8 @@ jobs:
           name: Sequencing E2E Test Results
           path: |
             **/sequencing-server/test-report.*
-      - name: Print Logs for Services
-        if: always()
-        run: docker compose -f ./e2e-tests/docker-compose-test.yml logs -t
-      - name: Stop Services
-        if: always()
-        run: |
-          docker ps -a
-          docker compose -f ./e2e-tests/docker-compose-test.yml down
-          docker ps -a
-      - name: Prune Volumes
-        if: always()
-        run: docker volume prune --force
+      - name: Shutdown E2E Test Backend
+        uses: ./.github/actions/shutdown-test-backend
 
   java-e2e-test:
     runs-on: ubuntu-latest
@@ -265,27 +166,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
-      - name: Cache Sequencing NPM Packages
-        uses: actions/cache@v5
-        with:
-          path: ./sequencing-server/node_modules
-          key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }}
-      - name: Cache Action NPM Packages
-        uses: actions/cache@v5
-        with:
-          path: ./action-server/node_modules
-          key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }}
-      - name: Extract PlanDev gateway docker tag from PR body
-        # look in the PR body for the string ___REQUIRES_GATEWAY_PR___=9999, extract the number if so & save to env var
-        # if gateway PR is labeled correctly, it will publish a docker tag called 'pr-9999' to use in tests
-        if: ${{ contains(env.PR_BODY, '___REQUIRES_GATEWAY_PR___=') }}
-        run: |
-          echo "GATEWAY_IMAGE_TAG=pr-$(echo $PR_BODY | sed -n 's/.*___REQUIRES_GATEWAY_PR___=\"\([0-9]\+\)\".*/\1/p')" >> $GITHUB_ENV
-      # Start Hasura and Postgres ahead of assembling the Java code, as the Java code takes a few minutes to compile.
-      # This means Hasura will have time to complete its start-up tasks without needing an extra "sleep 30" command
-      - name: Start Hasura and Postgres
-        run: |
-          docker compose -f ./e2e-tests/docker-compose-test.yml up -d postgres hasura
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
@@ -296,17 +176,10 @@ jobs:
         with:
           # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
-      - name: Assemble
-        # Don't generate docs for tests
-        run: ./gradlew assemble -x javadoc -x javadocJar -x generateDocumentation --parallel
+      - name: Start E2E Test Backend
+        uses: ./.github/actions/start-test-backend
       - name: Build scheduling procedure jars for testing
         run: ./gradlew e2e-tests:buildAllProcedureJars
-      - name: Start Services
-        run: |
-          echo "GATEWAY_IMAGE_TAG: $GATEWAY_IMAGE_TAG"
-          docker compose -f ./e2e-tests/docker-compose-test.yml up -d --build --quiet-pull
-          docker images
-          docker ps -a --no-trunc
       - name: Run E2E Tests
         run: ./gradlew e2e-tests:e2eTest
       - name: Upload E2E Test Results
@@ -316,15 +189,5 @@ jobs:
           name: E2E Test Results
           path: |
             **/e2e-tests/build/reports/tests/e2eTest
-      - name: Print Logs for Services
-        if: always()
-        run: docker compose -f ./e2e-tests/docker-compose-test.yml logs -t
-      - name: Stop Services
-        if: always()
-        run: |
-          docker ps -a
-          docker compose -f ./e2e-tests/docker-compose-test.yml down
-          docker ps -a
-      - name: Prune Volumes
-        if: always()
-        run: docker volume prune --force
+      - name: Shutdown Backend
+        uses: ./.github/actions/shutdown-test-backend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,25 +37,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v2
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:
-          cache-read-only: false #${{ github.ref != 'refs/heads/develop' }} # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Assemble
         run: ./gradlew assemble --parallel
       - name: Run Unit Tests
         run: ./gradlew test --parallel
       - name: Upload Test Results as XML and HTML
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Unit Test Results
           path: |
@@ -67,16 +66,17 @@ jobs:
     environment: e2e-test
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: actions/checkout@v6
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Run Action Server Unit Tests
         run: ./gradlew action-server:e2eTest
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Action Server Test Results
           path: |
@@ -87,9 +87,9 @@ jobs:
     environment: e2e-test
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
@@ -97,13 +97,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes postgresql-client
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v2
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Start Services
         run: |
-          echo "GATEWAY_IMAGE_TAG: $GATEWAY_IMAGE_TAG"
           docker compose -f ./e2e-tests/docker-compose-test.yml up postgres -d --build --quiet-pull
           docker images
           docker ps -a --no-trunc
@@ -114,7 +114,7 @@ jobs:
         run: ./gradlew db-tests:e2eTest
       - name: Upload DB Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DB Test Results
           path: |
@@ -137,7 +137,7 @@ jobs:
     environment: e2e-test
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Extract PlanDev gateway docker tag from PR body
         # look in the PR body for the string ___REQUIRES_GATEWAY_PR___=9999, extract the number if so & save to env var
         # if gateway PR is labeled correctly, it will publish a docker tag called 'pr-9999' to use in tests
@@ -150,14 +150,15 @@ jobs:
         run: |
             docker compose -f ./e2e-tests/docker-compose-test.yml up -d postgres hasura
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v2
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Assemble
         run: ./gradlew assemble --parallel
       - name: Start Remaining Services
@@ -170,7 +171,7 @@ jobs:
         run: ./gradlew sequencing-server:e2eTest
       - name: Upload Sequencing E2E Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Sequencing E2E Test Results
           path: |
@@ -193,7 +194,7 @@ jobs:
     environment: e2e-test
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Extract PlanDev gateway docker tag from PR body
         # look in the PR body for the string ___REQUIRES_GATEWAY_PR___=9999, extract the number if so & save to env var
         # if gateway PR is labeled correctly, it will publish a docker tag called 'pr-9999' to use in tests
@@ -206,14 +207,15 @@ jobs:
         run: |
           docker compose -f ./e2e-tests/docker-compose-test.yml up -d postgres hasura
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v2
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Assemble
         run: ./gradlew assemble --parallel
       - name: Build scheduling procedure jars for testing
@@ -228,7 +230,7 @@ jobs:
         run: ./gradlew e2e-tests:e2eTest
       - name: Upload E2E Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: E2E Test Results
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,13 +92,16 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+      - name: Setup NPM
+        uses: actions/setup-node@v6
         with:
-          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
-          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
+          node-version-file: ./action-server/.nvmrc
+          cache: npm
+          cache-dependency-path: ./action-server/package-lock.json
       - name: Run Action Server Unit Tests
-        run: ./gradlew action-server:e2eTest
+        run: |
+          cd ./action-server
+          npm i && npm --silent run test
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,31 @@ env:
   PR_BODY: "${{github.event.pull_request.body}}"
 
 jobs:
+  compile-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
+      - name: Assemble
+        run: ./gradlew assemble --parallel --daemon --profile
+      - name: Upload Profile
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ProfileResults
+          path: |
+            /home/runner/work/aerie/aerie/build/reports/profile/profile*
+
   unit-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,6 +142,11 @@ jobs:
         if: ${{ contains(env.PR_BODY, '___REQUIRES_GATEWAY_PR___=') }}
         run: |
           echo "GATEWAY_IMAGE_TAG=pr-$(echo $PR_BODY | sed -n 's/.*___REQUIRES_GATEWAY_PR___=\"\([0-9]\+\)\".*/\1/p')" >> $GITHUB_ENV
+      # Start Hasura and Postgres ahead of assembling the Java code, as the Java code takes a few minutes to compile.
+      # This means Hasura will have time to complete its start-up tasks without needing an extra "sleep 30" command.
+      - name: Start Hasura and Postgres
+        run: |
+            docker compose -f ./e2e-tests/docker-compose-test.yml up -d postgres hasura
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -153,15 +158,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
       - name: Assemble
         run: ./gradlew assemble --parallel
-      - name: Start Services
+      - name: Start Remaining Services
         run: |
           echo "GATEWAY_IMAGE_TAG: $GATEWAY_IMAGE_TAG"
           docker compose -f ./e2e-tests/docker-compose-test.yml up -d --build --quiet-pull
           docker images
           docker ps -a --no-trunc
-      - name: Sleep for 30 Seconds
-        run: sleep 30s
-        shell: bash
       - name: Run Sequencing E2E Tests
         run: ./gradlew sequencing-server:e2eTest
       - name: Upload Sequencing E2E Test Results
@@ -196,15 +198,16 @@ jobs:
         if: ${{ contains(env.PR_BODY, '___REQUIRES_GATEWAY_PR___=') }}
         run: |
           echo "GATEWAY_IMAGE_TAG=pr-$(echo $PR_BODY | sed -n 's/.*___REQUIRES_GATEWAY_PR___=\"\([0-9]\+\)\".*/\1/p')" >> $GITHUB_ENV
+      # Start Hasura and Postgres ahead of assembling the Java code, as the Java code takes a few minutes to compile.
+      # This means Hasura will have time to complete its start-up tasks without needing an extra "sleep 30" command
+      - name: Start Hasura and Postgres
+        run: |
+          docker compose -f ./e2e-tests/docker-compose-test.yml up -d postgres hasura
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "21"
-      - name: Setup Postgres Client (psql)
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes postgresql-client
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v2
       - name: Setup Gradle
@@ -219,9 +222,6 @@ jobs:
           docker compose -f ./e2e-tests/docker-compose-test.yml up -d --build --quiet-pull
           docker images
           docker ps -a --no-trunc
-      - name: Sleep for 30 Seconds
-        run: sleep 30s
-        shell: bash
       - name: Run E2E Tests
         run: ./gradlew e2e-tests:e2eTest
       - name: Upload E2E Test Results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,165 @@ jobs:
             **/build/test-results/test
             **/build/reports/tests/test
 
-  e2e-test:
+  db-tests:
+    runs-on: ubuntu-latest
+    environment: e2e-test
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+      - name: Setup Postgres Client (psql)
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes postgresql-client
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Start Services
+        run: |
+          echo "GATEWAY_IMAGE_TAG: $GATEWAY_IMAGE_TAG"
+          docker compose -f ./e2e-tests/docker-compose-test.yml up postgres -d --build --quiet-pull
+          docker images
+          docker ps -a --no-trunc
+      - name: Sleep for 5 Seconds
+        run: sleep 5s
+        shell: bash
+      - name: Run DB Tests
+        run: ./gradlew db-tests:e2eTest
+      - name: Upload DB Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: DB Test Results
+          path: |
+            **/db-tests/build/reports/tests/e2eTest
+      - name: Print Logs for Services
+        if: always()
+        run: docker compose -f ./e2e-tests/docker-compose-test.yml logs -t
+      - name: Stop Services
+        if: always()
+        run: |
+          docker ps -a
+          docker compose -f ./e2e-tests/docker-compose-test.yml down
+          docker ps -a
+      - name: Prune Volumes
+        if: always()
+        run: docker volume prune --force
+
+  sequencing-e2e-tests:
+    runs-on: ubuntu-latest
+    environment: e2e-test
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Extract PlanDev gateway docker tag from PR body
+        # look in the PR body for the string ___REQUIRES_GATEWAY_PR___=9999, extract the number if so & save to env var
+        # if gateway PR is labeled correctly, it will publish a docker tag called 'pr-9999' to use in tests
+        if: ${{ contains(env.PR_BODY, '___REQUIRES_GATEWAY_PR___=') }}
+        run: |
+          echo "GATEWAY_IMAGE_TAG=pr-$(echo $PR_BODY | sed -n 's/.*___REQUIRES_GATEWAY_PR___=\"\([0-9]\+\)\".*/\1/p')" >> $GITHUB_ENV
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Assemble
+        run: ./gradlew assemble --parallel
+      - name: Start Services
+        run: |
+          echo "GATEWAY_IMAGE_TAG: $GATEWAY_IMAGE_TAG"
+          docker compose -f ./e2e-tests/docker-compose-test.yml up -d --build --quiet-pull
+          docker images
+          docker ps -a --no-trunc
+      - name: Sleep for 30 Seconds
+        run: sleep 30s
+        shell: bash
+      - name: Run Sequencing E2E Tests
+        run: ./gradlew sequencing-server:e2eTest
+      - name: Upload Sequencing E2E Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Sequencing E2E Test Results
+          path: |
+            **/sequencing-server/test-report.*
+      - name: Print Logs for Services
+        if: always()
+        run: docker compose -f ./e2e-tests/docker-compose-test.yml logs -t
+      - name: Stop Services
+        if: always()
+        run: |
+          docker ps -a
+          docker compose -f ./e2e-tests/docker-compose-test.yml down
+          docker ps -a
+      - name: Prune Volumes
+        if: always()
+        run: docker volume prune --force
+
+  action-e2e-tests:
+    runs-on: ubuntu-latest
+    environment: e2e-test
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Extract PlanDev gateway docker tag from PR body
+        # look in the PR body for the string ___REQUIRES_GATEWAY_PR___=9999, extract the number if so & save to env var
+        # if gateway PR is labeled correctly, it will publish a docker tag called 'pr-9999' to use in tests
+        if: ${{ contains(env.PR_BODY, '___REQUIRES_GATEWAY_PR___=') }}
+        run: |
+          echo "GATEWAY_IMAGE_TAG=pr-$(echo $PR_BODY | sed -n 's/.*___REQUIRES_GATEWAY_PR___=\"\([0-9]\+\)\".*/\1/p')" >> $GITHUB_ENV
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Assemble
+        run: ./gradlew assemble --parallel
+      - name: Start Services
+        run: |
+          echo "GATEWAY_IMAGE_TAG: $GATEWAY_IMAGE_TAG"
+          docker compose -f ./e2e-tests/docker-compose-test.yml up -d --build --quiet-pull
+          docker images
+          docker ps -a --no-trunc
+      - name: Sleep for 30 Seconds
+        run: sleep 30s
+        shell: bash
+      - name: Run Action Server E2E Tests
+        run: ./gradlew action-server:e2eTest
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Action Server E2E Test Results
+          path: |
+            **/action-server/action-server-test-report.log
+      - name: Print Logs for Services
+        if: always()
+        run: docker compose -f ./e2e-tests/docker-compose-test.yml logs -t
+      - name: Stop Services
+        if: always()
+        run: |
+          docker ps -a
+          docker compose -f ./e2e-tests/docker-compose-test.yml down
+          docker ps -a
+      - name: Prune Volumes
+        if: always()
+        run: docker volume prune --force
+
+  java-e2e-test:
     runs-on: ubuntu-latest
     environment: e2e-test
     steps:
@@ -99,7 +257,7 @@ jobs:
         run: sleep 30s
         shell: bash
       - name: Run E2E Tests
-        run: ./gradlew e2eTest
+        run: ./gradlew e2e-tests:e2eTest
       - name: Upload E2E Test Results
         if: always()
         uses: actions/upload-artifact@v4
@@ -107,9 +265,6 @@ jobs:
           name: E2E Test Results
           path: |
             **/e2e-tests/build/reports/tests/e2eTest
-            **/db-tests/build/reports/tests/e2eTest
-            **/sequencing-server/test-report.*
-            **/action-server/action-server-test-report.log
       - name: Print Logs for Services
         if: always()
         run: docker compose -f ./e2e-tests/docker-compose-test.yml logs -t

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,9 +112,7 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Start Services
         run: |
-          docker compose -f ./e2e-tests/docker-compose-test.yml up postgres -d --build --quiet-pull
-          docker images
-          docker ps -a --no-trunc
+          docker compose -f ./e2e-tests/docker-compose-test.yml up postgres -d --quiet-pull
       - name: Sleep for 5 Seconds
         run: sleep 5s
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,18 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
+
+      - name: Cache Sequencing NPM Packages
+        uses: actions/cache@v5
+        with:
+          path: ./sequencing-server/node_modules
+          key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }}
+      - name: Cache Action NPM Packages
+        uses: actions/cache@v5
+        with:
+          path: ./action-server/node_modules
+          key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }}
+
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
@@ -86,6 +98,7 @@ jobs:
         with:
           # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
+
       - name: Assemble
         # Don't generate docs for tests
         run: ./gradlew assemble -x javadoc -x javadocJar -x generateDocumentation --parallel
@@ -188,6 +201,18 @@ jobs:
         if: ${{ contains(env.PR_BODY, '___REQUIRES_GATEWAY_PR___=') }}
         run: |
           echo "GATEWAY_IMAGE_TAG=pr-$(echo $PR_BODY | sed -n 's/.*___REQUIRES_GATEWAY_PR___=\"\([0-9]\+\)\".*/\1/p')" >> $GITHUB_ENV
+
+      - name: Cache Sequencing NPM Packages
+        uses: actions/cache@v5
+        with:
+          path: ./sequencing-server/node_modules
+          key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }}
+      - name: Cache Action NPM Packages
+        uses: actions/cache@v5
+        with:
+          path: ./action-server/node_modules
+          key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }}
+
       # Start Hasura and Postgres ahead of assembling the Java code, as the Java code takes a few minutes to compile.
       # This means Hasura will have time to complete its start-up tasks without needing an extra "sleep 30" command.
       - name: Start Hasura and Postgres
@@ -240,6 +265,16 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
+      - name: Cache Sequencing NPM Packages
+        uses: actions/cache@v5
+        with:
+          path: ./sequencing-server/node_modules
+          key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }}
+      - name: Cache Action NPM Packages
+        uses: actions/cache@v5
+        with:
+          path: ./action-server/node_modules
+          key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }}
       - name: Extract PlanDev gateway docker tag from PR body
         # look in the PR body for the string ___REQUIRES_GATEWAY_PR___=9999, extract the number if so & save to env var
         # if gateway PR is labeled correctly, it will publish a docker tag called 'pr-9999' to use in tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,9 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v2
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-read-only: false #${{ github.ref != 'refs/heads/develop' }} # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
       - name: Assemble
         run: ./gradlew assemble --parallel
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,18 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
+
+      - name: Cache Sequencing NPM Packages
+        uses: actions/cache@v5
+        with:
+          path: ./sequencing-server/node_modules
+          key: sequencing-${{ runner.os }}-${{ hashFiles('./sequencing-server/package-lock.json') }}
+      - name: Cache Action NPM Packages
+        uses: actions/cache@v5
+        with:
+          path: ./action-server/node_modules
+          key: action-${{ runner.os }}-${{ hashFiles('./action-server/package-lock.json') }}
+
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
@@ -98,10 +110,12 @@ jobs:
           node-version-file: ./action-server/.nvmrc
           cache: npm
           cache-dependency-path: ./action-server/package-lock.json
+      - name: Install Dependencies
+        run: npm i
+        working-directory: ./action-server
       - name: Run Action Server Unit Tests
-        run: |
-          cd ./action-server
-          npm i && npm --silent run test
+        run: npm --silent run test
+        working-directory: ./action-server
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,8 @@ jobs:
           # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Assemble
-        run: ./gradlew assemble --parallel --daemon --profile
+        # Don't generate docs for tests
+        run: ./gradlew assemble -x javadoc -x javadocJar -x generateDocumentation --parallel --profile
       - name: Upload Profile
         if: always()
         uses: actions/upload-artifact@v7
@@ -86,7 +87,8 @@ jobs:
           # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Assemble
-        run: ./gradlew assemble --parallel
+        # Don't generate docs for tests
+        run: ./gradlew assemble -x javadoc -x javadocJar -x generateDocumentation --parallel
       - name: Run Unit Tests
         run: ./gradlew test --parallel
       - name: Upload Test Results as XML and HTML
@@ -202,7 +204,8 @@ jobs:
           # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Assemble
-        run: ./gradlew assemble --parallel
+        # Don't generate docs for tests
+        run: ./gradlew assemble -x javadoc -x javadocJar -x generateDocumentation --parallel
       - name: Start Remaining Services
         run: |
           echo "GATEWAY_IMAGE_TAG: $GATEWAY_IMAGE_TAG"
@@ -259,7 +262,8 @@ jobs:
           # This action defaults to matching on "main" and "master" as the branches allowed to write to the cache
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Assemble
-        run: ./gradlew assemble --parallel
+        # Don't generate docs for tests
+        run: ./gradlew assemble -x javadoc -x javadocJar -x generateDocumentation --parallel
       - name: Build scheduling procedure jars for testing
         run: ./gradlew e2e-tests:buildAllProcedureJars
       - name: Start Services

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
           cache: npm
           cache-dependency-path: ./action-server/package-lock.json
       - name: Install Dependencies
-        run: npm i
+        run: npm ci
         working-directory: ./action-server
       - name: Run Action Server Unit Tests
         run: npm --silent run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,26 @@ jobs:
             **/build/test-results/test
             **/build/reports/tests/test
 
+  action-unit-tests:
+    runs-on: ubuntu-latest
+    environment: e2e-test
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Run Action Server Unit Tests
+        run: ./gradlew action-server:e2eTest
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Action Server Test Results
+          path: |
+            **/action-server/action-server-test-report.log
+
   db-tests:
     runs-on: ubuntu-latest
     environment: e2e-test
@@ -151,60 +171,6 @@ jobs:
           name: Sequencing E2E Test Results
           path: |
             **/sequencing-server/test-report.*
-      - name: Print Logs for Services
-        if: always()
-        run: docker compose -f ./e2e-tests/docker-compose-test.yml logs -t
-      - name: Stop Services
-        if: always()
-        run: |
-          docker ps -a
-          docker compose -f ./e2e-tests/docker-compose-test.yml down
-          docker ps -a
-      - name: Prune Volumes
-        if: always()
-        run: docker volume prune --force
-
-  action-e2e-tests:
-    runs-on: ubuntu-latest
-    environment: e2e-test
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-      - name: Extract PlanDev gateway docker tag from PR body
-        # look in the PR body for the string ___REQUIRES_GATEWAY_PR___=9999, extract the number if so & save to env var
-        # if gateway PR is labeled correctly, it will publish a docker tag called 'pr-9999' to use in tests
-        if: ${{ contains(env.PR_BODY, '___REQUIRES_GATEWAY_PR___=') }}
-        run: |
-          echo "GATEWAY_IMAGE_TAG=pr-$(echo $PR_BODY | sed -n 's/.*___REQUIRES_GATEWAY_PR___=\"\([0-9]\+\)\".*/\1/p')" >> $GITHUB_ENV
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "21"
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v2
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-      - name: Assemble
-        run: ./gradlew assemble --parallel
-      - name: Start Services
-        run: |
-          echo "GATEWAY_IMAGE_TAG: $GATEWAY_IMAGE_TAG"
-          docker compose -f ./e2e-tests/docker-compose-test.yml up -d --build --quiet-pull
-          docker images
-          docker ps -a --no-trunc
-      - name: Sleep for 30 Seconds
-        run: sleep 30s
-        shell: bash
-      - name: Run Action Server E2E Tests
-        run: ./gradlew action-server:e2eTest
-      - name: Upload Test Results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Action Server E2E Test Results
-          path: |
-            **/action-server/action-server-test-report.log
       - name: Print Logs for Services
         if: always()
         run: docker compose -f ./e2e-tests/docker-compose-test.yml logs -t

--- a/action-server/build.gradle
+++ b/action-server/build.gradle
@@ -5,6 +5,7 @@ plugins {
 node {
   version = '22.13.1'
   download = true
+  npmInstallCommand = System.getenv("CI") ? 'ci' : 'install'
 }
 
 task assemble(type: NpmTask) {

--- a/merlin-server/build.gradle
+++ b/merlin-server/build.gradle
@@ -16,6 +16,7 @@ node {
   nodeProjectDir = file("${project.projectDir.toPath().resolve("constraints-dsl-compiler")}")
   version = '20.12.1'
   download = true
+  npmInstallCommand = System.getenv("CI") ? 'ci' : 'install'
 }
 
 task assembleConstraintsDSLCompiler(type: NpmTask) {

--- a/scheduler-worker/build.gradle
+++ b/scheduler-worker/build.gradle
@@ -19,6 +19,7 @@ node {
   nodeProjectDir = file("${project.projectDir.toPath().resolve("scheduling-dsl-compiler")}")
   version = '20.12.1'
   download = true
+  npmInstallCommand = System.getenv("CI") ? 'ci' : 'install'
 }
 
 task deleteConstraintsTypescript(type: Delete) {

--- a/sequencing-server/build.gradle
+++ b/sequencing-server/build.gradle
@@ -5,6 +5,7 @@ plugins {
 node {
   version = '18.13.0'
   download = true
+  npmInstallCommand = System.getenv("CI") ? 'ci' : 'install'
 }
 
 task assemble(type: NpmTask) {


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Currently, the E2E Test task takes 15 minutes to execute, which is absurdly high. This PR aims to improve that number without making the tests flaky.

Breakdown of E2E Suite test speed locally (with services already setup):
- `:e2eTest:e2eTest:`: ~6 mins
- `:dbTest:e2eTest:`: ~2 mins
- `:sequencing-server:e2eTest:`: ~1 min
- `:action-server:e2eTest:`: ~5 sec

The first approach is to split the tests by suite into multiple parallel jobs. The suites should already be independent (especially as they're a mixture of Java and TS tests), but by running them in separate jobs we avoid any issues where two suites are trying to alter the DB at the same time. Additionally, by having them as separate jobs, it will be clearer which suite in particular is failing, as opposed to needing to go through the collected folder.

Breakdown of tests after this approach:
- `unitTests`: 6 min (2 min running tests, 3.5 min assembling)
- `:e2eTest:e2eTest:`: 11 min (5 min running tests, 3.5 min assembling)
- `:dbTest:e2eTest:`: 4.5 min (4 min running tests)
- `:sequencing-server:e2eTest:`: 7 min (1.5 min running tests, 3.5 min assembling the Java backend)
- `:action-server:e2eTest:`: 5 min (10s running tests, 3 min assembling the Java backend)

After that, I added the following improvements
- Removed the backend from the action server. While it requires the envvars from the `e2e-test` environment, it doesn't actually require the backend to be running
- Configure the gradle cache to cache build artifacts. It will now cache build artifacts generated by tests run on `develop`
- Cache `node_modules` for `action-server` and `sequencing-server`. These seemed to not be cached by the gradle caching task, so they're now being manually cached

Breakdown of tests after all of this:
- `unitTests`: 4.5 min (2 min running tests, 2 min assembling)
- `:e2eTest:e2eTest:`: 9 min (5 min running tests, 2 min assembling)
- `:dbTest:e2eTest:`: 4.5 min (4 min running tests)
- `:sequencing-server:e2eTest:`: 5 min (1.5 min running tests, 2 min assembling)
- `:action-server:e2eTest:`: 30s min (10s running tests)