### PR TITLE
WIP - Dependency updates to fix vulnerabilities from security scans

### DIFF
--- a/action-server/Dockerfile
+++ b/action-server/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:22.13.1-bookworm-slim
 
 # Install jemalloc
+# Update gnutls to pick up debian security fixes flagged by trivy (may not be needed after base image update)
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y libjemalloc-dev
+    && apt-get install --no-install-recommends -y libjemalloc-dev \
+    && apt-get install --no-install-recommends -y --only-upgrade libgnutls30 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set the path for jemalloc
 RUN echo "/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so" >> /etc/ld.so.preload

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -220,7 +220,7 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: warn
       HASURA_GRAPHQL_METADATA_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_hasura"
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: "hasura/graphql-engine:v2.12.1.cli-migrations-v3"
+    image: "${REPOSITORY_DOCKER_URL}/aerie-hasura:${DOCKER_TAG}"
     ports: ["8080:8080"]
     restart: always
     volumes:
@@ -243,7 +243,7 @@ services:
       SCHEDULER_DB_PASSWORD: "${SCHEDULER_PASSWORD}"
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
-    image: postgres:16.12-bookworm
+    image: "${REPOSITORY_DOCKER_URL}/aerie-postgres:${DOCKER_TAG}"
     ports: ["5432:5432"]
     restart: always
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -314,7 +314,7 @@ services:
       SCHEDULER_DB_PASSWORD: "${SCHEDULER_PASSWORD}"
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
-    image: postgres:16.12-bookworm
+    image: postgres:16.14-bookworm
     ports: ["5432:5432"]
     restart: always
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -277,6 +277,9 @@ services:
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store:ro
   hasura:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.hasura
     container_name: aerie_hasura
     depends_on: ["postgres"]
     environment:
@@ -293,12 +296,15 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: info
       HASURA_GRAPHQL_METADATA_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_hasura"
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: "hasura/graphql-engine:v2.12.1.cli-migrations-v3"
+    image: aerie_hasura
     ports: ["8080:8080"]
     restart: always
     volumes:
       - ./deployment/hasura/metadata:/hasura-metadata
   postgres:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.postgres
     container_name: aerie_postgres
     environment:
       POSTGRES_DB: postgres
@@ -314,7 +320,7 @@ services:
       SCHEDULER_DB_PASSWORD: "${SCHEDULER_PASSWORD}"
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
-    image: postgres:16.14-bookworm
+    image: aerie_postgres
     ports: ["5432:5432"]
     restart: always
     volumes:

--- a/docker/Dockerfile.postgres
+++ b/docker/Dockerfile.postgres
@@ -1,2 +1,8 @@
-FROM postgres:16.12-bookworm
+FROM postgres:16.14-bookworm
+
+# Update gnutls to pick up debian security fixes flagged by trivy (may not be needed after base image update)
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y --only-upgrade libgnutls30 \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY deployment/postgres-init-db /docker-entrypoint-initdb.d

--- a/e2e-tests/docker-compose-many-workers.yml
+++ b/e2e-tests/docker-compose-many-workers.yml
@@ -219,6 +219,9 @@ services:
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store:ro
   hasura:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.hasura
     container_name: aerie_hasura
     depends_on: ["postgres"]
     environment:
@@ -235,12 +238,15 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: info
       HASURA_GRAPHQL_METADATA_DATABASE_URL: "postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_hasura"
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: "hasura/graphql-engine:v2.12.1.cli-migrations-v3"
+    image: aerie_hasura
     ports: ["8080:8080"]
     restart: always
     volumes:
       - ./deployment/hasura/metadata:/hasura-metadata
   postgres:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.postgres
     container_name: aerie_postgres
     environment:
       POSTGRES_DB: postgres
@@ -256,7 +262,7 @@ services:
       SCHEDULER_DB_PASSWORD: "${SCHEDULER_PASSWORD}"
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
-    image: postgres:16.12-bookworm
+    image: aerie_postgres
     ports: ["5432:5432"]
     restart: always
     volumes:

