### PR TITLE
Fix Typo in Workspace Server HEALTHCHECK

### DIFF
--- a/deployment/proxy/docker-compose-proxy.yml
+++ b/deployment/proxy/docker-compose-proxy.yml
@@ -43,7 +43,7 @@ services:
       PUBLIC_GATEWAY_CLIENT_URL: https://${AERIE_HOST}:9000
       PUBLIC_HASURA_CLIENT_URL: https://${AERIE_HOST}:8080/v1/graphql
       PUBLIC_HASURA_WEB_SOCKET_URL: wss://${AERIE_HOST}:8080/v1/graphql
-      PUBLIC_WORKSPACE_CLIENT_URL: https://{AERIE_HOST}:28000
+      PUBLIC_WORKSPACE_CLIENT_URL: https://${AERIE_HOST}:28000
   hasura:
     ports: !reset []
   postgres:

--- a/workspace-server/Dockerfile
+++ b/workspace-server/Dockerfile
@@ -9,7 +9,7 @@ FROM eclipse-temurin:21-jre-jammy
 COPY --from=extractor /usr/src/app/extracted /usr/src/app
 
 HEALTHCHECK --interval=30s --timeout=2s --start-period=2s --retries=15 \
-CMD curl --sf http://localhost:$PORT/health || exit 1
+CMD curl -sf http://localhost:$WORKSPACE_PORT/health || exit 1
 
 WORKDIR /usr/src/app
 ENTRYPOINT ["/usr/src/app/bin/workspace-server"]


### PR DESCRIPTION
* **Tickets addressed:** Closes #1754 and Closes #1759
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Fixes two typos so the Healthcheck now runs as it should:
1. Removed the extra `-` in front of `-sf`
2. Corrected the ENVVAR `$PORT` to `$WORKSPACE_PORT`

Additionally fixed another typo in the `docker-compose-proxy.yml`, where a `$` was missing before an ENVVAR

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
With the `develop` images up, run `docker ps` in the command line. The entry for `aerie_workspace` will be marked as `unhealthy`

Then, check out this branch and bring up new image for `aerie_workspace`. The container will now be marked as `healthy`.
