### PR TITLE
Make Parcel Names Unique

### DIFF
--- a/deployment/hasura/migrations/Aerie/34_unique_parcel_names/down.sql
+++ b/deployment/hasura/migrations/Aerie/34_unique_parcel_names/down.sql
@@ -1,0 +1,2 @@
+alter table sequencing.parcel drop constraint parcel_name_key;
+call migrations.mark_migration_rolled_back(34);

--- a/deployment/hasura/migrations/Aerie/34_unique_parcel_names/up.sql
+++ b/deployment/hasura/migrations/Aerie/34_unique_parcel_names/up.sql
@@ -1,0 +1,31 @@
+-- Data migration: deduplicate parcel names:
+do $$
+begin
+  -- While there are duplicate names in the parcel table...
+  while exists(
+    select from sequencing.parcel
+    group by name
+    having count(name) > 1
+  ) loop
+    -- ...deduplicate them
+    update sequencing.parcel
+    set name = name || '(' || ir.row || ')'
+    from (
+        select id, row_number() over (partition by name) - 1 as row
+        from sequencing.parcel
+        where name in (
+          select p.name
+          from sequencing.parcel p
+          group by p.name
+          having count(1) > 1)
+    ) as ir
+    where ir.id = parcel.id
+    and row > 0;
+end loop;
+end $$;
+
+-- Add new uniqueness constraint to the parcel name
+alter table sequencing.parcel
+add unique(name);
+
+call migrations.mark_migration_applied(34);

--- a/deployment/postgres-init-db/sql/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/applied_migrations.sql
@@ -34,3 +34,5 @@ call migrations.mark_migration_applied(29);
 call migrations.mark_migration_applied(30);
 call migrations.mark_migration_applied(31);
 call migrations.mark_migration_applied(32);
+
+call migrations.mark_migration_applied(34);

--- a/deployment/postgres-init-db/sql/tables/sequencing/parcel.sql
+++ b/deployment/postgres-init-db/sql/tables/sequencing/parcel.sql
@@ -1,7 +1,7 @@
 create table sequencing.parcel (
   id integer generated always as identity,
 
-  name text not null,
+  name text not null unique,
 
   command_dictionary_id integer not null,
   channel_dictionary_id integer default null,


### PR DESCRIPTION
* **Tickets addressed:** Closes #1751 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
Adds a uniqueness constraint to parcel names in the DB.

The up migration will automatically deduplicate parcel names, repeating the process until there are no more duplicate names. 

Note: I've set this PR's migration to one higher than #1822, as I expect that PR to be merged first.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
I manually set up a DB where there with multiple parcels with unique names, multiple parcels named `parcel`, and a parcel named `parcel(1)` (which is the deduplication naming pattern). I then ran the DB migration via the Python script and observed that conflicting names were correctly deduplicated.
