### PR TITLE
change maven publishing URL to new plandev repo

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Properties for configuring the publish task.
 publishing.name=GitHubPackages
-publishing.url=https://maven.pkg.github.com/nasa-ammos/aerie
+publishing.url=https://maven.pkg.github.com/nasa-ammos/plandev
 publishing.usernameEnvironmentVariable=GITHUB_ACTOR
 publishing.passwordEnvironmentVariable=GITHUB_TOKEN
 


### PR DESCRIPTION
Fix issue with publishing Maven packages: https://github.com/NASA-AMMOS/plandev/actions/runs/23925739569/job/69782057731

Since the repo name changed we cannot use this as publishing URL anymore. However we believe that we can publish packages to the new namespace & the old will still be redirected for some time