### PR TITLE
Add default Derivation Group associations for Plans at the Model level

### DIFF
--- a/deployment/hasura/metadata/databases/tables/merlin/mission_model.yaml
+++ b/deployment/hasura/metadata/databases/tables/merlin/mission_model.yaml
@@ -39,6 +39,13 @@ array_relationships:
         table:
           name: plan
           schema: merlin
+  - name: derivation_group_specification
+    using:
+      foreign_key_constraint_on:
+        column: model_id
+        table:
+          name: model_derivation_group
+          schema: merlin
   - name: resource_types
     using:
       foreign_key_constraint_on:

--- a/deployment/hasura/metadata/databases/tables/merlin/model_derivation_group.yaml
+++ b/deployment/hasura/metadata/databases/tables/merlin/model_derivation_group.yaml
@@ -1,0 +1,53 @@
+table:
+  name: model_derivation_group
+  schema: merlin
+configuration:
+  custom_name: "model_derivation_group"
+object_relationships:
+  - name: mission_model
+    using:
+      foreign_key_constraint_on: model_id
+  - name: derivation_group
+    using:
+      foreign_key_constraint_on: derivation_group_name
+array_relationships:
+  - name: external_events
+    using:
+      manual_configuration:
+        remote_table:
+          name: external_event
+          schema: merlin
+        column_mapping:
+          derivation_group_name: derivation_group_name
+select_permissions:
+  - role: aerie_admin
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: user
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+  - role: viewer
+    permission:
+      columns: '*'
+      filter: {}
+      allow_aggregations: true
+insert_permissions:
+  - role: aerie_admin
+    permission:
+      columns: [model_id, derivation_group_name]
+      check: {}
+  - role: user
+    permission:
+      columns: [model_id, derivation_group_name]
+      check: {"mission_model": {"owner": {"_eq": "X-Hasura-User-Id"}}}
+delete_permissions:
+  - role: aerie_admin
+    permission:
+      filter: {}
+  - role: user
+    permission:
+      filter: {"mission_model": {"owner": {"_eq": "X-Hasura-User-Id"}}}

--- a/deployment/hasura/metadata/databases/tables/tables.yaml
+++ b/deployment/hasura/metadata/databases/tables/tables.yaml
@@ -113,6 +113,7 @@
 - "!include merlin/external_source.yaml"
 - "!include merlin/external_source_type.yaml"
 - "!include merlin/plan_derivation_group.yaml"
+- "!include merlin/model_derivation_group.yaml"
 
 # Constraints
 - "!include merlin/constraints/constraint_metadata.yaml"

--- a/deployment/hasura/migrations/Aerie/35_model_derivation_group/down.sql
+++ b/deployment/hasura/migrations/Aerie/35_model_derivation_group/down.sql
@@ -1,0 +1,5 @@
+drop trigger populate_derivation_groups_new_plan_trigger on merlin.plan;
+drop function merlin.populate_derivation_groups_new_plan cascade;
+drop table merlin.model_derivation_group cascade;
+
+call migrations.mark_migration_rolled_back('35');

--- a/deployment/hasura/migrations/Aerie/35_model_derivation_group/up.sql
+++ b/deployment/hasura/migrations/Aerie/35_model_derivation_group/up.sql
@@ -1,0 +1,47 @@
+create table merlin.model_derivation_group (
+    model_id integer not null,
+    derivation_group_name text not null,
+
+    constraint model_derivation_group_pkey
+      primary key (model_id, derivation_group_name),
+    constraint mdg_model_exists
+      foreign key (model_id)
+      references merlin.mission_model(id)
+      on delete cascade,
+    constraint mdg_derivation_group_exists
+      foreign key (derivation_group_name)
+      references merlin.derivation_group(name)
+      on update cascade
+      on delete restrict
+);
+
+comment on table merlin.model_derivation_group is e''
+  'The default set of derivation groups that any new plans created using this model would have linked to them.';
+
+comment on column merlin.model_derivation_group.model_id is e''
+  'The model with which the derivation group is associated.';
+comment on column merlin.model_derivation_group.derivation_group_name is e''
+  'The derivation group being associated with the model.';
+
+
+create function merlin.populate_derivation_groups_new_plan()
+returns trigger
+language plpgsql as $$
+begin
+  insert into merlin.plan_derivation_group (plan_id, derivation_group_name)
+  select new.id, mdg.derivation_group_name
+  from merlin.model_derivation_group mdg
+  where mdg.model_id = new.model_id;
+  return new;
+end;
+$$;
+
+comment on function merlin.populate_derivation_groups_new_plan() is e''
+'Populates the plan''s derivation group associations with the contents of its model''s derivation group associations.';
+
+create trigger populate_derivation_groups_new_plan_trigger
+after insert on merlin.plan
+for each row
+execute function merlin.populate_derivation_groups_new_plan();
+
+call migrations.mark_migration_applied('35');

