### PR TITLE
Fix `IllegalStateException` when Simulating during Scheduling

### DIFF
--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/BasicSchedulingTests.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/procedural/scheduling/BasicSchedulingTests.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.json.Json;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,7 +35,8 @@ public class BasicSchedulingTests extends ProceduralTestingSetup {
         "Test Scheduling Procedure 1",
         dumbRecurrenceGoalJarId,
         specId,
-        0
+        0,
+        true
     );
   }
 
@@ -184,7 +186,7 @@ public class BasicSchedulingTests extends ProceduralTestingSetup {
    * Run a spec that includes unfinished activities
    */
   @Test
-  void IncludesUnfinishedActivities() throws IOException {
+  void includesUnfinishedActivities() throws IOException {
     // Disable the recurrence goal to simplify scheduling results
     hasura.updateSchedulingSpecEnabled(dumbRecurrenceGoalId.invocationId(), false);
 
@@ -225,5 +227,48 @@ public class BasicSchedulingTests extends ProceduralTestingSetup {
     for(final var act : simResults.activities()) {
       assertNull(act.duration());
     }
+  }
+
+  /**
+   * Scheduling can handle two activities with the same parameters located that start at the same time without
+   * throwing an IllegalStateException.
+   *
+   * Uses DumbRecurrenceGoal for testing, as it will always place duplicate directives when the spec is rescheduled.
+   */
+  @Test
+  void duplicateActivitiesSupportedOnRerun() throws IOException {
+    final var args = Json.createObjectBuilder().add("quantity", 2).add("biteSize", 1).build();
+    hasura.updateSchedulingSpecGoalArguments(dumbRecurrenceGoalId.invocationId(), args);
+
+    hasura.awaitScheduling(planId);
+
+    final var initialActivities = hasura.getPlan(planId).activityDirectives();
+
+    // Rerun scheduling
+    hasura.updatePlanRevisionSchedulingSpec(planId);
+    hasura.awaitScheduling(planId);
+
+    final var updatedActivities = hasura.getPlan(planId).activityDirectives();
+
+    // Two new directives should have been placed on the plan
+    assertEquals(2, initialActivities.size());
+    assertEquals(4, updatedActivities.size());
+
+    // Sort the activities by start time
+    initialActivities.sort(Comparator.comparing(Plan.ActivityDirective::startOffset));
+    updatedActivities.sort(Comparator.comparing(Plan.ActivityDirective::startOffset));
+
+    // Check that the four activities are grouped into two sets of two.
+    final var firstStartTime = initialActivities.getFirst().startOffset();
+    assertEquals(2, updatedActivities.stream()
+                                     .filter(dir -> dir.startOffset().equals(firstStartTime))
+                                     .toList()
+                                     .size());
+
+    final var secondStartTime = initialActivities.getLast().startOffset();
+    assertEquals(2, updatedActivities.stream()
+                                     .filter(dir -> dir.startOffset().equals(secondStartTime))
+                                     .toList()
+                                     .size());
   }
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -9,14 +9,15 @@ import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivity;
 import gov.nasa.jpl.aerie.types.ActivityDirective;
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 public interface SimulationFacade {
   void setInitialSimResults(SimulationData simulationData);
@@ -82,28 +83,68 @@ public interface SimulationFacade {
      * `map` contains a mapping between *only the IDs that are different* between the two plans.
      */
     public Optional<Map<ActivityDirectiveId, ActivityDirectiveId>> equalsWithIdMap(PlanSimCorrespondence other) {
+      // If the simulations have a different amount of directives, they must not be equal
+      if(directiveIdActivityDirectiveMap.size() != other.directiveIdActivityDirectiveMap.size()) {
+        return Optional.empty();
+      }
+
+      // Build the maps of directives -> ids from the ids -> directives map
+      // Because multiple activities on a plan can be identical sans id, the inverted maps to a list of ids
+      final HashMap<ActivityDirective, List<ActivityDirectiveId>> thisInverted = HashMap.newHashMap(directiveIdActivityDirectiveMap.size());
+      directiveIdActivityDirectiveMap.forEach(
+          (key, value) -> {
+            thisInverted.putIfAbsent(value, new ArrayList<>());
+            thisInverted.get(value).add(key);
+          });
+
+      final HashMap<ActivityDirective, List<ActivityDirectiveId>> otherInverted = HashMap.newHashMap(other.directiveIdActivityDirectiveMap.size());
+      other.directiveIdActivityDirectiveMap.forEach(
+          (key, value) -> {
+            otherInverted.putIfAbsent(value, new ArrayList<>());
+            otherInverted.get(value).add(key);
+          });
+
+      // If these maps have different sizes, then the simulations must not be equal
+      if(thisInverted.size() != otherInverted.size()) {
+        return Optional.empty();
+      }
+
+      // Check every entry for equality while building up the return mapping
       final var result = new HashMap<ActivityDirectiveId, ActivityDirectiveId>();
-      final var thisInverse = directiveIdActivityDirectiveMap.entrySet()
-                                 .stream()
-                                 .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
-      final var otherInverse = other.directiveIdActivityDirectiveMap.entrySet()
-                                                             .stream()
-                                                             .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
-      for (var entry : thisInverse.entrySet()) {
-        final var otherId = otherInverse.remove(entry.getKey());
-        if (otherId == null) {
+      for (final var entry : thisInverted.entrySet()) {
+        // Check that at least one instance of this directive is on the other plan
+        if(!otherInverted.containsKey(entry.getKey())){
           return Optional.empty();
         }
-        if (!otherId.equals(entry.getValue())) {
-          result.put(entry.getValue(), otherId);
+
+        final var thisIds = entry.getValue();
+        final var otherIds = otherInverted.get(entry.getKey());
+
+        // Check that there is the same number of instances of this directive on the other plan
+        if (thisIds.size() != otherIds.size()) {
+          return Optional.empty();
+        }
+
+        // If the directive is unique (the most common case), then the two ids can be directly compared
+        if(thisIds.size() == 1) {
+          if(!thisIds.getFirst().equals(otherIds.getFirst())) {
+            result.put(thisIds.getFirst(), otherIds.getFirst());
+          }
+          continue;
+        }
+
+        // Filter out the ids that are on both lists, as this method does not provide a mapping for ids that have not changed
+        final List<ActivityDirectiveId> toRemove = thisIds.stream().filter(otherIds::contains).toList();
+        thisIds.removeAll(toRemove);
+        otherIds.removeAll(toRemove);
+
+        // Add the remaining mappings to the result
+        for(int i = 0; i < thisIds.size(); ++i) {
+          result.put(thisIds.get(i), otherIds.get(i));
         }
       }
 
-      if (otherInverse.isEmpty()) {
-        return Optional.of(result);
-      } else {
-        return Optional.empty();
-      }
+      return Optional.of(result);
     }
   }
 }


### PR DESCRIPTION
* **Tickets addressed:** Fixes #1786 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->
The method `PlanSimCorrespondence#equalsWithIdMap` has been reworked. Before, it was implicitly assuming that every activity on the plan was distinct in some way. It no longer makes that assumption, instead making the value in the inverted maps a `List` of `ActivityDirectiveId`s instead of just a single `ActivityDirectiveId`.

Additionally, the method now fast-fails when the number of directives in the two `PlanSimCorrespondence`s differ. Before, if the only difference between two `PlanSimCorrespondence`s was a new activity, the method would only realize that _after_ it had done all the work of populating the `result` map.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->
A new e2e test was added that schedules the procedural goal `DumbRecurrenceGoal` twice. `DumbRecurrenceGoal` is a goal that will **always** trigger this bug when it is scheduled more than once. This test fails on `develop` but passes on this branch.

A manual test can be done for this bug with the following Verification steps:
1. Deploy the `develop` branch
2. Run `./gradlew buildAllProcedureJars --parallel` to build the test JARs
3. Create a new plan and add the `DumbRecurrenceGoal` to its scheduling spec. Be sure to give it an argument for the `biteSize` parameter
4. Schedule the plan twice. Expected result: the second run should fail with an `IllegalStateException`
5. Checkout this branch, rebuild and redeploy (I recommend doing this without taking down the volumes, but if you do take them down, then repeat steps 2 and 3)
6. Schedule the plan as many times as you wish. There will be no more exception and each run will add more `BiteBanana` activities