### PR TITLE
update handlebars to v4.7.9 to fix security scan issues

### DIFF
--- a/sequencing-server/package-lock.json
+++ b/sequencing-server/package-lock.json
@@ -23,7 +23,7 @@
         "dataloader": "~2.2.0",
         "express": "~5.0.0-beta.1",
         "graphql-request": "~5.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "4.7.9",
         "jwt-decode": "~3.1.2",
         "pg": "~8.9.0",
         "pg-format": "~1.0.4",
@@ -3525,9 +3525,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -9429,9 +9429,9 @@
       }
     },
     "handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",

--- a/sequencing-server/package.json
+++ b/sequencing-server/package.json
@@ -38,7 +38,7 @@
     "dataloader": "~2.2.0",
     "express": "~5.0.0-beta.1",
     "graphql-request": "~5.1.0",
-    "handlebars": "^4.7.8",
+    "handlebars": "4.7.9",
     "jwt-decode": "~3.1.2",
     "pg": "~8.9.0",
     "pg-format": "~1.0.4",


### PR DESCRIPTION
Updating handlebars dependency to fix this security scan issue:

https://github.com/NASA-AMMOS/plandev/actions/runs/23914580419/job/69745606865?pr=1803

I'm not convinced the original security issue would have affected us, but this is a minor update with no breaking changes, so should be low-risk.