### PR TITLE
Call stepUpAll less frequently

### DIFF
--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/engine/SimulationEngine.java
@@ -196,6 +196,8 @@ public final class SimulationEngine implements AutoCloseable {
     return elapsedTime;
   }
 
+  int stepCount = 0;
+
   /** Step the engine forward one batch. **/
   public Status step(Duration simulationDuration) throws Throwable {
     final var nextTime = this.peekNextTime().orElse(Duration.MAX_VALUE);
@@ -210,7 +212,8 @@ public final class SimulationEngine implements AutoCloseable {
     final var delta = batch.offsetFromStart().minus(elapsedTime);
     elapsedTime = batch.offsetFromStart();
     timeline.add(delta);
-    if (!delta.isZero()) {
+    if (stepCount++ > 1000) {
+        stepCount = 0;
         cells.stepUpAll();
     }
 


### PR DESCRIPTION
`stepUpAll`, which is a measure to reduce memory footprint, is now a CPU hotspot. Calling it less frequently might help a bit, though I'm not sure about that.