### PR TITLE
Small fixes to action server port parsing, github workflows

### DIFF
--- a/.github/workflows/pgcmp.yml
+++ b/.github/workflows/pgcmp.yml
@@ -6,13 +6,15 @@ on:
       - "deployment/hasura/migrations/**"
       - "deployment/postgres-init-db/sql/**"
       - ".github/workflows/pgcmp.yml"
-      - ".github/workflows/scripts/compareDatabases*"
+      - ".github/scripts/compareDatabases*"
+      - ".github/scripts/explanations_*"
   push:
     paths:
       - "deployment/hasura/migrations/**"
       - "deployment/postgres-init-db/sql/**"
       - ".github/workflows/pgcmp.yml"
-      - ".github/workflows/scripts/compareDatabases*"
+      - ".github/scripts/compareDatabases*"
+      - ".github/scripts/explanations_*"
     branches:
       - develop
       - dev-[0-9]+.[0-9]+.[0-9]+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,7 +140,7 @@ jobs:
 
   scan:
     runs-on: ubuntu-latest
-    needs: containers
+    needs: [init, containers]
     if: needs.init.outputs.SHOULD_PUBLISH_IMAGES == 'true'
     strategy:
       matrix:
@@ -159,6 +159,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Extract metadata for ${{ matrix.image }}
+        id: metadata-step
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}
+
       - name: Scan ${{ matrix.image }} for vulnerabilities
         # pinned to commit for release https://github.com/aquasecurity/trivy-action/releases/tag/v0.24.0
         uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8
@@ -166,7 +172,7 @@ jobs:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:develop
+          image-ref: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ steps.metadata-step.outputs.version }}
           ignore-unfixed: true
           exit-code: "1"
           severity: "CRITICAL"

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 **/target/*
 .*.swp
 .tags
+.codex
 
 ### Build ###
 .m2

--- a/action-server/src/db.ts
+++ b/action-server/src/db.ts
@@ -17,7 +17,7 @@ export class ActionsDbManager {
       logger.info(`Creating PG pool`);
       ActionsDbManager.pool = new pg.Pool({
         host: AERIE_DB_HOST,
-        port: parseInt(AERIE_DB_PORT, 5432),
+        port: parseInt(AERIE_DB_PORT, 10),
         database: AERIE_DB,
         user: ACTION_DB_USER,
         password: ACTION_DB_PASSWORD,

--- a/action-server/src/db.ts
+++ b/action-server/src/db.ts
@@ -17,7 +17,7 @@ export class ActionsDbManager {
       logger.info(`Creating PG pool`);
       ActionsDbManager.pool = new pg.Pool({
         host: AERIE_DB_HOST,
-        port: parseInt(AERIE_DB_PORT, 10),
+        port: parseInt(AERIE_DB_PORT),
         database: AERIE_DB,
         user: ACTION_DB_USER,
         password: ACTION_DB_PASSWORD,

--- a/action-server/src/threads/worker.ts
+++ b/action-server/src/threads/worker.ts
@@ -20,7 +20,7 @@ function getDbPool() {
 
   dbPool = new pg.Pool({
     host: AERIE_DB_HOST,
-    port: parseInt(AERIE_DB_PORT, 10),
+    port: parseInt(AERIE_DB_PORT),
     database: AERIE_DB,
     user: ACTION_DB_USER,
     password: ACTION_DB_PASSWORD,

--- a/action-server/src/threads/worker.ts
+++ b/action-server/src/threads/worker.ts
@@ -20,7 +20,7 @@ function getDbPool() {
 
   dbPool = new pg.Pool({
     host: AERIE_DB_HOST,
-    port: parseInt(AERIE_DB_PORT, 5432),
+    port: parseInt(AERIE_DB_PORT, 10),
     database: AERIE_DB,
     user: ACTION_DB_USER,
     password: ACTION_DB_PASSWORD,


### PR DESCRIPTION
Sweeping up a couple tiny fixes I had in my notes:

* Action server was doing `parseInt(AERIE_DB_PORT, 5432),` like it was a fallback, in fact second argument is *radix* and this always returns NaN. This caused it to fallback to a default (5432) in another layer and **never** use custom `AERIE_DB_PORT` if passed
* Publish workflow should require  `init` step since it uses output from it on line 144. Also updated to make security scan scan the images from the PR branch instead of `develop`
* Pgcmp workflow had wrong paths for scripts, this only matters for auto-running the workflow if/when any of those scripts change
