### PR TITLE
update linux libc in hasura image to mitigate CVE-2022-49770

### DIFF
--- a/docker/Dockerfile.hasura
+++ b/docker/Dockerfile.hasura
@@ -1,2 +1,12 @@
 FROM hasura/graphql-engine:v2.12.1.cli-migrations-v3
+
+# update libc to mitigate CVE-2022-49770 from scan
+# remove pgdg to make install succeed due to https://www.postgresql.org/message-id/aCtIvml4sCYnRSjp%40msg.df7cb.de
+# (may not be needed after base image update)
+RUN rm -f /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y --only-upgrade linux-libc-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+
 COPY deployment/hasura/metadata /hasura-metadata


### PR DESCRIPTION
## Description
Updates our hasura image to update `linux-libc-dev` to handle CVE-2022-49770 from [recent failing Trivy security scans on the hasura container.](https://github.com/NASA-AMMOS/plandev/actions/runs/29287890495/job/86945393277?pr=1777)

## Verification
Security scan should pass on this branch. Also you can use this command to check the libc version on a container:
```
docker run --rm --entrypoint dpkg-query aerie_hasura:test -W -f='${Version}\n' linux-libc-dev
# now returns 5.4.0-216.236, > 5.4.0-144.161 (fixed version)
```

## Future work
This is an ad-hoc fix for this particular vulnerability. Long-term we should upgrade the `hasura` base image to a newer version, the one we're using (`v2.12.1.cli-migrations-v3`) is pretty old 
