### PR TITLE
Fix `Cascade` Delete Failing when handling Anchored Activities

### DIFF
--- a/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/AnchorCascadeDeleteGoal.java
+++ b/e2e-tests/src/main/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/procedures/AnchorCascadeDeleteGoal.java
@@ -1,0 +1,53 @@
+package gov.nasa.jpl.aerie.e2e.procedural.scheduling.procedures;
+
+import gov.nasa.ammos.aerie.procedural.scheduling.ActivityAutoDelete;
+import gov.nasa.ammos.aerie.procedural.scheduling.Goal;
+import gov.nasa.ammos.aerie.procedural.scheduling.annotations.SchedulingProcedure;
+import gov.nasa.ammos.aerie.procedural.scheduling.plan.DeletedAnchorStrategy;
+import gov.nasa.ammos.aerie.procedural.scheduling.plan.EditablePlan;
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.DirectiveStart;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.Plan;
+import gov.nasa.ammos.aerie.procedural.timeline.plan.SimulationResults;
+import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
+import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
+import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+@SchedulingProcedure
+public record AnchorCascadeDeleteGoal() implements Goal {
+
+  @Override
+  public ActivityAutoDelete shouldDeletePastCreations(
+      @NotNull final Plan plan,
+      @Nullable final SimulationResults simResults) {
+    // Delete activities created by previous runs of this goal, using Cascade to
+    // handle anchored activities
+    return new ActivityAutoDelete.AtBeginning(DeletedAnchorStrategy.Cascade, false);
+  }
+
+  @Override
+  public void run(@NotNull final EditablePlan plan) {
+    final var ids = new ActivityDirectiveId[3];
+
+    ids[0] = plan.create(
+        "BiteBanana",
+        new DirectiveStart.Absolute(Duration.HOUR),
+        Map.of("biteSize", SerializedValue.of(1))
+    );
+    ids[1] = plan.create(
+        "BiteBanana",
+        new DirectiveStart.Anchor(ids[0], Duration.HOUR, DirectiveStart.Anchor.AnchorPoint.End),
+        Map.of("biteSize", SerializedValue.of(2))
+    );
+    ids[2] = plan.create(
+        "BiteBanana",
+        new DirectiveStart.Anchor(ids[1], Duration.HOUR, DirectiveStart.Anchor.AnchorPoint.Start),
+        Map.of("biteSize", SerializedValue.of(3))
+    );
+
+    plan.commit();
+  }
+}

--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/AutoDeletionTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/AutoDeletionTests.java
@@ -8,16 +8,19 @@ import org.junit.jupiter.api.Test;
 
 import javax.json.Json;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AutoDeletionTests extends ProceduralTestingSetup {
   private GoalInvocationId edslId;
   private GoalInvocationId procedureId;
+  private GoalInvocationId cascadeProcedureId;
 
   @BeforeEach
   void localBeforeEach() throws IOException {
@@ -51,7 +54,7 @@ public class AutoDeletionTests extends ProceduralTestingSetup {
           false
       );
 
-      int procedureJarId = gateway.uploadJarFile("build/libs/ActivityAutoDeletionGoal.jar");
+      final int procedureJarId = gateway.uploadJarFile("build/libs/ActivityAutoDeletionGoal.jar");
       // Add Scheduling Procedure
       procedureId = hasura.createSchedulingSpecProcedure(
           "Test Scheduling Procedure",
@@ -60,11 +63,23 @@ public class AutoDeletionTests extends ProceduralTestingSetup {
           1,
           false
       );
+
+      // Upload and by default disable the cascade test procedure
+      final int cascadeJarProcedureId = gateway.uploadJarFile("build/libs/AnchorCascadeDeleteGoal.jar");
+      cascadeProcedureId = hasura.createSchedulingSpecProcedure(
+          "Anchor Deletion Cascade Mode Test Procedure",
+          cascadeJarProcedureId,
+          specId,
+          2,
+          true
+      );
+      hasura.updateSchedulingSpecEnabled(cascadeProcedureId.invocationId(), false);
     }
   }
 
   @AfterEach
   void localAfterEach() throws IOException {
+    hasura.deleteSchedulingGoal(cascadeProcedureId.goalId());
     hasura.deleteSchedulingGoal(procedureId.goalId());
     hasura.deleteSchedulingGoal(edslId.goalId());
   }
@@ -184,6 +199,54 @@ public class AutoDeletionTests extends ProceduralTestingSetup {
       assertTrue(activities.stream().anyMatch(
           it -> Objects.equals(it.type(), "BiteBanana")
       ));
+    }
+  }
+
+  @Test
+  void schedulerDeletesCascade() throws IOException {
+    // Enable the cascade test, disable the other two
+    hasura.updateSchedulingSpecEnabled(cascadeProcedureId.invocationId(), true);
+    hasura.updateSchedulingSpecEnabled(procedureId.invocationId(), false);
+    hasura.updateSchedulingSpecEnabled(edslId.invocationId(), false);
+
+    // Run Scheduling
+    hasura.awaitScheduling(specId);
+
+    // Get a record of the plan post-scheduling
+    final var originalActivities = hasura.getPlan(planId).activityDirectives();
+
+    // Run Scheduling again. This will trigger the goal's autodeletion behavior
+    hasura.updatePlanRevisionSchedulingSpec(planId);
+    hasura.awaitScheduling(specId);
+
+    // Get a new copy of the plan
+    final var updatedActivities = hasura.getPlan(planId).activityDirectives();
+
+    // Sort the activities on their bite size
+    originalActivities.sort(Comparator.comparingInt(a -> a.arguments().getInt("biteSize")));
+    updatedActivities.sort(Comparator.comparingInt(a -> a.arguments().getInt("biteSize")));
+
+    // Prove that the activities were deleted and remade during scheduling
+    assertEquals(originalActivities.size(), updatedActivities.size());
+    for(int i = 0; i < originalActivities.size(); ++i) {
+      final var originalAct = originalActivities.get(i);
+      final var updatedAct = updatedActivities.get(i);
+
+      // The Activities should be identical, except for their ids, which should differ
+      assertNotEquals(originalAct.id(), updatedAct.id());
+
+      if(originalAct.anchorId() == null) {
+        assertNull(updatedAct.anchorId());
+      } else {
+        assertNotEquals(originalAct.anchorId(), updatedAct.anchorId());
+      }
+
+      assertEquals(originalAct.planId(), updatedAct.planId());
+      assertEquals(originalAct.type(), updatedAct.type());
+      assertEquals(originalAct.startOffset(), updatedAct.startOffset());
+      assertEquals(originalAct.arguments(), updatedAct.arguments());
+      assertEquals(originalAct.name(), updatedAct.name());
+      assertEquals(originalAct.anchoredToStart(), updatedAct.anchoredToStart());
     }
   }
 }