--- a/deployment/postgres-init-db/sql/applied_migrations.sql
+++ b/deployment/postgres-init-db/sql/applied_migrations.sql
@@ -36,3 +36,4 @@ call migrations.mark_migration_applied(31);
 call migrations.mark_migration_applied(32);
 call migrations.mark_migration_applied(33);
 call migrations.mark_migration_applied(34);
+call migrations.mark_migration_applied(35);

--- a/deployment/postgres-init-db/sql/init_merlin.sql
+++ b/deployment/postgres-init-db/sql/init_merlin.sql
@@ -29,7 +29,7 @@ begin;
 
   -- Scheduling Goals and Scheduling Goal Specification
   \ir init_scheduler_mid_merlin.sql
-  
+
   -- Activity Directives
   \ir tables/merlin/activity_directive/activity_directive_metadata_schema.sql
   \ir tables/merlin/activity_directive/activity_directive.sql
@@ -85,6 +85,7 @@ begin;
   \ir tables/merlin/external_events/external_source.sql
   \ir tables/merlin/external_events/external_event.sql
   \ir tables/merlin/external_events/plan_derivation_group.sql
+  \ir tables/merlin/external_events/model_derivation_group.sql
 
   ------------
   -- Functions

--- a/deployment/postgres-init-db/sql/tables/merlin/external_events/model_derivation_group.sql
+++ b/deployment/postgres-init-db/sql/tables/merlin/external_events/model_derivation_group.sql
@@ -1,0 +1,24 @@
+create table merlin.model_derivation_group (
+    model_id integer not null,
+    derivation_group_name text not null,
+
+    constraint model_derivation_group_pkey
+      primary key (model_id, derivation_group_name),
+    constraint mdg_model_exists
+      foreign key (model_id)
+      references merlin.mission_model(id)
+      on delete cascade,
+    constraint mdg_derivation_group_exists
+      foreign key (derivation_group_name)
+      references merlin.derivation_group(name)
+      on update cascade
+      on delete restrict
+);
+
+comment on table merlin.model_derivation_group is e''
+  'The default set of derivation groups that any new plans created using this model would have linked to them.';
+
+comment on column merlin.model_derivation_group.model_id is e''
+  'The model with which the derivation group is associated.';
+comment on column merlin.model_derivation_group.derivation_group_name is e''
+  'The derivation group being associated with the model.';

--- a/deployment/postgres-init-db/sql/tables/merlin/plan.sql
+++ b/deployment/postgres-init-db/sql/tables/merlin/plan.sql
@@ -113,6 +113,26 @@ after insert on merlin.plan
 for each row
 execute function merlin.populate_constraint_spec_new_plan();
 
+create function merlin.populate_derivation_groups_new_plan()
+returns trigger
+language plpgsql as $$
+begin
+  insert into merlin.plan_derivation_group (plan_id, derivation_group_name)
+  select new.id, mdg.derivation_group_name
+  from merlin.model_derivation_group mdg
+  where mdg.model_id = new.model_id;
+  return new;
+end;
+$$;
+
+comment on function merlin.populate_derivation_groups_new_plan() is e''
+'Populates the plan''s derivation group associations with the contents of its model''s derivation group associations.';
+
+create trigger populate_derivation_groups_new_plan_trigger
+after insert on merlin.plan
+for each row
+execute function merlin.populate_derivation_groups_new_plan();
+
 -- Insert or Update Triggers
 
 create trigger set_timestamp


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
During the exploration of PlanDev by operators, it was found that manual association of derivation groups on new plan creation was rather tedious, as the same derivation groups were repeatedly being associated with each new plan.


This PR suggests a QoL fix, in tandem with [this PR on plandev-ui](https://github.com/NASA-AMMOS/plandev-ui/pull/1934), to allow derivation group association defaults to be set up at a model level. This is much like the default association specifications that are possible for goals, constraints, and conditions, and is modeled after that functionality.

## Verification
No new tests were added, but the changes were tested in the UI, which require that these few changes on the backend are correct and functional.

## Documentation
No updates to documentation should be necessary.

## Future work
No future work is anticipated with regards to this update specifically.