--- a/e2e-tests/docker-compose-test.yml
+++ b/e2e-tests/docker-compose-test.yml
@@ -264,6 +264,9 @@ services:
     volumes:
       - aerie_file_store:/usr/src/app/merlin_file_store:ro
   hasura:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.hasura
     container_name: hasura
     depends_on: ['postgres']
     environment:
@@ -279,12 +282,15 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: info
       HASURA_GRAPHQL_METADATA_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_hasura'
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: 'hasura/graphql-engine:v2.12.1.cli-migrations-v3'
+    image: aerie_hasura
     ports: ['8080:8080']
     restart: always
     volumes:
       - ./../deployment/hasura/metadata:/hasura-metadata
   postgres:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.postgres
     container_name: postgres
     environment:
       POSTGRES_DB: postgres
@@ -300,7 +306,7 @@ services:
       SCHEDULER_DB_PASSWORD: "${SCHEDULER_PASSWORD}"
       SEQUENCING_DB_USER: "${SEQUENCING_USERNAME}"
       SEQUENCING_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
-    image: postgres:16.12-bookworm
+    image: aerie_postgres
     ports: ['5432:5432']
     restart: always
     volumes:

--- a/sequencing-server/Dockerfile
+++ b/sequencing-server/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:18.20-bookworm-slim
 
 # Install jemalloc
+# Update gnutls to pick up debian security fixes flagged by trivy (may not be needed after base image update)
 RUN apt-get update \
     && apt-get install --no-install-recommends -y libjemalloc-dev \
     && apt-get install --no-install-recommends -y --only-upgrade libgnutls30 \

--- a/sequencing-server/Dockerfile
+++ b/sequencing-server/Dockerfile
@@ -2,7 +2,9 @@ FROM node:18.20-bookworm-slim
 
 # Install jemalloc
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y libjemalloc-dev
+    && apt-get install --no-install-recommends -y libjemalloc-dev \
+    && apt-get install --no-install-recommends -y --only-upgrade libgnutls30 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set the path for jemalloc
 RUN echo "/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so" >> /etc/ld.so.preload

--- a/sequencing-server/package-lock.json
+++ b/sequencing-server/package-lock.json
@@ -43,7 +43,7 @@
         "@types/pg-format": "~1.0.2",
         "@types/reserved-words": "~0.1.0",
         "ajv": "~8.12.0",
-        "concurrently": "~7.6.0",
+        "concurrently": "^8.2.2",
         "dotenv": "~16.0.3",
         "form-data": "~4.0.4",
         "jest": "~29.4.1",
@@ -680,6 +680,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2558,27 +2567,27 @@
       "dev": true
     },
     "node_modules/concurrently": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.6.0.tgz",
-      "integrity": "sha512-BKtRgvcJGeZ4XttiDiNcFiRlxoAeZOseqUvyYRUp/Vtd+9p1ULmeoSqGsDA+2ivdeDFpqrJvGvmI+StKfKl5hw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
       "dev": true,
       "dependencies": {
-        "chalk": "^4.1.0",
-        "date-fns": "^2.29.1",
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
         "lodash": "^4.17.21",
-        "rxjs": "^7.0.0",
-        "shell-quote": "^1.7.3",
-        "spawn-command": "^0.0.2-1",
-        "supports-color": "^8.1.0",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
         "tree-kill": "^1.2.2",
-        "yargs": "^17.3.1"
+        "yargs": "^17.7.2"
       },
       "bin": {
         "conc": "dist/bin/concurrently.js",
         "concurrently": "dist/bin/concurrently.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.0 || >=16.0.0"
+        "node": "^14.13.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
@@ -2683,10 +2692,13 @@
       "integrity": "sha512-Mu+FrW2umtFB8mFSSLtqRPWRvuFN5wF0YExbBWnmW/DVZIV2PvIkcoe6WdX9aCgx6zl4FKf3tRPrUBSpbY2tUg=="
     },
     "node_modules/date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
       "engines": {
         "node": ">=0.11"
       },