--- a/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/plan/EditablePlan.kt
+++ b/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/plan/EditablePlan.kt
@@ -54,6 +54,12 @@ interface EditablePlan: Plan {
    */
   fun delete(directive: Directive<AnyDirective>, strategy: DeletedAnchorStrategy)
 
+  /**
+   * Delete an activity if it exists with a strategy to handle activities that are anchored to it.
+   *
+   * If other anchored activities are affected, extra addition and deletion edits may be created.
+   */
+  fun deleteIfExists(id: ActivityDirectiveId, strategy: DeletedAnchorStrategy)
 
   /** Commit plan edits, making them final. */
   fun commit()

--- a/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/utils/DefaultEditablePlanDriver.kt
+++ b/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/utils/DefaultEditablePlanDriver.kt
@@ -260,6 +260,14 @@ class DefaultEditablePlanDriver(
     delete(matchingDirectives.first(), strategy)
   }
 
+  override fun deleteIfExists(id: ActivityDirectiveId, strategy: DeletedAnchorStrategy) {
+    val matchingDirectives = directives().filter { it.id == id }.collect()
+    if (matchingDirectives.isEmpty()) return;
+    if (matchingDirectives.size > 1) throw Exception("multiple activities with ID found: $id")
+
+    delete(matchingDirectives.first(), strategy)
+  }
+
   override fun commit() {
     // Early return if there are no changes. This prevents multiple commits from sharing ownership of the set,
     // because new sets are only created when edits are made.

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Procedure.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/goals/Procedure.java
@@ -171,11 +171,12 @@ public class Procedure extends Goal {
       final DeletedAnchorStrategy strategy,
       final Map<ActivityDirectiveId, GoalId> sourceSchedulingGoals
   ) {
-    for (final var activity: ((SchedulerPlanEditAdapter) plan.getAdapter()).getPlan().getActivities()) {
-      final var goalId = sourceSchedulingGoals.getOrDefault(activity.id(), null);
-      if (goalId != null && goalId.goalInvocationId().equals(this.goalId.goalInvocationId())) {
-        plan.delete(activity.id(), strategy);
-      }
-    }
+    sourceSchedulingGoals
+        .entrySet()
+        .stream()
+        // Filter the sourceSchedulingGoals map to get the set of ActivityDirectiveIds placed by this procedure
+        .filter(entry -> entry.getValue() != null && entry.getValue().goalInvocationId().equals(this.goalId.goalInvocationId()))
+        .map(Map.Entry::getKey)
+        .forEach(id -> plan.deleteIfExists(id, strategy));
   }
 }


### PR DESCRIPTION
* **Tickets addressed:** Closes #1797 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
A new method has been added to the `EditablePlan` interface: `deleteIfExists`. Unlike `delete`, if the activity does not exist, then the method silently returns instead of throwing an Exception. 

`Procedure.deletePastCreations` has been updated to call this new method instead of `delete`. Additionally, the way the method gets the set of ids to be deleted has been simplified: rather than iterating through every activity on the plan and checking that a) it has a corresponding entry in the `sourceSchedulingGoals` map and b) that entry corresponds to the `Procedure`'s `goalId`, it now directly filters the `sourceSchedulingGoals` for the keys that have the `Procedure`'s `goalId` as a value.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
A test going through the reproduction steps on the ticket were added.
