### PR TITLE
Seqdev Actions: add `undefined` as allowed value for non-required variant-type parameters

### DIFF
--- a/action-server/src/utils/codeRunner.ts
+++ b/action-server/src/utils/codeRunner.ts
@@ -209,6 +209,8 @@ function validateParameters(
       const allowedValues = paramDefinition.variants;
 
       if (allowedValues !== undefined && allowedValues.length > 0) {
+        // `undefined` is also a valid value for non-required variants
+        allowedValues.push({key: undefined, label: "undefined"});
         const paramValue = parameters[paramDefKey];
 
         if (!allowedValues.some(({ key }) => key === paramValue)) {


### PR DESCRIPTION
We recently added validation for **`variant` (enum) type parameters** for SeqDev actions in https://github.com/NASA-AMMOS/plandev/pull/1817, to ensure that the value passed in an action run is one of the allowed values in the action's parameter definition. 

For **non-required** variant parameters, the user should still be able to *not* pass a value - however since `undefined` is not one of the allowed values, validation currently fails on this case. This adds `undefined` as an allowed value when validating `variant` parameters.

Related UI PR/comment: https://github.com/NASA-AMMOS/plandev-ui/pull/1911#pullrequestreview-4192143418

@AaronPlave let's discuss tomorrow whether it makes more sense to add unit tests here for this, or to test in the new [aerie-action-demo](https://github.com/NASA-AMMOS/plandev-ui/blob/develop/e2e-tests/data/aerie-action-demo.js) e2e tests. 