### PR TITLE
Re-use output type object across instances of DeferredSerializedValue

### DIFF
--- a/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Registrar.java
+++ b/merlin-framework/src/main/java/gov/nasa/jpl/aerie/merlin/framework/Registrar.java
@@ -103,6 +103,25 @@ public final class Registrar {
       final JsonWriter<Value> jsonWriter,
       final String description
   ) {
+    OutputType<Value> outputType = new OutputType<>() {
+      @Override
+      public ValueSchema getSchema() {
+        if (description != null) {
+          return ValueSchema.withMeta("description", SerializedValue.of(Map.of("value", SerializedValue.of(description))), valueSchema);
+        }
+        return valueSchema;
+      }
+
+      @Override
+      public SerializedValue serialize(final Value value) {
+        return serializer.apply(value);
+      }
+
+      @Override
+      public void writeJson(final Value value, final JsonGenerator gen) throws IOException {
+        jsonWriter.write(value, gen);
+      }
+    };
     return new gov.nasa.jpl.aerie.merlin.protocol.model.Resource<>() {
       @Override
       public String getType() {
@@ -111,25 +130,7 @@ public final class Registrar {
 
       @Override
       public OutputType<Value> getOutputType() {
-        return new OutputType<>() {
-          @Override
-          public ValueSchema getSchema() {
-            if (description != null) {
-              return ValueSchema.withMeta("description", SerializedValue.of(Map.of("value", SerializedValue.of(description))), valueSchema);
-            }
-            return valueSchema;
-          }
-
-          @Override
-          public SerializedValue serialize(final Value value) {
-            return serializer.apply(value);
-          }
-
-          @Override
-          public void writeJson(final Value value, final JsonGenerator gen) throws IOException {
-            jsonWriter.write(value, gen);
-          }
-        };
+        return outputType;
       }
 
       @Override


### PR DESCRIPTION
I took a look at a heap dump and found a very large number (~80 million) of instances of OutputType (technically the class name was `Registrar$1$1`). I tracked it down to this field of DeferredSerializedValue: https://github.com/NASA-AMMOS/aerie/blob/660b71b00d107127a8bac74eec134568096447f7/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/resources/DeferredSerializedValue.java#L16

I didn't trace the data flow for how the object gets here, but I did know for sure that it was coming from the Registrar's `makeResource` method (I tracked it there by using `javap` to examine the class files for `Registrar`, `Registrar$1` and `Registrar$1$1`). Based on the facts stated so far, I figure that `getOutputType` is called once for every profile segment.

This PR eagerly creates a single output type per resource, and then returns references to that object from `getOutputType`.

### Alternatives considered
We could try to find the code that calls `getOutputType` and do the caching there. This PR's solution was easier to implement, and I don't think there's any harm in eagerly creating these objects and caching them, as opposed to lazily creating them.