### PR TITLE
Drop references to Slabs that have already been processed

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/CachedSimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/CachedSimulationEngine.java
@@ -29,7 +29,7 @@ public record CachedSimulationEngine(
     // Specify a topic on which tasks can log the activity they're associated with.
     final var activityTopic = new Topic<ActivityDirectiveId>();
     try {
-      engine.init(missionModel.getResources(), missionModel.getDaemon());
+      engine.init(missionModel.getResources(), missionModel.getDaemon(), activityTopic, missionModel.getTopics());
 
       return new CachedSimulationEngine(
           Duration.MIN_VALUE,

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
@@ -66,7 +66,7 @@ public final class SimulationDriver {
       final var activityTopic = new Topic<ActivityDirectiveId>();
 
       try {
-        engine.init(missionModel.getResources(), missionModel.getDaemon());
+        engine.init(missionModel.getResources(), missionModel.getDaemon(), activityTopic, missionModel.getTopics());
 
         // Get all activities as close as possible to absolute time
         // Schedule all activities.
@@ -139,7 +139,8 @@ public final class SimulationDriver {
     try (final var engine = new SimulationEngine(missionModel.getInitialCells())) {
       // Track resources and kick off daemon tasks
       try {
-        engine.init(missionModel.getResources(), missionModel.getDaemon());
+        final var activityTopic = new Topic<ActivityDirectiveId>();
+        engine.init(missionModel.getResources(), missionModel.getDaemon(), activityTopic, missionModel.getTopics());
       } catch (Throwable t) {
         throw new RuntimeException("Exception thrown while starting daemon tasks", t);
       }

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -96,6 +96,7 @@ public final class SimulationEngine implements AutoCloseable {
   /* The top-level simulation timeline. */
   private final TemporalEventSource timeline;
   private final TemporalEventSource referenceTimeline;
+  private SpanInfo spanInfo;
   private final LiveCells cells;
   private Duration elapsedTime;
 
@@ -155,7 +156,9 @@ public final class SimulationEngine implements AutoCloseable {
   }
 
   /** Initialize the engine by tracking resources and kicking off daemon tasks. **/
-  public void init(Map<String, Resource<?>> resources, TaskFactory<Unit> daemons) throws Throwable {
+  public void init(Map<String, Resource<?>> resources, TaskFactory<Unit> daemons, Topic<ActivityDirectiveId> activityTopic, Iterable<SerializableTopic<?>> serializableTopics) throws Throwable {
+    this.spanInfo = new SpanInfo(activityTopic, serializableTopics);
+
     // Begin tracking all resources.
     for (final var entry : resources.entrySet()) {
       final var name = entry.getKey();
@@ -206,6 +209,9 @@ public final class SimulationEngine implements AutoCloseable {
     final var delta = batch.offsetFromStart().minus(elapsedTime);
     elapsedTime = batch.offsetFromStart();
     timeline.add(delta);
+    if (!delta.isZero()) {
+        cells.stepUpAll();
+    }
 
     // TODO: Advance a dense time counter so that future tasks are strictly ordered relative to these,
     //   even if they occur at the same real time.
@@ -215,6 +221,7 @@ public final class SimulationEngine implements AutoCloseable {
     final var results = this.performJobs(batch.jobs(), cells, elapsedTime, simulationDuration);
     for (final var commit : results.commits()) {
       timeline.add(commit);
+      spanInfo.add(commit);
     }
     if (results.error.isPresent()) {
       throw results.error.get();
@@ -590,10 +597,11 @@ public final class SimulationEngine implements AutoCloseable {
   private record SpanInfo(
       Map<SpanId, ActivityDirectiveId> spanToPlannedDirective,
       Map<SpanId, SerializedActivity> input,
-      Map<SpanId, SerializedValue> output
+      Map<SpanId, SerializedValue> output,
+      Trait trait
   ) {
-    public SpanInfo() {
-      this(new HashMap<>(), new HashMap<>(), new HashMap<>());
+    public SpanInfo(Topic<ActivityDirectiveId> activityTopic, Iterable<SerializableTopic<?>> serializableTopics) {
+      this(new HashMap<>(), new HashMap<>(), new HashMap<>(), new Trait(serializableTopics, activityTopic));
     }
 
     public boolean isActivity(final SpanId id) {
@@ -606,6 +614,10 @@ public final class SimulationEngine implements AutoCloseable {
 
     public ActivityDirectiveId getDirective(SpanId id) {
       return this.spanToPlannedDirective.get(id);
+    }
+
+    public void add(EventGraph<Event> commit) {
+      commit.evaluate(trait, trait::atom).accept(this);
     }
 
     public record Trait(
@@ -703,9 +715,6 @@ public final class SimulationEngine implements AutoCloseable {
       final Iterable<SerializableTopic<?>> serializableTopics,
       final SpanId spanId
   ) {
-    // Collect per-span information from the event graph.
-    final var spanInfo = computeSpanInfo(activityTopic, serializableTopics, this.timeline);
-
     // Identify the nearest ancestor directive by walking up the parent
     // span tree. Save the activity trace along the way
     Optional<SpanId> directiveSpanId = Optional.of(spanId);
@@ -733,23 +742,6 @@ public final class SimulationEngine implements AutoCloseable {
       Map<ActivityInstanceId, UnfinishedActivity> unfinishedActivities
   ) {}
 
-  private SpanInfo computeSpanInfo(
-      final Topic<ActivityDirectiveId> activityTopic,
-      final Iterable<SerializableTopic<?>> serializableTopics,
-      final TemporalEventSource timeline
-  ) {
-    // Collect per-span information from the event graph.
-    final var spanInfo = new SpanInfo();
-
-    for (final var point : timeline) {
-      if (!(point instanceof TemporalEventSource.TimePoint.Commit p)) continue;
-
-      final var trait = new SpanInfo.Trait(serializableTopics, activityTopic);
-      p.events().evaluate(trait, trait::atom).accept(spanInfo);
-    }
-    return spanInfo;
-  }
-
   /**
    * Compute SpanInfo with ONLY inputs (arguments), skipping expensive output serialization.
    * This is much faster when you only need activity arguments and don't need return values.
@@ -767,9 +759,6 @@ public final class SimulationEngine implements AutoCloseable {
       }
     }
 
-    // Collect per-span information from the event graph - inputs only!
-    final var spanInfo = new SpanInfo();
-
     for (final var point : timeline) {
       if (!(point instanceof TemporalEventSource.TimePoint.Commit p)) continue;
 
@@ -786,7 +775,7 @@ public final class SimulationEngine implements AutoCloseable {
   ) {
     return computeActivitySimulationResults(
         startTime,
-        computeSpanInfo(activityTopic, serializableTopics, combineTimeline())
+        spanInfo
     );
   }
 
@@ -1068,8 +1057,6 @@ public final class SimulationEngine implements AutoCloseable {
       final SimulationResourceManager resourceManager
   ) {
     final var combinedTimeline = this.combineTimeline();
-    // Collect per-task information from the event graph.
-    final var spanInfo = computeSpanInfo(activityTopic, serializableTopics, combinedTimeline);
 
     // Extract profiles for every resource.
     final var resourceProfiles = resourceManager.computeProfiles(elapsedTime);
@@ -1110,10 +1097,7 @@ public final class SimulationEngine implements AutoCloseable {
       final SimulationResourceManager resourceManager,
       final Set<String> resourceNames
   ) {
-    final var combinedTimeline = this.combineTimeline();
-    // Collect per-task information from the event graph.
-    final var spanInfo = computeSpanInfo(activityTopic, serializableTopics, combinedTimeline);
-
+//    final var combinedTimeline = this.combineTimeline();
     // Extract profiles for every resource.
     final var resourceProfiles = resourceManager.computeProfiles(elapsedTime, resourceNames);
     final var realProfiles = resourceProfiles.realProfiles();

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -104,6 +104,7 @@ public final class SimulationEngine implements AutoCloseable {
     timeline = new TemporalEventSource();
     referenceTimeline = new TemporalEventSource();
     cells = new LiveCells(timeline, initialCells);
+    cells.stepUpAll(); // make sure all iterators have been initialized
     elapsedTime = Duration.ZERO;
 
     scheduledJobs = new JobSchedule<>();
@@ -968,8 +969,8 @@ public final class SimulationEngine implements AutoCloseable {
     final var discreteProfiles = resourceProfiles.discreteProfiles();
 
     // Compute span info with INPUTS ONLY (skips expensive output serialization)
-    final var combinedTimeline = this.combineTimeline();
-    final var spanInfo = computeSpanInfoInputsOnly(activityTopic, serializableTopics, combinedTimeline);
+//    final var combinedTimeline = this.combineTimeline();
+//    final var spanInfo = computeSpanInfoInputsOnly(activityTopic, serializableTopics, combinedTimeline);
 
     // Use the same activity ID assignment logic as full computation
     final var activityParents = new HashMap<SpanId, SpanId>();
@@ -1056,7 +1057,7 @@ public final class SimulationEngine implements AutoCloseable {
       final Iterable<SerializableTopic<?>> serializableTopics,
       final SimulationResourceManager resourceManager
   ) {
-    final var combinedTimeline = this.combineTimeline();
+//    final var combinedTimeline = this.combineTimeline();
 
     // Extract profiles for every resource.
     final var resourceProfiles = resourceManager.computeProfiles(elapsedTime);

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SlabList.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SlabList.java
@@ -18,10 +18,8 @@ public final class SlabList<T> implements Iterable<T> {
   /** ~4 KiB of elements (or at least, references thereof). */
   private static final int SLAB_SIZE = 1024;
 
-  private final Slab<T> head = new Slab<>();
+  private Slab<T> tail = new Slab<>();
 
-  /*derived*/
-  private Slab<T> tail = this.head;
   /*derived*/
   private int size = 0;
   private boolean frozen = false;
@@ -43,23 +41,6 @@ public final class SlabList<T> implements Iterable<T> {
     return this.size;
   }
 
-  @Override
-  public boolean equals(final Object o) {
-    if (!(o instanceof SlabList<?> other)) return false;
-
-    return Objects.equals(this.head, other.head);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.head);
-  }
-
-  @Override
-  public String toString() {
-    return SlabList.class.getSimpleName() + "[" + this.head + ']';
-  }
-
   /**
    * Returns an iterator that is stable through appends.
    *
@@ -72,10 +53,14 @@ public final class SlabList<T> implements Iterable<T> {
   }
 
   public final class SlabIterator implements Iterator<T> {
-    private Slab<T> slab = SlabList.this.head;
+    private Slab<T> slab = SlabList.this.tail;
     private int index = 0;
 
-    private SlabIterator() {}
+    private SlabIterator() {
+        if (SlabList.this.size() != 0) {
+            throw new IllegalStateException("Cannot create iterator on non-empty SlabList");
+        }
+    }
 
     @Override
     public boolean hasNext() {

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/timeline/LiveCells.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/timeline/LiveCells.java
@@ -3,8 +3,12 @@ package gov.nasa.jpl.aerie.merlin.driver.timeline;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public final class LiveCells {
   // INVARIANT: Every Query<T> maps to a LiveCell<T>; that is, the type parameters are correlated.
@@ -68,5 +72,15 @@ public final class LiveCells {
   public void freeze() {
     if (this.parent != null) this.parent.freeze();
     this.source.freeze();
+  }
+
+  private Stream<Query<?>> allQueriesStream() {
+      var myStream = this.cells.keySet().stream();
+      if (this.parent == null) return myStream;
+      return Stream.concat(this.parent.allQueriesStream(), myStream);
+  }
+
+  public void stepUpAll() {
+      allQueriesStream().forEach(this::getCell);
   }
 }


### PR DESCRIPTION
Paired with @DavidLegg to re-implement the changes in https://github.com/NASA-AMMOS/plandev/tree/perf/timeline-trim in a way that made sense to us.

Key changes:
- Maintain SpanInfo from start to finish of simulation
- Remove `head` field from SlabList, asserting that any iterators are created before any items are inserted
- Add method to step up all cells, moving the iterators up and (hopefully) dropping the last references to Slabs, allowing the GC to collect them