### PR TITLE
[HOTFIX] Add External Event relationship to plan_derivation_group

### DIFF
--- a/deployment/hasura/metadata/databases/tables/merlin/plan_derivation_group.yaml
+++ b/deployment/hasura/metadata/databases/tables/merlin/plan_derivation_group.yaml
@@ -10,6 +10,15 @@ object_relationships:
 - name: derivation_group
   using:
     foreign_key_constraint_on: derivation_group_name
+array_relationships:
+  - name: external_events
+    using:
+      manual_configuration:
+        remote_table:
+          name: external_event
+          schema: merlin
+        column_mapping:
+          derivation_group_name: derivation_group_name
 select_permissions:
   - role: aerie_admin
     permission:


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The issue at hand was that the UI was making an extensive query to get the external event types associated with a plan (see `getExternalEventTypes` in `effects.ts` in [plandev-ui](https://github.com/NASA-AMMOS/plandev-ui/blob/develop/src/utilities/effects.ts)). On the LRO deployment, this multi-layered join caused 15 seconds of latency, and often timed out. The purpose of this PR was to make a small change to the Hasura metadata, such that this same request could be completed with fewer joins, and in a minimally intrusive manner.

The former query was (see [`gql.ts`](https://github.com/NASA-AMMOS/plandev-ui/blob/develop/src/enums/gql.ts)):
```
query GetPlanEventTypes($plan_id: Int!){
  ${Queries.PLAN_DERIVATION_GROUP}(where: {plan_id: {_eq: $plan_id}}) {
    derivation_group {
      external_sources {
        external_events {
          external_event_type {
            attribute_schema
            name
          }
        }
      }
    }
  }
}
```

and the new query was:
```
query GetPlanEventTypes($plan_id: Int!) {
  ${Queries.PLAN_DERIVATION_GROUP}(where: {plan_id: {_eq: $plan_id}}) {
    external_events (distinct_on: event_type_name) {
      external_event_type {
        name
        attribute_schema
      }
    }
  }
}
```

## Verification
No tests were added. It was verified locally and on the deployment, improving times from 15 seconds to 900ms.

## Documentation
None.

## Future work
A small PR to reflect the Hasura request suggested above will be made in plandev-ui!