@@ -5665,9 +5677,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -5837,10 +5849,13 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
-      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5920,9 +5935,9 @@
       }
     },
     "node_modules/spawn-command": {
-      "version": "0.0.2-1",
-      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
       "dev": true
     },
     "node_modules/split2": {
@@ -6648,9 +6663,9 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
-      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -6659,7 +6674,7 @@
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
@@ -7229,6 +7244,12 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.19.0"
       }
+    },
+    "@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true
     },
     "@babel/template": {
       "version": "7.22.15",
@@ -8694,20 +8715,20 @@
       "dev": true
     },
     "concurrently": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.6.0.tgz",
-      "integrity": "sha512-BKtRgvcJGeZ4XttiDiNcFiRlxoAeZOseqUvyYRUp/Vtd+9p1ULmeoSqGsDA+2ivdeDFpqrJvGvmI+StKfKl5hw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
       "dev": true,
       "requires": {
-        "chalk": "^4.1.0",
-        "date-fns": "^2.29.1",
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
         "lodash": "^4.17.21",
-        "rxjs": "^7.0.0",
-        "shell-quote": "^1.7.3",
-        "spawn-command": "^0.0.2-1",
-        "supports-color": "^8.1.0",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
         "tree-kill": "^1.2.2",
-        "yargs": "^17.3.1"
+        "yargs": "^17.7.2"
       }
     },
     "content-disposition": {
@@ -8785,10 +8806,13 @@
       "integrity": "sha512-Mu+FrW2umtFB8mFSSLtqRPWRvuFN5wF0YExbBWnmW/DVZIV2PvIkcoe6WdX9aCgx6zl4FKf3tRPrUBSpbY2tUg=="
     },
     "date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
-      "dev": true
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      }
     },
     "debug": {
       "version": "2.6.9",
@@ -11012,9 +11036,9 @@
       }
     },
     "rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
@@ -11147,9 +11171,9 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "shell-quote": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
-      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true
     },
     "side-channel": {
@@ -11219,9 +11243,9 @@
       }
     },
     "spawn-command": {
-      "version": "0.0.2-1",
-      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
       "dev": true
     },
     "split2": {
@@ -11719,9 +11743,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
-      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "requires": {
         "cliui": "^8.0.1",
@@ -11730,7 +11754,7 @@
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       }
     },
     "yargs-parser": {

--- a/sequencing-server/package.json
+++ b/sequencing-server/package.json
@@ -58,7 +58,7 @@
     "@types/pg-format": "~1.0.2",
     "@types/reserved-words": "~0.1.0",
     "ajv": "~8.12.0",
-    "concurrently": "~7.6.0",
+    "concurrently": "^8.2.2",
     "dotenv": "~16.0.3",
     "form-data": "~4.0.4",
     "jest": "~29.4.1",


### PR DESCRIPTION
Fixing issues noted by Trivy security scans, see e.g.: https://github.com/NASA-AMMOS/plandev/actions/runs/28532014528/job/84584395217

* [x] sequencing server - 3 vulnerabilities
* [x] postgres - 2 vulnerabilities
* [x] action server - 2 vulnerabilities

Trivy scans (in the `publish` workflow) are now all passing on this PR, so it's ready to review.

### Postgres/Hasura Docker image changes

As part of our release process, we publish wrapped versions of the [`postgres`](https://github.com/NASA-AMMOS/plandev/pkgs/container/aerie-postgres) and [`hasura`](https://github.com/NASA-AMMOS/plandev/pkgs/container/aerie-postgres) docker images. Previously, there was an **inconsistency** between the `docker-compose` files in this repo vs. the ones in our quick-start/mission model template: the ones in the template use **our published, wrapped images**, while the ones in this repo used **the base docker hub images directly** (eg. `postgres:16.14-bookworm`).

After discussion, we've decided that all compose files in this repo should be changed to use our published, wrapped versions, so **this PR includes that change**. While they usually don't differ much from the base image, this is an important "shim" that allows us to insert security updates/fixes, and it's important that all deployments of PlanDev get those fixes, including dev environments.

### Node sidenote
Some of our backend services still use Node 18, which is now EOL. We need to upgrade them to Node 22 at least in the near future, if not Node 24, for LTS support. @duranb is looking into this as part of a wider dependency security update.